### PR TITLE
Fix SLTP futures duplicate action handling and enable position switches

### DIFF
--- a/tests/envs/binance/test_torch_env_futures_sltp.py
+++ b/tests/envs/binance/test_torch_env_futures_sltp.py
@@ -845,3 +845,176 @@ class TestCriticalEdgeCases:
             mock_trader.trade.reset_mock()
             next_td2 = env.step(action_td)
             mock_trader.trade.assert_called_once()
+
+
+class TestDuplicateActionPrevention:
+    """Test duplicate action prevention and position switch logic (PR #XXX)."""
+
+    @pytest.fixture
+    def env_with_mocks(self):
+        """Create environment for duplicate action testing."""
+        from torchtrade.envs.binance.torch_env_futures_sltp import (
+            BinanceFuturesSLTPTorchTradingEnv,
+            BinanceFuturesSLTPTradingEnvConfig,
+        )
+
+        mock_observer = MagicMock()
+        mock_observer.get_keys = MagicMock(return_value=["1m_10"])
+
+        def mock_get_observations(return_base_ohlc=False):
+            obs = {"1m_10": np.random.randn(10, 4).astype(np.float32)}
+            if return_base_ohlc:
+                obs["base_features"] = np.array(
+                    [[50000, 50100, 49900, 50050]] * 10, dtype=np.float32
+                )
+            return obs
+
+        mock_observer.get_observations = MagicMock(side_effect=mock_get_observations)
+        mock_observer.intervals = ["1m"]
+        mock_observer.window_sizes = [10]
+
+        mock_trader = MagicMock()
+        mock_trader.cancel_open_orders = MagicMock(return_value=True)
+        mock_trader.close_position = MagicMock(return_value=True)
+        mock_trader.get_account_balance = MagicMock(return_value={
+            "total_wallet_balance": 1000.0,
+            "available_balance": 900.0,
+            "total_margin_balance": 1000.0,
+        })
+        mock_trader.get_mark_price = MagicMock(return_value=50000.0)
+        mock_trader.get_status = MagicMock(return_value={"position_status": None})
+        mock_trader.trade = MagicMock(return_value=True)
+
+        config = BinanceFuturesSLTPTradingEnvConfig(
+            symbol="BTCUSDT",
+            time_frames=["1m"],
+            window_sizes=[10],
+            stoploss_levels=(-0.02,),
+            takeprofit_levels=(0.03,),
+            include_short_positions=True,
+        )
+
+        with patch("time.sleep"):
+            with patch.object(BinanceFuturesSLTPTorchTradingEnv, "_wait_for_next_timestamp"):
+                env = BinanceFuturesSLTPTorchTradingEnv(
+                    config=config,
+                    observer=mock_observer,
+                    trader=mock_trader,
+                )
+                return env, mock_trader
+
+    def test_long_to_long_ignored(self, env_with_mocks):
+        """Test that Long → Long duplicate action is ignored."""
+        env, mock_trader = env_with_mocks
+        env.reset()
+
+        # Reset mocks after reset() (which may call close_position)
+        mock_trader.reset_mock()
+
+        # Open a long position (action 1 = long)
+        env.position.current_position = 1
+
+        # Try to open another long
+        action_tuple = ("long", -0.02, 0.03)
+        trade_info = env._execute_trade_if_needed(action_tuple)
+
+        # Trade should NOT be executed (duplicate action)
+        assert trade_info["executed"] is False
+        mock_trader.trade.assert_not_called()
+        mock_trader.close_position.assert_not_called()
+
+    def test_short_to_short_ignored(self, env_with_mocks):
+        """Test that Short → Short duplicate action is ignored."""
+        env, mock_trader = env_with_mocks
+        env.reset()
+        mock_trader.reset_mock()
+
+        # Open a short position
+        env.position.current_position = -1
+
+        # Try to open another short
+        action_tuple = ("short", 0.03, -0.02)
+        trade_info = env._execute_trade_if_needed(action_tuple)
+
+        # Trade should NOT be executed (duplicate action)
+        assert trade_info["executed"] is False
+        mock_trader.trade.assert_not_called()
+        mock_trader.close_position.assert_not_called()
+
+    def test_long_to_short_switches_position(self, env_with_mocks):
+        """Test that Long → Short switches position (closes long, opens short)."""
+        env, mock_trader = env_with_mocks
+        env.reset()
+        mock_trader.reset_mock()
+
+        # Start with long position
+        env.position.current_position = 1
+
+        # Switch to short
+        action_tuple = ("short", 0.03, -0.02)
+        trade_info = env._execute_trade_if_needed(action_tuple)
+
+        # Should close existing position
+        mock_trader.close_position.assert_called_once()
+        # Should open new short position
+        mock_trader.trade.assert_called_once()
+        call_kwargs = mock_trader.trade.call_args.kwargs
+        assert call_kwargs["side"] == "SELL"
+
+    def test_short_to_long_switches_position(self, env_with_mocks):
+        """Test that Short → Long switches position (closes short, opens long)."""
+        env, mock_trader = env_with_mocks
+        env.reset()
+        mock_trader.reset_mock()
+
+        # Start with short position
+        env.position.current_position = -1
+
+        # Switch to long
+        action_tuple = ("long", -0.02, 0.03)
+        trade_info = env._execute_trade_if_needed(action_tuple)
+
+        # Should close existing position
+        mock_trader.close_position.assert_called_once()
+        # Should open new long position
+        mock_trader.trade.assert_called_once()
+        call_kwargs = mock_trader.trade.call_args.kwargs
+        assert call_kwargs["side"] == "BUY"
+
+    def test_hold_action_with_no_position(self, env_with_mocks):
+        """Test that HOLD action does nothing when no position."""
+        env, mock_trader = env_with_mocks
+        env.reset()
+        mock_trader.reset_mock()
+
+        # No position
+        env.position.current_position = 0
+
+        # HOLD action
+        action_tuple = (None, None, None)
+        trade_info = env._execute_trade_if_needed(action_tuple)
+
+        # Should not execute any trade
+        assert trade_info["executed"] is False
+        mock_trader.trade.assert_not_called()
+        mock_trader.close_position.assert_not_called()
+
+    def test_hold_action_maintains_position(self, env_with_mocks):
+        """Test that HOLD action maintains existing position."""
+        env, mock_trader = env_with_mocks
+        env.reset()
+        mock_trader.reset_mock()
+
+        # Start with long position
+        env.position.current_position = 1
+
+        # HOLD action
+        action_tuple = (None, None, None)
+        trade_info = env._execute_trade_if_needed(action_tuple)
+
+        # Should not execute any trade or close position
+        assert trade_info["executed"] is False
+        mock_trader.trade.assert_not_called()
+        mock_trader.close_position.assert_not_called()
+        # Position should remain unchanged
+        assert env.position.current_position == 1

