### PR TITLE
Fix weighted average entry price to use quantity, not notional

### DIFF
--- a/torchtrade/envs/offline/sequential.py
+++ b/torchtrade/envs/offline/sequential.py
@@ -713,14 +713,14 @@ class SequentialTradingEnv(TorchTradeOfflineEnv):
         self.balance -= fee + margin_required
         self._clamp_balance()
 
-        # Calculate weighted average entry price
-        current_value = abs(self.position.position_size * self.position.entry_price)
-        new_value = delta_notional
-        total_value = current_value + new_value
+        # Calculate weighted average entry price (weight by quantity, not notional)
+        old_qty = abs(self.position.position_size)
+        new_qty = abs(delta_position)
+        total_qty = old_qty + new_qty
 
-        if total_value > 0:
+        if total_qty > 0:
             self.position.entry_price = (
-                (self.position.entry_price * current_value + execution_price * new_value) / total_value
+                (self.position.entry_price * old_qty + execution_price * new_qty) / total_qty
             )
 
         # Update position


### PR DESCRIPTION
## Summary

Fixes critical bug #171: `_increase_position_size` was computing weighted average entry price using notional values (qty × price) instead of quantities.

## The Bug

```python
# OLD (wrong) - weights by notional
current_value = abs(position_size * entry_price)  # notional
new_value = delta_notional
new_entry = (entry * current_value + exec_price * new_value) / total_value

# NEW (correct) - weights by quantity
old_qty = abs(position_size)
new_qty = abs(delta_position)
new_entry = (entry * old_qty + exec_price * new_qty) / total_qty
```

## Example

- 1.0 BTC @ $50,000 + 0.5 BTC @ $60,000
- **Wrong** (notional-weighted): $53,750
- **Correct** (qty-weighted): $53,333.33
- **Error**: 1.25% on entry price

## Impact

This error directly affects:
- Unrealized PnL calculations
- Distance-to-liquidation metric
- Reward signals during training

## Test plan

- [x] Added `TestWeightedEntryDirectFormula` with 4 parametrized test cases
- [x] Tests directly call `_increase_position_size` with different price/qty combinations
- [x] Verifies result matches qty-weighted formula, not notional-weighted
- [x] All 442 offline tests pass

Closes #171

🤖 Generated with [Claude Code](https://claude.ai/code)