### PR TITLE
feat: Add replay components for live SLTP environments (historical data simulation)

### DIFF
--- a/docs/environments/online.md
+++ b/docs/environments/online.md
@@ -376,6 +376,17 @@ td = env.reset()
 
 The `ReplayOrderExecutor` simulates bracket order execution with intrabar SL/TP detection (checks high/low, SL before TP).
 
+**End-of-data handling:** The observer raises `StopIteration` when historical data is exhausted. Wrap your evaluation loop accordingly:
+
+```python
+try:
+    while True:
+        action = policy(td)
+        td = env.step(action)["next"]
+except StopIteration:
+    pass  # End of historical data
+```
+
 ---
 
 ## API Key Setup

--- a/docs/environments/online.md
+++ b/docs/environments/online.md
@@ -346,7 +346,7 @@ This is useful for deploying policies trained on `OneStepTradingEnv` where posit
 
 ### Replay Mode (Historical Data Simulation)
 
-All live SLTP environments support replaying historical data through the live pipeline using `ReplayObserver` and `ReplayOrderExecutor`. This is useful for:
+All live environments (both SLTP and non-SLTP) support replaying historical data through the live pipeline using `ReplayObserver` and `ReplayOrderExecutor`. This is useful for:
 
 - Verifying that the live pipeline produces identical results to backtesting
 - Data-driven integration tests with real price data
@@ -366,8 +366,10 @@ observer = ReplayObserver(
     executor=executor,
 )
 
-# Inject into any live SLTP env — no code changes needed
+# Inject into any live env — no code changes needed
 env = BinanceFuturesSLTPTorchTradingEnv(config, observer=observer, trader=executor)
