### PR TITLE
Fix sampler silent column remapping (BUG 6)

### DIFF
--- a/examples/llm/frontier/offline.py
+++ b/examples/llm/frontier/offline.py
@@ -39,7 +39,6 @@ def main():
     print("\nLoading data...")
     dataset = datasets.load_dataset("Torch-Trade/btcusdt_spot_1m_03_2023_to_12_2025")
     df = dataset["train"].to_pandas()
-    df.columns = ["timestamp", "open", "high", "low", "close", "volume"]
 
     # Convert timestamp column to datetime for proper filtering
     df['timestamp'] = pd.to_datetime(df['timestamp'])

--- a/examples/llm/local/offline.py
+++ b/examples/llm/local/offline.py
@@ -42,7 +42,6 @@ def main():
     print("\nLoading data...")
     dataset = datasets.load_dataset("Torch-Trade/btcusdt_spot_1m_03_2023_to_12_2025")
     df = dataset["train"].to_pandas()
-    df.columns = ["timestamp", "open", "high", "low", "close", "volume"]
 
     # Convert timestamp column to datetime for proper filtering
     df['timestamp'] = pd.to_datetime(df['timestamp'])

--- a/examples/offline_rl/iql/train.py
+++ b/examples/offline_rl/iql/train.py
@@ -73,7 +73,6 @@ def main(cfg: DictConfig):  # noqa: F821
     # Create env
     df = datasets.load_dataset(cfg.env.data_path)
     df = df["train"].to_pandas()
-    df.columns = ["timestamp", "open", "high", "low", "close", "volume"]
     test_df = df[0:(1440 * 14)]  # 14 days
     train_df = df[(1440 * 14):]
 

--- a/examples/online_rl/dqn/train.py
+++ b/examples/online_rl/dqn/train.py
@@ -62,7 +62,6 @@ def main(cfg: DictConfig):  # noqa: F821
     # Load data from HuggingFace
     df = datasets.load_dataset(cfg.env.data_path)
     df = df["train"].to_pandas()
-    df.columns = ["timestamp", "open", "high", "low", "close", "volume"]
 
     # Convert timestamp column to datetime for proper filtering
     df['timestamp'] = pd.to_datetime(df['timestamp'])

--- a/examples/online_rl/dsac/train.py
+++ b/examples/online_rl/dsac/train.py
@@ -73,7 +73,6 @@ def main(cfg: DictConfig):  # noqa: F821
     # Create environments
     df = datasets.load_dataset(cfg.env.data_path)
     df = df["train"].to_pandas()
-    df.columns = ["timestamp", "open", "high", "low", "close", "volume"]
 
     # Convert timestamp column to datetime for proper filtering
     df['timestamp'] = pd.to_datetime(df['timestamp'])

--- a/examples/online_rl/grpo/train.py
+++ b/examples/online_rl/grpo/train.py
@@ -52,7 +52,6 @@ def main(cfg: DictConfig):  # noqa: F821
     # Load data from HuggingFace
     df = datasets.load_dataset(cfg.env.data_path)
     df = df["train"].to_pandas()
-    df.columns = ["timestamp", "open", "high", "low", "close", "volume"]
 
     # Convert timestamp column to datetime for proper filtering
     df['timestamp'] = pd.to_datetime(df['timestamp'])

--- a/examples/online_rl/iql/train.py
+++ b/examples/online_rl/iql/train.py
@@ -71,7 +71,6 @@ def main(cfg: DictConfig):  # noqa: F821
     # Create env
     df = datasets.load_dataset(cfg.env.data_path)
     df = df["train"].to_pandas()
-    df.columns = ["timestamp", "open", "high", "low", "close", "volume"]
 
     # Convert timestamp column to datetime for proper filtering
     df['timestamp'] = pd.to_datetime(df['timestamp'])

--- a/examples/online_rl/ppo/train.py
+++ b/examples/online_rl/ppo/train.py
@@ -44,7 +44,6 @@ def main(cfg: DictConfig):  # noqa: F821
     # Create env
     df = datasets.load_dataset(cfg.env.data_path)
     df = df["train"].to_pandas()
-    df.columns = ["timestamp", "open", "high", "low", "close", "volume"]
 
     # Convert timestamp column to datetime for proper filtering
     df['timestamp'] = pd.to_datetime(df['timestamp'])

--- a/examples/online_rl/ppo_chronos/train.py
+++ b/examples/online_rl/ppo_chronos/train.py
@@ -49,7 +49,6 @@ def main(cfg: DictConfig):  # noqa: F821
     # Load data from HuggingFace
     df = datasets.load_dataset(cfg.env.data_path)
     df = df["train"].to_pandas()
-    df.columns = ["timestamp", "open", "high", "low", "close", "volume"]
 
     # Convert timestamp column to datetime for proper filtering
     df['timestamp'] = pd.to_datetime(df['timestamp'])

--- a/examples/rule_based/offline.py
+++ b/examples/rule_based/offline.py
@@ -27,7 +27,6 @@ def main():
     print("\nLoading data...")
     dataset = datasets.load_dataset("Torch-Trade/btcusdt_spot_1m_03_2023_to_12_2025")
     df = dataset["train"].to_pandas()
-    df.columns = ["timestamp", "open", "high", "low", "close", "volume"]
     df['timestamp'] = pd.to_datetime(df['timestamp'])
 
     # Create actor first to get its preprocessing function

--- a/examples/transforms/chronos_embedding_example.py
+++ b/examples/transforms/chronos_embedding_example.py
@@ -40,7 +40,6 @@ def example_basic_and_multitimeframe():
 
     df = datasets.load_dataset("Torch-Trade/btcusdt_spot_1m_03_2023_to_12_2025")
     df = df["train"].to_pandas()
-    df.columns = ["timestamp", "open", "high", "low", "close", "volume"]
 
     # Create environment with multiple timeframes
     config = SequentialTradingEnvConfig(
@@ -100,7 +99,6 @@ def example_with_policy():
 
     df = datasets.load_dataset("Torch-Trade/btcusdt_spot_1m_03_2023_to_12_2025")
     df = df["train"].to_pandas()
-    df.columns = ["timestamp", "open", "high", "low", "close", "volume"]
 
     # Create environment with Chronos embedding
     config = SequentialTradingEnvConfig(


### PR DESCRIPTION
## Summary
- **Replaced silent column rename with ValueError** in `MarketDataObservationSampler.__init__()`. Previously, when DataFrame columns didn't match `["timestamp", "open", "high", "low", "close", "volume"]`, the sampler silently renamed them by position — causing open prices to become timestamps, highs to become opens, etc. Now raises a clear error.
- **Added parametrized regression test** covering 3 failure modes: shifted columns, wrong names, and missing columns.

## Test plan
- [x] All 73 sampler tests pass (including 3 new regression tests)
- [x] All 459 offline environment tests pass
- [x] Verified existing correct-column DataFrames still initialize fine

🤖 Generated with [Claude Code](https://claude.com/claude-code)