### PR TITLE
Fix terminated signal including truncated (#150)

### DIFF
--- a/tests/envs/offline/test_onestep.py
+++ b/tests/envs/offline/test_onestep.py
@@ -421,6 +421,21 @@ class TestOneStepRegression:
             next_td = onestep_env.step(action_td)
             assert next_td["next"]["done"].item()
 
+    def test_non_truncated_step_sets_terminated(self, onestep_env):
+        """Non-truncated one-step episode should set terminated=True, truncated=False.
+
+        Regression test for #150: one-step envs must distinguish terminated
+        (SL/TP trigger, hold completed) from truncated (data exhaustion).
+        """
+        td = onestep_env.reset()
+        action_td = td.clone()
+        action_td["action"] = torch.tensor(0)  # Hold - no rollout, no truncation
+        next_td = onestep_env.step(action_td)
+
+        assert next_td["next"]["done"].item() is True
+        assert next_td["next"]["terminated"].item() is True
+        assert next_td["next"]["truncated"].item() is False
+
     def test_action_spec_immutable(self, onestep_env):
         """Action spec should not change during episode."""
         initial_spec = onestep_env.action_spec

--- a/torchtrade/envs/offline/onestep.py
+++ b/torchtrade/envs/offline/onestep.py
@@ -329,13 +329,14 @@ class OneStepTradingEnv(SequentialTradingEnvSLTP):
         # Update the reward in history
         self.history.rewards[-1] = reward
 
-        # Check termination (always done for one-step environments)
-        done = True  # One-step environment - always done after single action
-
+        # One-step environment - always done after single action
+        # But distinguish: truncated (data ran out during rollout) vs
+        # terminated (SL/TP trigger, liquidation, or hold completed normally)
+        terminated = not self.truncated
         next_tensordict.set("reward", reward)
-        next_tensordict.set("done", done)
+        next_tensordict.set("terminated", terminated)
         next_tensordict.set("truncated", self.truncated)
-        next_tensordict.set("terminated", done)
+        next_tensordict.set("done", True)
 
         return next_tensordict
 

--- a/torchtrade/envs/offline/sequential_sltp.py
+++ b/torchtrade/envs/offline/sequential_sltp.py
@@ -397,13 +397,14 @@ class SequentialTradingEnvSLTP(SequentialTradingEnv):
         # Update the reward in history
         self.history.rewards[-1] = reward
 
-        # Check termination
-        done = self._check_termination(new_portfolio_value)
+        # Check termination (bankruptcy) and truncation (time/data limit)
+        terminated = self._check_termination(new_portfolio_value)
+        truncated = self._check_truncation()
 
         next_tensordict.set("reward", reward)
-        next_tensordict.set("done", self.truncated or done)
-        next_tensordict.set("truncated", self.truncated)
-        next_tensordict.set("terminated", self.truncated or done)
+        next_tensordict.set("terminated", terminated)
+        next_tensordict.set("truncated", truncated)
+        next_tensordict.set("done", terminated or truncated)
 
         return next_tensordict
 


### PR DESCRIPTION
## Summary

- Separate `terminated` (bankruptcy/liquidation) from `truncated` (data exhaustion/max steps) in all offline environments
- Extract `_check_truncation()` method from `_check_termination()` so max_steps is correctly treated as truncation, not termination
- Fix `OneStepTradingEnv` to set `terminated = not self.truncated` instead of always `True`
- Add regression tests across all three env types, parametrized over spot/futures modes

Fixes #150

## Changes

**`sequential.py`**: Split `_check_termination` into `_check_termination` (bankruptcy only) and `_check_truncation` (time/data limit). Update `_step` to use both.

**`sequential_sltp.py`**: Same `_step` fix (inherits the new methods from parent).

**`onestep.py`**: Set `terminated = not self.truncated` — when the internal rollout ends due to data exhaustion, the position didn't reach a natural conclusion.

## Signal semantics after fix

| Scenario | terminated | truncated | done |
|----------|-----------|-----------|------|
| Normal step | False | False | False |
| Bankruptcy/liquidation | True | False | True |
| Data exhaustion | False | True | True |
| Max steps reached | False | True | True |

## Test plan

- [x] `test_truncation_does_not_set_terminated` — parametrized spot/futures for `SequentialTradingEnv` and `SequentialTradingEnvSLTP`
- [x] `test_bankruptcy_sets_terminated_not_truncated` — verifies inverse case (bankruptcy = terminated, not truncated)
- [x] `test_normal_step_signals` — verifies non-terminal steps have all flags False
- [x] `test_non_truncated_step_sets_terminated` — verifies OneStep env sets terminated correctly
- [x] Full offline test suite: 428 passed
- [x] Full test suite: 938 passed (5 pre-existing example failures unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)