### PR TITLE
Fix Bitget symbol format - preserve CCXT format with slashes

### DIFF
--- a/torchtrade/envs/live/bitget/observation.py
+++ b/torchtrade/envs/live/bitget/observation.py
@@ -99,9 +99,6 @@ class BitgetObservationClass(BaseFuturesObservationClass):
         Returns:
             Raw kline data from CCXT: list of [timestamp_ms, open, high, low, close, volume]
         """
-        # Ensure symbol is normalized (in case parent class modified it)
-        symbol = normalize_symbol(symbol)
-
         # CCXT uses standardized timeframe strings (1m, 5m, 1h, 1d)
         interval_ccxt = interval.lower()
 

--- a/torchtrade/envs/live/shared/futures_base_obs.py
+++ b/torchtrade/envs/live/shared/futures_base_obs.py
@@ -39,8 +39,8 @@ class BaseFuturesObservationClass(ABC):
             client: Optional pre-configured client for dependency injection (useful for testing)
             demo: Whether to use demo/testnet environment (default: True)
         """
-        # Normalize symbol (remove slash if present)
-        self.symbol = symbol.replace("/", "")
+        # Store symbol as-is (provider-specific normalization happens in subclasses)
+        self.symbol = symbol
 
         # Normalize time_frames and window_sizes to lists
         self.time_frames = [time_frames] if isinstance(time_frames, TimeFrame) else time_frames


### PR DESCRIPTION
## Summary
- Fix symbol format handling for Bitget CCXT integration
- The base observation class was incorrectly stripping `/` from symbols
- Bitget uses CCXT format which requires slashes (e.g., `BTC/USDT:USDT`)

## Changes
- `futures_base_obs.py`: Keep symbol as-is instead of stripping `/`
- `bitget/observation.py`: Remove redundant `normalize_symbol` call in `_fetch_klines`

## Problem
When passing `BTC/USDT:USDT` to Bitget environment:
1. Base class stripped `/` → `BTCUSDT:USDT`
2. `_fetch_klines` called `normalize_symbol("BTCUSDT:USDT")` 
3. `normalize_symbol` saw `:` but no `/`, applied wrong logic → `BTCUSDT:/USDT:USDT`
4. CCXT threw `BadSymbol` error

## Test plan
- [x] Tested live with Bitget Futures testnet
- [ ] Run existing tests to ensure no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)