### PR TITLE
Organize example outputs with Hydra directory configuration

### DIFF
--- a/examples/offline/iql/config.yaml
+++ b/examples/offline/iql/config.yaml
@@ -63,3 +63,11 @@ compile:
   compile: False
   compile_mode:
   cudagraphs: False
+
+# Hydra configuration - saves outputs in example directory
+hydra:
+  run:
+    dir: ./outputs/${now:%Y-%m-%d}/${now:%H-%M-%S}
+  sweep:
+    dir: ./outputs/multirun/${now:%Y-%m-%d}/${now:%H-%M-%S}
+    subdir: ${hydra.job.num}

--- a/examples/online/dsac/config.yaml
+++ b/examples/online/dsac/config.yaml
@@ -65,3 +65,11 @@ logger:
   mode: online
   eval_iter: 20000
   video: False
+
+# Hydra configuration - saves outputs in example directory
+hydra:
+  run:
+    dir: ./outputs/${now:%Y-%m-%d}/${now:%H-%M-%S}
+  sweep:
+    dir: ./outputs/multirun/${now:%Y-%m-%d}/${now:%H-%M-%S}
+    subdir: ${hydra.job.num}

--- a/examples/online/grpo_futures_onestep/config.yaml
+++ b/examples/online/grpo_futures_onestep/config.yaml
@@ -50,3 +50,11 @@ compile:
   compile: False
   compile_mode:
   cudagraphs: False
+
+# Hydra configuration - saves outputs in example directory
+hydra:
+  run:
+    dir: ./outputs/${now:%Y-%m-%d}/${now:%H-%M-%S}
+  sweep:
+    dir: ./outputs/multirun/${now:%Y-%m-%d}/${now:%H-%M-%S}
+    subdir: ${hydra.job.num}

--- a/examples/online/iql/config.yaml
+++ b/examples/online/iql/config.yaml
@@ -72,3 +72,11 @@ compile:
   compile: False
   compile_mode:
   cudagraphs: False
+
+# Hydra configuration - saves outputs in example directory
+hydra:
+  run:
+    dir: ./outputs/${now:%Y-%m-%d}/${now:%H-%M-%S}
+  sweep:
+    dir: ./outputs/multirun/${now:%Y-%m-%d}/${now:%H-%M-%S}
+    subdir: ${hydra.job.num}

--- a/examples/online/long_onestep_env/config.yaml
+++ b/examples/online/long_onestep_env/config.yaml
@@ -47,3 +47,11 @@ compile:
   compile: False
   compile_mode:
   cudagraphs: False
+
+# Hydra configuration - saves outputs in example directory
+hydra:
+  run:
+    dir: ./outputs/${now:%Y-%m-%d}/${now:%H-%M-%S}
+  sweep:
+    dir: ./outputs/multirun/${now:%Y-%m-%d}/${now:%H-%M-%S}
+    subdir: ${hydra.job.num}

--- a/examples/online/ppo/config.yaml
+++ b/examples/online/ppo/config.yaml
@@ -63,3 +63,11 @@ compile:
   compile: False
   compile_mode:
   cudagraphs: False
+
+# Hydra configuration - saves outputs in example directory
+hydra:
+  run:
+    dir: ./outputs/${now:%Y-%m-%d}/${now:%H-%M-%S}
+  sweep:
+    dir: ./outputs/multirun/${now:%Y-%m-%d}/${now:%H-%M-%S}
+    subdir: ${hydra.job.num}

--- a/examples/online/ppo_chronos/config.yaml
+++ b/examples/online/ppo_chronos/config.yaml
@@ -64,3 +64,11 @@ compile:
   compile: False
   compile_mode:
   cudagraphs: False
+
+# Hydra configuration - saves outputs in example directory
+hydra:
+  run:
+    dir: ./outputs/${now:%Y-%m-%d}/${now:%H-%M-%S}
+  sweep:
+    dir: ./outputs/multirun/${now:%Y-%m-%d}/${now:%H-%M-%S}
+    subdir: ${hydra.job.num}

