### PR TITLE
Fix SL/TP off-by-one timing in SequentialTradingEnvSLTP

### DIFF
--- a/torchtrade/envs/offline/sequential.py
+++ b/torchtrade/envs/offline/sequential.py
@@ -387,6 +387,18 @@ class SequentialTradingEnv(TorchTradeOfflineEnv):
         # Get market data (scaffold sets current_timestamp and truncated)
         obs_dict, base_features = self._get_observation_scaffold()
         self._cached_base_features = base_features
+        return self._build_observation_from_data(obs_dict, base_features)
+
+    def _build_observation_from_data(self, obs_dict: dict, base_features: dict) -> TensorDictBase:
+        """Build observation TensorDict from already-fetched market data.
+
+        Args:
+            obs_dict: Market data observations for each timeframe.
+            base_features: Base OHLCV features for the current timestamp.
+
+        Returns:
+            TensorDict with account state and market data.
+        """
         current_price = base_features["close"]
 
         # Calculate position value (absolute value of notional)


### PR DESCRIPTION
## Summary

- Fix off-by-one timing bug where `_step()` checked SL/TP against the stale cached bar (bar N, already observed by agent) instead of the new bar (bar N+1, first unseen bar)
- Extract `_build_observation_from_data()` from `_get_observation()` to decouple sampler advancement from observation construction
- Add 3 regression tests (SL timing, TP timing, futures liquidation timing) with deterministic synthetic data
- Fix 2 silent test bugs (`trading_mode` string vs int comparison that made futures tests silently run as spot)
- Delete 2 low-value tests (`test_no_action_when_no_position`, `test_sltp_respects_transaction_fees`)

## Context

Positions got one free bar of SL/TP immunity because `_step()` checked triggers against the stale bar the agent already observed. The OneStep environment already handled this correctly — its `_rollout()` loop fetches each new bar and immediately checks SL/TP. This PR aligns the sequential SLTP env with the same semantics.

**Before (buggy):**
```
Step N: check SL/TP on bar N (stale!) → execute action → advance to bar N+1
```

**After (fixed):**
```
Step N: advance to bar N+1 → check SL/TP on bar N+1 → execute action at bar N price
```

## Test plan

- [x] 35/35 SLTP tests pass (3 new, 2 deleted, 2 bug-fixed)
- [x] 454/454 offline tests pass
- [x] 993/993 full suite passes (1 pre-existing PPO example failure)
- [x] Reviewed by TorchRL Engineer agent (TensorDict correctness verified)
- [x] Reviewed by Code Simplifier agent (suggestions applied)
- [x] Reviewed by Test Analyzer agent (8/10 gaps addressed: TP + liquidation timing tests)
- [x] Reviewed by Test Justification agent (dead tests removed, test bugs found & fixed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)