### PR TITLE
Fix timeframe parsing for live environments with string syntax

### DIFF
--- a/torchtrade/envs/core/live.py
+++ b/torchtrade/envs/core/live.py
@@ -129,6 +129,12 @@ class TorchTradeLiveEnv(TorchTradeBaseEnv):
             "Minute": "minutes",
             "Hour": "hours",
             "Day": "days",
+            # Pandas frequency codes (from TimeFrameUnit enum values)
+            "Min": "minutes",
+            "H": "hours",
+            "D": "days",
+            # Binance uses seconds-based intervals
+            "seconds": "seconds",
         }
 
         if self.execute_on_unit not in unit_to_timedelta:


### PR DESCRIPTION
## Summary

- Fixes error "Unsupported time unit: Min" when using string timeframe syntax like `"1Min"` in live environment configs
- Adds support for pandas frequency codes (`'Min'`, `'H'`, `'D'`) in `_wait_for_next_timestamp()` method
- Adds support for Binance's seconds-based intervals
- Enables simplified string syntax to work across all live environments (Alpaca, Binance, Bitget)

## Background

The issue occurred because:
1. String timeframes like `"1Min"` are parsed to `TimeFrame(1, TimeFrameUnit.Minute)`
2. `TimeFrameUnit.Minute.value` returns `'Min'` (the pandas frequency code)
3. Alpaca environments set `execute_on_unit = str(config.execute_on.unit.value)` which results in `"Min"`
4. But `_wait_for_next_timestamp()` only accepted `"Minute"`, `"Hour"`, `"Day"`, not the pandas codes

This fix enables the simplified string syntax used in the LLM live collection example (commit f420b37) to work correctly.

## Test plan

- [ ] Test Alpaca environment with string timeframe syntax: `time_frames=["1Min"]`, `execute_on="1Min"`
- [ ] Test Binance environment with string timeframe syntax
- [ ] Test Bitget environment with string timeframe syntax
- [ ] Verify examples/live/alpaca/collect_live_llm.py runs without errors
- [ ] Run existing live environment tests to ensure no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)