### PR TITLE
Clean up example scripts

### DIFF
--- a/examples/human/human_exe_longseq/utils.py
+++ b/examples/human/human_exe_longseq/utils.py
@@ -15,7 +15,6 @@ from torchrl.collectors import SyncDataCollector
 
 from torchtrade.envs.offline.seqlongonly import SeqLongOnlyEnv, SeqLongOnlyEnvConfig
 from torchtrade.envs.offline.utils import TimeFrame, TimeFrameUnit
-import ta
 import pandas as pd
 
 # ====================================================================

--- a/examples/online/dsac/train.py
+++ b/examples/online/dsac/train.py
@@ -149,15 +149,6 @@ def main(cfg: DictConfig):  # noqa: F821
         cfg, train_env, actor_model_explore=model[0], compile_mode=compile_mode
     )
 
-    if cfg.compile.compile:
-        update = torch.compile(update, mode=compile_mode)
-    if cfg.compile.cudagraphs:
-        warnings.warn(
-            "CudaGraphModule is experimental and may lead to silently wrong results. Use with caution.",
-            category=UserWarning,
-        )
-        update = CudaGraphModule(update, warmup=50)
-
     # Main loop
     collected_frames = 0
     pbar = tqdm.tqdm(total=cfg.collector.total_frames)

--- a/examples/online/dsac/utils.py
+++ b/examples/online/dsac/utils.py
@@ -9,7 +9,7 @@ import tempfile
 from contextlib import nullcontext
 
 import torch
-from tensordict.nn import InteractionType, TensorDictModule
+from tensordict.nn import InteractionType
 
 from torch import nn, optim
 from torchrl.collectors import SyncDataCollector
@@ -32,8 +32,6 @@ from torchrl.envs import (
 )
 from torchrl.envs.utils import ExplorationType, set_exploration_type
 from torchrl.modules import MLP, SafeModule, SafeSequential
-
-from torchrl.modules.distributions import OneHotCategorical
 
 from torchrl.modules.tensordict_module.actors import ProbabilisticActor
 from torchrl.objectives import SoftUpdate

--- a/examples/online/long_onestep_env/train.py
+++ b/examples/online/long_onestep_env/train.py
@@ -3,10 +3,8 @@ from __future__ import annotations
 import warnings
 
 import hydra
-from sympy.logic.boolalg import true
 from torchrl._utils import compile_with_warmup
 import datasets
-import torchtrade.losses
 from torchtrade.losses import GRPOLoss
 
 

--- a/examples/online/long_onestep_env/utils.py
+++ b/examples/online/long_onestep_env/utils.py
@@ -5,9 +5,7 @@
 from __future__ import annotations
 import functools
 
-from pandas.tseries import frequencies
 import torch.nn
-from tensordict.nn import TensorDictModule
 from torchrl.envs import (
     DoubleToFloat,
     EnvCreator,
@@ -18,26 +16,19 @@ from torchrl.envs import (
     Compose,
     TransformedEnv,
     StepCounter,
-    VecNorm,
 )
 from torchrl.collectors import SyncDataCollector
-from torchrl.data import MultiCategorical, Categorical
 
 from torchrl.modules import (
-    ActorValueOperator,
     MLP,
     ProbabilisticActor,
-    ValueOperator,
     SafeModule,
     SafeSequential,
 )
 from trading_nets.architectures.tabl.tabl import BiNMTABLModel, BiNTabularEncoder
-from trading_nets.architectures.wavenet.simple_1d_wave import Simple1DWaveEncoder
 
 from torchtrade.envs import LongOnlyOneStepEnv, LongOnlyOneStepEnvConfig, SeqLongOnlySLTPEnvConfig, SeqLongOnlySLTPEnv
 from torchtrade.envs.offline.utils import TimeFrame, TimeFrameUnit, get_timeframe_unit
-import ta
-import numpy as np
 import pandas as pd
 from torchrl.trainers.helpers.models import ACTIVATIONS
 
@@ -321,29 +312,6 @@ def make_grpo_policy(env, device, cfg):
     print(f"Total number of parameters: {total_params}")
 
     return policy
-
-
-# ====================================================================
-# Evaluation utils
-# --------------------------------------------------------------------
-
-
-
-def eval_model(actor, test_env, num_episodes=3):
-    test_rewards = []
-    for _ in range(num_episodes):
-        td_test = test_env.rollout(
-            policy=actor,
-            auto_reset=True,
-            auto_cast_to_device=True,
-            break_when_any_done=True,
-            max_steps=10_000_000,
-        )
-        test_env.apply(dump_video)
-        reward = td_test["next", "episode_reward"][td_test["next", "done"]]
-        test_rewards.append(reward.cpu())
-    del td_test
-    return torch.cat(test_rewards, 0).mean()
 
 
 def make_collector(cfg, train_env, actor_model_explore, compile_mode):

--- a/examples/online/ppo/train.py
+++ b/examples/online/ppo/train.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import warnings
 
 import hydra
-from sympy.logic.boolalg import true
 from torchrl._utils import compile_with_warmup
 import datasets
 
@@ -88,7 +87,7 @@ def main(cfg: DictConfig):  # noqa: F821
         compile_mode,
     )
     # Create data buffer