--- a/torchtrade/envs/bitget/torch_env_futures_sltp.py
+++ b/torchtrade/envs/bitget/torch_env_futures_sltp.py
@@ -252,13 +252,26 @@ class BitgetFuturesSLTPTorchTradingEnv(SLTPMixin, BitgetBaseTorchTradingEnv):
 
         side, stop_loss_pct, take_profit_pct = action_tuple
 
-        # HOLD action or already in position
-        if action_tuple == (None, None, None) or self.position.current_position != 0:
+        # HOLD action - do nothing
+        if side is None:
             return trade_info
+
+        # Check if already in same position (ignore duplicate actions)
+        position_map = {"long": 1, "short": -1}
+        if side in position_map and self.position.current_position == position_map[side]:
+            return trade_info  # Already in this position, ignore duplicate action
 
         # Get current price for calculating absolute SL/TP levels
         obs = self.observer.get_observations(return_base_ohlc=True)
         current_price = obs["base_features"][-1, 3]  # Close price
+
+        # Close opposite position if switching directions
+        if self.position.current_position != 0:
+            # We have an existing position that needs to be closed before opening new one
+            if (side == "long" and self.position.current_position == -1) or \
+               (side == "short" and self.position.current_position == 1):
+                self.trader.close_position()
+                self.position.current_position = 0
 
         if side == "long":
             # Open LONG with SL/TP bracket order


### PR DESCRIPTION
## Summary

This PR fixes a critical bug in SLTP futures environments (Binance and Bitget) that was blocking all actions when a position was open, preventing position switches between long and short.

## Problem

The old logic blocked ALL trades when a position existed:

```python
# ❌ OLD (INCORRECT)
if action_tuple == (None, None, None) or self.position.current_position != 0:
    return trade_info  # Blocked position switches!
```

This caused:
- Long → Long: ✅ Correctly ignored (but by accident)
- Short → Short: ✅ Correctly ignored (but by accident)  
- **Long → Short: ❌ Incorrectly blocked**
- **Short → Long: ❌ Incorrectly blocked**

## Solution

Implemented explicit duplicate action prevention while allowing position switches:

```python
# ✅ NEW (CORRECT)
# 1. HOLD action - do nothing
if side is None:
    return trade_info

# 2. Check if already in same position (ignore duplicate actions)
position_map = {"long": 1, "short": -1}
if side in position_map and self.position.current_position == position_map[side]:
    return trade_info  # Already in this position, ignore duplicate action

# 3. Close opposite position if switching directions
if self.position.current_position != 0:
    if (side == "long" and self.position.current_position == -1) or \
       (side == "short" and self.position.current_position == 1):
        self.trader.close_position()
        self.position.current_position = 0
```

## Changes

### Modified Files
- `torchtrade/envs/binance/torch_env_futures_sltp.py:258-278`
- `torchtrade/envs/bitget/torch_env_futures_sltp.py:255-274`

### Tests Added
Comprehensive test suite in `TestDuplicateActionPrevention` class:
- ✅ `test_long_to_long_ignored` - Duplicate long actions are ignored
- ✅ `test_short_to_short_ignored` - Duplicate short actions are ignored
- ✅ `test_long_to_short_switches_position` - Position switches work (closes long, opens short)
- ✅ `test_short_to_long_switches_position` - Position switches work (closes short, opens long)
- ✅ `test_hold_action_with_no_position` - HOLD does nothing when flat
- ✅ `test_hold_action_maintains_position` - HOLD maintains existing position

All 12 tests passing (6 for Binance, 6 for Bitget).

## Impact

This brings SLTP environments in line with the base futures environments (SeqFuturesEnv, FuturesOneStepEnv, BinanceFuturesTorchTradingEnv, BitgetFuturesTorchTradingEnv) which already had correct duplicate action prevention logic.

## Testing

```bash
pytest tests/envs/binance/test_torch_env_futures_sltp.py::TestDuplicateActionPrevention -xvs
pytest tests/envs/bitget/test_torch_env_futures_sltp.py::TestDuplicateActionPrevention -xvs
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)