### PR TITLE
Fix truncation using fixed max_steps instead of per-episode max_traj_length

### DIFF
--- a/torchtrade/envs/core/offline_base.py
+++ b/torchtrade/envs/core/offline_base.py
@@ -83,7 +83,6 @@ class TorchTradeOfflineEnv(TorchTradeBaseEnv):
 
         # Initialize step counter
         self.step_counter = 0
-        self.max_steps = self.sampler.get_max_steps()
 
         # Initialize state attributes (set to valid defaults, will be properly set in _reset)
         self.current_timestamp = None

--- a/torchtrade/envs/offline/sequential.py
+++ b/torchtrade/envs/offline/sequential.py
@@ -828,7 +828,7 @@ class SequentialTradingEnv(TorchTradeOfflineEnv):
 
     def _check_truncation(self) -> bool:
         """Check if episode should be truncated (time limit or data exhaustion)."""
-        return self.truncated or self.step_counter >= self.max_steps
+        return self.truncated or self.step_counter >= self.max_traj_length
 
     def close(self):
         """Clean up resources."""


### PR DESCRIPTION
## Summary
- Fix `_check_truncation` to use `self.max_traj_length` (per-episode) instead of `self.max_steps` (fixed at init), which caused incorrect episode boundaries with `random_start=True`
- Remove dead `self.max_steps` assignment from `offline_base.py`
- Add regression test verifying truncation respects per-episode length with `random_start=True`

Closes #158

## Test plan
- [x] Existing 970 tests pass
- [x] New regression test covers spot and futures modes with `random_start=True`
- [x] Verified `self.max_steps` on env is no longer referenced anywhere

🤖 Generated with [Claude Code](https://claude.com/claude-code)