-    sampler = SamplerWithoutReplacement(drop_last=true)
+    sampler = SamplerWithoutReplacement(drop_last=True)
     data_buffer = TensorDictReplayBuffer(
         storage=LazyTensorStorage(
             frames_per_batch, compilable=cfg.compile.compile, device=device

--- a/examples/online/ppo/utils.py
+++ b/examples/online/ppo/utils.py
@@ -5,7 +5,6 @@
 from __future__ import annotations
 import functools
 
-from pandas.tseries import frequencies
 import torch.nn
 from tensordict.nn import TensorDictModule
 from torchrl.envs import (
@@ -18,10 +17,8 @@ from torchrl.envs import (
     Compose,
     TransformedEnv,
     StepCounter,
-    VecNorm,
 )
 from torchrl.collectors import SyncDataCollector
-from torchrl.data import MultiCategorical, Categorical
 
 from torchrl.modules import (
     ActorValueOperator,
@@ -32,7 +29,6 @@ from torchrl.modules import (
     SafeSequential,
 )
 from trading_nets.architectures.tabl.tabl import BiNMTABLModel, BiNTabularEncoder
-from trading_nets.architectures.wavenet.simple_1d_wave import Simple1DWaveEncoder
 
 from torchtrade.envs import SeqLongOnlyEnv, SeqLongOnlyEnvConfig, SeqLongOnlySLTPEnv, SeqLongOnlySLTPEnvConfig
 from torchtrade.envs.offline.utils import TimeFrame, TimeFrameUnit, get_timeframe_unit
@@ -315,98 +311,6 @@ def make_discrete_ppo_binmtabl_model(cfg, env, device):
 
     return common_module, policy_module, value_module
 
-def make_discrete_ppo_wavenet_model(cfg, env, device):
-    """Make discrete PPO agent."""
-    action_spec = env.action_spec
-
-    market_data_keys = [k for k in list(env.observation_spec.keys()) if k.startswith("market_data")]
-    assert "account_state" in list(env.observation_spec.keys()), "Account state key not in observation spec"
-    # Define Actor Network
-    time_frames = cfg.env.time_frames
-    assert len(time_frames) == len(market_data_keys), f"Amount of time frames {len(time_frames)} and env market data keys do not match! Keys: {market_data_keys}"
-    encoders = []
-    
-    # Build the encoder
-    for key, freq, t, w in zip(market_data_keys, cfg.env.freqs, cfg.env.time_frames, cfg.env.window_sizes):
-        net = Simple1DWaveEncoder(feature_dim=14,
-                                base_channels=32,
-                                num_layers=4,
-                                out_channels=14,
-                                squeeze_output=True,
-                                dil_norm_type='layernorm'
-                                )
-        encoders.append(SafeModule(net, in_keys=key, out_keys=[f"encoding_{t}_{freq}_{w}"]))
-
-    account_state_encoder = SafeModule(
-        module=MLP(
-            num_cells=[32],
-            out_features=14,
-            activation_class=ACTIVATIONS["relu"],
-            device=device,
-        ),
-        in_keys=["account_state"],
-        out_keys=["encoding_account_state"],
-    )
-
-
-    
-    common = MLP(
-        num_cells=[128, 128],
-        out_features=128,
-        activation_class=ACTIVATIONS["relu"],
-        device=device,
-    )
-
-    common_module = SafeModule(
-        module=common,
-        in_keys=[f"encoding_{t}_{fre}_{w}" for t, w, fre in zip(time_frames, cfg.env.window_sizes, cfg.env.freqs)] + ["encoding_account_state"],
-        out_keys=["common_features"],
-    )
-    common_module = SafeSequential(*encoders, account_state_encoder, common_module)
-
-    # Define on head for the policy
-    policy_net = MLP(
-        in_features=128,
-        out_features=action_spec.n,
-        activation_class=ACTIVATIONS["relu"],
-        num_cells=[],
-        device=device,
-    )
-    policy_module = TensorDictModule(
-        module=policy_net,
-        in_keys=["common_features"],
-        out_keys=["logits"],
-    )
-
-    # Add probabilistic sampling of the actions
-    distribution_class = torch.distributions.Categorical
-    distribution_kwargs = {}
-
-    policy_module = ProbabilisticActor(
-        policy_module,
-        in_keys=["logits"],
-        spec=env.full_action_spec_unbatched.to(device),
-        distribution_class=distribution_class,
-        distribution_kwargs=distribution_kwargs,
-        return_log_prob=True,
-        default_interaction_type=ExplorationType.RANDOM,
-    )
-
-    # Define another head for the value
-    value_net = MLP(
-        activation_class=torch.nn.ReLU,
-        in_features=128,
-        out_features=1,
-        num_cells=[],
-        device=device,
-    )
-    value_module = ValueOperator(
-        value_net,
-        in_keys=["common_features"],
-    )
-
-    return common_module, policy_module, value_module
-
 
 def make_ppo_models(env, device, cfg):
     common_module, policy_module, value_module = make_discrete_ppo_binmtabl_model(
@@ -434,29 +338,6 @@ def make_ppo_models(env, device, cfg):
     critic = actor_critic.get_value_operator()
 
     return actor, critic
-
-
-# ====================================================================
-# Evaluation utils
-# --------------------------------------------------------------------
-
-
-
-def eval_model(actor, test_env, num_episodes=3):
-    test_rewards = []
-    for _ in range(num_episodes):
-        td_test = test_env.rollout(
-            policy=actor,
-            auto_reset=True,
-            auto_cast_to_device=True,
-            break_when_any_done=True,
-            max_steps=10_000_000,
-        )
-        test_env.apply(dump_video)
-        reward = td_test["next", "episode_reward"][td_test["next", "done"]]
-        test_rewards.append(reward.cpu())
-    del td_test
-    return torch.cat(test_rewards, 0).mean()
 
 
 def make_collector(cfg, train_env, actor_model_explore, compile_mode):


### PR DESCRIPTION
## Summary

- Remove unused imports across all example files (8 files cleaned)
- Remove unused functions that were either dead code or referenced undefined functions
- Fix code quality issues including replacing `sympy.logic.boolalg.true` with Python `True`
- Remove duplicate compile/cudagraph wrapping code in dsac/train.py

### Changes by file:

| File | Cleanup |
|------|---------|
| `examples/offline/iql/utils.py` | Removed: `SyncDataCollector`, `VideoRecorder`, `BiNMTABLModel`, `CategoricalSpec` imports; `make_collector`, `make_discrete_iql_binmtabl_model`, `dump_video` functions |
| `examples/online/dsac/utils.py` | Removed: `TensorDictModule`, `OneHotCategorical` imports |
| `examples/online/dsac/train.py` | Removed duplicate compile/cudagraph wrapping code |
| `examples/online/ppo/utils.py` | Removed: `frequencies`, `VecNorm`, `MultiCategorical`, `Categorical`, `Simple1DWaveEncoder` imports; `make_discrete_ppo_wavenet_model`, `eval_model` functions |
| `examples/online/ppo/train.py` | Replaced `sympy.logic.boolalg.true` with Python `True` |
| `examples/online/long_onestep_env/utils.py` | Removed: `frequencies`, `VecNorm`, `MultiCategorical`, `Categorical`, `ActorValueOperator`, `ValueOperator`, `Simple1DWaveEncoder`, `numpy` imports; `eval_model` function |
| `examples/online/long_onestep_env/train.py` | Removed unused `torchtrade.losses` import |
| `examples/human/human_exe_longseq/utils.py` | Removed: `ta` import |

**Net result: -361 lines of dead code removed**

## Test plan

- [ ] Verify example scripts still run correctly after cleanup
- [ ] Confirm no import errors in modified files

Fixes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)