### PR TITLE
Add SeqFuturesSLTPEnv for futures trading with stop-loss/take-profit

### DIFF
--- a/examples/online/ppo_futures_sltp/config.yaml
+++ b/examples/online/ppo_futures_sltp/config.yaml
@@ -1,0 +1,65 @@
+env:
+  name: SeqFuturesSLTPEnv
+  symbol: "BTC/USD"
+  freqs: ["Min"]
+  time_frames: [15]
+  window_sizes: [32]
+  execute_on: [15, "Min"]
+  initial_cash: [1000, 5000]
+  transaction_fee: 0.0004  # 0.04% typical futures fee
+  slippage: 0.001
+  bankrupt_threshold: 0.1
+  leverage: 5  # 5x leverage
+  stoploss_levels: [-0.02, -0.05, -0.1]  # 2%, 5%, 10% stop loss
+  takeprofit_levels: [0.05, 0.1, 0.2]    # 5%, 10%, 20% take profit
+  exp_name: ${logger.exp_name}
+  seed: 0
+  train_envs: 10
+  eval_envs: 2
+  data_path: Sebasdi/TorchTrade_btcusd_spot_1m_12_2024_to_09_2025
+
+# collector
+collector:
+  device:
+  frames_per_batch: 100000
+  total_frames: 100_000_000
+
+# logger
+logger:
+  mode: online
+  backend: wandb
+  project_name: TorchTrade-FuturesSLTP
+  group_name: ${env.name}
+  exp_name: ppo_futures_sltp
+  test_interval: 1_000_000
+  num_test_episodes: 1
+
+# model
+model:
+  activation: tanh
+
+# optimization
+optim:
+  lr: 2.5e-4
+  eps: 1.0e-6
+  weight_decay: 0.0
+  max_grad_norm: 0.5
+  anneal_lr: True
+  device:
+
+# loss
+loss:
+  gamma: 0.9
+  mini_batch_size: 33333
+  ppo_epochs: 3
+  gae_lambda: 0.95
+  clip_epsilon: 0.1
+  anneal_clip_epsilon: True
+  critic_coef: 1.0
+  entropy_coef: 0.01
+  loss_critic_type: l2
+
+compile:
+  compile: False
+  compile_mode:
+  cudagraphs: False

