### PR TITLE
Document intentional SL-first priority in SLTP trigger

### DIFF
--- a/torchtrade/envs/offline/sequential_sltp.py
+++ b/torchtrade/envs/offline/sequential_sltp.py
@@ -193,6 +193,11 @@ class SequentialTradingEnvSLTP(SequentialTradingEnv):
         Uses intrabar OHLC data to detect SL/TP triggers that may occur
         within the candle, not just at the close.
 
+        NOTE: SL is checked before TP intentionally. When both could trigger
+        within the same candle, we assume the worst case (SL). This pessimistic
+        bias ensures backtesting underestimates performance, so live trading
+        can only outperform the backtest.
+
         Args:
             ohlcv: Dictionary with keys "open", "high", "low", "close", "volume"
 


### PR DESCRIPTION
## Summary

- Adds a NOTE to `_check_sltp_trigger` docstring explaining that SL is checked before TP by design
- When both could trigger within the same candle, assuming the worst case (SL) ensures pessimistic backtesting

## Context

The v1 bug audit flagged this as a potential bias issue. It is intentional — we want backtesting to underestimate performance so live trading can only outperform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)