+# Also works with non-SLTP envs:
+# env = BinanceFuturesTorchTradingEnv(config, observer=observer, trader=executor)
 td = env.reset()
 # Run episode with historical data through the exact live pipeline
 ```

--- a/docs/environments/online.md
+++ b/docs/environments/online.md
@@ -344,6 +344,36 @@ config = BinanceFuturesSLTPTradingEnvConfig(
 
 This is useful for deploying policies trained on `OneStepTradingEnv` where positions are inherently locked to a single decision. See the [offline Position Locking docs](offline.md#position-locking) for details.
 
+### Replay Mode (Historical Data Simulation)
+
+All live SLTP environments support replaying historical data through the live pipeline using `ReplayObserver` and `ReplayOrderExecutor`. This is useful for:
+
+- Verifying that the live pipeline produces identical results to backtesting
+- Data-driven integration tests with real price data
+- Catching feature ordering, normalization, or action mapping bugs before deployment
+
+```python
+from torchtrade.envs.replay import ReplayObserver, ReplayOrderExecutor
+
+# Create replay components from historical data
+executor = ReplayOrderExecutor(initial_balance=10000, leverage=5, transaction_fee=0.0004)
+observer = ReplayObserver(
+    df=historical_df,  # DataFrame with timestamp, open, high, low, close, volume
+    time_frames=config.time_frames,
+    window_sizes=config.window_sizes,
+    execute_on=config.execute_on,
+    feature_preprocessing_fn=feature_fn,
+    executor=executor,
+)
+
+# Inject into any live SLTP env — no code changes needed
+env = BinanceFuturesSLTPTorchTradingEnv(config, observer=observer, trader=executor)
+td = env.reset()
+# Run episode with historical data through the exact live pipeline
+```
+
+The `ReplayOrderExecutor` simulates bracket order execution with intrabar SL/TP detection (checks high/low, SL before TP).
+
 ---
 
 ## API Key Setup

--- a/tests/envs/binance/test_torch_env_futures.py
+++ b/tests/envs/binance/test_torch_env_futures.py
@@ -461,3 +461,73 @@ class TestBinanceInitCleanup:
             mock_trader.close_position.assert_called_once()
         else:
             mock_trader.close_position.assert_not_called()
+
+
+class TestWithReplayData:
+    """Integration tests using ReplayObserver + ReplayOrderExecutor with real price data."""
+
+    @pytest.fixture
+    def replay_df(self):
+        """Create realistic OHLCV test data."""
+        import pandas as pd
+
+        n = 200
+        rng = np.random.default_rng(42)
+        base = 50000 + np.cumsum(rng.normal(0, 50, n))
+        return pd.DataFrame({
+            "timestamp": pd.date_range("2024-01-01", periods=n, freq="1min"),
+            "open": base,
+            "high": base + np.abs(rng.normal(30, 20, n)),
+            "low": base - np.abs(rng.normal(30, 20, n)),
+            "close": base + rng.normal(0, 20, n),
+            "volume": rng.uniform(100, 1000, n),
+        })
+
+    def test_multi_step_episode_with_replay(self, replay_df):
+        """Run a multi-step episode with realistic price data."""
+        from torchtrade.envs.live.binance.env import BinanceFuturesTorchTradingEnv, BinanceFuturesTradingEnvConfig
+        from torchtrade.envs.replay import ReplayObserver, ReplayOrderExecutor
+
+        config = BinanceFuturesTradingEnvConfig(
+            symbol="BTCUSDT",
+            time_frames=["1m"],
+            window_sizes=[10],
+            execute_on="1m",
+            leverage=5,
+            demo=True,
+        )
+
+        executor = ReplayOrderExecutor(initial_balance=10000.0, leverage=5)
+        observer = ReplayObserver(
+            df=replay_df,
+            time_frames=config.time_frames,
+            window_sizes=config.window_sizes,
+            execute_on=config.execute_on,
+            executor=executor,
+        )
+
+        with patch("time.sleep"), \
+             patch.object(BinanceFuturesTorchTradingEnv, "_wait_for_next_timestamp"):
+            env = BinanceFuturesTorchTradingEnv(
+                config=config, observer=observer, trader=executor,
+            )
+
+        with patch.object(env, "_wait_for_next_timestamp"):
+            td = env.reset()
+
+            for i in range(20):
+                # Cycle through action levels (hold, long, hold, short, hold, close...)
+                action_idx = i % len(env.action_levels)
+                action_td = td.clone()
+                action_td["action"] = torch.tensor(action_idx)
+                result = env.step(action_td)
+                td = result["next"]
+
+                assert "reward" in td.keys()
+                assert "done" in td.keys()
+                assert td["account_state"].shape == (6,)
+
+                if td["done"].item():
+                    break
+
+            assert executor.current_price > 0

--- a/tests/envs/binance/test_torch_env_futures_sltp.py
+++ b/tests/envs/binance/test_torch_env_futures_sltp.py
@@ -1163,3 +1163,130 @@ class TestBinanceSLTPLockPosition:
         assert trade_info["executed"] is False
         mock_trader.trade.assert_not_called()
         mock_trader.close_position.assert_not_called()
+
+
+class TestWithReplayData:
+    """Integration tests using ReplayObserver + ReplayOrderExecutor with real price data."""
+
+    @pytest.fixture
+    def replay_df(self):
+        """Create realistic OHLCV test data with price movement."""
+        import pandas as pd
+
+        n = 200
+        timestamps = pd.date_range("2024-01-01", periods=n, freq="1min")
+        base = 50000 + np.cumsum(np.random.default_rng(42).normal(0, 50, n))
+        return pd.DataFrame({
+            "timestamp": timestamps,
+            "open": base,
+            "high": base + np.abs(np.random.default_rng(43).normal(30, 20, n)),
+            "low": base - np.abs(np.random.default_rng(44).normal(30, 20, n)),
+            "close": base + np.random.default_rng(45).normal(0, 20, n),
+            "volume": np.random.default_rng(46).uniform(100, 1000, n),
+        })
+
+    def test_multi_step_episode_with_replay(self, replay_df):
+        """Run a full multi-step episode with realistic price data."""
+        from torchtrade.envs.live.binance.env_sltp import (
+            BinanceFuturesSLTPTorchTradingEnv,
+            BinanceFuturesSLTPTradingEnvConfig,
+        )
+        from torchtrade.envs.replay import ReplayObserver, ReplayOrderExecutor
+
+        config = BinanceFuturesSLTPTradingEnvConfig(
+            symbol="BTCUSDT",
+            time_frames=["1m"],
+            window_sizes=[10],
+            execute_on="1m",
+            stoploss_levels=(-0.02,),
+            takeprofit_levels=(0.03,),
+            leverage=5,
+            trade_mode="quantity",
+            quantity_per_trade=0.01,
+        )
+
+        executor = ReplayOrderExecutor(initial_balance=10000.0, leverage=5)
+        observer = ReplayObserver(
+            df=replay_df,
+            time_frames=config.time_frames,
+            window_sizes=config.window_sizes,
+            execute_on=config.execute_on,
+            executor=executor,
+        )
+
+        with patch("time.sleep"), \
+             patch.object(BinanceFuturesSLTPTorchTradingEnv, "_wait_for_next_timestamp"):
+            env = BinanceFuturesSLTPTorchTradingEnv(
+                config=config, observer=observer, trader=executor,
+            )
+
+        with patch.object(env, "_wait_for_next_timestamp"):
+            td = env.reset()
+
+            for i in range(50):
+                action = [0, 1, 0, 0, len(env.action_map) - 1, 0][i % 6]
+                action_td = td.clone()
+                action_td["action"] = torch.tensor(action)
+                result = env.step(action_td)
+                td = result["next"]
+
+                assert "reward" in td.keys()
+                assert "done" in td.keys()
+                assert td["account_state"].shape == (6,)
+
+                if td["done"].item():
+                    break
+
+    def test_replay_portfolio_tracks_price_movement(self, replay_df):
+        """Portfolio value should change with price movement, not stay static."""
+        from torchtrade.envs.live.binance.env_sltp import (
+            BinanceFuturesSLTPTorchTradingEnv,
+            BinanceFuturesSLTPTradingEnvConfig,
+        )
+        from torchtrade.envs.replay import ReplayObserver, ReplayOrderExecutor
+
+        config = BinanceFuturesSLTPTradingEnvConfig(
+            symbol="BTCUSDT",
+            time_frames=["1m"],
+            window_sizes=[10],
+            execute_on="1m",
+            stoploss_levels=(-0.05,),
+            takeprofit_levels=(0.05,),
+            leverage=5,
+            trade_mode="quantity",
+            quantity_per_trade=0.01,
+        )
+
+        executor = ReplayOrderExecutor(initial_balance=10000.0, leverage=5)
+        observer = ReplayObserver(
+            df=replay_df,
+            time_frames=config.time_frames,
+            window_sizes=config.window_sizes,
+            execute_on=config.execute_on,
+            executor=executor,
+        )
+
+        with patch("time.sleep"), \
+             patch.object(BinanceFuturesSLTPTorchTradingEnv, "_wait_for_next_timestamp"):
+            env = BinanceFuturesSLTPTorchTradingEnv(
+                config=config, observer=observer, trader=executor,
+            )
+
+        with patch.object(env, "_wait_for_next_timestamp"):
+            td = env.reset()
+
+            # Open a long position
+            action_td = td.clone()
+            action_td["action"] = torch.tensor(1)
+            td = env.step(action_td)["next"]
+
+            # Hold for several steps -- price should move, changing portfolio value
+            rewards = []
+            for _ in range(10):
+                action_td = td.clone()
+                action_td["action"] = torch.tensor(0)  # HOLD
+                td = env.step(action_td)["next"]
+                rewards.append(td["reward"].item())
+
+            # With real price movement, rewards should not all be identical
+            assert len(set(rewards)) > 1, "Rewards should vary with price movement"

--- a/tests/envs/binance/test_torch_env_futures_sltp.py
+++ b/tests/envs/binance/test_torch_env_futures_sltp.py
@@ -1281,12 +1281,12 @@ class TestWithReplayData:
             td = env.step(action_td)["next"]
 
             # Hold for several steps -- price should move, changing portfolio value
-            rewards = []
+            balances = []
             for _ in range(10):
                 action_td = td.clone()
                 action_td["action"] = torch.tensor(0)  # HOLD
                 td = env.step(action_td)["next"]
-                rewards.append(td["reward"].item())
+                balances.append(executor.get_account_balance()["total_wallet_balance"])
 
-            # With real price movement, rewards should not all be identical
-            assert len(set(rewards)) > 1, "Rewards should vary with price movement"
+            # With real price movement, portfolio value should not stay static
+            assert max(balances) != min(balances), "Portfolio value should vary with price movement"

--- a/tests/envs/bitget/test_torch_env_futures.py
+++ b/tests/envs/bitget/test_torch_env_futures.py
@@ -481,3 +481,73 @@ class TestBitgetInitCleanup:
             mock_trader.close_position.assert_called_once()
         else:
             mock_trader.close_position.assert_not_called()
+
+
+class TestWithReplayData:
+    """Integration tests using ReplayObserver + ReplayOrderExecutor with real price data."""
+
+    @pytest.fixture
+    def replay_df(self):
+        """Create realistic OHLCV test data."""
+        import pandas as pd
+
+        n = 200
+        rng = np.random.default_rng(42)
+        base = 50000 + np.cumsum(rng.normal(0, 50, n))
+        return pd.DataFrame({
+            "timestamp": pd.date_range("2024-01-01", periods=n, freq="1min"),
+            "open": base,
+            "high": base + np.abs(rng.normal(30, 20, n)),
+            "low": base - np.abs(rng.normal(30, 20, n)),
+            "close": base + rng.normal(0, 20, n),
+            "volume": rng.uniform(100, 1000, n),
+        })
+
+    def test_multi_step_episode_with_replay(self, replay_df):
+        """Run a multi-step episode with realistic price data."""
+        from torchtrade.envs.live.bitget.env import BitgetFuturesTorchTradingEnv, BitgetFuturesTradingEnvConfig
+        from torchtrade.envs.replay import ReplayObserver, ReplayOrderExecutor
+
+        config = BitgetFuturesTradingEnvConfig(
+            symbol="BTC/USDT:USDT",
+            time_frames=["1m"],
+            window_sizes=[10],
+            execute_on="1m",
+            leverage=5,
+            demo=True,
+        )
+
+        executor = ReplayOrderExecutor(initial_balance=10000.0, leverage=5)
+        observer = ReplayObserver(
+            df=replay_df,
+            time_frames=config.time_frames,
+            window_sizes=config.window_sizes,
+            execute_on=config.execute_on,
+            executor=executor,
+        )
+
+        with patch("time.sleep"), \
+             patch.object(BitgetFuturesTorchTradingEnv, "_wait_for_next_timestamp"):
+            env = BitgetFuturesTorchTradingEnv(
+                config=config, observer=observer, trader=executor,
+            )
+
+        with patch.object(env, "_wait_for_next_timestamp"):
+            td = env.reset()
+
+            for i in range(20):
+                # Cycle through action levels (hold, long, hold, short, hold, close...)
+                action_idx = i % len(env.action_levels)
+                action_td = td.clone()
+                action_td["action"] = torch.tensor(action_idx)
+                result = env.step(action_td)
+                td = result["next"]
+
+                assert "reward" in td.keys()
+                assert "done" in td.keys()
+                assert td["account_state"].shape == (6,)
+
+                if td["done"].item():
+                    break
+
+            assert executor.current_price > 0

--- a/tests/envs/bitget/test_torch_env_futures_sltp.py
+++ b/tests/envs/bitget/test_torch_env_futures_sltp.py
@@ -865,3 +865,130 @@ class TestBitgetSLTPLockPosition:
         assert trade_info["executed"] is False
         mock_trader.trade.assert_not_called()
         mock_trader.close_position.assert_not_called()
+
+
+class TestWithReplayData:
+    """Integration tests using ReplayObserver + ReplayOrderExecutor with real price data."""
+
+    @pytest.fixture
+    def replay_df(self):
+        """Create realistic OHLCV test data with price movement."""
+        import pandas as pd
+
+        n = 200
+        timestamps = pd.date_range("2024-01-01", periods=n, freq="1min")
+        base = 50000 + np.cumsum(np.random.default_rng(42).normal(0, 50, n))
+        return pd.DataFrame({
+            "timestamp": timestamps,
+            "open": base,
+            "high": base + np.abs(np.random.default_rng(43).normal(30, 20, n)),
+            "low": base - np.abs(np.random.default_rng(44).normal(30, 20, n)),
+            "close": base + np.random.default_rng(45).normal(0, 20, n),
+            "volume": np.random.default_rng(46).uniform(100, 1000, n),
+        })
+
+    def test_multi_step_episode_with_replay(self, replay_df):
+        """Run a full multi-step episode with realistic price data."""
+        from torchtrade.envs.live.bitget.env_sltp import (
+            BitgetFuturesSLTPTorchTradingEnv,
+            BitgetFuturesSLTPTradingEnvConfig,
+        )
+        from torchtrade.envs.replay import ReplayObserver, ReplayOrderExecutor
+
+        config = BitgetFuturesSLTPTradingEnvConfig(
+            symbol="BTC/USDT:USDT",
+            time_frames=["1m"],
+            window_sizes=[10],
+            execute_on="1m",
+            stoploss_levels=(-0.02,),
+            takeprofit_levels=(0.03,),
+            leverage=5,
+            trade_mode="quantity",
+            quantity_per_trade=0.01,
+        )
+
+        executor = ReplayOrderExecutor(initial_balance=10000.0, leverage=5)
+        observer = ReplayObserver(
+            df=replay_df,
+            time_frames=config.time_frames,
+            window_sizes=config.window_sizes,
+            execute_on=config.execute_on,
+            executor=executor,
+        )
+
+        with patch("time.sleep"), \
+             patch.object(BitgetFuturesSLTPTorchTradingEnv, "_wait_for_next_timestamp"):
+            env = BitgetFuturesSLTPTorchTradingEnv(
+                config=config, observer=observer, trader=executor,
+            )
+
+        with patch.object(env, "_wait_for_next_timestamp"):
+            td = env.reset()
+
+            for i in range(50):
+                action = [0, 1, 0, 0, len(env.action_map) - 1, 0][i % 6]
+                action_td = td.clone()
+                action_td["action"] = torch.tensor(action)
+                result = env.step(action_td)
+                td = result["next"]
+
+                assert "reward" in td.keys()
+                assert "done" in td.keys()
+                assert td["account_state"].shape == (6,)
+
+                if td["done"].item():
+                    break
+
+    def test_replay_portfolio_tracks_price_movement(self, replay_df):
+        """Portfolio value should change with price movement, not stay static."""
+        from torchtrade.envs.live.bitget.env_sltp import (
+            BitgetFuturesSLTPTorchTradingEnv,
+            BitgetFuturesSLTPTradingEnvConfig,
+        )
+        from torchtrade.envs.replay import ReplayObserver, ReplayOrderExecutor
+
+        config = BitgetFuturesSLTPTradingEnvConfig(
+            symbol="BTC/USDT:USDT",
+            time_frames=["1m"],
+            window_sizes=[10],
+            execute_on="1m",
+            stoploss_levels=(-0.05,),
+            takeprofit_levels=(0.05,),
+            leverage=5,
+            trade_mode="quantity",
+            quantity_per_trade=0.01,
+        )
+
+        executor = ReplayOrderExecutor(initial_balance=10000.0, leverage=5)
+        observer = ReplayObserver(
+            df=replay_df,
+            time_frames=config.time_frames,
+            window_sizes=config.window_sizes,
+            execute_on=config.execute_on,
+            executor=executor,
+        )
+
+        with patch("time.sleep"), \
+             patch.object(BitgetFuturesSLTPTorchTradingEnv, "_wait_for_next_timestamp"):
+            env = BitgetFuturesSLTPTorchTradingEnv(
+                config=config, observer=observer, trader=executor,
+            )
+
+        with patch.object(env, "_wait_for_next_timestamp"):
+            td = env.reset()
+
+            # Open a long position
+            action_td = td.clone()
+            action_td["action"] = torch.tensor(1)
+            td = env.step(action_td)["next"]
+
+            # Hold for several steps -- price should move, changing portfolio value
+            rewards = []
+            for _ in range(10):
+                action_td = td.clone()
+                action_td["action"] = torch.tensor(0)  # HOLD
+                td = env.step(action_td)["next"]
+                rewards.append(td["reward"].item())
+
+            # With real price movement, rewards should not all be identical
+            assert len(set(rewards)) > 1, "Rewards should vary with price movement"

--- a/tests/envs/bitget/test_torch_env_futures_sltp.py
+++ b/tests/envs/bitget/test_torch_env_futures_sltp.py
@@ -983,12 +983,12 @@ class TestWithReplayData:
             td = env.step(action_td)["next"]
 
             # Hold for several steps -- price should move, changing portfolio value
-            rewards = []
+            balances = []
             for _ in range(10):
                 action_td = td.clone()
                 action_td["action"] = torch.tensor(0)  # HOLD
                 td = env.step(action_td)["next"]
-                rewards.append(td["reward"].item())
+                balances.append(executor.get_account_balance()["total_wallet_balance"])
 
-            # With real price movement, rewards should not all be identical
-            assert len(set(rewards)) > 1, "Rewards should vary with price movement"
+            # With real price movement, portfolio value should not stay static
+            assert max(balances) != min(balances), "Portfolio value should vary with price movement"

--- a/tests/envs/bybit/test_torch_env_futures.py
+++ b/tests/envs/bybit/test_torch_env_futures.py
@@ -491,3 +491,73 @@ class TestBybitFractionalPositionResizing:
             # Verify no float artifacts (e.g., 0.00300000000003)
             qty_str = str(qty)
             assert len(qty_str.split('.')[-1]) <= 3, f"Float artifact in quantity: {qty}"
+
+
+class TestWithReplayData:
+    """Integration tests using ReplayObserver + ReplayOrderExecutor with real price data."""
+
+    @pytest.fixture
+    def replay_df(self):
+        """Create realistic OHLCV test data."""
+        import pandas as pd
+
+        n = 200
+        rng = np.random.default_rng(42)
+        base = 50000 + np.cumsum(rng.normal(0, 50, n))
+        return pd.DataFrame({
+            "timestamp": pd.date_range("2024-01-01", periods=n, freq="1min"),
+            "open": base,
+            "high": base + np.abs(rng.normal(30, 20, n)),
+            "low": base - np.abs(rng.normal(30, 20, n)),
+            "close": base + rng.normal(0, 20, n),
+            "volume": rng.uniform(100, 1000, n),
+        })
+
+    def test_multi_step_episode_with_replay(self, replay_df):
+        """Run a multi-step episode with realistic price data."""
+        from torchtrade.envs.live.bybit.env import BybitFuturesTorchTradingEnv, BybitFuturesTradingEnvConfig
+        from torchtrade.envs.replay import ReplayObserver, ReplayOrderExecutor
+
+        config = BybitFuturesTradingEnvConfig(
+            symbol="BTCUSDT",
+            time_frames=["1m"],
+            window_sizes=[10],
+            execute_on="1m",
+            leverage=5,
+            demo=True,
+        )
+
+        executor = ReplayOrderExecutor(initial_balance=10000.0, leverage=5)
+        observer = ReplayObserver(
+            df=replay_df,
+            time_frames=config.time_frames,
+            window_sizes=config.window_sizes,
+            execute_on=config.execute_on,
+            executor=executor,
+        )
+
+        with patch("time.sleep"), \
+             patch.object(BybitFuturesTorchTradingEnv, "_wait_for_next_timestamp"):
+            env = BybitFuturesTorchTradingEnv(
+                config=config, observer=observer, trader=executor,
+            )
+
+        with patch.object(env, "_wait_for_next_timestamp"):
+            td = env.reset()
+
+            for i in range(20):
+                # Cycle through action levels (hold, long, hold, short, hold, close...)
+                action_idx = i % len(env.action_levels)
+                action_td = td.clone()
+                action_td["action"] = torch.tensor(action_idx)
+                result = env.step(action_td)
+                td = result["next"]
+
+                assert "reward" in td.keys()
+                assert "done" in td.keys()
+                assert td["account_state"].shape == (6,)
+
+                if td["done"].item():
+                    break
+
+            assert executor.current_price > 0

--- a/tests/envs/bybit/test_torch_env_futures_sltp.py
+++ b/tests/envs/bybit/test_torch_env_futures_sltp.py
@@ -823,12 +823,12 @@ class TestWithReplayData:
             td = env.step(action_td)["next"]
 
             # Hold for several steps -- price should move, changing portfolio value
-            rewards = []
+            balances = []
             for _ in range(10):
                 action_td = td.clone()
                 action_td["action"] = torch.tensor(0)  # HOLD
                 td = env.step(action_td)["next"]
-                rewards.append(td["reward"].item())
+                balances.append(executor.get_account_balance()["total_wallet_balance"])
 
-            # With real price movement, rewards should not all be identical
-            assert len(set(rewards)) > 1, "Rewards should vary with price movement"
+            # With real price movement, portfolio value should not stay static
+            assert max(balances) != min(balances), "Portfolio value should vary with price movement"

--- a/tests/envs/bybit/test_torch_env_futures_sltp.py
+++ b/tests/envs/bybit/test_torch_env_futures_sltp.py
@@ -704,3 +704,131 @@ class TestBybitSLTPLockPosition:
             env._execute_trade_if_needed(("short", 0.02, -0.03))
             mock_env_trader.close_position.assert_called()
             mock_env_trader.trade.assert_called()
+
+
+class TestWithReplayData:
+    """Integration tests using ReplayObserver + ReplayOrderExecutor with real price data."""
+
+    @pytest.fixture
+    def replay_df(self):
+        """Create realistic OHLCV test data with price movement."""
+        import numpy as np
+        import pandas as pd
+
+        n = 200
+        timestamps = pd.date_range("2024-01-01", periods=n, freq="1min")
+        base = 50000 + np.cumsum(np.random.default_rng(42).normal(0, 50, n))
+        return pd.DataFrame({
+            "timestamp": timestamps,
+            "open": base,
+            "high": base + np.abs(np.random.default_rng(43).normal(30, 20, n)),
+            "low": base - np.abs(np.random.default_rng(44).normal(30, 20, n)),
+            "close": base + np.random.default_rng(45).normal(0, 20, n),
+            "volume": np.random.default_rng(46).uniform(100, 1000, n),
+        })
+
+    def test_multi_step_episode_with_replay(self, replay_df):
+        """Run a full multi-step episode with realistic price data."""
+        from torchtrade.envs.live.bybit.env_sltp import (
+            BybitFuturesSLTPTorchTradingEnv,
+            BybitFuturesSLTPTradingEnvConfig,
+        )
+        from torchtrade.envs.replay import ReplayObserver, ReplayOrderExecutor
+
+        config = BybitFuturesSLTPTradingEnvConfig(
+            symbol="BTCUSDT",
+            time_frames=["1m"],
+            window_sizes=[10],
+            execute_on="1m",
+            stoploss_levels=(-0.02,),
+            takeprofit_levels=(0.03,),
+            leverage=5,
+            trade_mode="quantity",
+            quantity_per_trade=0.01,
+        )
+
+        executor = ReplayOrderExecutor(initial_balance=10000.0, leverage=5)
+        observer = ReplayObserver(
+            df=replay_df,
+            time_frames=config.time_frames,
+            window_sizes=config.window_sizes,
+            execute_on=config.execute_on,
+            executor=executor,
+        )
+
+        with patch("time.sleep"), \
+             patch.object(BybitFuturesSLTPTorchTradingEnv, "_wait_for_next_timestamp"):
+            env = BybitFuturesSLTPTorchTradingEnv(
+                config=config, observer=observer, trader=executor,
+            )
+
+        with patch.object(env, "_wait_for_next_timestamp"):
+            td = env.reset()
+
+            for i in range(50):
+                action = [0, 1, 0, 0, len(env.action_map) - 1, 0][i % 6]
+                action_td = td.clone()
+                action_td["action"] = torch.tensor(action)
+                result = env.step(action_td)
+                td = result["next"]
+
+                assert "reward" in td.keys()
+                assert "done" in td.keys()
+                assert td["account_state"].shape == (6,)
+
+                if td["done"].item():
+                    break
+
+    def test_replay_portfolio_tracks_price_movement(self, replay_df):
+        """Portfolio value should change with price movement, not stay static."""
+        from torchtrade.envs.live.bybit.env_sltp import (
+            BybitFuturesSLTPTorchTradingEnv,
+            BybitFuturesSLTPTradingEnvConfig,
+        )
+        from torchtrade.envs.replay import ReplayObserver, ReplayOrderExecutor
+
+        config = BybitFuturesSLTPTradingEnvConfig(
+            symbol="BTCUSDT",
+            time_frames=["1m"],
+            window_sizes=[10],
+            execute_on="1m",
+            stoploss_levels=(-0.05,),
+            takeprofit_levels=(0.05,),
+            leverage=5,
+            trade_mode="quantity",
+            quantity_per_trade=0.01,
+        )
+
+        executor = ReplayOrderExecutor(initial_balance=10000.0, leverage=5)
+        observer = ReplayObserver(
+            df=replay_df,
+            time_frames=config.time_frames,
+            window_sizes=config.window_sizes,
+            execute_on=config.execute_on,
+            executor=executor,
+        )
+
+        with patch("time.sleep"), \
+             patch.object(BybitFuturesSLTPTorchTradingEnv, "_wait_for_next_timestamp"):
+            env = BybitFuturesSLTPTorchTradingEnv(
+                config=config, observer=observer, trader=executor,
+            )
+
+        with patch.object(env, "_wait_for_next_timestamp"):
+            td = env.reset()
+
+            # Open a long position
+            action_td = td.clone()
+            action_td["action"] = torch.tensor(1)
+            td = env.step(action_td)["next"]
+
+            # Hold for several steps -- price should move, changing portfolio value
+            rewards = []
+            for _ in range(10):
+                action_td = td.clone()
+                action_td["action"] = torch.tensor(0)  # HOLD
+                td = env.step(action_td)["next"]
+                rewards.append(td["reward"].item())
+
+            # With real price movement, rewards should not all be identical
+            assert len(set(rewards)) > 1, "Rewards should vary with price movement"

--- a/tests/envs/replay/test_replay.py
+++ b/tests/envs/replay/test_replay.py
@@ -1,0 +1,132 @@
+"""Tests for replay components."""
+
+import pytest
+from torchtrade.envs.replay.order_executor import ReplayOrderExecutor
+
+
+class TestReplayOrderExecutor:
+    """Test ReplayOrderExecutor simulated trading."""
+
+    @pytest.fixture
+    def executor(self):
+        return ReplayOrderExecutor(initial_balance=10000.0, leverage=5, transaction_fee=0.001)
+
+    def test_initial_state(self, executor):
+        """Executor starts flat with full balance."""
+        status = executor.get_status()
+        assert status["position_status"] is None
+        balance = executor.get_account_balance()
+        assert balance["total_wallet_balance"] == 10000.0
+
+    def test_open_long_position(self, executor):
+        """trade(BUY) opens a long position."""
+        executor.advance_bar({"open": 50000, "high": 50100, "low": 49900, "close": 50000})
+        success = executor.trade(side="BUY", quantity=0.1, order_type="market")
+        assert success is True
+        status = executor.get_status()
+        pos = status["position_status"]
+        assert pos is not None
+        assert pos.qty == pytest.approx(0.1)
+        assert pos.entry_price == pytest.approx(50000.0)
+
+    def test_open_short_position(self, executor):
+        """trade(SELL) opens a short position."""
+        executor.advance_bar({"open": 50000, "high": 50100, "low": 49900, "close": 50000})
+        executor.trade(side="SELL", quantity=0.1, order_type="market")
+        status = executor.get_status()
+        pos = status["position_status"]
+        assert pos.qty == pytest.approx(-0.1)
+
+    def test_close_position_with_pnl(self, executor):
+        """Closing a long position updates balance with P&L."""
+        executor.advance_bar({"open": 50000, "high": 50100, "low": 49900, "close": 50000})
+        executor.trade(side="BUY", quantity=0.1, order_type="market")
+        executor.advance_bar({"open": 50000, "high": 51000, "low": 49900, "close": 51000})
+        executor.close_position()
+        status = executor.get_status()
+        assert status["position_status"] is None
+        balance = executor.get_account_balance()
+        assert balance["total_wallet_balance"] > 10000.0
+
+    def test_get_mark_price(self, executor):
+        """get_mark_price returns the latest close price."""
+        executor.advance_bar({"open": 50000, "high": 50100, "low": 49900, "close": 50050})
+        assert executor.get_mark_price() == 50050.0
+
+    def test_bracket_status_set_on_trade(self, executor):
+        """trade() with SL/TP sets bracket_status."""
+        executor.advance_bar({"open": 50000, "high": 50100, "low": 49900, "close": 50000})
+        executor.trade(side="BUY", quantity=0.1, take_profit=51000, stop_loss=49000)
+        assert executor.bracket_status == {"tp_placed": True, "sl_placed": True}
+
+    def test_cancel_open_orders_clears_brackets(self, executor):
+        """cancel_open_orders clears active SL/TP brackets."""
+        executor.advance_bar({"open": 50000, "high": 50100, "low": 49900, "close": 50000})
+        executor.trade(side="BUY", quantity=0.1, take_profit=51000, stop_loss=49000)
+        executor.cancel_open_orders()
+        assert executor.sl_price == 0.0
+        assert executor.tp_price == 0.0
+
+
+class TestReplayOrderExecutorSLTPTriggers:
+    """Test intrabar SL/TP trigger detection via advance_bar."""
+
+    @pytest.fixture
+    def executor(self):
+        return ReplayOrderExecutor(initial_balance=10000.0, leverage=5, transaction_fee=0.0)
+
+    def test_long_sl_triggers_on_low(self, executor):
+        """Long SL triggers when bar low <= stop_loss price."""
+        executor.advance_bar({"open": 50000, "high": 50100, "low": 49900, "close": 50000})
+        executor.trade(side="BUY", quantity=0.1, stop_loss=49500, take_profit=51000)
+        executor.advance_bar({"open": 50000, "high": 50200, "low": 49000, "close": 49800})
+        status = executor.get_status()
+        assert status["position_status"] is None
+
+    def test_long_tp_triggers_on_high(self, executor):
+        """Long TP triggers when bar high >= take_profit price."""
+        executor.advance_bar({"open": 50000, "high": 50100, "low": 49900, "close": 50000})
+        executor.trade(side="BUY", quantity=0.1, stop_loss=49000, take_profit=50500)
+        executor.advance_bar({"open": 50000, "high": 51000, "low": 49900, "close": 50800})
+        status = executor.get_status()
+        assert status["position_status"] is None
+
+    def test_short_sl_triggers_on_high(self, executor):
+        """Short SL triggers when bar high >= stop_loss price."""
+        executor.advance_bar({"open": 50000, "high": 50100, "low": 49900, "close": 50000})
+        executor.trade(side="SELL", quantity=0.1, stop_loss=50500, take_profit=49000)
+        executor.advance_bar({"open": 50000, "high": 51000, "low": 49900, "close": 50800})
+        status = executor.get_status()
+        assert status["position_status"] is None
+
+    def test_short_tp_triggers_on_low(self, executor):
+        """Short TP triggers when bar low <= take_profit price."""
+        executor.advance_bar({"open": 50000, "high": 50100, "low": 49900, "close": 50000})
+        executor.trade(side="SELL", quantity=0.1, stop_loss=51000, take_profit=49500)
+        executor.advance_bar({"open": 50000, "high": 50200, "low": 49000, "close": 49800})
+        status = executor.get_status()
+        assert status["position_status"] is None
+
+    def test_sl_checked_before_tp(self, executor):
+        """When both SL and TP trigger on same bar, SL wins (pessimistic)."""
+        executor.advance_bar({"open": 50000, "high": 50100, "low": 49900, "close": 50000})
+        executor.trade(side="BUY", quantity=0.1, stop_loss=49500, take_profit=50500)
+        executor.advance_bar({"open": 50000, "high": 51000, "low": 49000, "close": 50000})
+        balance = executor.get_account_balance()
+        assert balance["total_wallet_balance"] < 10000.0
+
+    def test_no_trigger_when_flat(self, executor):
+        """advance_bar with no position should not crash."""
+        executor.advance_bar({"open": 50000, "high": 51000, "low": 49000, "close": 50000})
+        status = executor.get_status()
+        assert status["position_status"] is None
+
+    def test_transaction_fee_applied(self):
+        """Fees deducted on open and close."""
+        executor = ReplayOrderExecutor(initial_balance=10000.0, leverage=5, transaction_fee=0.001)
+        executor.advance_bar({"open": 50000, "high": 50100, "low": 49900, "close": 50000})
+        executor.trade(side="BUY", quantity=0.1, order_type="market")
+        executor.advance_bar({"open": 50000, "high": 50100, "low": 49900, "close": 50000})
+        executor.close_position()
+        balance = executor.get_account_balance()
+        assert balance["total_wallet_balance"] == pytest.approx(10000.0 - 10.0, rel=0.01)

--- a/tests/envs/replay/test_replay.py
+++ b/tests/envs/replay/test_replay.py
@@ -150,6 +150,49 @@ class TestReplayOrderExecutorSLTPTriggers:
         balance = executor.get_account_balance()
         assert balance["total_wallet_balance"] == pytest.approx(10000.0 - 10.0, rel=0.01)
 
+    def test_reset_restores_all_state(self):
+        """reset() must restore executor to initial state completely."""
+        executor = ReplayOrderExecutor(initial_balance=10000.0, leverage=5, transaction_fee=0.001)
+        executor.advance_bar({"open": 50000, "high": 50100, "low": 49900, "close": 50000})
+        executor.trade(side="BUY", quantity=0.1, stop_loss=49000, take_profit=51000)
+
+        executor.reset()
+
+        assert executor.position_qty == 0.0
+        assert executor.entry_price == 0.0
+        assert executor.balance == 10000.0
+        assert executor.sl_price == 0.0
+        assert executor.tp_price == 0.0
+        assert executor.current_price == 0.0
+        assert executor.bracket_status == {"tp_placed": False, "sl_placed": False}
+        assert executor.last_order_id is None
+        status = executor.get_status()
+        assert status["position_status"] is None
+
+    def test_short_profit_pnl(self):
+        """Short position with price drop should produce profit."""
+        executor = ReplayOrderExecutor(initial_balance=10000.0, leverage=5, transaction_fee=0.0)
+        executor.advance_bar({"open": 50000, "high": 50100, "low": 49900, "close": 50000})
+        executor.trade(side="SELL", quantity=0.1)
+        # Price drops — short profits
+        executor.advance_bar({"open": 49000, "high": 49100, "low": 48900, "close": 49000})
+        executor.close_position()
+        balance = executor.get_account_balance()
+        # PnL: -0.1 * (49000 - 50000) = +100
+        assert balance["total_wallet_balance"] > 10000.0
+
+    def test_short_loss_pnl(self):
+        """Short position with price rise should produce loss."""
+        executor = ReplayOrderExecutor(initial_balance=10000.0, leverage=5, transaction_fee=0.0)
+        executor.advance_bar({"open": 50000, "high": 50100, "low": 49900, "close": 50000})
+        executor.trade(side="SELL", quantity=0.1)
+        # Price rises — short loses
+        executor.advance_bar({"open": 51000, "high": 51100, "low": 50900, "close": 51000})
+        executor.close_position()
+        balance = executor.get_account_balance()
+        # PnL: -0.1 * (51000 - 50000) = -100
+        assert balance["total_wallet_balance"] < 10000.0
+
 
 class TestReplayObserver:
     """Test ReplayObserver wrapping MarketDataObservationSampler."""

--- a/tests/envs/replay/test_replay.py
+++ b/tests/envs/replay/test_replay.py
@@ -221,3 +221,65 @@ class TestReplayObserver:
         obs_after_reset = observer.get_observations(return_base_ohlc=True)
         reset_price = obs_after_reset["base_features"][-1, 3]
         assert reset_price == pytest.approx(first_price, rel=1e-4)
+
+
+from unittest.mock import patch
+
+
+class TestReplayIntegrationWithLiveEnv:
+    """Test replay components injected into a real live SLTP env."""
+
+    @pytest.fixture
+    def df(self):
+        return _make_test_df(200)
+
+    def test_replay_with_bybit_sltp_env(self, df):
+        """ReplayObserver + ReplayOrderExecutor work as drop-in for Bybit SLTP."""
+        from torchtrade.envs.live.bybit.env_sltp import (
+            BybitFuturesSLTPTorchTradingEnv,
+            BybitFuturesSLTPTradingEnvConfig,
+        )
+
+        config = BybitFuturesSLTPTradingEnvConfig(
+            symbol="BTCUSDT",
+            time_frames=["1m"],
+            window_sizes=[10],
+            execute_on="1m",
+            stoploss_levels=(-0.02,),
+            takeprofit_levels=(0.03,),
+            leverage=5,
+            trade_mode="quantity",
+            quantity_per_trade=0.01,
+        )
+
+        executor = ReplayOrderExecutor(initial_balance=10000.0, leverage=5)
+        observer = ReplayObserver(
+            df=df,
+            time_frames=config.time_frames,
+            window_sizes=config.window_sizes,
+            execute_on=config.execute_on,
+            executor=executor,
+        )
+
+        with patch("time.sleep"), \
+             patch.object(BybitFuturesSLTPTorchTradingEnv, "_wait_for_next_timestamp"):
+            env = BybitFuturesSLTPTorchTradingEnv(
+                config=config,
+                observer=observer,
+                trader=executor,
+            )
+
+        with patch.object(env, "_wait_for_next_timestamp"):
+            td = env.reset()
+
+            import torch
+            for i in range(10):
+                action = 1 if i % 3 == 0 else 0
+                action_td = td.clone()
+                action_td["action"] = torch.tensor(action)
+                td = env.step(action_td)["next"]
+
+                assert "reward" in td.keys()
+                assert "done" in td.keys()
+
+            assert executor.current_price > 0

--- a/tests/envs/replay/test_replay.py
+++ b/tests/envs/replay/test_replay.py
@@ -3,6 +3,7 @@
 import numpy as np
 import pandas as pd
 import pytest
+from unittest.mock import patch
 
 from torchtrade.envs.replay.observer import ReplayObserver
 from torchtrade.envs.replay.order_executor import ReplayOrderExecutor
@@ -265,8 +266,6 @@ class TestReplayObserver:
         reset_price = obs_after_reset["base_features"][-1, 3]
         assert reset_price == pytest.approx(first_price, rel=1e-4)
 
-
-from unittest.mock import patch
 
 
 class TestReplayIntegrationWithLiveEnv:

--- a/tests/envs/replay/test_replay.py
+++ b/tests/envs/replay/test_replay.py
@@ -3,6 +3,7 @@
 import numpy as np
 import pandas as pd
 import pytest
+import torch
 from unittest.mock import patch
 
 from torchtrade.envs.replay.observer import ReplayObserver
@@ -268,7 +269,6 @@ class TestReplayObserver:
         assert reset_price == pytest.approx(first_price, rel=1e-4)
 
 
-
 class TestReplayIntegrationWithLiveEnv:
     """Test replay components injected into a real live SLTP env."""
 
@@ -315,7 +315,6 @@ class TestReplayIntegrationWithLiveEnv:
         with patch.object(env, "_wait_for_next_timestamp"):
             td = env.reset()
 
-            import torch
             for i in range(10):
                 action = 1 if i % 3 == 0 else 0
                 action_td = td.clone()

--- a/tests/envs/replay/test_replay.py
+++ b/tests/envs/replay/test_replay.py
@@ -1,7 +1,26 @@
 """Tests for replay components."""
 
+import numpy as np
+import pandas as pd
 import pytest
+
+from torchtrade.envs.replay.observer import ReplayObserver
 from torchtrade.envs.replay.order_executor import ReplayOrderExecutor
+from torchtrade.envs.utils.timeframe import TimeFrame, TimeFrameUnit
+
+
+def _make_test_df(n=100):
+    """Create a simple test DataFrame with OHLCV data."""
+    timestamps = pd.date_range("2024-01-01", periods=n, freq="1min")
+    prices = np.linspace(50000, 51000, n)
+    return pd.DataFrame({
+        "timestamp": timestamps,
+        "open": prices,
+        "high": prices + 50,
+        "low": prices - 50,
+        "close": prices,
+        "volume": np.ones(n) * 100,
+    })
 
 
 class TestReplayOrderExecutor:
@@ -130,3 +149,75 @@ class TestReplayOrderExecutorSLTPTriggers:
         executor.close_position()
         balance = executor.get_account_balance()
         assert balance["total_wallet_balance"] == pytest.approx(10000.0 - 10.0, rel=0.01)
+
+
+class TestReplayObserver:
+    """Test ReplayObserver wrapping MarketDataObservationSampler."""
+
+    @pytest.fixture
+    def df(self):
+        return _make_test_df(100)
+
+    @pytest.fixture
+    def observer(self, df):
+        return ReplayObserver(
+            df=df,
+            time_frames=[TimeFrame(1, TimeFrameUnit.Minute)],
+            window_sizes=[10],
+            execute_on=TimeFrame(1, TimeFrameUnit.Minute),
+        )
+
+    def test_get_keys(self, observer):
+        """get_keys returns sampler observation keys."""
+        keys = observer.get_keys()
+        assert len(keys) == 1
+
+    def test_get_observations_returns_numpy(self, observer):
+        """get_observations returns numpy arrays (not tensors)."""
+        obs = observer.get_observations()
+        key = observer.get_keys()[0]
+        assert isinstance(obs[key], np.ndarray)
+        assert obs[key].shape[0] == 10  # window_size
+
+    def test_get_observations_advances_bar(self, observer):
+        """Each call to get_observations advances to the next bar."""
+        obs1 = observer.get_observations(return_base_ohlc=True)
+        price1 = obs1["base_features"][-1, 3]  # close
+
+        obs2 = observer.get_observations(return_base_ohlc=True)
+        price2 = obs2["base_features"][-1, 3]
+
+        assert price1 != price2
+
+    def test_get_observations_with_base_ohlc(self, observer):
+        """return_base_ohlc=True includes base_features."""
+        obs = observer.get_observations(return_base_ohlc=True)
+        assert "base_features" in obs
+        assert obs["base_features"].shape == (10, 4)
+
+    def test_observer_feeds_executor(self, df):
+        """Observer calls executor.advance_bar on each get_observations."""
+        executor = ReplayOrderExecutor(initial_balance=10000.0)
+        observer = ReplayObserver(
+            df=df,
+            time_frames=[TimeFrame(1, TimeFrameUnit.Minute)],
+            window_sizes=[10],
+            execute_on=TimeFrame(1, TimeFrameUnit.Minute),
+            executor=executor,
+        )
+
+        observer.get_observations()
+        assert executor.current_price > 0
+
+    def test_reset_resets_sampler(self, observer):
+        """reset() resets to start."""
+        obs1 = observer.get_observations(return_base_ohlc=True)
+        first_price = obs1["base_features"][-1, 3]
+
+        observer.get_observations()
+        observer.get_observations()
+        observer.reset()
+
+        obs_after_reset = observer.get_observations(return_base_ohlc=True)
+        reset_price = obs_after_reset["base_features"][-1, 3]
+        assert reset_price == pytest.approx(first_price, rel=1e-4)

--- a/tests/envs/replay/test_replay.py
+++ b/tests/envs/replay/test_replay.py
@@ -86,6 +86,7 @@ class TestReplayOrderExecutor:
         executor.cancel_open_orders()
         assert executor.sl_price == 0.0
         assert executor.tp_price == 0.0
+        assert executor.bracket_status == {"tp_placed": False, "sl_placed": False}
 
 
 class TestReplayOrderExecutorSLTPTriggers:

--- a/torchtrade/envs/replay/__init__.py
+++ b/torchtrade/envs/replay/__init__.py
@@ -1,0 +1,4 @@
+from torchtrade.envs.replay.observer import ReplayObserver
+from torchtrade.envs.replay.order_executor import ReplayOrderExecutor
+
+__all__ = ["ReplayObserver", "ReplayOrderExecutor"]

--- a/torchtrade/envs/replay/observer.py
+++ b/torchtrade/envs/replay/observer.py
@@ -58,6 +58,8 @@ class ReplayObserver:
             result[key] = tensor.numpy().astype(np.float32)
 
         if return_base_ohlc:
+            # Only the last row is populated — live envs only access [-1, 3] (close price).
+            # Earlier rows are zero-filled to match the expected (window_size, 4) shape.
             ws = self.sampler.window_sizes[0]
             base_arr = np.zeros((ws, 4), dtype=np.float32)
             base_arr[-1] = [base["open"], base["high"], base["low"], base["close"]]

--- a/torchtrade/envs/replay/observer.py
+++ b/torchtrade/envs/replay/observer.py
@@ -39,10 +39,20 @@ class ReplayObserver:
         )
         self.sampler.reset(random_start=False)
         self._obs_keys = self.sampler.get_observation_keys()
+        self.truncated = False
 
     def get_observations(self, return_base_ohlc: bool = False) -> Dict[str, np.ndarray]:
-        """Get next observation by advancing the sampler one bar."""
-        obs, timestamp, truncated = self.sampler.get_sequential_observation()
+        """Get next observation by advancing the sampler one bar.
+
+        Raises:
+            StopIteration: When historical data is exhausted
+        """
+        try:
+            obs, timestamp, truncated = self.sampler.get_sequential_observation()
+        except ValueError:
+            raise StopIteration("ReplayObserver reached end of historical data")
+
+        self.truncated = truncated
         base = self.sampler.get_base_features(timestamp)
 
         if self.executor is not None:
@@ -85,5 +95,6 @@ class ReplayObserver:
     def reset(self):
         """Reset observer to start of data."""
         self.sampler.reset(random_start=False)
+        self.truncated = False
         if self.executor is not None:
             self.executor.reset()

--- a/torchtrade/envs/replay/observer.py
+++ b/torchtrade/envs/replay/observer.py
@@ -47,7 +47,7 @@ class ReplayObserver:
         Raises:
             StopIteration: When historical data is exhausted
         """
-        if self.sampler._sequential_idx >= self.sampler._end_idx:
+        if self._is_exhausted():
             raise StopIteration("ReplayObserver reached end of historical data")
 
         obs, timestamp, truncated = self.sampler.get_sequential_observation()
@@ -91,6 +91,15 @@ class ReplayObserver:
             "observation_features": [k for k in feature_keys if k.startswith("features_")],
             "original_features": ["open", "high", "low", "close", "volume"],
         }
+
+    def _is_exhausted(self) -> bool:
+        """Check if the sampler has no more data.
+
+        Note: Accesses sampler internals (_sequential_idx, _end_idx).
+        If MarketDataObservationSampler adds a public is_exhausted() method,
+        prefer that instead.
+        """
+        return self.sampler._sequential_idx >= self.sampler._end_idx
 
     def reset(self):
         """Reset observer to start of data."""

--- a/torchtrade/envs/replay/observer.py
+++ b/torchtrade/envs/replay/observer.py
@@ -49,8 +49,10 @@ class ReplayObserver:
         """
         try:
             obs, timestamp, truncated = self.sampler.get_sequential_observation()
-        except ValueError:
-            raise StopIteration("ReplayObserver reached end of historical data")
+        except ValueError as e:
+            if "no more" in str(e).lower():
+                raise StopIteration("ReplayObserver reached end of historical data") from e
+            raise
 
         self.truncated = truncated
         base = self.sampler.get_base_features(timestamp)

--- a/torchtrade/envs/replay/observer.py
+++ b/torchtrade/envs/replay/observer.py
@@ -47,12 +47,10 @@ class ReplayObserver:
         Raises:
             StopIteration: When historical data is exhausted
         """
-        try:
-            obs, timestamp, truncated = self.sampler.get_sequential_observation()
-        except ValueError as e:
-            if "no more" in str(e).lower():
-                raise StopIteration("ReplayObserver reached end of historical data") from e
-            raise
+        if self.sampler._sequential_idx >= self.sampler._end_idx:
+            raise StopIteration("ReplayObserver reached end of historical data")
+
+        obs, timestamp, truncated = self.sampler.get_sequential_observation()
 
         self.truncated = truncated
         base = self.sampler.get_base_features(timestamp)

--- a/torchtrade/envs/replay/observer.py
+++ b/torchtrade/envs/replay/observer.py
@@ -1,0 +1,87 @@
+"""Replay observer for historical data playback through live envs."""
+
+import logging
+from typing import Callable, Dict, List, Optional, Union
+
+import numpy as np
+import pandas as pd
+
+from torchtrade.envs.offline.infrastructure.sampler import MarketDataObservationSampler
+from torchtrade.envs.utils.timeframe import TimeFrame
+
+logger = logging.getLogger(__name__)
+
+
+class ReplayObserver:
+    """Replay observer that feeds historical data through the live observer interface.
+
+    Wraps MarketDataObservationSampler to provide bar-by-bar observation playback.
+    Implements the same interface as BinanceObservationClass/BybitObservationClass
+    so it can be injected into any live SLTP environment.
+    """
+
+    def __init__(
+        self,
+        df: pd.DataFrame,
+        time_frames: Union[List[TimeFrame], TimeFrame],
+        window_sizes: Union[List[int], int],
+        execute_on: TimeFrame,
+        feature_preprocessing_fn: Optional[Callable] = None,
+        executor=None,
+    ):
+        self.executor = executor
+        self.sampler = MarketDataObservationSampler(
+            df=df,
+            time_frames=time_frames,
+            window_sizes=window_sizes,
+            execute_on=execute_on,
+            feature_processing_fn=feature_preprocessing_fn,
+        )
+        self.sampler.reset(random_start=False)
+        self._obs_keys = self.sampler.get_observation_keys()
+
+    def get_observations(self, return_base_ohlc: bool = False) -> Dict[str, np.ndarray]:
+        """Get next observation by advancing the sampler one bar."""
+        obs, timestamp, truncated = self.sampler.get_sequential_observation()
+        base = self.sampler.get_base_features(timestamp)
+
+        if self.executor is not None:
+            self.executor.advance_bar({
+                "open": base["open"],
+                "high": base["high"],
+                "low": base["low"],
+                "close": base["close"],
+            })
+
+        result = {}
+        for key, tensor in obs.items():
+            result[key] = tensor.numpy().astype(np.float32)
+
+        if return_base_ohlc:
+            ws = self.sampler.window_sizes[0]
+            base_arr = np.zeros((ws, 4), dtype=np.float32)
+            base_arr[-1] = [base["open"], base["high"], base["low"], base["close"]]
+            result["base_features"] = base_arr
+
+        return result
+
+    def get_keys(self) -> List[str]:
+        """Get observation dictionary keys."""
+        return self._obs_keys
+
+    def get_features(self) -> Dict[str, List[str]]:
+        """Get feature column names."""
+        try:
+            feature_keys = self.sampler.get_feature_keys()
+        except ValueError:
+            feature_keys = []
+        return {
+            "observation_features": [k for k in feature_keys if k.startswith("features_")],
+            "original_features": ["open", "high", "low", "close", "volume"],
+        }
+
+    def reset(self):
+        """Reset observer to start of data."""
+        self.sampler.reset(random_start=False)
+        if self.executor is not None:
+            self.executor.reset()

--- a/torchtrade/envs/replay/observer.py
+++ b/torchtrade/envs/replay/observer.py
@@ -1,6 +1,5 @@
 """Replay observer for historical data playback through live envs."""
 
-import logging
 from typing import Callable, Dict, List, Optional, Union
 
 import numpy as np
@@ -9,8 +8,6 @@ import pandas as pd
 from torchtrade.envs.offline.infrastructure.sampler import MarketDataObservationSampler
 from torchtrade.envs.utils.timeframe import TimeFrame
 
-logger = logging.getLogger(__name__)
-
 
 class ReplayObserver:
     """Replay observer that feeds historical data through the live observer interface.
@@ -18,6 +15,10 @@ class ReplayObserver:
     Wraps MarketDataObservationSampler to provide bar-by-bar observation playback.
     Implements the same interface as BinanceObservationClass/BybitObservationClass
     so it can be injected into any live SLTP environment.
+
+    Note: Raises StopIteration when historical data is exhausted. Live envs do not
+    catch this — ensure replay episodes are shorter than the available data, or wrap
+    the env in a try/except StopIteration handler for long-running evaluations.
     """
 
     def __init__(

--- a/torchtrade/envs/replay/order_executor.py
+++ b/torchtrade/envs/replay/order_executor.py
@@ -16,7 +16,8 @@ class PositionStatus:
     unrealized_pnl_pct: float
     mark_price: float
     leverage: int
-    margin_type: str
+    margin_type: str    # Binance-compatible
+    margin_mode: str    # Bybit-compatible
     liquidation_price: float
 
 
@@ -140,6 +141,10 @@ class ReplayOrderExecutor:
         side_upper = side.upper()
         price = self.current_price
 
+        # Close existing position first (if any) to avoid margin accounting errors
+        if self.position_qty != 0:
+            self._close_at_price(price)
+
         # Calculate margin and fee
         notional = quantity * price
         fee = notional * self.transaction_fee
@@ -194,6 +199,7 @@ class ReplayOrderExecutor:
                 mark_price=self.current_price,
                 leverage=self.leverage,
                 margin_type="ISOLATED",
+                margin_mode="isolated",
                 liquidation_price=0.0,
             )
         }

--- a/torchtrade/envs/replay/order_executor.py
+++ b/torchtrade/envs/replay/order_executor.py
@@ -140,8 +140,14 @@ class ReplayOrderExecutor:
             True (always succeeds in simulation)
         """
         side_upper = side.upper()
-        price = self.current_price
+        if side_upper not in ("BUY", "SELL"):
+            raise ValueError(f"Unsupported side: {side}")
+        if order_type.lower() != "market":
+            raise ValueError(f"Unsupported order_type: {order_type}")
+        if quantity <= 0:
+            raise ValueError(f"quantity must be > 0, got {quantity}")
 
+        price = self.current_price
         if price <= 0:
             raise RuntimeError("ReplayOrderExecutor.trade() called before advance_bar() set a valid price")
 
@@ -157,6 +163,11 @@ class ReplayOrderExecutor:
         notional = quantity * price
         fee = notional * self.transaction_fee
         margin_required = notional / self.leverage
+
+        # Check sufficient balance
+        if self.balance < margin_required + fee:
+            logger.warning(f"Insufficient balance: need={margin_required + fee:.2f} have={self.balance:.2f}")
+            return False
 
         # Deduct margin and fee from balance
         self.balance -= margin_required + fee
@@ -246,6 +257,7 @@ class ReplayOrderExecutor:
         """Cancel active bracket orders."""
         self.sl_price = 0.0
         self.tp_price = 0.0
+        self.bracket_status = {"tp_placed": False, "sl_placed": False}
         return True
 
     def get_open_orders(self):

--- a/torchtrade/envs/replay/order_executor.py
+++ b/torchtrade/envs/replay/order_executor.py
@@ -111,6 +111,7 @@ class ReplayOrderExecutor:
         self.entry_price = 0.0
         self.sl_price = 0.0
         self.tp_price = 0.0
+        self.bracket_status = {"tp_placed": False, "sl_placed": False}
 
     def trade(
         self,
@@ -140,6 +141,13 @@ class ReplayOrderExecutor:
         """
         side_upper = side.upper()
         price = self.current_price
+
+        if price <= 0:
+            raise RuntimeError("ReplayOrderExecutor.trade() called before advance_bar() set a valid price")
+
+        # Handle reduce_only: close existing position, don't open new one
+        if reduce_only:
+            return self.close_position()
 
         # Close existing position first (if any) to avoid margin accounting errors
         if self.position_qty != 0:

--- a/torchtrade/envs/replay/order_executor.py
+++ b/torchtrade/envs/replay/order_executor.py
@@ -1,0 +1,255 @@
+"""Replay order executor for simulated trading with historical data."""
+
+import logging
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class PositionStatus:
+    qty: float
+    notional_value: float
+    entry_price: float
+    unrealized_pnl: float
+    unrealized_pnl_pct: float
+    mark_price: float
+    leverage: int
+    margin_type: str
+    liquidation_price: float
+
+
+class ReplayOrderExecutor:
+    """Simulated order executor for replaying historical data through live envs.
+
+    Implements the same interface as BinanceFuturesOrderClass/BybitFuturesOrderClass
+    so it can be injected into any live SLTP environment.
+
+    Features:
+    - Position tracking (long/short with entry price)
+    - Balance management (margin, fees, P&L)
+    - Bracket order simulation (SL/TP prices)
+    - Intrabar SL/TP trigger detection via advance_bar()
+    """
+
+    def __init__(
+        self,
+        initial_balance: float = 10000.0,
+        leverage: int = 1,
+        transaction_fee: float = 0.0,
+    ):
+        self.initial_balance = initial_balance
+        self.leverage = leverage
+        self.transaction_fee = transaction_fee
+
+        # Position state
+        self.position_qty = 0.0
+        self.entry_price = 0.0
+        self.balance = initial_balance
+
+        # Bracket orders
+        self.sl_price = 0.0
+        self.tp_price = 0.0
+        self.bracket_status = {"tp_placed": False, "sl_placed": False}
+
+        # Current market price (updated by advance_bar)
+        self.current_price = 0.0
+
+        # Order tracking
+        self.last_order_id = None
+        self._order_counter = 0
+
+    def advance_bar(self, ohlc: Dict[str, float]):
+        """Advance to new bar and check SL/TP triggers.
+
+        Called by ReplayObserver after each bar advance.
+
+        Args:
+            ohlc: Dict with keys "open", "high", "low", "close"
+        """
+        self.current_price = float(ohlc["close"])
+
+        if self.position_qty == 0 or (self.sl_price == 0 and self.tp_price == 0):
+            return
+
+        high = float(ohlc["high"])
+        low = float(ohlc["low"])
+
+        # Check SL first (pessimistic -- matching offline env)
+        sl_triggered = False
+        tp_triggered = False
+
+        if self.sl_price > 0:
+            if self.position_qty > 0 and low <= self.sl_price:
+                sl_triggered = True
+            elif self.position_qty < 0 and high >= self.sl_price:
+                sl_triggered = True
+
+        if self.tp_price > 0:
+            if self.position_qty > 0 and high >= self.tp_price:
+                tp_triggered = True
+            elif self.position_qty < 0 and low <= self.tp_price:
+                tp_triggered = True
+
+        # SL wins over TP (pessimistic)
+        if sl_triggered:
+            self._close_at_price(self.sl_price)
+        elif tp_triggered:
+            self._close_at_price(self.tp_price)
+
+    def _close_at_price(self, price: float):
+        """Close position at specified price, updating balance."""
+        pnl = self.position_qty * (price - self.entry_price)
+        notional = abs(self.position_qty * price)
+        fee = notional * self.transaction_fee
+        margin_return = abs(self.position_qty * self.entry_price) / self.leverage
+
+        self.balance += pnl - fee + margin_return
+        self.position_qty = 0.0
+        self.entry_price = 0.0
+        self.sl_price = 0.0
+        self.tp_price = 0.0
+
+    def trade(
+        self,
+        side: str,
+        quantity: float,
+        order_type: str = "market",
+        position_side: str = "BOTH",
+        limit_price: Optional[float] = None,
+        stop_price: Optional[float] = None,
+        take_profit: Optional[float] = None,
+        stop_loss: Optional[float] = None,
+        reduce_only: bool = False,
+        time_in_force: str = "GTC",
+    ) -> bool:
+        """Execute a simulated trade.
+
+        Args:
+            side: "BUY" or "SELL" (case-insensitive)
+            quantity: Amount in base asset units
+            order_type: Only "market" supported
+            take_profit: TP price for bracket order
+            stop_loss: SL price for bracket order
+            Other args: Accepted for interface compat, ignored
+
+        Returns:
+            True (always succeeds in simulation)
+        """
+        side_upper = side.upper()
+        price = self.current_price
+
+        # Calculate margin and fee
+        notional = quantity * price
+        fee = notional * self.transaction_fee
+        margin_required = notional / self.leverage
+
+        # Deduct margin and fee from balance
+        self.balance -= margin_required + fee
+
+        # Set position
+        if side_upper == "BUY":
+            self.position_qty = quantity
+        else:
+            self.position_qty = -quantity
+        self.entry_price = price
+
+        # Set bracket orders
+        self.sl_price = float(stop_loss) if stop_loss is not None else 0.0
+        self.tp_price = float(take_profit) if take_profit is not None else 0.0
+
+        self.bracket_status = {
+            "tp_placed": take_profit is not None,
+            "sl_placed": stop_loss is not None,
+        }
+
+        # Track order
+        self._order_counter += 1
+        self.last_order_id = str(self._order_counter)
+
+        return True
+
+    def get_status(self) -> Dict[str, Optional[PositionStatus]]:
+        """Get current position status."""
+        if self.position_qty == 0:
+            return {"position_status": None}
+
+        unrealized_pnl = self.position_qty * (self.current_price - self.entry_price)
+        if self.entry_price > 0:
+            if self.position_qty > 0:
+                unrealized_pnl_pct = (self.current_price - self.entry_price) / self.entry_price
+            else:
+                unrealized_pnl_pct = (self.entry_price - self.current_price) / self.entry_price
+        else:
+            unrealized_pnl_pct = 0.0
+
+        return {
+            "position_status": PositionStatus(
+                qty=self.position_qty,
+                notional_value=abs(self.position_qty * self.current_price),
+                entry_price=self.entry_price,
+                unrealized_pnl=unrealized_pnl,
+                unrealized_pnl_pct=unrealized_pnl_pct,
+                mark_price=self.current_price,
+                leverage=self.leverage,
+                margin_type="ISOLATED",
+                liquidation_price=0.0,
+            )
+        }
+
+    def get_account_balance(self) -> Dict[str, float]:
+        """Get simulated account balance."""
+        unrealized_pnl = (
+            self.position_qty * (self.current_price - self.entry_price)
+            if self.position_qty != 0
+            else 0.0
+        )
+        total = self.balance + unrealized_pnl
+        if self.position_qty != 0:
+            margin_used = abs(self.position_qty * self.entry_price) / self.leverage
+            total += margin_used
+
+        return {
+            "total_wallet_balance": total,
+            "available_balance": self.balance,
+            "total_unrealized_profit": unrealized_pnl,
+            "total_margin_balance": total,
+        }
+
+    def get_mark_price(self) -> float:
+        """Get current mark price (latest close)."""
+        return self.current_price
+
+    def close_position(self, position_side: str = "BOTH") -> bool:
+        """Close the current position at current price."""
+        if self.position_qty == 0:
+            return True
+        self._close_at_price(self.current_price)
+        return True
+
+    def cancel_open_orders(self) -> bool:
+        """Cancel active bracket orders."""
+        self.sl_price = 0.0
+        self.tp_price = 0.0
+        return True
+
+    def get_open_orders(self):
+        """Get open orders (empty in replay)."""
+        return []
+
+    def get_lot_size(self) -> Dict[str, float]:
+        """Get lot size constraints (permissive in replay)."""
+        return {"min_qty": 0.000001, "qty_step": 0.000001}
+
+    def reset(self):
+        """Reset executor to initial state."""
+        self.position_qty = 0.0
+        self.entry_price = 0.0
+        self.balance = self.initial_balance
+        self.sl_price = 0.0
+        self.tp_price = 0.0
+        self.current_price = 0.0
+        self.bracket_status = {"tp_placed": False, "sl_placed": False}
+        self.last_order_id = None
+        self._order_counter = 0


### PR DESCRIPTION
## Summary

Closes #217

Adds exchange-agnostic `ReplayObserver` and `ReplayOrderExecutor` that replay historical data through the live SLTP pipeline. Injected via existing dependency injection — works with any live SLTP env (Binance, Bybit, Bitget, Alpaca) without code changes.

### Use cases

1. **Live-vs-backtest verification** — replay historical data through the live pipeline to catch integration bugs (feature ordering, normalization) before deploying real money
2. **Data-driven test fixtures** — replace static MagicMock with realistic price data in live env tests

### Components

| Component | File | What it does |
|-----------|------|-------------|
| `ReplayObserver` | `torchtrade/envs/replay/observer.py` | Wraps `MarketDataObservationSampler`, implements live observer interface |
| `ReplayOrderExecutor` | `torchtrade/envs/replay/order_executor.py` | Simulates positions, P&L, intrabar SL/TP detection (high/low, SL before TP) |

### Usage

```python
from torchtrade.envs.replay import ReplayObserver, ReplayOrderExecutor

executor = ReplayOrderExecutor(initial_balance=10000, leverage=5)
observer = ReplayObserver(
    df=historical_df,
    time_frames=config.time_frames,
    window_sizes=config.window_sizes,
    execute_on=config.execute_on,
    feature_preprocessing_fn=feature_fn,
    executor=executor,
)

# Inject into any live SLTP env
env = BinanceFuturesSLTPTorchTradingEnv(config, observer=observer, trader=executor)
```

### Key design decisions

- **Observer → Executor coupling**: Observer calls `executor.advance_bar(ohlc)` after each bar advance, enabling intrabar SL/TP detection before `get_status()` is called
- **SL before TP**: Pessimistic trigger ordering matches offline SLTP env behavior
- **Defensive `trade()`**: Auto-closes existing position before opening new one to prevent margin accounting errors

## Test plan

- [x] 24 tests: 7 basic trading, 7 SL/TP triggers, 3 state management (reset, short P&L), 6 observer, 1 integration with Bybit SLTP
- [x] Integration test runs 10 steps through real BybitFuturesSLTPTorchTradingEnv with replay components
- [x] Full suite: 1432 passed, 5 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)