### PR TITLE
Remove dead code and replace print with logging

### DIFF
--- a/torchtrade/envs/core/offline_base.py
+++ b/torchtrade/envs/core/offline_base.py
@@ -377,21 +377,6 @@ class TorchTradeOfflineEnv(TorchTradeBaseEnv):
         base_features = self.sampler.get_base_features(self.current_timestamp)
         return obs_dict, base_features
 
-    def _update_position_metrics(self, current_price: float):
-        """Update position value and unrealized PnL based on current price.
-
-        This is common logic used by most environments to update position metrics
-        from the current price. Sets self.position.position_value and self.position.unrealized_pnlpc.
-
-        Args:
-            current_price: Current asset price
-        """
-        self.position.position_value = self.position.position_size * current_price
-        if self.position.position_size > 0:
-            self.position.unrealized_pnlpc = (current_price - self.position.entry_price) / self.position.entry_price
-        else:
-            self.position.unrealized_pnlpc = 0.0
-
     def _build_standard_observation(
         self,
         obs_dict: dict,

--- a/torchtrade/envs/live/binance/env.py
+++ b/torchtrade/envs/live/binance/env.py
@@ -377,7 +377,6 @@ class BinanceFuturesTorchTradingEnv(BinanceBaseTorchTradingEnv):
             current_price=current_price,
             leverage=self.config.leverage,
             transaction_fee=fee_rate,
-            allow_short=True
         )
         position_size, notional_value, side = calculate_fractional_position(params)
 

--- a/torchtrade/envs/live/bitget/env.py
+++ b/torchtrade/envs/live/bitget/env.py
@@ -301,7 +301,6 @@ class BitgetFuturesTorchTradingEnv(BitgetBaseTorchTradingEnv):
             current_price=current_price,
             leverage=self.config.leverage,
             transaction_fee=fee_rate,
-            allow_short=True
         )
         position_size, notional_value, side = calculate_fractional_position(params)
 

--- a/torchtrade/envs/offline/infrastructure/sampler.py
+++ b/torchtrade/envs/offline/infrastructure/sampler.py
@@ -1,5 +1,6 @@
 from collections import deque, namedtuple
 from typing import Dict, List, Optional, Tuple, Union, Callable, Sequence
+import logging
 import warnings
 import numpy as np
 import pandas as pd
@@ -9,6 +10,8 @@ from torchtrade.envs.utils.timeframe import TimeFrame, TimeFrameUnit, tf_to_time
 
 # Type alias for feature processing function(s)
 FeatureProcessingFn = Optional[Union[Callable, Sequence[Callable]]]
+
+logger = logging.getLogger(__name__)
 
 # PERF: NamedTuple is faster than dict for attribute access
 OHLCV = namedtuple('OHLCV', ['open', 'high', 'low', 'close', 'volume'])
@@ -185,7 +188,7 @@ class MarketDataObservationSampler:
             raise ValueError("Window duration is too large for the given dataset, no execution times found")
 
         self.max_steps = len(self.exec_times) - 1 if self.max_traj_length is None else min(len(self.exec_times) - 1, self.max_traj_length)
-        print("Max steps:", self.max_steps)
+        logger.debug("Max steps: %d", self.max_steps)
 
         self._sequential_idx = 0
         self._end_idx = len(self.exec_times)

--- a/torchtrade/envs/offline/sequential.py
+++ b/torchtrade/envs/offline/sequential.py
@@ -562,7 +562,6 @@ class SequentialTradingEnv(TorchTradeOfflineEnv):
             current_price=current_price,
             leverage=self.leverage,
             transaction_fee=self.transaction_fee,
-            allow_short=self.allows_short
         )
         position_size, notional_value, side = calculate_fractional_position(params)
 

--- a/torchtrade/envs/offline/sequential_sltp.py
+++ b/torchtrade/envs/offline/sequential_sltp.py
@@ -501,7 +501,6 @@ class SequentialTradingEnvSLTP(SequentialTradingEnv):
             current_price=execution_price,
             leverage=self.leverage,
             transaction_fee=self.transaction_fee,
-            allow_short=(side == "short")
         )
         position_size, notional_value, calc_side = calculate_fractional_position(params)
 

--- a/torchtrade/envs/utils/fractional_sizing.py
+++ b/torchtrade/envs/utils/fractional_sizing.py
@@ -12,7 +12,6 @@ class PositionCalculationParams:
     current_price: float
     leverage: int = 1
     transaction_fee: float = 0.0
-    allow_short: bool = True
 
 
 # Position tolerance constants


### PR DESCRIPTION
## Summary
- Delete unused `_update_position_metrics()` from `offline_base.py` (never called anywhere)
- Remove unused `allow_short` field from `PositionCalculationParams` and all 4 call sites (field was set but never read by `calculate_fractional_position()`)
- Replace `print("Max steps:", ...)` with `logger.debug()` in sampler

## Test plan
- [x] No behavior changes — pure dead code removal
- [x] All 1008 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)