### PR TITLE
Show exposure percentage instead of position size in render_history

### DIFF
--- a/torchtrade/envs/core/offline_base.py
+++ b/torchtrade/envs/core/offline_base.py
@@ -541,21 +541,27 @@ class TorchTradeOfflineEnv(TorchTradeBaseEnv):
             ax2.legend()
             ax2.grid(True, alpha=0.3)
 
-            # Plot position history
+            # Plot exposure percentage history
+            # Calculate exposure % = (position_size * price / portfolio_value) * 100
+            exposure_pct = [
+                (pos * price / pv * 100) if pv > 0 else 0.0
+                for pos, price, pv in zip(position_history, price_history, portfolio_value_history)
+            ]
+
             ax3.fill_between(
-                time_indices, position_history, 0,
-                where=[p > 0 for p in position_history],
+                time_indices, exposure_pct, 0,
+                where=[e > 0 for e in exposure_pct],
                 color='green', alpha=0.3, label='Long'
             )
             ax3.fill_between(
-                time_indices, position_history, 0,
-                where=[p < 0 for p in position_history],
+                time_indices, exposure_pct, 0,
+                where=[e < 0 for e in exposure_pct],
                 color='red', alpha=0.3, label='Short'
             )
             ax3.axhline(y=0, color='black', linestyle='-', linewidth=0.5)
             ax3.set_xlabel('Time (Index)')
-            ax3.set_ylabel('Position Size')
-            ax3.set_title('Position History')
+            ax3.set_ylabel('Exposure (%)')
+            ax3.set_title('Exposure History')
             ax3.legend()
             ax3.grid(True, alpha=0.3)
 


### PR DESCRIPTION
## Summary

Replaces raw position size with **percentage exposure** in the `render_history()` position subplot for futures environments.

Fixes #141

## Changes

- **Calculate exposure percentage**: `(position_size * price / portfolio_value) * 100`
- **Update y-axis label**: "Position Size" → "Exposure (%)"  
- **Update subplot title**: "Position History" → "Exposure History"

## Benefits

✅ **Normalized view**: Shows risk as % of portfolio regardless of portfolio size
✅ **Leverage-aware**: A 6x leveraged position shows ~600% exposure, making leverage visible
✅ **Comparable across runs**: Easy to compare exposure between different experiments
✅ **Intuitive interpretation**: 
   - 100% = fully invested
   - 0% = flat
   - -100% = fully short
   - 600% = 6x leveraged long position

## Example Visualization

```
Exposure (%)
   600% |     ████
   300% |   ██████████
     0% |───────────────────
  -300% |              ██████
  -600% |
```

## Files Modified

- `torchtrade/envs/core/offline_base.py` - `render_history()` method (futures section only)

## Tests

✅ All existing tests pass:
- `tests/envs/offline/test_render_history.py` - 4/4 tests passing
- `tests/envs/offline/test_render_history_edge_cases.py` - 8/8 tests passing

No test changes required (tests verify rendering works without errors).