--- a/examples/online/ppo_futures_sltp/train.py
+++ b/examples/online/ppo_futures_sltp/train.py
@@ -1,0 +1,311 @@
+"""PPO training example for SeqFuturesSLTPEnv.
+
+This script demonstrates PPO training on the SeqFuturesSLTPEnv environment
+for futures trading with leverage, stop-loss, and take-profit support.
+"""
+from __future__ import annotations
+
+import warnings
+
+import hydra
+from torchrl._utils import compile_with_warmup
+import datasets
+
+
+@hydra.main(config_path="", config_name="config", version_base="1.1")
+def main(cfg: DictConfig):  # noqa: F821
+
+    import torch.optim
+    import tqdm
+    import wandb
+    from tensordict import TensorDict
+    from tensordict.nn import CudaGraphModule
+
+    from torchrl._utils import timeit
+    from torchrl.data import LazyTensorStorage, TensorDictReplayBuffer
+    from torchrl.data.replay_buffers.samplers import SamplerWithoutReplacement
+    from torchrl.envs import ExplorationType, set_exploration_type
+    from torchrl.objectives import ClipPPOLoss
+    from torchrl.objectives.value.advantages import GAE
+    from torchrl.record.loggers import generate_exp_name, get_logger
+    from utils import make_environment, make_ppo_models, make_collector, log_metrics
+
+    torch.set_float32_matmul_precision("high")
+
+    device = cfg.optim.device
+    if device in ("", None):
+        if torch.cuda.is_available():
+            device = "cuda:0"
+        else:
+            device = "cpu"
+    device = torch.device(device)
+    print("USING DEVICE: ", device)
+
+    # Load data from HuggingFace
+    df = datasets.load_dataset(cfg.env.data_path)
+    df = df["train"].to_pandas()
+    test_df = df[0 : (1440 * 21)]  # 21 days for test
+    train_df = df[(1440 * 21) :]
+
+    max_train_traj_length = cfg.collector.frames_per_batch // cfg.env.train_envs
+    max_eval_traj_length = len(test_df)
+    train_env, eval_env = make_environment(
+        train_df,
+        test_df,
+        cfg,
+        train_num_envs=cfg.env.train_envs,
+        eval_num_envs=cfg.env.eval_envs,
+        max_train_traj_length=max_train_traj_length,
+        max_eval_traj_length=max_eval_traj_length,
+    )
+    eval_env.to(device)
+
+    total_frames = cfg.collector.total_frames
+    frames_per_batch = cfg.collector.frames_per_batch
+    mini_batch_size = cfg.loss.mini_batch_size
+    test_interval = cfg.logger.test_interval
+
+    compile_mode = None
+    if cfg.compile.compile:
+        compile_mode = cfg.compile.compile_mode
+        if compile_mode in ("", None):
+            if cfg.compile.cudagraphs:
+                compile_mode = "default"
+            else:
+                compile_mode = "reduce-overhead"
+
+    # Create models
+    actor, critic = make_ppo_models(
+        eval_env,
+        device=device,
+        cfg=cfg,
+    )
+
+    # Create collector
+    collector = make_collector(
+        cfg,
+        train_env,
+        actor,
+        compile_mode,
+    )
+
+    # Create data buffer
+    sampler = SamplerWithoutReplacement(drop_last=True)
+    data_buffer = TensorDictReplayBuffer(
+        storage=LazyTensorStorage(
+            frames_per_batch, compilable=cfg.compile.compile, device=device
+        ),
+        sampler=sampler,
+        batch_size=mini_batch_size,
+        compilable=cfg.compile.compile,
+    )
+
+    # Create loss and advantage modules
+    adv_module = GAE(
+        gamma=cfg.loss.gamma,
+        lmbda=cfg.loss.gae_lambda,
+        value_network=critic,
+        average_gae=False,
+        device=device,
+        time_dim=-3,
+        vectorized=not cfg.compile.compile,
+    )
+    loss_module = ClipPPOLoss(
+        actor_network=actor,
+        critic_network=critic,
+        clip_epsilon=cfg.loss.clip_epsilon,
+        loss_critic_type=cfg.loss.loss_critic_type,
+        entropy_coef=cfg.loss.entropy_coef,
+        critic_coef=cfg.loss.critic_coef,
+        normalize_advantage=True,
+    )
+
+    # Create optimizer
+    optim = torch.optim.Adam(
+        loss_module.parameters(),
+        lr=cfg.optim.lr,
+        weight_decay=cfg.optim.weight_decay,
+        eps=cfg.optim.eps,
+    )
+
+    # Create logger
+    logger = None
+    if cfg.logger.backend:
+        exp_name = generate_exp_name("TorchTrade-FuturesSLTP-PPO", cfg.logger.exp_name)
+        logger = get_logger(
+            cfg.logger.backend,
+            logger_name="ppo_futures_sltp_logging",
+            experiment_name=exp_name,
+            wandb_kwargs={
+                "mode": cfg.logger.mode,
+                "config": dict(cfg),
+                "project": cfg.logger.project_name,
+                "group": cfg.logger.group_name,
+            },
+        )
+
+    # Main loop
+    collected_frames = 0
+    num_network_updates = torch.zeros((), dtype=torch.int64, device=device)
+    pbar = tqdm.tqdm(total=total_frames)
+    num_mini_batches = frames_per_batch // mini_batch_size
+    total_network_updates = (
+        (total_frames // frames_per_batch) * cfg.loss.ppo_epochs * num_mini_batches
+    )
+
+    def update(batch, num_network_updates):
+        optim.zero_grad(set_to_none=True)
+        alpha = torch.ones((), device=device)
+        if cfg_optim_anneal_lr:
+            alpha = 1 - (num_network_updates / total_network_updates)
+            for group in optim.param_groups:
+                group["lr"] = cfg_optim_lr * alpha
+        if cfg_loss_anneal_clip_eps:
+            loss_module.clip_epsilon.copy_(cfg_loss_clip_epsilon * alpha)
+
+        batch = batch.to(device, non_blocking=True)
+
+        # Forward pass PPO loss
+        loss = loss_module(batch)
+        loss_sum = loss["loss_critic"] + loss["loss_objective"] + loss["loss_entropy"]
+
+        # Backward pass
+        loss_sum.backward()
+        torch.nn.utils.clip_grad_norm_(
+            loss_module.parameters(), max_norm=cfg_optim_max_grad_norm
+        )
+
+        # Update the networks
+        optim.step()
+        return loss.detach().set("alpha", alpha), num_network_updates
+
+    if cfg.compile.compile:
+        update = compile_with_warmup(update, mode=compile_mode, warmup=1)
+        adv_module = compile_with_warmup(adv_module, mode=compile_mode, warmup=1)
+
+    if cfg.compile.cudagraphs:
+        warnings.warn(
+            "CudaGraphModule is experimental and may lead to silently wrong results. Use with caution.",
+            category=UserWarning,
+        )
+        update = CudaGraphModule(update, in_keys=[], out_keys=[], warmup=5)
+        adv_module = CudaGraphModule(adv_module)
+
+    # Extract cfg variables
+    cfg_loss_ppo_epochs = cfg.loss.ppo_epochs
+    cfg_optim_anneal_lr = cfg.optim.anneal_lr
+    cfg_optim_lr = cfg.optim.lr
+    cfg_loss_anneal_clip_eps = cfg.loss.anneal_clip_epsilon
+    cfg_loss_clip_epsilon = cfg.loss.clip_epsilon
+    cfg_optim_max_grad_norm = cfg.optim.max_grad_norm
+    cfg.loss.clip_epsilon = cfg_loss_clip_epsilon
+    losses = TensorDict(batch_size=[cfg_loss_ppo_epochs, num_mini_batches])
+
+    collector_iter = iter(collector)
+    total_iter = len(collector)
+    for i in range(total_iter):
+        timeit.printevery(1000, total_iter, erase=True)
+
+        with timeit("collecting"):
+            data = next(collector_iter).to(device)
+
+        metrics_to_log = {}
+        frames_in_batch = data.numel()
+        metrics_to_log["train/action_std"] = data["action"].float().std().item()
+        collected_frames += frames_in_batch
+        pbar.update(frames_in_batch)
+
+        # Get training rewards and episode lengths
+        episode_rewards = data["next", "episode_reward"][data["next", "terminated"]]
+        if len(episode_rewards) > 0:
+            episode_length = data["next", "step_count"][data["next", "terminated"]]
+            metrics_to_log.update(
+                {
+                    "train/reward": episode_rewards.mean().item(),
+                    "train/episode_length": episode_length.sum().item()
+                    / len(episode_length),
+                }
+            )
+
+        with timeit("training"):
+            for j in range(cfg_loss_ppo_epochs):
+                # Compute GAE
+                with torch.no_grad(), timeit("adv"):
+                    torch.compiler.cudagraph_mark_step_begin()
+                    data = adv_module(data)
+                    if compile_mode:
+                        data = data.clone()
+                with timeit("rb - extend"):
+                    # Update the data buffer
+                    data_reshape = data.reshape(-1)
+                    data_buffer.extend(data_reshape)
+
+                for k, batch in enumerate(data_buffer):
+                    with timeit("update"):
+                        torch.compiler.cudagraph_mark_step_begin()
+                        loss, num_network_updates = update(
+                            batch, num_network_updates=num_network_updates
+                        )
+                    loss = loss.clone()
+                    num_network_updates = num_network_updates.clone()
+                    losses[j, k] = loss.select(
+                        "loss_critic", "loss_entropy", "loss_objective"
+                    )
+
+        # Get training losses and times
+        losses_mean = losses.apply(lambda x: x.float().mean(), batch_size=[])
+        for key, value in losses_mean.items():
+            metrics_to_log.update({f"train/{key}": value.item()})
+        metrics_to_log.update(
+            {
+                "train/lr": loss["alpha"] * cfg_optim_lr,
+                "train/clip_epsilon": loss["alpha"] * cfg_loss_clip_epsilon,
+            }
+        )
+
+        # Evaluation
+        with torch.no_grad(), set_exploration_type(
+            ExplorationType.DETERMINISTIC
+        ), timeit("eval"):
+            if ((i - 1) * frames_in_batch) // test_interval < (
+                i * frames_in_batch
+            ) // test_interval:
+                actor.eval()
+                eval_rollout = eval_env.rollout(
+                    max_eval_traj_length,
+                    actor,
+                    auto_cast_to_device=True,
+                    break_when_any_done=True,
+                )
+                eval_rollout.squeeze()
+                eval_reward = eval_rollout["next", "reward"].sum(-2).mean().item()
+                metrics_to_log["eval/reward"] = eval_reward
+                fig = eval_env.base_env.render_history(return_fig=True)
+                eval_env.reset()
+                if fig is not None and logger is not None:
+                    # render_history returns a figure directly for SeqFuturesSLTPEnv
+                    metrics_to_log["eval/history"] = wandb.Image(fig[0])
+                torch.save(actor.state_dict(), f"ppo_futures_sltp_policy_{i}.pth")
+                actor.train()
+
+        if logger is not None:
+            time_dict = timeit.todict(prefix="time")
+            metrics_to_log.update(timeit.todict(prefix="time"))
+            metrics_to_log["time/speed"] = pbar.format_dict["rate"]
+            metrics_to_log["time/SPS-collecting"] = (
+                frames_in_batch / time_dict["time/collecting"]
+            )
+            metrics_to_log["time/SPS-total"] = frames_in_batch / sum(time_dict.values())
+            log_metrics(logger, metrics_to_log, collected_frames)
+
+        collector.update_policy_weights_()
+
+    collector.shutdown()
+    if not eval_env.is_closed:
+        eval_env.close()
+    if not train_env.is_closed:
+        train_env.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/online/ppo_futures_sltp/utils.py
+++ b/examples/online/ppo_futures_sltp/utils.py
@@ -1,0 +1,325 @@
+"""Utility functions for PPO training on SeqFuturesSLTPEnv."""
+from __future__ import annotations
+import functools
+
+import torch.nn
+from tensordict.nn import TensorDictModule
+from torchrl.envs import (
+    DoubleToFloat,
+    EnvCreator,
+    ExplorationType,
+    ParallelEnv,
+    RewardSum,
+    InitTracker,
+    Compose,
+    TransformedEnv,
+    StepCounter,
+)
+from torchrl.collectors import SyncDataCollector
+
+from torchrl.modules import (
+    ActorValueOperator,
+    MLP,
+    ProbabilisticActor,
+    ValueOperator,
+    SafeModule,
+    SafeSequential,
+)
+
+from torchtrade.envs import SeqFuturesSLTPEnv, SeqFuturesSLTPEnvConfig
+from torchtrade.envs.offline.utils import TimeFrame, TimeFrameUnit, get_timeframe_unit
+import numpy as np
+import pandas as pd
+from torchrl.trainers.helpers.models import ACTIVATIONS
+
+# ====================================================================
+# Environment utils
+# --------------------------------------------------------------------
+
+
+def custom_preprocessing(df: pd.DataFrame) -> pd.DataFrame:
+    """
+    Preprocess OHLCV dataframe with features for RL trading.
+
+    Expected columns: ["open", "high", "low", "close", "volume"]
+    Index can be datetime or integer.
+    """
+    df = df.copy().reset_index(drop=False)
+
+    # Basic OHLCV features
+    df["features_close"] = df["close"]
+    df["features_open"] = df["open"]
+    df["features_high"] = df["high"]
+    df["features_low"] = df["low"]
+    df["features_volume"] = df["volume"]
+
+    # Fill NaN values
+    df.fillna(0, inplace=True)
+
+    return df
+
+
+def env_maker(df, cfg, device="cpu", max_traj_length=1, random_start=False):
+    """Create a SeqFuturesSLTPEnv instance."""
+    # Convert Hydra ListConfig to regular Python lists
+    window_sizes = list(cfg.env.window_sizes)
+    execute_on = list(cfg.env.execute_on)
+    stoploss_levels = list(cfg.env.stoploss_levels)
+    takeprofit_levels = list(cfg.env.takeprofit_levels)
+
+    time_frames = [
+        TimeFrame(t, get_timeframe_unit(f))
+        for t, f in zip(cfg.env.time_frames, cfg.env.freqs)
+    ]
+    execute_on = TimeFrame(execute_on[0], get_timeframe_unit(execute_on[1]))
+
+    config = SeqFuturesSLTPEnvConfig(
+        symbol=cfg.env.symbol,
+        time_frames=time_frames,
+        window_sizes=window_sizes,
+        execute_on=execute_on,
+        include_base_features=False,
+        initial_cash=cfg.env.initial_cash,
+        slippage=cfg.env.slippage,
+        transaction_fee=cfg.env.transaction_fee,
+        bankrupt_threshold=cfg.env.bankrupt_threshold,
+        seed=cfg.env.seed,
+        max_traj_length=max_traj_length,
+        random_start=random_start,
+        leverage=cfg.env.leverage,
+        stoploss_levels=stoploss_levels,
+        takeprofit_levels=takeprofit_levels,
+    )
+    return SeqFuturesSLTPEnv(df, config, feature_preprocessing_fn=custom_preprocessing)
+
+
+def apply_env_transforms(env, max_steps):
+    """Apply standard transforms to the environment."""
+    transformed_env = TransformedEnv(
+        env,
+        Compose(
+            InitTracker(),
+            DoubleToFloat(),
+            RewardSum(),
+            StepCounter(max_steps=max_steps),
+        ),
+    )
+    return transformed_env
+
+
+def make_environment(
+    train_df,
+    test_df,
+    cfg,
+    train_num_envs=1,
+    eval_num_envs=1,
+    max_train_traj_length=1,
+    max_eval_traj_length=1,
+):
+    """Make environments for training and evaluation."""
+    maker = functools.partial(
+        env_maker, train_df, cfg, max_traj_length=max_train_traj_length, random_start=True
+    )
+    max_train_steps = train_df.shape[0]
+    parallel_env = ParallelEnv(
+        train_num_envs,
+        EnvCreator(maker),
+        serial_for_single=True,
+    )
+    parallel_env.set_seed(cfg.env.seed)
+
+    train_env = apply_env_transforms(parallel_env, max_train_steps)
+
+    maker = functools.partial(
+        env_maker, test_df, cfg, max_traj_length=max_eval_traj_length
+    )
+    eval_env = TransformedEnv(
+        ParallelEnv(
+            eval_num_envs,
+            EnvCreator(maker),
+            serial_for_single=True,
+        ),
+        train_env.transform.clone(),
+    )
+    return train_env, eval_env
+
+
+# ====================================================================
+# Model utils
+# --------------------------------------------------------------------
+
+
+def make_discrete_ppo_mlp_model(cfg, env, device):
+    """Make discrete PPO agent with MLP encoder."""
+    activation = cfg.model.activation
+    action_spec = env.action_spec
+    market_data_keys = [
+        k for k in list(env.observation_spec.keys()) if k.startswith("market_data")
+    ]
+    assert (
+        "account_state" in list(env.observation_spec.keys())
+    ), "Account state key not in observation spec"
+
+    time_frames = cfg.env.time_frames
+    window_sizes = cfg.env.window_sizes
+    freqs = cfg.env.freqs
+    assert len(time_frames) == len(
+        market_data_keys
+    ), f"Amount of time frames {len(time_frames)} and env market data keys do not match! Keys: {market_data_keys}"
+
+    # Build simple MLP encoders for each market data input
+    encoders = []
+    for key, t, w, freq in zip(market_data_keys, time_frames, window_sizes, freqs):
+        num_features = env.observation_spec[key].shape[-1]
+        input_dim = w * num_features
+
+        # Flatten and encode market data
+        encoder = SafeModule(
+            module=torch.nn.Sequential(
+                torch.nn.Flatten(start_dim=-2),
+                MLP(
+                    in_features=input_dim,
+                    out_features=32,
+                    num_cells=[64],
+                    activation_class=ACTIVATIONS[activation],
+                    device=device,
+                ),
+            ),
+            in_keys=[key],
+            out_keys=[f"encoding_{t}_{freq}_{w}"],
+        ).to(device)
+        encoders.append(encoder)
+
+    # Account state encoder (10 elements for futures)
+    account_encoder = SafeModule(
+        module=MLP(
+            in_features=10,
+            out_features=32,
+            num_cells=[32],
+            activation_class=ACTIVATIONS[activation],
+            device=device,
+        ),
+        in_keys=["account_state"],
+        out_keys=["encoding_account_state"],
+    ).to(device)
+
+    # Common feature extractor
+    encoding_keys = [
+        f"encoding_{t}_{freq}_{w}"
+        for t, w, freq in zip(time_frames, window_sizes, freqs)
+    ] + ["encoding_account_state"]
+    total_encoding_dim = 32 * (len(market_data_keys) + 1)
+
+    common = MLP(
+        in_features=total_encoding_dim,
+        num_cells=[128, 128],
+        out_features=128,
+        activation_class=ACTIVATIONS[activation],
+        device=device,
+    )
+
+    common_module = SafeModule(
+        module=common,
+        in_keys=encoding_keys,
+        out_keys=["common_features"],
+    )
+    common_module = SafeSequential(*encoders, account_encoder, common_module)
+
+    # Policy head - action_spec.n gives the number of actions
+    action_out_features = action_spec.n
+    distribution_class = torch.distributions.Categorical
+    distribution_kwargs = {}
+
+    policy_net = MLP(
+        in_features=128,
+        out_features=action_out_features,
+        activation_class=ACTIVATIONS[activation],
+        num_cells=[],
+        device=device,
+    )
+    policy_module = SafeModule(
+        module=policy_net,
+        in_keys=["common_features"],
+        out_keys=["logits"],
+    )
+
+    policy_module = ProbabilisticActor(
+        policy_module,
+        in_keys=["logits"],
+        spec=env.full_action_spec_unbatched.to(device),
+        distribution_class=distribution_class,
+        distribution_kwargs=distribution_kwargs,
+        return_log_prob=True,
+        default_interaction_type=ExplorationType.RANDOM,
+    )
+
+    # Value head
+    value_net = MLP(
+        activation_class=torch.nn.ReLU,
+        in_features=128,
+        out_features=1,
+        num_cells=[],
+        device=device,
+    )
+    value_module = ValueOperator(
+        value_net,
+        in_keys=["common_features"],
+    )
+
+    return common_module, policy_module, value_module
+
+
+def make_ppo_models(env, device, cfg):
+    """Create PPO actor and critic models."""
+    common_module, policy_module, value_module = make_discrete_ppo_mlp_model(
+        cfg,
+        env,
+        device=device,
+    )
+
+    # Wrap modules in a single ActorCritic operator
+    actor_critic = ActorValueOperator(
+        common_operator=common_module,
+        policy_operator=policy_module,
+        value_operator=value_module,
+    ).to(device)
+
+    with torch.no_grad():
+        td = env.fake_tensordict().unsqueeze(0).expand(3, 2).to(actor_critic.device)
+        actor_critic(td)
+        del td
+
+    total_params = sum(p.numel() for p in actor_critic.parameters())
+    print(f"Total number of parameters: {total_params}")
+
+    actor = actor_critic.get_policy_operator()
+    critic = actor_critic.get_value_operator()
+
+    return actor, critic
+
+
+def make_collector(cfg, train_env, actor_model_explore, compile_mode):
+    """Make data collector."""
+    device = cfg.collector.device
+    if device in ("", None):
+        if torch.cuda.is_available():
+            device = torch.device("cuda:0")
+        else:
+            device = torch.device("cpu")
+    collector = SyncDataCollector(
+        train_env,
+        actor_model_explore,
+        frames_per_batch=cfg.collector.frames_per_batch,
+        total_frames=cfg.collector.total_frames,
+        device=device,
+        compile_policy={"mode": compile_mode} if compile_mode else False,
+        cudagraph_policy={"warmup": 10} if cfg.compile.cudagraphs else False,
+    )
+    collector.set_seed(cfg.env.seed)
+    return collector
+
+
+def log_metrics(logger, metrics, step):
+    """Log metrics to the logger."""
+    for metric_name, metric_value in metrics.items():
+        logger.log_scalar(metric_name, metric_value, step)