--- a/examples/online/ppo_futures/config.yaml
+++ b/examples/online/ppo_futures/config.yaml
@@ -61,3 +61,11 @@ compile:
   compile: False
   compile_mode:
   cudagraphs: False
+
+# Hydra configuration - saves outputs in example directory
+hydra:
+  run:
+    dir: ./outputs/${now:%Y-%m-%d}/${now:%H-%M-%S}
+  sweep:
+    dir: ./outputs/multirun/${now:%Y-%m-%d}/${now:%H-%M-%S}
+    subdir: ${hydra.job.num}

--- a/examples/online/ppo_futures_onestep/config.yaml
+++ b/examples/online/ppo_futures_onestep/config.yaml
@@ -77,3 +77,11 @@ compile:
   compile: False
   compile_mode:
   cudagraphs: False
+
+# Hydra configuration - saves outputs in example directory
+hydra:
+  run:
+    dir: ./outputs/${now:%Y-%m-%d}/${now:%H-%M-%S}
+  sweep:
+    dir: ./outputs/multirun/${now:%Y-%m-%d}/${now:%H-%M-%S}
+    subdir: ${hydra.job.num}

--- a/examples/online/ppo_futures_sltp/config.yaml
+++ b/examples/online/ppo_futures_sltp/config.yaml
@@ -63,3 +63,11 @@ compile:
   compile: False
   compile_mode:
   cudagraphs: False
+
+# Hydra configuration - saves outputs in example directory
+hydra:
+  run:
+    dir: ./outputs/${now:%Y-%m-%d}/${now:%H-%M-%S}
+  sweep:
+    dir: ./outputs/multirun/${now:%Y-%m-%d}/${now:%H-%M-%S}
+    subdir: ${hydra.job.num}


### PR DESCRIPTION
## Summary

This PR configures Hydra to save training outputs in each example's directory instead of the project root, providing better organization and preparing for future evaluation scripts.

## Changes

- ✅ Added Hydra output directory configuration to all 10 training example configs
- ✅ Outputs now saved to `examples/<algo>/outputs/<date>/<time>/`
- ✅ Automatic timestamping and config tracking via Hydra
- ✅ Applied to: PPO, IQL, GRPO, DSAC, and all futures/SLTP variants

## Configuration Added

```yaml
# Hydra configuration - saves outputs in example directory
hydra:
  run:
    dir: ./outputs/${now:%Y-%m-%d}/${now:%H-%M-%S}
  sweep:
    dir: ./outputs/multirun/${now:%Y-%m-%d}/${now:%H-%M-%S}
    subdir: ${hydra.job.num}
```

## Benefits

- **Clean root directory**: No more scattered `.pth` files in project root
- **Better organization**: Each algorithm's outputs in its own folder
- **Easy evaluation**: Evaluation scripts can easily find models in `examples/<algo>/outputs/`
- **Run history**: Timestamped folders preserve all training runs
- **Config tracking**: Hydra automatically saves exact config used for each run

## Example Output Structure

```
examples/online/ppo/
├── config.yaml
├── train.py
├── utils.py
└── outputs/
    └── 2026-01-24/
        └── 16-30-45/
            ├── .hydra/
            │   ├── config.yaml      # Copy of config used
            │   └── overrides.yaml   # CLI overrides
            ├── ppo_policy_100.pth
            └── ppo_policy_200.pth
```

## Test Plan

- [ ] Run example training script
- [ ] Verify outputs saved to `examples/<algo>/outputs/` directory
- [ ] Verify timestamped subdirectory created
- [ ] Verify `.hydra/` folder contains config snapshot
- [ ] Verify model checkpoints saved in correct location

🤖 Generated with [Claude Code](https://claude.com/claude-code)