### PR TITLE
Make _cached_base_features data flow explicit

### DIFF
--- a/torchtrade/envs/core/offline_base.py
+++ b/torchtrade/envs/core/offline_base.py
@@ -349,14 +349,15 @@ class TorchTradeOfflineEnv(TorchTradeBaseEnv):
         - self.current_timestamp: Current observation timestamp
         - self.truncated: Whether insufficient data remains to build full observation windows
           (True when approaching end of dataset, not just when completely exhausted)
-        - self._cached_base_features: Cached base features for timestamp
 
         Returns:
-            Dictionary with market data observations for each timeframe
+            Tuple of (obs_dict, base_features) where obs_dict is a dictionary with
+            market data observations for each timeframe, and base_features contains
+            the base OHLCV features for the current timestamp.
         """
         obs_dict, self.current_timestamp, self.truncated = self.sampler.get_sequential_observation()
-        self._cached_base_features = self.sampler.get_base_features(self.current_timestamp)
-        return obs_dict
+        base_features = self.sampler.get_base_features(self.current_timestamp)
+        return obs_dict, base_features
 
     def _update_position_metrics(self, current_price: float):
         """Update position value and unrealized PnL based on current price.

--- a/torchtrade/envs/offline/onestep.py
+++ b/torchtrade/envs/offline/onestep.py
@@ -182,7 +182,8 @@ class OneStepTradingEnv(SequentialTradingEnvSLTP):
         # Get market data
         if initial or self.position.position_size == 0:
             # Initial observation or no position - get new observation
-            obs_dict = self._get_observation_scaffold()
+            obs_dict, base_features = self._get_observation_scaffold()
+            self._cached_base_features = base_features
             self.rollout_returns = []
         else:
             # Position exists - rollout until SL/TP trigger or truncation
@@ -433,7 +434,8 @@ class OneStepTradingEnv(SequentialTradingEnvSLTP):
 
         # If loop never executed (truncated from start), get an observation
         if obs_dict is None:
-            obs_dict = self._get_observation_scaffold()
+            obs_dict, base_features = self._get_observation_scaffold()
+            self._cached_base_features = base_features
 
         return trade_info, obs_dict
 

--- a/torchtrade/envs/offline/sequential.py
+++ b/torchtrade/envs/offline/sequential.py
@@ -370,9 +370,10 @@ class SequentialTradingEnv(TorchTradeOfflineEnv):
 
     def _get_observation(self) -> TensorDictBase:
         """Get the current observation state."""
-        # Get market data (scaffold sets current_timestamp, truncated, and caches base features)
-        obs_dict = self._get_observation_scaffold()
-        current_price = self._cached_base_features["close"]
+        # Get market data (scaffold sets current_timestamp and truncated)
+        obs_dict, base_features = self._get_observation_scaffold()
+        self._cached_base_features = base_features
+        current_price = base_features["close"]
 
         # Calculate position value (absolute value of notional)
         self.position.position_value = abs(self.position.position_size * current_price)


### PR DESCRIPTION
## Summary
- Fixes #161
- `_get_observation_scaffold()` now returns `(obs_dict, base_features)` instead of silently setting `self._cached_base_features`
- Each caller (`sequential.py`, `onestep.py`) explicitly sets the cache, making every write visible at the call site

## Test plan
- [x] All 972 tests pass unchanged (no behavioral change, pure refactor)
- [x] Grep confirms no hidden writes to `_cached_base_features` remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)