### PR TITLE
Add warning when balance clamp hides negative values

### DIFF
--- a/torchtrade/envs/offline/sequential_sltp.py
+++ b/torchtrade/envs/offline/sequential_sltp.py
@@ -291,7 +291,7 @@ class SequentialTradingEnvSLTP(SequentialTradingEnv):
 
         # Update balance: add realized PnL, subtract fee, return locked margin
         self.balance += pnl - fee + margin_to_return
-        self.balance = max(0.0, self.balance)
+        self._clamp_balance()
 
         # Reset position and SLTP state
         self.position.position_size = 0.0
@@ -510,7 +510,7 @@ class SequentialTradingEnvSLTP(SequentialTradingEnv):
         # For spot (leverage=1): margin_required = notional_value (full cost)
         # For futures (leverage>1): margin_required = notional_value / leverage
         self.balance -= fee + margin_required
-        self.balance = max(0.0, self.balance)
+        self._clamp_balance()
 
         # Set position
         self.position.position_size = position_size if side == "long" else -abs(position_size)


### PR DESCRIPTION
## Summary

- Adds `_clamp_balance()` helper on `SequentialTradingEnv` that warns when balance goes significantly negative (< -1e-10) before clamping to zero
- Replaces 7 inline `max(0.0, self.balance)` calls across `sequential.py` (5) and `sequential_sltp.py` (2) with the helper
- Uses module-level logger (`logging.getLogger(__name__)`) for proper log configuration

## Test plan

- [x] All 434 offline environment tests pass
- [x] No behavioral change — logging only, clamp preserved
- [x] Reviewed by pr-test-analyzer, code-simplifier, and torchrl-engineer agents

Fixes #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)