### PR TITLE
Fix InitialBalanceSampler crash on float initial_cash

### DIFF
--- a/tests/envs/offline/test_onestep.py
+++ b/tests/envs/offline/test_onestep.py
@@ -491,6 +491,6 @@ class TestOneStepRegression:
         assert onestep_env.action_spec.n == initial_n
 
     def test_check_env_specs_passes(self, onestep_env):
-        """Regression BUG 7: check_env_specs must pass — specs must match actual output shapes."""
+        """check_env_specs must pass — specs must match actual output shapes."""
         from torchrl.envs.utils import check_env_specs
         check_env_specs(onestep_env)

--- a/tests/envs/offline/test_sampler.py
+++ b/tests/envs/offline/test_sampler.py
@@ -74,7 +74,7 @@ class TestSamplerInitialization:
         ["timestamp", "open", "high", "low", "close"],
     ], ids=["shifted-columns", "wrong-names", "missing-volume"])
     def test_sampler_raises_on_wrong_columns(self, execute_timeframe, columns):
-        """Regression BUG 6: wrong columns must raise, not silently remap by position."""
+        """Wrong columns must raise, not silently remap by position."""
         n = 200
         df = pd.DataFrame(np.random.rand(n, len(columns)), columns=columns)
 
@@ -1372,7 +1372,7 @@ class TestSamplerMultiTimeframeAlignment:
 
 class TestUndersizedWindowPadding:
     """
-    Regression tests for BUG 5 (#157): Sampler returns undersized windows silently.
+    Sampler returns undersized windows silently.
 
     When _get_observation_sequential encounters a negative start index (insufficient
     history), it must zero-pad the window to maintain the declared shape.

--- a/tests/envs/offline/test_seeding.py
+++ b/tests/envs/offline/test_seeding.py
@@ -178,6 +178,12 @@ class TestInitialBalanceSamplerSeeding:
         # Sequences should differ
         assert samples1 != samples2, "Different seeds should produce different sampling sequences"
 
+    def test_float_initial_cash_works(self):
+        """Float initial_cash should not crash."""
+        sampler = InitialBalanceSampler(initial_cash=10000.0, seed=42)
+        result = sampler.sample()
+        assert result == 10000.0
+
     def test_does_not_pollute_global_rng_state(self):
         """InitialBalanceSampler should not affect global NumPy RNG state."""
         # Set global state

--- a/tests/envs/offline/test_sequential.py
+++ b/tests/envs/offline/test_sequential.py
@@ -799,7 +799,7 @@ class TestSequentialEnvRegression:
         assert td["next"]["done"].item() is False
 
     def test_check_env_specs_passes(self, unified_env):
-        """Regression BUG 7: check_env_specs must pass — specs must match actual output shapes."""
+        """check_env_specs must pass — specs must match actual output shapes."""
         from torchrl.envs.utils import check_env_specs
         check_env_specs(unified_env)
 

--- a/tests/envs/offline/test_sequential_sltp.py
+++ b/tests/envs/offline/test_sequential_sltp.py
@@ -720,6 +720,6 @@ class TestSLTPRegression:
         env.close()
 
     def test_check_env_specs_passes(self, sltp_env):
-        """Regression BUG 7: check_env_specs must pass — specs must match actual output shapes."""
+        """check_env_specs must pass — specs must match actual output shapes."""
         from torchrl.envs.utils import check_env_specs
         check_env_specs(sltp_env)

--- a/torchtrade/envs/offline/infrastructure/utils.py
+++ b/torchtrade/envs/offline/infrastructure/utils.py
@@ -64,7 +64,7 @@ class InitialBalanceSampler:
         initial_cash: Fixed amount (int) or range [min, max] (list) for randomization
         seed: Optional random seed for reproducibility
     """
-    def __init__(self, initial_cash: Union[List[int], int], seed: Optional[int] = None):
+    def __init__(self, initial_cash: Union[List[int], int, float], seed: Optional[int] = None):
         self.initial_cash = initial_cash
         self.np_rng = np.random.default_rng(seed)
 
@@ -74,7 +74,7 @@ class InitialBalanceSampler:
         Returns:
             Initial balance as float
         """
-        if isinstance(self.initial_cash, int):
+        if isinstance(self.initial_cash, (int, float)):
             return float(self.initial_cash)
 
         return float(self.np_rng.integers(self.initial_cash[0], self.initial_cash[1]))

--- a/torchtrade/envs/offline/sequential.py
+++ b/torchtrade/envs/offline/sequential.py
@@ -52,7 +52,7 @@ class SequentialTradingEnvConfig:
     time_frames: Union[List[Union[str, TimeFrame]], Union[str, TimeFrame]] = "1Hour"
     window_sizes: Union[List[int], int] = 10
     execute_on: Union[str, TimeFrame] = "1Hour"
-    initial_cash: Union[Tuple[int, int], int] = 10000
+    initial_cash: Union[Tuple[int, int], int, float] = 10000
     transaction_fee: float = 0.0
     slippage: float = 0.0
     bankrupt_threshold: float = 0.1


### PR DESCRIPTION
## Summary
- `InitialBalanceSampler.sample()` crashed when `initial_cash` was a float (e.g. `10000.0`) because `isinstance(10000.0, int)` is `False`, causing it to fall through to the tuple/list branch
- Changed `isinstance` check to accept `(int, float)` and updated type annotations in both the sampler and config dataclass

## Test plan
- [x] Added regression test `test_float_initial_cash_works` in `test_seeding.py`
- [x] All 1008 tests pass (466 offline, full suite green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)