--- a/tests/envs/offline/test_seqfuturessltp.py
+++ b/tests/envs/offline/test_seqfuturessltp.py
@@ -1,0 +1,828 @@
+"""
+Tests for SeqFuturesSLTPEnv environment with stop-loss/take-profit and futures functionality.
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+import torch
+
+from torchtrade.envs.offline.seqfuturessltp import (
+    SeqFuturesSLTPEnv,
+    SeqFuturesSLTPEnvConfig,
+    futures_sltp_action_map,
+)
+from torchtrade.envs.offline.utils import TimeFrame, TimeFrameUnit
+
+
+def simple_feature_fn(df: pd.DataFrame) -> pd.DataFrame:
+    """Simple feature processing function for testing."""
+    df = df.copy().reset_index(drop=False)
+    df["features_close"] = df["close"]
+    df["features_volume"] = df["volume"]
+    df.fillna(0, inplace=True)
+    return df
+
+
+# Note: sample_ohlcv_df, trending_up_df, trending_down_df fixtures are defined in conftest.py
+
+
+@pytest.fixture
+def default_config():
+    """Default environment configuration for testing."""
+    return SeqFuturesSLTPEnvConfig(
+        symbol="TEST/USD",
+        time_frames=[TimeFrame(1, TimeFrameUnit.Minute)],
+        window_sizes=[10],
+        execute_on=TimeFrame(1, TimeFrameUnit.Minute),
+        initial_cash=1000,
+        leverage=10,
+        transaction_fee=0.0004,
+        stoploss_levels=[-0.05, -0.1],  # 5% and 10% stop loss
+        takeprofit_levels=[0.05, 0.1],   # 5% and 10% take profit
+        slippage=0.0,  # Disable slippage for deterministic tests
+        seed=42,
+        max_traj_length=100,
+        random_start=False,
+    )
+
+
+@pytest.fixture
+def env(sample_ohlcv_df, default_config):
+    """Create a SeqFuturesSLTPEnv instance for testing."""
+    return SeqFuturesSLTPEnv(
+        df=sample_ohlcv_df,
+        config=default_config,
+        feature_preprocessing_fn=simple_feature_fn,
+    )
+
+
+class TestFuturesSLTPActionMap:
+    """Tests for the futures_sltp_action_map function."""
+
+    def test_action_map_includes_hold(self):
+        """Action 0 should always be hold (None, None, None)."""
+        action_map = futures_sltp_action_map([-0.05], [0.1])
+        assert action_map[0] == (None, None, None)
+
+    def test_action_map_size(self):
+        """Action map size should be 1 + 2*(num_sl * num_tp)."""
+        sl_levels = [-0.05, -0.1]
+        tp_levels = [0.05, 0.1, 0.15]
+        action_map = futures_sltp_action_map(sl_levels, tp_levels)
+        # 1 hold + 6 long combinations + 6 short combinations = 13
+        expected_size = 1 + 2 * len(sl_levels) * len(tp_levels)
+        assert len(action_map) == expected_size
+
+    def test_action_map_contains_long_positions(self):
+        """Action map should contain long positions with all SL/TP combinations."""
+        sl_levels = [-0.05, -0.1]
+        tp_levels = [0.1, 0.2]
+        action_map = futures_sltp_action_map(sl_levels, tp_levels)
+
+        # Get all long actions
+        long_actions = [v for k, v in action_map.items() if v[0] == "long"]
+
+        # Check all combinations exist
+        for sl in sl_levels:
+            for tp in tp_levels:
+                assert ("long", sl, tp) in long_actions
+
+    def test_action_map_contains_short_positions(self):
+        """Action map should contain short positions with all SL/TP combinations."""
+        sl_levels = [-0.05, -0.1]
+        tp_levels = [0.1, 0.2]
+        action_map = futures_sltp_action_map(sl_levels, tp_levels)
+
+        # Get all short actions
+        short_actions = [v for k, v in action_map.items() if v[0] == "short"]
+
+        # Check all combinations exist
+        for sl in sl_levels:
+            for tp in tp_levels:
+                assert ("short", sl, tp) in short_actions
+
+    def test_action_map_single_levels(self):
+        """Should work with single SL and TP level."""
+        action_map = futures_sltp_action_map([-0.05], [0.1])
+        # 1 hold + 1 long + 1 short = 3
+        assert len(action_map) == 3
+        assert action_map[1] == ("long", -0.05, 0.1)
+        assert action_map[2] == ("short", -0.05, 0.1)
+
+
+class TestSeqFuturesSLTPEnvInitialization:
+    """Tests for environment initialization."""
+
+    def test_env_initializes(self, env):
+        """Environment should initialize without errors."""
+        assert env is not None
+
+    def test_action_spec_size(self, env):
+        """Action spec should match action map size."""
+        # 1 hold + 4 long (2 SL * 2 TP) + 4 short = 9
+        expected_size = 1 + 2 * 2 * 2
+        assert env.action_spec.n == expected_size
+
+    def test_action_map_created(self, env):
+        """Action map should be created correctly."""
+        assert 0 in env.action_map
+        assert env.action_map[0] == (None, None, None)
+
+    def test_observation_spec_has_account_state(self, env):
+        """Observation spec should include account_state."""
+        assert "account_state" in env.observation_spec.keys()
+
+    def test_account_state_shape_is_10(self, env):
+        """Account state should have 10 elements (futures)."""
+        td = env.reset()
+        assert td["account_state"].shape == (10,)
+
+    def test_invalid_transaction_fee_raises(self, sample_ohlcv_df):
+        """Should raise error for invalid transaction fee."""
+        config = SeqFuturesSLTPEnvConfig(transaction_fee=1.5)
+        with pytest.raises(ValueError, match="Transaction fee"):
+            SeqFuturesSLTPEnv(sample_ohlcv_df, config)
+
+    def test_invalid_leverage_raises(self, sample_ohlcv_df):
+        """Should raise error for invalid leverage."""
+        config = SeqFuturesSLTPEnvConfig(leverage=0)
+        with pytest.raises(ValueError, match="Leverage"):
+            SeqFuturesSLTPEnv(sample_ohlcv_df, config)
+
+        config = SeqFuturesSLTPEnvConfig(leverage=200)
+        with pytest.raises(ValueError, match="Leverage"):
+            SeqFuturesSLTPEnv(sample_ohlcv_df, config)
+
+
+class TestSeqFuturesSLTPEnvReset:
+    """Tests for environment reset."""
+
+    def test_reset_returns_tensordict(self, env):
+        """Reset should return a TensorDict."""
+        td = env.reset()
+        assert td is not None
+
+    def test_reset_clears_sl_tp(self, env):
+        """Reset should clear stop loss and take profit."""
+        env.reset()
+        assert env.stop_loss == 0.0
+        assert env.take_profit == 0.0
+
+    def test_reset_clears_position(self, env):
+        """Reset should clear position."""
+        env.reset()
+        assert env.position_size == 0.0
+        assert env.current_position == 0
+        assert env.entry_price == 0.0
+        assert env.liquidation_price == 0.0
+
+    def test_reset_clears_histories(self, env):
+        """Reset should clear history lists."""
+        env.reset()
+        assert len(env.base_price_history) == 0
+        assert len(env.action_history) == 0
+        assert len(env.reward_history) == 0
+        assert len(env.portfolio_value_history) == 0
+        assert len(env.position_history) == 0
+
+
+class TestSeqFuturesSLTPEnvLongWithSLTP:
+    """Tests for long positions with SL/TP."""
+
+    def test_long_sets_stop_loss(self, env):
+        """Long action should set stop loss level."""
+        td = env.reset()
+
+        # Action 1 should be first long SL/TP combination
+        td.set("action", torch.tensor(1))
+        env.step(td)
+
+        assert env.stop_loss > 0
+        assert env.stop_loss < env.entry_price  # SL is below entry for long
+
+    def test_long_sets_take_profit(self, env):
+        """Long action should set take profit level."""
+        td = env.reset()
+
+        td.set("action", torch.tensor(1))
+        env.step(td)
+
+        assert env.take_profit > 0
+        assert env.take_profit > env.entry_price  # TP is above entry for long
+
+    def test_long_position_is_positive(self, env):
+        """Long position should have positive position_size."""
+        td = env.reset()
+
+        td.set("action", torch.tensor(1))
+        env.step(td)
+
+        assert env.position_size > 0
+        assert env.current_position == 1
+
+    def test_long_sl_tp_calculated_correctly(self, env):
+        """SL/TP should be calculated as percentages of entry price for long."""
+        td = env.reset()
+
+        # Get the SL/TP percentages for action 1
+        _, sl_pct, tp_pct = env.action_map[1]
+
+        td.set("action", torch.tensor(1))
+        env.step(td)
+
+        expected_sl = env.entry_price * (1 + sl_pct)
+        expected_tp = env.entry_price * (1 + tp_pct)
+
+        assert abs(env.stop_loss - expected_sl) < 0.01
+        assert abs(env.take_profit - expected_tp) < 0.01
+
+
+class TestSeqFuturesSLTPEnvShortWithSLTP:
+    """Tests for short positions with SL/TP."""
+
+    def test_short_sets_stop_loss(self, env):
+        """Short action should set stop loss level."""
+        td = env.reset()
+
+        # First short action is at index 5 (1 hold + 4 long)
+        num_long_actions = len(env.stoploss_levels) * len(env.takeprofit_levels)
+        short_action = 1 + num_long_actions
+
+        td.set("action", torch.tensor(short_action))
+        env.step(td)
+
+        assert env.stop_loss > 0
+        assert env.stop_loss > env.entry_price  # SL is above entry for short
+
+    def test_short_sets_take_profit(self, env):
+        """Short action should set take profit level."""
+        td = env.reset()
+
+        num_long_actions = len(env.stoploss_levels) * len(env.takeprofit_levels)
+        short_action = 1 + num_long_actions
+
+        td.set("action", torch.tensor(short_action))
+        env.step(td)
+
+        assert env.take_profit > 0
+        assert env.take_profit < env.entry_price  # TP is below entry for short
+
+    def test_short_position_is_negative(self, env):
+        """Short position should have negative position_size."""
+        td = env.reset()
+
+        num_long_actions = len(env.stoploss_levels) * len(env.takeprofit_levels)
+        short_action = 1 + num_long_actions
+
+        td.set("action", torch.tensor(short_action))
+        env.step(td)
+
+        assert env.position_size < 0
+        assert env.current_position == -1
+
+
+class TestSeqFuturesSLTPEnvTriggers:
+    """Tests for SL/TP trigger conditions."""
+
+    def test_long_position_exits_on_sl_trigger(self, trending_down_df):
+        """Long position should exit when stop loss is triggered."""
+        config = SeqFuturesSLTPEnvConfig(
+            time_frames=[TimeFrame(1, TimeFrameUnit.Minute)],
+            window_sizes=[10],
+            execute_on=TimeFrame(1, TimeFrameUnit.Minute),
+            initial_cash=1000,
+            leverage=10,
+            transaction_fee=0.001,
+            stoploss_levels=[-0.02],  # 2% stop loss - should trigger in downtrend
+            takeprofit_levels=[0.5],   # 50% TP - won't trigger
+            slippage=0.0,
+            max_traj_length=200,
+            random_start=False,
+        )
+        env = SeqFuturesSLTPEnv(trending_down_df, config, simple_feature_fn)
+
+        td = env.reset()
+
+        # Open long position
+        td.set("action", torch.tensor(1))
+        result = env.step(td)
+        td = result["next"]
+
+        assert env.position_size > 0
+        initial_position = env.position_size
+
+        # Continue stepping - SL should trigger
+        sl_triggered = False
+        for _ in range(150):
+            td.set("action", torch.tensor(0))  # hold
+            result = env.step(td)
+            td = result["next"]
+
+            if env.position_size == 0 and initial_position > 0:
+                sl_triggered = True
+                break
+
+            if td.get("done", False):
+                break
+
+        assert sl_triggered, "Stop loss should have triggered in downtrend"
+
+    def test_long_position_exits_on_tp_trigger(self, trending_up_df):
+        """Long position should exit when take profit is triggered."""
+        config = SeqFuturesSLTPEnvConfig(
+            time_frames=[TimeFrame(1, TimeFrameUnit.Minute)],
+            window_sizes=[10],
+            execute_on=TimeFrame(1, TimeFrameUnit.Minute),
+            initial_cash=1000,
+            leverage=10,
+            transaction_fee=0.001,
+            stoploss_levels=[-0.5],   # 50% SL - won't trigger
+            takeprofit_levels=[0.02],  # 2% TP - should trigger in uptrend
+            slippage=0.0,
+            max_traj_length=200,
+            random_start=False,
+        )
+        env = SeqFuturesSLTPEnv(trending_up_df, config, simple_feature_fn)
+
+        td = env.reset()
+
+        # Open long position
+        td.set("action", torch.tensor(1))
+        result = env.step(td)
+        td = result["next"]
+
+        assert env.position_size > 0
+        initial_position = env.position_size
+
+        # Continue stepping - TP should trigger
+        tp_triggered = False
+        for _ in range(150):
+            td.set("action", torch.tensor(0))  # hold
+            result = env.step(td)
+            td = result["next"]
+
+            if env.position_size == 0 and initial_position > 0:
+                tp_triggered = True
+                break
+
+            if td.get("done", False):
+                break
+
+        assert tp_triggered, "Take profit should have triggered in uptrend"
+
+    def test_short_position_exits_on_sl_trigger(self, trending_up_df):
+        """Short position should exit when stop loss is triggered (price goes up)."""
+        config = SeqFuturesSLTPEnvConfig(
+            time_frames=[TimeFrame(1, TimeFrameUnit.Minute)],
+            window_sizes=[10],
+            execute_on=TimeFrame(1, TimeFrameUnit.Minute),
+            initial_cash=1000,
+            leverage=10,
+            transaction_fee=0.001,
+            stoploss_levels=[-0.02],  # 2% stop loss - should trigger in uptrend for short
+            takeprofit_levels=[0.5],   # 50% TP - won't trigger
+            slippage=0.0,
+            max_traj_length=200,
+            random_start=False,
+        )
+        env = SeqFuturesSLTPEnv(trending_up_df, config, simple_feature_fn)
+
+        td = env.reset()
+
+        # Open short position (action 2 = first short action)
+        td.set("action", torch.tensor(2))
+        result = env.step(td)
+        td = result["next"]
+
+        assert env.position_size < 0
+        initial_position = env.position_size
+
+        # Continue stepping - SL should trigger
+        sl_triggered = False
+        for _ in range(150):
+            td.set("action", torch.tensor(0))  # hold
+            result = env.step(td)
+            td = result["next"]
+
+            if env.position_size == 0 and initial_position < 0:
+                sl_triggered = True
+                break
+
+            if td.get("done", False):
+                break
+
+        assert sl_triggered, "Stop loss should have triggered for short in uptrend"
+
+    def test_short_position_exits_on_tp_trigger(self, trending_down_df):
+        """Short position should exit when take profit is triggered (price goes down)."""
+        config = SeqFuturesSLTPEnvConfig(
+            time_frames=[TimeFrame(1, TimeFrameUnit.Minute)],
+            window_sizes=[10],
+            execute_on=TimeFrame(1, TimeFrameUnit.Minute),
+            initial_cash=1000,
+            leverage=10,
+            transaction_fee=0.001,
+            stoploss_levels=[-0.5],   # 50% SL - won't trigger
+            takeprofit_levels=[0.02],  # 2% TP - should trigger in downtrend
+            slippage=0.0,
+            max_traj_length=200,
+            random_start=False,
+        )
+        env = SeqFuturesSLTPEnv(trending_down_df, config, simple_feature_fn)
+
+        td = env.reset()
+
+        # Open short position (action 2 = first short action)
+        td.set("action", torch.tensor(2))
+        result = env.step(td)
+        td = result["next"]
+
+        assert env.position_size < 0
+        initial_position = env.position_size
+
+        # Continue stepping - TP should trigger
+        tp_triggered = False
+        for _ in range(150):
+            td.set("action", torch.tensor(0))  # hold
+            result = env.step(td)
+            td = result["next"]
+
+            if env.position_size == 0 and initial_position < 0:
+                tp_triggered = True
+                break
+
+            if td.get("done", False):
+                break
+
+        assert tp_triggered, "Take profit should have triggered for short in downtrend"
+
+    def test_sl_tp_cleared_after_trigger(self, trending_down_df):
+        """SL/TP should be cleared after position exits."""
+        config = SeqFuturesSLTPEnvConfig(
+            time_frames=[TimeFrame(1, TimeFrameUnit.Minute)],
+            window_sizes=[10],
+            execute_on=TimeFrame(1, TimeFrameUnit.Minute),
+            initial_cash=1000,
+            leverage=10,
+            transaction_fee=0.001,
+            stoploss_levels=[-0.01],  # 1% SL
+            takeprofit_levels=[0.5],
+            slippage=0.0,
+            max_traj_length=100,
+            random_start=False,
+        )
+        env = SeqFuturesSLTPEnv(trending_down_df, config, simple_feature_fn)
+
+        td = env.reset()
+
+        # Open long
+        td.set("action", torch.tensor(1))
+        result = env.step(td)
+        td = result["next"]
+
+        # Wait for SL to trigger
+        for _ in range(50):
+            td.set("action", torch.tensor(0))
+            result = env.step(td)
+            td = result["next"]
+
+            if env.position_size == 0:
+                # Position exited - check SL/TP cleared
+                assert env.stop_loss == 0.0
+                assert env.take_profit == 0.0
+                assert env.entry_price == 0.0
+                break
+
+            if td.get("done", False):
+                break
+
+
+class TestSeqFuturesSLTPEnvLiquidation:
+    """Tests for liquidation functionality."""
+
+    def test_long_liquidation_on_price_drop(self, trending_down_df):
+        """Long position should be liquidated if price drops below liquidation price."""
+        config = SeqFuturesSLTPEnvConfig(
+            time_frames=[TimeFrame(1, TimeFrameUnit.Minute)],
+            window_sizes=[10],
+            execute_on=TimeFrame(1, TimeFrameUnit.Minute),
+            initial_cash=1000,
+            leverage=50,  # High leverage for faster liquidation
+            transaction_fee=0.001,
+            stoploss_levels=[-0.5],   # Wide SL so liquidation happens first
+            takeprofit_levels=[0.5],
+            slippage=0.0,
+            max_traj_length=200,
+            random_start=False,
+            maintenance_margin_rate=0.004,
+        )
+        env = SeqFuturesSLTPEnv(trending_down_df, config, simple_feature_fn)
+
+        td = env.reset()
+
+        # Open long position
+        td.set("action", torch.tensor(1))
+        result = env.step(td)
+        td = result["next"]
+
+        assert env.position_size > 0
+        assert env.liquidation_price > 0
+
+        # Track if liquidation happens
+        was_liquidated = False
+        initial_position = env.position_size
+
+        for _ in range(100):
+            td.set("action", torch.tensor(0))  # hold
+            result = env.step(td)
+            td = result["next"]
+
+            # Check if liquidation occurred
+            if env.position_size == 0 and initial_position > 0:
+                was_liquidated = True
+                break
+
+            if td.get("done", False):
+                break
+
+        # Either liquidated or hit SL (both are valid exits)
+        assert was_liquidated or env.position_size == 0
+
+    def test_liquidation_clears_sltp(self, trending_down_df):
+        """Liquidation should clear SL/TP levels."""
+        config = SeqFuturesSLTPEnvConfig(
+            time_frames=[TimeFrame(1, TimeFrameUnit.Minute)],
+            window_sizes=[10],
+            execute_on=TimeFrame(1, TimeFrameUnit.Minute),
+            initial_cash=1000,
+            leverage=50,
+            transaction_fee=0.001,
+            stoploss_levels=[-0.5],   # Wide SL
+            takeprofit_levels=[0.5],
+            slippage=0.0,
+            max_traj_length=200,
+            random_start=False,
+        )
+        env = SeqFuturesSLTPEnv(trending_down_df, config, simple_feature_fn)
+
+        td = env.reset()
+
+        # Open long position
+        td.set("action", torch.tensor(1))
+        result = env.step(td)
+        td = result["next"]
+
+        initial_position = env.position_size
+
+        for _ in range(100):
+            td.set("action", torch.tensor(0))
+            result = env.step(td)
+            td = result["next"]
+
+            if env.position_size == 0 and initial_position > 0:
+                # Position was closed - SL/TP should be cleared
+                assert env.stop_loss == 0.0
+                assert env.take_profit == 0.0
+                break
+
+            if td.get("done", False):
+                break
+
+
+class TestSeqFuturesSLTPEnvReward:
+    """Tests for reward calculation."""
+
+    def test_reward_not_nan(self, env):
+        """Reward should never be NaN."""
+        td = env.reset()
+
+        for _ in range(50):
+            action = env.action_spec.sample()
+            td.set("action", action)
+            result = env.step(td)
+            td = result["next"]
+
+            assert not torch.isnan(td["reward"]).any()
+
+            if td.get("done", False):
+                break
+
+    def test_dense_reward_on_steps(self, env):
+        """Should receive dense rewards during episode."""
+        td = env.reset()
+
+        # Open a position
+        td.set("action", torch.tensor(1))
+        result = env.step(td)
+        td = result["next"]
+
+        # Take a few more steps
+        for _ in range(5):
+            td.set("action", torch.tensor(0))  # hold
+            result = env.step(td)
+            td = result["next"]
+
+            # Dense rewards should be present (may be small but not always zero)
+            if td.get("done", False):
+                break
+
+
+class TestSeqFuturesSLTPEnvStep:
+    """Tests for step functionality."""
+
+    def test_hold_does_not_open_position(self, env):
+        """Hold action should not open a position."""
+        td = env.reset()
+
+        td.set("action", torch.tensor(0))  # hold
+        env.step(td)
+
+        assert env.position_size == 0.0
+        assert env.stop_loss == 0.0
+        assert env.take_profit == 0.0
+
+    def test_hold_closes_existing_position(self, env):
+        """Hold action should close existing position."""
+        td = env.reset()
+
+        # Open long
+        td.set("action", torch.tensor(1))
+        result = env.step(td)
+        td = result["next"]
+
+        assert env.position_size > 0
+
+        # Hold should close
+        td.set("action", torch.tensor(0))
+        result = env.step(td)
+
+        assert env.position_size == 0.0
+        assert env.stop_loss == 0.0
+        assert env.take_profit == 0.0
+
+    def test_flip_from_long_to_short(self, env):
+        """Should be able to flip from long to short position."""
+        td = env.reset()
+
+        # Open long
+        td.set("action", torch.tensor(1))
+        result = env.step(td)
+        td = result["next"]
+
+        assert env.position_size > 0
+
+        # Open short (close long first internally)
+        num_long_actions = len(env.stoploss_levels) * len(env.takeprofit_levels)
+        short_action = 1 + num_long_actions
+
+        td.set("action", torch.tensor(short_action))
+        result = env.step(td)
+        td = result["next"]
+
+        assert env.position_size < 0
+        assert env.current_position == -1
+
+    def test_flip_from_short_to_long(self, env):
+        """Should be able to flip from short to long position."""
+        td = env.reset()
+
+        # Open short
+        num_long_actions = len(env.stoploss_levels) * len(env.takeprofit_levels)
+        short_action = 1 + num_long_actions
+
+        td.set("action", torch.tensor(short_action))
+        result = env.step(td)
+        td = result["next"]
+
+        assert env.position_size < 0
+
+        # Open long (close short first internally)
+        td.set("action", torch.tensor(1))
+        result = env.step(td)
+        td = result["next"]
+
+        assert env.position_size > 0
+        assert env.current_position == 1
+
+    def test_full_episode_completes(self, env):
+        """Full episode should complete without errors."""
+        td = env.reset()
+        steps = 0
+
+        while steps < env.max_traj_length:
+            action = env.action_spec.sample()
+            td.set("action", action)
+            result = env.step(td)
+            td = result["next"]
+            steps += 1
+
+            if td.get("done", False):
+                break
+
+        assert steps > 0
+
+
+class TestSeqFuturesSLTPEnvEdgeCases:
+    """Tests for edge cases."""
+
+    def test_single_sl_tp_level(self, sample_ohlcv_df):
+        """Should work with single SL and TP level."""
+        config = SeqFuturesSLTPEnvConfig(
+            time_frames=[TimeFrame(1, TimeFrameUnit.Minute)],
+            window_sizes=[10],
+            execute_on=TimeFrame(1, TimeFrameUnit.Minute),
+            initial_cash=1000,
+            leverage=10,
+            stoploss_levels=[-0.05],
+            takeprofit_levels=[0.1],
+            max_traj_length=50,
+            random_start=False,
+        )
+        env = SeqFuturesSLTPEnv(sample_ohlcv_df, config, simple_feature_fn)
+
+        # Should have 3 actions: hold, long, short
+        assert env.action_spec.n == 3
+
+        td = env.reset()
+        td.set("action", torch.tensor(1))
+        result = env.step(td)
+
+        assert result is not None
+
+    def test_many_sl_tp_levels(self, sample_ohlcv_df):
+        """Should work with many SL/TP levels."""
+        config = SeqFuturesSLTPEnvConfig(
+            time_frames=[TimeFrame(1, TimeFrameUnit.Minute)],
+            window_sizes=[10],
+            execute_on=TimeFrame(1, TimeFrameUnit.Minute),
+            initial_cash=1000,
+            leverage=10,
+            stoploss_levels=[-0.01, -0.02, -0.05, -0.1],
+            takeprofit_levels=[0.01, 0.02, 0.05, 0.1],
+            max_traj_length=50,
+            random_start=False,
+        )
+        env = SeqFuturesSLTPEnv(sample_ohlcv_df, config, simple_feature_fn)
+
+        # Should have 1 + 16 long + 16 short = 33 actions
+        assert env.action_spec.n == 33
+
+    def test_multiple_episodes(self, env):
+        """Should work correctly across multiple episodes."""
+        for episode in range(3):
+            td = env.reset()
+
+            assert env.stop_loss == 0.0
+            assert env.take_profit == 0.0
+            assert env.position_size == 0.0
+            assert env.liquidation_price == 0.0
+
+            for _ in range(20):
+                action = env.action_spec.sample()
+                td.set("action", action)
+                result = env.step(td)
+                td = result["next"]
+
+                if td.get("done", False):
+                    break
+
+    def test_leverage_affects_position_size(self, sample_ohlcv_df):
+        """Higher leverage should allow larger position sizes."""
+        config_low = SeqFuturesSLTPEnvConfig(
+            time_frames=[TimeFrame(1, TimeFrameUnit.Minute)],
+            window_sizes=[10],
+            initial_cash=1000,
+            leverage=5,
+            stoploss_levels=[-0.05],
+            takeprofit_levels=[0.1],
+            slippage=0.0,
+            max_traj_length=50,
+            random_start=False,
+        )
+        config_high = SeqFuturesSLTPEnvConfig(
+            time_frames=[TimeFrame(1, TimeFrameUnit.Minute)],
+            window_sizes=[10],
+            initial_cash=1000,
+            leverage=20,
+            stoploss_levels=[-0.05],
+            takeprofit_levels=[0.1],
+            slippage=0.0,
+            max_traj_length=50,
+            random_start=False,
+        )
+
+        env_low = SeqFuturesSLTPEnv(sample_ohlcv_df, config_low, simple_feature_fn)
+        env_high = SeqFuturesSLTPEnv(sample_ohlcv_df, config_high, simple_feature_fn)
+
+        td_low = env_low.reset()
+        td_high = env_high.reset()
+
+        td_low.set("action", torch.tensor(1))
+        env_low.step(td_low)
+
+        td_high.set("action", torch.tensor(1))
+        env_high.step(td_high)
+
+        # Higher leverage should result in larger position
+        assert abs(env_high.position_size) > abs(env_low.position_size)

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -444,6 +444,15 @@ EXAMPLE_COMMANDS = {
         "logger.backend= "
         "logger.test_interval=1000000 "
     ),
+    "ppo_seqfuturessltp": (
+        "python examples/online/ppo_futures_sltp/train.py "
+        "collector.total_frames=100 "
+        "collector.frames_per_batch=50 "
+        "env.train_envs=2 "
+        "loss.mini_batch_size=25 "
+        "logger.backend= "
+        "logger.test_interval=1000000 "
+    ),
 
     # ==========================================================================
     # IQL Examples
@@ -559,11 +568,14 @@ class TestExampleImports:
             LongOnlyOneStepEnvConfig,
             SeqFuturesEnv,
             SeqFuturesEnvConfig,
+            SeqFuturesSLTPEnv,
+            SeqFuturesSLTPEnvConfig,
         )
         assert SeqLongOnlyEnv is not None
         assert SeqLongOnlySLTPEnv is not None
         assert LongOnlyOneStepEnv is not None
         assert SeqFuturesEnv is not None
+        assert SeqFuturesSLTPEnv is not None
 
     def test_import_alpaca_envs(self):
         """Test importing Alpaca environments."""

--- a/torchtrade/envs/__init__.py
+++ b/torchtrade/envs/__init__.py
@@ -2,6 +2,7 @@ from torchtrade.envs.offline.seqlongonly import SeqLongOnlyEnv, SeqLongOnlyEnvCo
 from torchtrade.envs.offline.seqlongonlysltp import SeqLongOnlySLTPEnv, SeqLongOnlySLTPEnvConfig
 from torchtrade.envs.offline.longonlyonestepenv import LongOnlyOneStepEnv, LongOnlyOneStepEnvConfig
 from torchtrade.envs.offline.seqfutures import SeqFuturesEnv, SeqFuturesEnvConfig, MarginType
+from torchtrade.envs.offline.seqfuturessltp import SeqFuturesSLTPEnv, SeqFuturesSLTPEnvConfig
 from torchtrade.envs.offline.sampler import MarketDataObservationSampler
 
 # Binance environments

--- a/torchtrade/envs/offline/__init__.py
+++ b/torchtrade/envs/offline/__init__.py
@@ -1,4 +1,6 @@
 from torchtrade.envs.offline.seqlongonly import SeqLongOnlyEnv, SeqLongOnlyEnvConfig
 from torchtrade.envs.offline.seqlongonlysltp import SeqLongOnlySLTPEnv, SeqLongOnlySLTPEnvConfig
 from torchtrade.envs.offline.longonlyonestepenv import LongOnlyOneStepEnv, LongOnlyOneStepEnvConfig
+from torchtrade.envs.offline.seqfutures import SeqFuturesEnv, SeqFuturesEnvConfig, MarginType
+from torchtrade.envs.offline.seqfuturessltp import SeqFuturesSLTPEnv, SeqFuturesSLTPEnvConfig
 from torchtrade.envs.offline.sampler import MarketDataObservationSampler

--- a/torchtrade/envs/offline/seqfuturessltp.py
+++ b/torchtrade/envs/offline/seqfuturessltp.py
@@ -1,0 +1,992 @@
+"""Sequential Futures Environment with Stop-Loss/Take-Profit support.
+
+This environment combines:
+- Long/short positions with leverage from SeqFuturesEnv
+- Stop-loss/take-profit bracket orders from SeqLongOnlySLTPEnv
+"""
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Tuple, Union, Callable
+from itertools import product
+from enum import Enum
+import random
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import torch
+from tensordict import TensorDict, TensorDictBase
+from torchrl.data import Categorical, Bounded
+from torchrl.data.tensor_specs import CompositeSpec
+from torchrl.envs import EnvBase
+
+from torchtrade.envs.offline.sampler import MarketDataObservationSampler
+from torchtrade.envs.offline.utils import TimeFrame, TimeFrameUnit
+
+
+class MarginType(Enum):
+    """Margin type for futures trading."""
+    ISOLATED = "isolated"
+    CROSSED = "crossed"
+
+
+def futures_sltp_action_map(
+    stoploss_levels: List[float],
+    takeprofit_levels: List[float],
+) -> Dict[int, Tuple[Optional[str], Optional[float], Optional[float]]]:
+    """
+    Create action map for futures SLTP environment.
+
+    Action space:
+    - 0: HOLD/Close (no new position)
+    - 1 to N: Long positions with (SL, TP) combinations
+    - N+1 to 2N: Short positions with (SL, TP) combinations
+
+    Returns:
+        Dict mapping action index to (side, sl_pct, tp_pct)
+        where side is None, "long", or "short"
+    """
+    action_map = {}
+    # 0 = HOLD/Close
+    action_map[0] = (None, None, None)
+
+    idx = 1
+    # Long positions
+    for sl, tp in product(stoploss_levels, takeprofit_levels):
+        action_map[idx] = ("long", sl, tp)
+        idx += 1
+
+    # Short positions
+    for sl, tp in product(stoploss_levels, takeprofit_levels):
+        action_map[idx] = ("short", sl, tp)
+        idx += 1
+
+    return action_map
+
+
+@dataclass
+class SeqFuturesSLTPEnvConfig:
+    """Configuration for Sequential Futures SLTP Environment.
+
+    This environment supports:
+    - Long and short positions
+    - Configurable leverage (1x - 125x)
+    - Stop-loss and take-profit bracket orders
+    - Liquidation mechanics
+    """
+    symbol: str = "BTC/USD"
+    time_frames: Union[List[TimeFrame], TimeFrame] = field(
+        default_factory=lambda: TimeFrame(1, TimeFrameUnit.Minute)
+    )
+    window_sizes: Union[List[int], int] = 10
+    execute_on: TimeFrame = field(
+        default_factory=lambda: TimeFrame(1, TimeFrameUnit.Minute)
+    )
+
+    # Initial capital settings
+    initial_cash: Union[Tuple[int, int], int] = (1000, 5000)
+
+    # Leverage and margin settings
+    leverage: int = 1  # 1x to 125x
+    margin_type: MarginType = MarginType.ISOLATED
+    maintenance_margin_rate: float = 0.004  # 0.4% maintenance margin
+
+    # Stop-loss and take-profit levels (as percentage, e.g., -0.05 = -5%)
+    stoploss_levels: Union[List[float], Tuple[float, ...]] = (-0.025, -0.05, -0.1)
+    takeprofit_levels: Union[List[float], Tuple[float, ...]] = (0.05, 0.1, 0.2)
+
+    # Trading costs
+    transaction_fee: float = 0.0004  # 0.04% typical futures fee
+    slippage: float = 0.001  # 0.1% slippage
+
+    # Risk management
+    bankrupt_threshold: float = 0.1  # 10% of initial balance
+    max_position_size: float = 1.0  # Max position as fraction of balance
+
+    # Environment settings
+    seed: Optional[int] = 42
+    include_base_features: bool = False
+    max_traj_length: Optional[int] = None
+    random_start: bool = True
+
+    # Reward settings
+    reward_scaling: float = 1.0
+
+
+class SeqFuturesSLTPEnv(EnvBase):
+    """
+    Sequential Futures Environment with Stop-Loss/Take-Profit support.
+
+    Combines the leverage and shorting capabilities of SeqFuturesEnv with
+    the bracket order functionality of SeqLongOnlySLTPEnv.
+
+    Action Space:
+    - Action 0: Hold / Close position
+    - Actions 1 to N: Long positions with (SL, TP) combinations
+    - Actions N+1 to 2N: Short positions with (SL, TP) combinations
+
+    Where N = num_sl_levels * num_tp_levels
+
+    Account State (10 elements, matching SeqFuturesEnv):
+    [cash, position_size, position_value, entry_price, current_price,
+     unrealized_pnl_pct, leverage, margin_ratio, liquidation_price, holding_time]
+
+    Position size is:
+    - Positive for long positions
+    - Negative for short positions
+    - Zero for no position
+    """
+
+    def __init__(
+        self,
+        df: pd.DataFrame,
+        config: SeqFuturesSLTPEnvConfig,
+        feature_preprocessing_fn: Optional[Callable] = None,
+    ):
+        """
+        Initialize the SeqFuturesSLTPEnv.
+
+        Args:
+            df: DataFrame with OHLCV data
+            config: Environment configuration
+            feature_preprocessing_fn: Optional custom preprocessing function
+        """
+        self.config = config
+        self.transaction_fee = config.transaction_fee
+        self.slippage = config.slippage
+        self.leverage = config.leverage
+        self.margin_type = config.margin_type
+        self.maintenance_margin_rate = config.maintenance_margin_rate
+
+        if not (0 <= config.transaction_fee <= 1):
+            raise ValueError("Transaction fee must be between 0 and 1.")
+        if not (0 <= config.slippage <= 1):
+            raise ValueError("Slippage must be between 0 and 1.")
+        if not (1 <= config.leverage <= 125):
+            raise ValueError("Leverage must be between 1 and 125.")
+
+        # Convert to lists if needed
+        self.stoploss_levels = (
+            list(config.stoploss_levels)
+            if not isinstance(config.stoploss_levels, list)
+            else config.stoploss_levels
+        )
+        self.takeprofit_levels = (
+            list(config.takeprofit_levels)
+            if not isinstance(config.takeprofit_levels, list)
+            else config.takeprofit_levels
+        )
+
+        # Create action map
+        self.action_map = futures_sltp_action_map(
+            self.stoploss_levels, self.takeprofit_levels
+        )
+
+        self.sampler = MarketDataObservationSampler(
+            df,
+            time_frames=config.time_frames,
+            window_sizes=config.window_sizes,
+            execute_on=config.execute_on,
+            feature_processing_fn=feature_preprocessing_fn,
+            features_start_with="features_",
+            max_traj_length=config.max_traj_length,
+        )
+        self.random_start = config.random_start
+        self.max_traj_length = config.max_traj_length
+        self.execute_on_value = config.execute_on.value
+        self.execute_on_unit = config.execute_on.unit.value
+
+        # Reset settings
+        self.initial_cash = config.initial_cash
+        self.position_hold_counter = 0
+
+        # Define action spec
+        self.action_spec = Categorical(len(self.action_map))
+
+        # Get the number of features from the sampler
+        market_data_keys = self.sampler.get_observation_keys()
+        num_features = len(self.sampler.get_feature_keys())
+
+        # Observation space
+        self.observation_spec = CompositeSpec(shape=())
+
+        self.market_data_key = "market_data"
+        self.account_state_key = "account_state"
+
+        # Account state spec (10 elements for futures):
+        # [cash, position_size, position_value, entry_price, current_price,
+        #  unrealized_pnl_pct, leverage, margin_ratio, liquidation_price, holding_time]
+        account_state_spec = Bounded(
+            low=-torch.inf, high=torch.inf, shape=(10,), dtype=torch.float
+        )
+
+        self.market_data_keys = []
+        window_sizes_list = (
+            config.window_sizes
+            if isinstance(config.window_sizes, list)
+            else [config.window_sizes]
+        )
+        for i, market_data_name in enumerate(market_data_keys):
+            market_data_key = f"market_data_{market_data_name}_{window_sizes_list[i]}"
+            market_data_spec = Bounded(
+                low=-torch.inf, high=torch.inf,
+                shape=(window_sizes_list[i], num_features), dtype=torch.float
+            )
+            self.observation_spec.set(market_data_key, market_data_spec)
+            self.market_data_keys.append(market_data_key)
+        self.observation_spec.set(self.account_state_key, account_state_spec)
+
+        self.reward_spec = Bounded(
+            low=-torch.inf, high=torch.inf, shape=(1,), dtype=torch.float
+        )
+        self.max_steps = self.sampler.get_max_steps()
+        self.step_counter = 0
+
+        # History tracking
+        self.base_price_history = []
+        self.action_history = []
+        self.reward_history = []
+        self.portfolio_value_history = []
+        self.position_history = []
+
+        super().__init__()
+
+    def _calculate_liquidation_price(
+        self, entry_price: float, position_size: float
+    ) -> float:
+        """
+        Calculate liquidation price for a position.
+
+        For ISOLATED margin:
+        - Long: liquidation_price = entry_price * (1 - 1/leverage + maintenance_margin_rate)
+        - Short: liquidation_price = entry_price * (1 + 1/leverage - maintenance_margin_rate)
+        """
+        if position_size == 0:
+            return 0.0
+
+        margin_fraction = 1.0 / self.leverage
+
+        if position_size > 0:
+            # Long position - liquidated if price drops
+            liquidation_price = entry_price * (
+                1 - margin_fraction + self.maintenance_margin_rate
+            )
+        else:
+            # Short position - liquidated if price rises
+            liquidation_price = entry_price * (
+                1 + margin_fraction - self.maintenance_margin_rate
+            )
+
+        return max(0, liquidation_price)
+
+    def _calculate_margin_required(self, position_value: float) -> float:
+        """Calculate initial margin required for a position."""
+        return abs(position_value) / self.leverage
+
+    def _calculate_unrealized_pnl(
+        self, entry_price: float, current_price: float, position_size: float
+    ) -> float:
+        """
+        Calculate unrealized PnL.
+
+        For long: PnL = (current_price - entry_price) * position_size
+        For short: PnL = (entry_price - current_price) * abs(position_size)
+        """
+        if position_size == 0 or entry_price == 0:
+            return 0.0
+
+        if position_size > 0:
+            # Long position
+            return (current_price - entry_price) * position_size
+        else:
+            # Short position
+            return (entry_price - current_price) * abs(position_size)
+
+    def _calculate_unrealized_pnl_pct(
+        self, entry_price: float, current_price: float, position_size: float
+    ) -> float:
+        """Calculate unrealized PnL as a percentage."""
+        if entry_price == 0:
+            return 0.0
+
+        if position_size > 0:
+            # Long position
+            return (current_price - entry_price) / entry_price
+        elif position_size < 0:
+            # Short position
+            return (entry_price - current_price) / entry_price
+        return 0.0
+
+    def _check_liquidation(self, current_price: float) -> bool:
+        """Check if current position should be liquidated."""
+        if self.position_size == 0:
+            return False
+
+        if self.position_size > 0:
+            # Long position - liquidated if price below liquidation price
+            return current_price <= self.liquidation_price
+        else:
+            # Short position - liquidated if price above liquidation price
+            return current_price >= self.liquidation_price
+
+    def _check_sltp_trigger(self, ohlcv: dict) -> Optional[str]:
+        """
+        Check if stop-loss or take-profit should trigger.
+
+        Returns:
+            "sl" if stop-loss triggered
+            "tp" if take-profit triggered
+            None if neither triggered
+        """
+        if self.position_size == 0:
+            return None
+        if self.stop_loss == 0.0 and self.take_profit == 0.0:
+            return None
+
+        open_price = ohlcv["open"]
+        high_price = ohlcv["high"]
+        low_price = ohlcv["low"]
+        close_price = ohlcv["close"]
+
+        if self.position_size > 0:
+            # Long position
+            # SL triggers when price drops below SL level
+            if self.stop_loss > 0:
+                if open_price <= self.stop_loss:
+                    return "sl"
+                if low_price <= self.stop_loss:
+                    return "sl"
+            # TP triggers when price rises above TP level
+            if self.take_profit > 0:
+                if open_price >= self.take_profit:
+                    return "tp"
+                if high_price >= self.take_profit:
+                    return "tp"
+            # Check close for final determination
+            if self.stop_loss > 0 and close_price <= self.stop_loss:
+                return "sl"
+            if self.take_profit > 0 and close_price >= self.take_profit:
+                return "tp"
+        else:
+            # Short position
+            # SL triggers when price rises above SL level
+            if self.stop_loss > 0:
+                if open_price >= self.stop_loss:
+                    return "sl"
+                if high_price >= self.stop_loss:
+                    return "sl"
+            # TP triggers when price drops below TP level
+            if self.take_profit > 0:
+                if open_price <= self.take_profit:
+                    return "tp"
+                if low_price <= self.take_profit:
+                    return "tp"
+            # Check close for final determination
+            if self.stop_loss > 0 and close_price >= self.stop_loss:
+                return "sl"
+            if self.take_profit > 0 and close_price <= self.take_profit:
+                return "tp"
+
+        return None
+
+    def _get_observation(self) -> TensorDictBase:
+        """Get the current observation state."""
+        # Get market data
+        obs_dict, self.current_timestamp, self.truncated = (
+            self.sampler.get_sequential_observation()
+        )
+
+        current_price = self.sampler.get_base_features(self.current_timestamp)["close"]
+
+        # Calculate position value (absolute value of notional)
+        self.position_value = abs(self.position_size * current_price)
+
+        # Calculate unrealized PnL
+        if self.position_size != 0:
+            self.unrealized_pnl = self._calculate_unrealized_pnl(
+                self.entry_price, current_price, self.position_size
+            )
+            self.unrealized_pnl_pct = self._calculate_unrealized_pnl_pct(
+                self.entry_price, current_price, self.position_size
+            )
+        else:
+            self.unrealized_pnl = 0.0
+            self.unrealized_pnl_pct = 0.0
+
+        # Calculate margin ratio
+        total_balance = self.balance + self.unrealized_pnl
+        margin_ratio = self.position_value / total_balance if total_balance > 0 else 0.0
+
+        # Account state (10 elements, matching live futures env)
+        account_state = [
+            self.balance,
+            self.position_size,  # Positive=long, Negative=short
+            self.position_value,
+            self.entry_price,
+            current_price,
+            self.unrealized_pnl_pct,
+            float(self.leverage),
+            margin_ratio,
+            self.liquidation_price,
+            float(self.position_hold_counter),
+        ]
+        account_state = torch.tensor(account_state, dtype=torch.float)
+
+        obs_data = {self.account_state_key: account_state}
+        obs_data.update(dict(zip(self.market_data_keys, obs_dict.values())))
+        out_td = TensorDict(obs_data, batch_size=())
+
+        return out_td
+
+    def _calculate_reward(
+        self,
+        old_portfolio_value: float,
+        new_portfolio_value: float,
+        action: int,
+        trade_info: Dict,
+    ) -> float:
+        """
+        Calculate the step reward.
+
+        Uses a hybrid approach:
+        - Dense rewards based on portfolio return
+        - Sparse terminal reward comparing to buy-and-hold
+        """
+        if old_portfolio_value == 0:
+            return 0.0
+
+        # Portfolio return
+        portfolio_return = (
+            (new_portfolio_value - old_portfolio_value) / old_portfolio_value
+        )
+
+        # Dense reward
+        dense_reward = portfolio_return
+
+        # Transaction cost penalty
+        if trade_info.get("fee_paid", 0) > 0:
+            dense_reward -= trade_info["fee_paid"] / old_portfolio_value
+
+        # Liquidation penalty
+        if trade_info.get("liquidated", False):
+            dense_reward -= 0.1  # Significant penalty for liquidation
+
+        # Clip dense reward
+        dense_reward = np.clip(dense_reward, -0.1, 0.1)
+
+        # Terminal reward
+        if self.step_counter >= self.max_traj_length - 1:
+            buy_and_hold_value = (
+                self.initial_portfolio_value / self.base_price_history[0]
+            ) * self.base_price_history[-1]
+
+            compare_value = max(self.initial_portfolio_value, buy_and_hold_value)
+            if compare_value > 0:
+                terminal_reward = (
+                    100 * (new_portfolio_value - compare_value) / compare_value
+                )
+                return terminal_reward
+
+        return dense_reward * self.config.reward_scaling
+
+    def _get_portfolio_value(self) -> float:
+        """Calculate total portfolio value including unrealized PnL."""
+        current_price = self.sampler.get_base_features(self.current_timestamp)["close"]
+        unrealized_pnl = self._calculate_unrealized_pnl(
+            self.entry_price, current_price, self.position_size
+        )
+        return self.balance + unrealized_pnl
+
+    def _set_seed(self, seed: int):
+        """Set the seed for the environment."""
+        if seed is not None:
+            np.random.seed(seed)
+            torch.manual_seed(seed)
+        else:
+            np.random.seed(self.config.seed)
+            torch.manual_seed(self.config.seed)
+
+    def _reset(self, tensordict: TensorDictBase, **kwargs) -> TensorDictBase:
+        """Reset the environment."""
+        # Reset history
+        self.base_price_history = []
+        self.action_history = []
+        self.reward_history = []
+        self.portfolio_value_history = []
+        self.position_history = []
+
+        max_episode_steps = self.sampler.reset(random_start=self.random_start)
+        self.max_traj_length = max_episode_steps
+
+        # Initialize balance
+        initial_portfolio_value = (
+            self.initial_cash
+            if isinstance(self.initial_cash, int)
+            else random.randint(self.initial_cash[0], self.initial_cash[1])
+        )
+        self.balance = initial_portfolio_value
+        self.initial_portfolio_value = initial_portfolio_value
+
+        # Reset position state
+        self.position_hold_counter = 0
+        self.current_position = 0  # -1=short, 0=none, 1=long
+        self.position_size = 0.0  # Negative for short, positive for long
+        self.position_value = 0.0
+        self.entry_price = 0.0
+        self.unrealized_pnl = 0.0
+        self.unrealized_pnl_pct = 0.0
+        self.liquidation_price = 0.0
+        self.step_counter = 0
+
+        # Reset SLTP
+        self.stop_loss = 0.0
+        self.take_profit = 0.0
+
+        return self._get_observation()
+
+    def _step(self, tensordict: TensorDictBase) -> TensorDictBase:
+        """Execute one environment step."""
+        self.step_counter += 1
+
+        # Store old portfolio value
+        old_portfolio_value = self._get_portfolio_value()
+
+        # Get action
+        action_idx = tensordict.get("action", 0)
+        if isinstance(action_idx, torch.Tensor):
+            action_idx = action_idx.item()
+        action_tuple = self.action_map[action_idx]
+        side, sl_pct, tp_pct = action_tuple
+
+        # Get current OHLCV for checks
+        ohlcv = self.sampler.get_base_features(self.current_timestamp)
+        current_price = ohlcv["close"]
+
+        # Initialize trade info
+        trade_info = {
+            "executed": False,
+            "side": None,
+            "fee_paid": 0.0,
+            "liquidated": False,
+            "sltp_triggered": None,
+        }
+
+        # Priority order: Liquidation > SL/TP > New action
+
+        # 1. Check for liquidation first
+        if self._check_liquidation(current_price):
+            trade_info = self._execute_liquidation(current_price)
+        # 2. Check for SL/TP trigger
+        elif self.position_size != 0:
+            sltp_trigger = self._check_sltp_trigger(ohlcv)
+            if sltp_trigger is not None:
+                trade_info = self._execute_sltp_close(ohlcv, sltp_trigger)
+        # 3. Execute action if no position closed
+        if not trade_info["executed"]:
+            trade_info = self._execute_action(side, sl_pct, tp_pct)
+
+        # Record history
+        trade_action = 0
+        if trade_info["executed"]:
+            if trade_info["side"] == "long":
+                trade_action = 1
+            elif trade_info["side"] == "short":
+                trade_action = -1
+        self.action_history.append(trade_action)
+        self.base_price_history.append(current_price)
+        self.portfolio_value_history.append(old_portfolio_value)
+        self.position_history.append(self.position_size)
+
+        # Get updated state
+        next_tensordict = self._get_observation()
+        new_portfolio_value = self._get_portfolio_value()
+
+        # Calculate reward
+        reward = self._calculate_reward(
+            old_portfolio_value, new_portfolio_value, action_idx, trade_info
+        )
+        self.reward_history.append(reward)
+
+        # Check termination
+        done = self._check_termination(new_portfolio_value)
+
+        next_tensordict.set("reward", reward)
+        next_tensordict.set("done", self.truncated or done)
+        next_tensordict.set("truncated", self.truncated)
+        next_tensordict.set("terminated", self.truncated or done)
+
+        return next_tensordict
+
+    def _execute_liquidation(self, current_price: float) -> Dict:
+        """Execute forced liquidation of position."""
+        trade_info = {
+            "executed": True,
+            "side": "liquidation",
+            "fee_paid": 0.0,
+            "liquidated": True,
+            "sltp_triggered": None,
+        }
+
+        # Realize the loss at liquidation price
+        if self.position_size > 0:
+            # Long position liquidated
+            loss = (self.liquidation_price - self.entry_price) * self.position_size
+        else:
+            # Short position liquidated
+            loss = (self.entry_price - self.liquidation_price) * abs(self.position_size)
+
+        # Apply loss and fees
+        liquidation_fee = (
+            abs(self.position_size * self.liquidation_price) * self.transaction_fee
+        )
+        self.balance += loss - liquidation_fee
+        trade_info["fee_paid"] = liquidation_fee
+
+        # Reset position
+        self._reset_position()
+
+        return trade_info
+
+    def _execute_sltp_close(self, ohlcv: dict, trigger_type: str) -> Dict:
+        """Execute SL/TP triggered close."""
+        trade_info = {
+            "executed": True,
+            "side": "close",
+            "fee_paid": 0.0,
+            "liquidated": False,
+            "sltp_triggered": trigger_type,
+        }
+
+        # Determine execution price based on trigger
+        if trigger_type == "sl":
+            execution_price = self.stop_loss
+        else:  # tp
+            execution_price = self.take_profit
+
+        # Calculate PnL
+        pnl = self._calculate_unrealized_pnl(
+            self.entry_price, execution_price, self.position_size
+        )
+
+        # Calculate fee
+        notional = abs(self.position_size * execution_price)
+        fee = notional * self.transaction_fee
+
+        # Update balance
+        self.balance += pnl - fee
+        trade_info["fee_paid"] = fee
+
+        # Reset position
+        self._reset_position()
+
+        return trade_info
+
+    def _execute_action(
+        self,
+        side: Optional[str],
+        sl_pct: Optional[float],
+        tp_pct: Optional[float],
+    ) -> Dict:
+        """Execute the action."""
+        trade_info = {
+            "executed": False,
+            "side": None,
+            "fee_paid": 0.0,
+            "liquidated": False,
+            "sltp_triggered": None,
+        }
+
+        current_price = self.sampler.get_base_features(self.current_timestamp)["close"]
+
+        # Apply slippage
+        price_noise = torch.empty(1).uniform_(
+            1 - self.slippage, 1 + self.slippage
+        ).item()
+
+        if side is None:
+            # Hold or close action
+            if self.position_size != 0:
+                # Close existing position
+                trade_info = self._close_position(current_price, price_noise)
+            # Update hold counter if still holding
+            if self.position_size != 0:
+                self.position_hold_counter += 1
+            return trade_info
+
+        # Opening a new position
+        if side == "long":
+            if self.position_size < 0:
+                # Close short first
+                self._close_position(current_price, price_noise)
+
+            if self.position_size <= 0:
+                # Open long position
+                trade_info = self._open_position(
+                    "long", current_price, price_noise, sl_pct, tp_pct
+                )
+
+        elif side == "short":
+            if self.position_size > 0:
+                # Close long first
+                self._close_position(current_price, price_noise)
+
+            if self.position_size >= 0:
+                # Open short position
+                trade_info = self._open_position(
+                    "short", current_price, price_noise, sl_pct, tp_pct
+                )
+
+        # Update hold counter
+        if self.position_size != 0:
+            self.position_hold_counter += 1
+
+        return trade_info
+
+    def _open_position(
+        self,
+        side: str,
+        current_price: float,
+        price_noise: float,
+        sl_pct: float,
+        tp_pct: float,
+    ) -> Dict:
+        """Open a new position with SL/TP."""
+        trade_info = {
+            "executed": True,
+            "side": side,
+            "fee_paid": 0.0,
+            "liquidated": False,
+            "sltp_triggered": None,
+        }
+
+        execution_price = current_price * price_noise
+
+        # Calculate position size based on available balance and leverage
+        usable_balance = self.balance * self.config.max_position_size
+        margin_plus_fee_rate = (1.0 / self.leverage) + self.transaction_fee
+        # Apply 0.1% safety margin to avoid floating-point precision issues
+        max_notional = usable_balance / margin_plus_fee_rate * 0.999
+        notional_value = max_notional
+        position_qty = notional_value / execution_price
+
+        # Calculate margin required
+        margin_required = self._calculate_margin_required(notional_value)
+
+        # Calculate fee
+        fee = notional_value * self.transaction_fee
+
+        if margin_required + fee > self.balance:
+            # Not enough balance
+            trade_info["executed"] = False
+            return trade_info
+
+        # Execute trade
+        self.balance -= fee
+        trade_info["fee_paid"] = fee
+
+        if side == "long":
+            self.position_size = position_qty
+            self.current_position = 1
+            # For long: SL is below entry, TP is above entry
+            self.stop_loss = execution_price * (1 + sl_pct)  # sl_pct is negative
+            self.take_profit = execution_price * (1 + tp_pct)  # tp_pct is positive
+        else:  # short
+            self.position_size = -position_qty
+            self.current_position = -1
+            # For short: SL is above entry, TP is below entry
+            self.stop_loss = execution_price * (1 - sl_pct)  # sl_pct is negative, so this goes up
+            self.take_profit = execution_price * (1 - tp_pct)  # tp_pct is positive, so this goes down
+
+        self.entry_price = execution_price
+        self.position_value = notional_value
+        self.liquidation_price = self._calculate_liquidation_price(
+            execution_price, self.position_size
+        )
+        self.position_hold_counter = 0
+
+        return trade_info
+
+    def _close_position(self, current_price: float, price_noise: float) -> Dict:
+        """Close existing position."""
+        trade_info = {
+            "executed": True,
+            "side": "close",
+            "fee_paid": 0.0,
+            "liquidated": False,
+            "sltp_triggered": None,
+        }
+
+        if self.position_size == 0:
+            trade_info["executed"] = False
+            return trade_info
+
+        execution_price = current_price * price_noise
+
+        # Calculate PnL
+        pnl = self._calculate_unrealized_pnl(
+            self.entry_price, execution_price, self.position_size
+        )
+
+        # Calculate fee
+        notional = abs(self.position_size * execution_price)
+        fee = notional * self.transaction_fee
+
+        # Update balance
+        self.balance += pnl - fee
+        trade_info["fee_paid"] = fee
+
+        # Reset position
+        self._reset_position()
+
+        return trade_info
+
+    def _reset_position(self):
+        """Reset position state."""
+        self.position_size = 0.0
+        self.position_value = 0.0
+        self.entry_price = 0.0
+        self.liquidation_price = 0.0
+        self.current_position = 0
+        self.position_hold_counter = 0
+        self.stop_loss = 0.0
+        self.take_profit = 0.0
+
+    def _check_termination(self, portfolio_value: float) -> bool:
+        """Check if episode should terminate."""
+        bankruptcy_threshold = (
+            self.config.bankrupt_threshold * self.initial_portfolio_value
+        )
+        return portfolio_value < bankruptcy_threshold or self.step_counter >= self.max_steps
+
+    def close(self):
+        """Clean up resources."""
+        pass
+
+    def render_history(self, return_fig=False):
+        """Render the history of the environment."""
+        price_history = self.base_price_history
+        time_indices = list(range(len(price_history)))
+        action_history = self.action_history
+        portfolio_value_history = self.portfolio_value_history
+        position_history = self.position_history
+
+        # Calculate buy-and-hold balance
+        initial_balance = portfolio_value_history[0]
+        initial_price = price_history[0]
+        units_held = initial_balance / initial_price
+        buy_and_hold_balance = [units_held * price for price in price_history]
+
+        # Create subplots
+        fig, axes = plt.subplots(
+            3, 1, figsize=(12, 10), sharex=True,
+            gridspec_kw={'height_ratios': [3, 2, 1]}
+        )
+        ax1, ax2, ax3 = axes
+
+        # Plot price history
+        ax1.plot(
+            time_indices, price_history,
+            label='Price History', color='blue', linewidth=1.5
+        )
+
+        # Plot buy/sell actions
+        long_indices = [i for i, action in enumerate(action_history) if action == 1]
+        long_prices = [price_history[i] for i in long_indices]
+        short_indices = [i for i, action in enumerate(action_history) if action == -1]
+        short_prices = [price_history[i] for i in short_indices]
+
+        ax1.scatter(
+            long_indices, long_prices,
+            marker='^', color='green', s=80, label='Long', zorder=5
+        )
+        ax1.scatter(
+            short_indices, short_prices,
+            marker='v', color='red', s=80, label='Short', zorder=5
+        )
+
+        ax1.set_ylabel('Price (USD)')
+        ax1.set_title('Price History with Long/Short Actions')
+        ax1.legend()
+        ax1.grid(True, alpha=0.3)
+
+        # Plot portfolio value
+        ax2.plot(
+            time_indices, portfolio_value_history,
+            label='Portfolio Value', color='green', linewidth=1.5
+        )
+        ax2.plot(
+            time_indices, buy_and_hold_balance,
+            label='Buy and Hold', color='purple', linestyle='--', linewidth=1.5
+        )
+        ax2.set_ylabel('Portfolio Value (USD)')
+        ax2.set_title('Portfolio Value vs Buy and Hold')
+        ax2.legend()
+        ax2.grid(True, alpha=0.3)
+
+        # Plot position
+        ax3.fill_between(
+            time_indices, position_history, 0,
+            where=[p > 0 for p in position_history], color='green', alpha=0.3, label='Long'
+        )
+        ax3.fill_between(
+            time_indices, position_history, 0,
+            where=[p < 0 for p in position_history], color='red', alpha=0.3, label='Short'
+        )
+        ax3.axhline(y=0, color='black', linestyle='-', linewidth=0.5)
+        ax3.set_xlabel('Time (Index)')
+        ax3.set_ylabel('Position Size')
+        ax3.set_title('Position History')
+        ax3.legend()
+        ax3.grid(True, alpha=0.3)
+
+        plt.tight_layout()
+
+        if return_fig:
+            return fig
+        else:
+            plt.show()
+
+
+if __name__ == "__main__":
+    time_frames = [
+        TimeFrame(1, TimeFrameUnit.Minute),
+    ]
+    window_sizes = [12]
+    execute_on = TimeFrame(1, TimeFrameUnit.Minute)
+
+    # Load sample data
+    df = pd.read_csv(
+        "/home/sebastian/Documents/TorchTrade/torchrl_alpaca_env/torchtrade/data/"
+        "binance_spot_1m_cleaned/btcusdt_spot_1m_12_2024_to_09_2025.csv"
+    )
+
+    config = SeqFuturesSLTPEnvConfig(
+        symbol="BTC/USD",
+        time_frames=time_frames,
+        window_sizes=window_sizes,
+        execute_on=execute_on,
+        leverage=10,
+        stoploss_levels=[-0.02, -0.05],
+        takeprofit_levels=[0.05, 0.1],
+        transaction_fee=0.0004,
+        slippage=0.001,
+        bankrupt_threshold=0.1,
+    )
+    env = SeqFuturesSLTPEnv(df, config)
+
+    print(f"Action space size: {env.action_spec.n}")
+    print(f"Action map: {env.action_map}")
+
+    td = env.reset()
+    for i in range(env.max_steps):
+        action = env.action_spec.sample()
+        td.set("action", action)
+        td = env.step(td)
+        td = td["next"]
+        portfolio_value = td["account_state"][0].item() + td["account_state"][2].item()
+        print(f"Step {i}: Action={action.item()}, Portfolio=${portfolio_value:.2f}")
+        if td["done"]:
+            print(f"Episode done at step {i}")
+            break
+
+    env.render_history()


### PR DESCRIPTION
## Summary

This PR adds `SeqFuturesSLTPEnv`, a new offline backtesting environment that combines:
- **Long/short positions with leverage** (1x-125x) from `SeqFuturesEnv`
- **Stop-loss/take-profit bracket orders** from `SeqLongOnlySLTPEnv`
- **Liquidation mechanics** from `SeqFuturesEnv`

### Action Space

The action space has `1 + 2 * (num_sl * num_tp)` actions:
- **Action 0**: Hold / Close existing position
- **Actions 1-N**: Long positions with (SL, TP) combinations
- **Actions N+1-2N**: Short positions with (SL, TP) combinations

For example, with 3 SL levels and 3 TP levels: `1 + 2*9 = 19` actions (9 long + 9 short + 1 hold/close)

### Account State

10-element vector matching `SeqFuturesEnv`:
`[cash, position_size, position_value, entry_price, current_price, unrealized_pnl_pct, leverage, margin_ratio, liquidation_price, holding_time]`

### SLTP Trigger Logic

- **Long positions**: SL triggers when price drops below SL level, TP triggers when price rises above TP level
- **Short positions**: SL triggers when price rises above SL level, TP triggers when price drops below TP level

### Files Added/Modified

**New files:**
- `torchtrade/envs/offline/seqfuturessltp.py` - Environment implementation
- `tests/envs/offline/test_seqfuturessltp.py` - 41 comprehensive tests
- `examples/online/ppo_futures_sltp/` - PPO training example (train.py, utils.py, config.yaml)

**Modified files:**
- `torchtrade/envs/__init__.py` - Export SeqFuturesSLTPEnv
- `torchtrade/envs/offline/__init__.py` - Export SeqFuturesSLTPEnv
- `tests/test_examples.py` - Add ppo_seqfuturessltp test

## Test plan

- [x] All 41 SeqFuturesSLTPEnv tests pass
- [x] PPO example test passes
- [x] All 268 offline environment tests pass
- [x] Import tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)