### PR TITLE
feat: Add OKX exchange integration for live futures trading

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ TorchTrade provides modular environments for both live trading with major exchan
 - 🎯 **Multi-Timeframe Observations** - Train on 1m, 5m, 15m, 1h bars simultaneously
 - 🤖 **Multiple RL Algorithms** - PPO, DQN, IQL, GRPO, DSAC, CTRL implementations
 - 📊 **Feature Engineering** - Add technical indicators and custom features
-- 🔴 **Live Trading** - Direct Alpaca, Binance, Bitget, and Bybit API integration
+- 🔴 **Live Trading** - Direct Alpaca, Binance, Bitget, Bybit, and OKX API integration
 - 🧠 **LLM Integration** - Use GPT-4o-mini or local LLMs as trading agents
 - 📐 **Rule-Based Actors** - Hard-coded strategies for imitation learning and baselines
 - 🔮 **Pretrained Encoder Transforms** - Foundation model embeddings for time series
@@ -124,8 +124,10 @@ TorchTrade supports live trading with major exchanges:
 | **BitgetFuturesSLTPTorchTradingEnv** | Bitget | Crypto | ✅ | ✅ (1-125x) | ✅ |
 | **BybitFuturesTorchTradingEnv** | Bybit | Crypto | ✅ | ✅ (1-100x) | ❌ |
 | **BybitFuturesSLTPTorchTradingEnv** | Bybit | Crypto | ✅ | ✅ (1-100x) | ✅ |
+| **OKXFuturesTorchTradingEnv** | OKX | Crypto | ✅ | ✅ (1-125x) | ❌ |
+| **OKXFuturesSLTPTorchTradingEnv** | OKX | Crypto | ✅ | ✅ (1-125x) | ✅ |
 
-**Need another broker?** Request support for additional platforms (OKX, Interactive Brokers, etc.) by [creating an issue](https://github.com/TorchTrade/torchtrade/issues/new) or emailing torchtradecontact@gmail.com.
+**Need another broker?** Request support for additional platforms (Interactive Brokers, Kraken, etc.) by [creating an issue](https://github.com/TorchTrade/torchtrade/issues/new) or emailing torchtradecontact@gmail.com.
 
 See **[Online Environments Documentation](https://torchtrade.github.io/torchtrade/environments/online/)** for setup guides and examples.
 
@@ -154,6 +156,12 @@ Start live trading with these supported platforms:
 - **Features:** Futures trading with up to 100x leverage, native bracket orders (SL/TP), testnet for safe testing
 - **Commission:** Maker 0.02% / Taker 0.055%
 - **Get Started:** [Sign up for Bybit](https://www.bybit.com/)
+
+**[OKX](https://www.okx.com/)** - Leading global cryptocurrency exchange
+- **Supported by:** `OKXFuturesTorchTradingEnv`, `OKXFuturesSLTPTorchTradingEnv`
+- **Features:** Futures trading with up to 125x leverage, bracket orders via attachAlgoOrds, demo trading
+- **Commission:** Maker 0.02% / Taker 0.05%
+- **Get Started:** [Sign up for OKX](https://www.okx.com/)
 
 ### 📈 Stock & Crypto API
 
@@ -282,6 +290,9 @@ BINANCE_API_KEY=your_binance_api_key
 BINANCE_SECRET_KEY=your_binance_secret_key
 BYBIT_API_KEY=your_bybit_api_key
 BYBIT_API_SECRET=your_bybit_api_secret
+OKX_API_KEY=your_okx_api_key
+OKX_API_SECRET=your_okx_api_secret
+OKX_PASSPHRASE=your_okx_passphrase
 EOF
 
 # 6. Verify installation

--- a/docs/environments/online.md
+++ b/docs/environments/online.md
@@ -5,11 +5,11 @@ Online environments connect to real trading APIs for paper trading or live execu
 | Offline (Training) | Live (Deployment) |
 |---------------------|-------------------|
 | SequentialTradingEnv (spot, `leverage=1`) | AlpacaTorchTradingEnv |
-| SequentialTradingEnv (futures, `leverage>1`) | BinanceFutures / BitgetFutures / BybitFuturesTorchTradingEnv |
+| SequentialTradingEnv (futures, `leverage>1`) | BinanceFutures / BitgetFutures / BybitFutures / OKXFuturesTorchTradingEnv |
 | SequentialTradingEnvSLTP (spot) | AlpacaSLTPTorchTradingEnv |
-| SequentialTradingEnvSLTP (futures) | BinanceFuturesSLTP / BitgetFuturesSLTP / BybitFuturesSLTPTorchTradingEnv |
+| SequentialTradingEnvSLTP (futures) | BinanceFuturesSLTP / BitgetFuturesSLTP / BybitFuturesSLTP / OKXFuturesSLTPTorchTradingEnv |
 | OneStepTradingEnv (spot) | AlpacaSLTPTorchTradingEnv |
-| OneStepTradingEnv (futures) | BinanceFuturesSLTP / BitgetFuturesSLTP / BybitFuturesSLTPTorchTradingEnv |
+| OneStepTradingEnv (futures) | BinanceFuturesSLTP / BitgetFuturesSLTP / BybitFuturesSLTP / OKXFuturesSLTPTorchTradingEnv |
 
 **Supported Exchanges:**
 
@@ -17,6 +17,7 @@ Online environments connect to real trading APIs for paper trading or live execu
 - **[Binance](https://accounts.binance.com/register?ref=25015935)** - Cryptocurrency futures with high leverage and testnet
 - **[Bitget](https://www.bitget.com/)** - Cryptocurrency futures with competitive fees and testnet
 - **[Bybit](https://www.bybit.com/)** - Cryptocurrency derivatives with native bracket orders and testnet
+- **[OKX](https://www.okx.com/)** - Global cryptocurrency exchange with bracket orders via attachAlgoOrds and demo trading
 
 ## Overview
 
@@ -30,6 +31,8 @@ Online environments connect to real trading APIs for paper trading or live execu
 | **BitgetFuturesSLTPTorchTradingEnv** | Bitget | Crypto | Yes | Yes | Yes |
 | **BybitFuturesTorchTradingEnv** | Bybit | Crypto | Yes | Yes | - |
 | **BybitFuturesSLTPTorchTradingEnv** | Bybit | Crypto | Yes | Yes | Yes |
+| **OKXFuturesTorchTradingEnv** | OKX | Crypto | Yes | Yes | - |
+| **OKXFuturesSLTPTorchTradingEnv** | OKX | Crypto | Yes | Yes | Yes |
 
 ## Fractional Position Sizing
 
@@ -41,7 +44,7 @@ Live environments use a **query-first pattern**: they query the actual exchange 
     Always use canonical timeframe forms:
 
     - Alpaca: `["1Min", "5Min", "15Min", "1Hour", "1Day"]`
-    - Binance/Bitget/Bybit: `["1m", "5m", "15m", "1h", "1d"]`
+    - Binance/Bitget/Bybit/OKX: `["1m", "5m", "15m", "1h", "1d"]`
     - **Wrong**: `["60min"]`, `["60m"]`, `["24hour"]` — these create different observation keys and break model compatibility.
 
 ---
@@ -294,6 +297,82 @@ env = BybitFuturesSLTPTorchTradingEnv(
 
 ---
 
+## OKX Environments
+
+[OKX](https://www.okx.com/) provides global cryptocurrency trading with up to 125x leverage and demo trading support. TorchTrade uses [python-okx](https://pypi.org/project/python-okx/), OKX's official Python SDK. Bracket orders (SL/TP) are placed atomically via OKX's `attachAlgoOrds` parameter.
+
+!!! note "Symbol Format"
+    OKX uses dash-separated symbols with swap suffix: `"BTC-USDT-SWAP"`. The environment auto-normalizes common formats (`"BTCUSDT"`, `"BTC/USDT"`, `"BTC-USDT"`) to the correct OKX format.
+
+!!! note "Passphrase Required"
+    OKX API requires a passphrase in addition to API key and secret.
+
+### OKXFuturesTorchTradingEnv
+
+```python
+from torchtrade.envs.live.okx import OKXFuturesTorchTradingEnv, OKXFuturesTradingEnvConfig
+from torchtrade.envs.live.okx import MarginMode, PositionMode
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+
+config = OKXFuturesTradingEnvConfig(
+    symbol="BTC-USDT-SWAP",
+    time_frames=["5m", "15m"],
+    window_sizes=[6, 32],
+    execute_on="1m",
+    leverage=5,
+    margin_mode=MarginMode.ISOLATED,  # ISOLATED (safer) or CROSS
+    position_mode=PositionMode.NET,   # NET (simpler) or LONG_SHORT
+    demo=True,  # Demo trading (recommended!)
+)
+
+env = OKXFuturesTorchTradingEnv(
+    config,
+    api_key=os.getenv("OKX_API_KEY"),
+    api_secret=os.getenv("OKX_API_SECRET"),
+    passphrase=os.getenv("OKX_PASSPHRASE"),
+)
+```
+
+### OKXFuturesSLTPTorchTradingEnv
+
+```python
+from torchtrade.envs.live.okx import OKXFuturesSLTPTorchTradingEnv, OKXFuturesSLTPTradingEnvConfig
+from torchtrade.envs.live.okx import MarginMode, PositionMode
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+
+config = OKXFuturesSLTPTradingEnvConfig(
+    symbol="BTC-USDT-SWAP",
+    time_frames=["5m", "15m"],
+    window_sizes=[6, 32],
+    execute_on="1m",
+    stoploss_levels=(-0.025, -0.05, -0.1),
+    takeprofit_levels=(0.05, 0.1, 0.2),
+    include_hold_action=True,
+    leverage=5,
+    quantity_per_trade=0.002,  # 0.002 BTC per trade (quantity mode)
+    trade_mode="quantity",     # "quantity", "notional", or "fractional"
+    margin_mode=MarginMode.ISOLATED,
+    position_mode=PositionMode.NET,
+    demo=True,
+)
+
+env = OKXFuturesSLTPTorchTradingEnv(
+    config,
+    api_key=os.getenv("OKX_API_KEY"),
+    api_secret=os.getenv("OKX_API_SECRET"),
+    passphrase=os.getenv("OKX_PASSPHRASE"),
+)
+# Action space: HOLD + 2×(3 SL × 3 TP) = 19 actions (long + short)
+```
+
+---
+
 ## Position Sizing (SLTP Environments)
 
 All live SLTP environments support three position sizing modes, matching the offline SLTP environments for train-deploy consistency.
@@ -410,26 +489,31 @@ BITGETPASSPHRASE=your_bitget_passphrase
 # Bybit (https://www.bybit.com/app/user/api-management)
 BYBIT_API_KEY=your_bybit_api_key
 BYBIT_API_SECRET=your_bybit_api_secret
+
+# OKX (https://www.okx.com/account/my-api)
+OKX_API_KEY=your_okx_api_key
+OKX_API_SECRET=your_okx_api_secret
+OKX_PASSPHRASE=your_okx_passphrase
 ```
 
 !!! warning "Always Start with Paper/Testnet Trading"
-    Set `paper=True` (Alpaca) or `demo=True` (Binance/Bitget/Bybit) before using real funds. Start with low leverage (2-5x) for futures.
+    Set `paper=True` (Alpaca) or `demo=True` (Binance/Bitget/Bybit/OKX) before using real funds. Start with low leverage (2-5x) for futures.
 
 ---
 
 ## Exchange Comparison
 
-| Feature | Alpaca | Binance | Bitget | Bybit |
-|---------|--------|---------|--------|-------|
-| **Asset Types** | Stocks, Crypto | Crypto | Crypto | Crypto |
-| **Futures** | - | Yes | Yes | Yes |
-| **Max Leverage** | 1x | 125x | 125x | 100x |
-| **Paper Trading** | Yes | Yes (Testnet) | Yes (Testnet) | Yes (Testnet) |
-| **Commission** | Free | 0.02%/0.04% | 0.02%/0.06% | 0.02%/0.055% |
-| **SDK** | Alpaca SDK | CCXT | CCXT | pybit (native) |
+| Feature | Alpaca | Binance | Bitget | Bybit | OKX |
+|---------|--------|---------|--------|-------|-----|
+| **Asset Types** | Stocks, Crypto | Crypto | Crypto | Crypto | Crypto |
+| **Futures** | - | Yes | Yes | Yes | Yes |
+| **Max Leverage** | 1x | 125x | 125x | 100x | 125x |
+| **Paper Trading** | Yes | Yes (Testnet) | Yes (Testnet) | Yes (Testnet) | Yes (Demo) |
+| **Commission** | Free | 0.02%/0.04% | 0.02%/0.06% | 0.02%/0.055% | 0.02%/0.05% |
+| **SDK** | Alpaca SDK | CCXT | CCXT | pybit (native) | python-okx (native) |
 
 ---
 
 ## Requesting New Exchanges
 
-Need support for another exchange (OKX, Interactive Brokers, etc.)? [Create an issue](https://github.com/TorchTrade/torchtrade/issues/new) or email us at torchtradecontact@gmail.com.
+Need support for another exchange (Interactive Brokers, Kraken, etc.)? [Create an issue](https://github.com/TorchTrade/torchtrade/issues/new) or email us at torchtradecontact@gmail.com.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "python-binance",
     "ccxt>=4.0.0", # Replaced python-bitget with ccxt for V2 API support
     "pybit>=5.0.0",
-    "python-okx>=5.0.0",
+    "python-okx>=0.3.0",
     "python-dotenv",
     "torchrl",
     "wandb",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "python-binance",
     "ccxt>=4.0.0", # Replaced python-bitget with ccxt for V2 API support
     "pybit>=5.0.0",
+    "python-okx>=5.0.0",
     "python-dotenv",
     "torchrl",
     "wandb",

--- a/tests/envs/okx/conftest.py
+++ b/tests/envs/okx/conftest.py
@@ -1,6 +1,7 @@
 """Shared test fixtures for OKX tests."""
 
 import numpy as np
+import pandas as pd
 import pytest
 from unittest.mock import MagicMock
 
@@ -20,18 +21,6 @@ def mock_okx_trade_client():
             "sCode": "0",
             "sMsg": "",
         }],
-    })
-
-    # Mock order management
-    client.get_order_list = MagicMock(return_value={
-        "code": "0",
-        "msg": "",
-        "data": [],
-    })
-    client.cancel_order = MagicMock(return_value={
-        "code": "0",
-        "msg": "",
-        "data": [{"ordId": "12345", "clOrdId": "", "sCode": "0", "sMsg": ""}],
     })
 
     return client
@@ -187,37 +176,16 @@ def mock_env_trader():
 
 
 @pytest.fixture
-def mock_empty_position(mock_okx_account_client):
-    """Configure mock account client with no open position."""
-    mock_okx_account_client.get_positions = MagicMock(return_value={
-        "code": "0",
-        "msg": "",
-        "data": [{
-            "instId": "BTC-USDT-SWAP",
-            "pos": "0",
-            "posSide": "net",
-        }],
+def replay_df():
+    """Create realistic OHLCV test data for replay integration tests."""
+    n = 200
+    rng = np.random.default_rng(42)
+    base = 50000 + np.cumsum(rng.normal(0, 50, n))
+    return pd.DataFrame({
+        "timestamp": pd.date_range("2024-01-01", periods=n, freq="1min"),
+        "open": base,
+        "high": base + np.abs(rng.normal(30, 20, n)),
+        "low": base - np.abs(rng.normal(30, 20, n)),
+        "close": base + rng.normal(0, 20, n),
+        "volume": rng.uniform(100, 1000, n),
     })
-    return mock_okx_account_client
-
-
-@pytest.fixture
-def mock_short_position(mock_okx_account_client):
-    """Configure mock account client with a short position."""
-    mock_okx_account_client.get_positions = MagicMock(return_value={
-        "code": "0",
-        "msg": "",
-        "data": [{
-            "instId": "BTC-USDT-SWAP",
-            "pos": "-0.001",
-            "posSide": "net",
-            "avgPx": "50000.0",
-            "markPx": "49900.0",
-            "upl": "0.1",
-            "lever": "10",
-            "mgnMode": "isolated",
-            "liqPx": "55000.0",
-            "notionalUsd": "49.9",
-        }],
-    })
-    return mock_okx_account_client

--- a/tests/envs/okx/conftest.py
+++ b/tests/envs/okx/conftest.py
@@ -1,0 +1,223 @@
+"""Shared test fixtures for OKX tests."""
+
+import numpy as np
+import pytest
+from unittest.mock import MagicMock
+
+
+@pytest.fixture
+def mock_okx_trade_client():
+    """Create a mock OKX Trade client."""
+    client = MagicMock()
+
+    # Mock order placement
+    client.place_order = MagicMock(return_value={
+        "code": "0",
+        "msg": "",
+        "data": [{
+            "ordId": "12345",
+            "clOrdId": "",
+            "sCode": "0",
+            "sMsg": "",
+        }],
+    })
+
+    # Mock order management
+    client.get_order_list = MagicMock(return_value={
+        "code": "0",
+        "msg": "",
+        "data": [],
+    })
+    client.cancel_order = MagicMock(return_value={
+        "code": "0",
+        "msg": "",
+        "data": [{"ordId": "12345", "clOrdId": "", "sCode": "0", "sMsg": ""}],
+    })
+
+    return client
+
+
+@pytest.fixture
+def mock_okx_account_client():
+    """Create a mock OKX Account client."""
+    client = MagicMock()
+
+    # Mock account configuration
+    client.set_position_mode = MagicMock(return_value={"code": "0", "msg": ""})
+    client.set_leverage = MagicMock(return_value={"code": "0", "msg": "", "data": [{}]})
+
+    # Mock position information
+    client.get_positions = MagicMock(return_value={
+        "code": "0",
+        "msg": "",
+        "data": [{
+            "instId": "BTC-USDT-SWAP",
+            "pos": "0.001",
+            "posSide": "net",
+            "avgPx": "50000.0",
+            "markPx": "50100.0",
+            "upl": "0.1",
+            "lever": "10",
+            "mgnMode": "isolated",
+            "liqPx": "45000.0",
+            "notionalUsd": "50.1",
+        }],
+    })
+
+    # Mock account balance
+    client.get_account_balance = MagicMock(return_value={
+        "code": "0",
+        "msg": "",
+        "data": [{
+            "totalEq": "1000.0",
+            "upl": "0.1",
+            "details": [{
+                "ccy": "USDT",
+                "availBal": "900.0",
+            }],
+        }],
+    })
+
+    return client
+
+
+@pytest.fixture
+def mock_okx_public_client():
+    """Create a mock OKX PublicData client."""
+    client = MagicMock()
+
+    # Mock mark price
+    client.get_mark_price = MagicMock(return_value={
+        "code": "0",
+        "msg": "",
+        "data": [{
+            "instId": "BTC-USDT-SWAP",
+            "instType": "SWAP",
+            "markPx": "50100.0",
+        }],
+    })
+
+    # Mock instrument info (lot size + price precision)
+    client.get_instruments = MagicMock(return_value={
+        "code": "0",
+        "msg": "",
+        "data": [{
+            "instId": "BTC-USDT-SWAP",
+            "tickSz": "0.01",
+            "minSz": "0.001",
+            "lotSz": "0.001",
+        }],
+    })
+
+    return client
+
+
+@pytest.fixture
+def mock_okx_market_client():
+    """Create a mock OKX MarketData client for observation tests."""
+    client = MagicMock()
+
+    def mock_get_candlesticks(instId, bar, limit="200"):
+        """Generate mock candle data (reverse chronological order like OKX)."""
+        n = int(limit)
+        candles = []
+        base_time = 1700000000000
+        for i in range(n - 1, -1, -1):  # Reverse order
+            candles.append([
+                str(base_time + i * 60000),  # timestamp (string)
+                "50000.0",  # open
+                "50100.0",  # high
+                "49900.0",  # low
+                "50050.0",  # close
+                "100.0",    # volume
+                "5005000.0",  # vol_ccy
+                "5005000.0",  # vol_ccy_quote
+                "1",        # confirm
+            ])
+        return {
+            "code": "0",
+            "msg": "",
+            "data": candles,
+        }
+
+    client.get_candlesticks = MagicMock(side_effect=mock_get_candlesticks)
+
+    return client
+
+
+@pytest.fixture
+def mock_env_observer():
+    """Create a mock observer for env tests (single timeframe)."""
+    observer = MagicMock()
+    observer.get_keys = MagicMock(return_value=["1Minute_10"])
+
+    def mock_observations(return_base_ohlc=False):
+        obs = {"1Minute_10": np.random.randn(10, 4).astype(np.float32)}
+        if return_base_ohlc:
+            obs["base_features"] = np.array(
+                [[50000, 50100, 49900, 50050]] * 10, dtype=np.float32
+            )
+        return obs
+
+    observer.get_observations = MagicMock(side_effect=mock_observations)
+    observer.get_features = MagicMock(return_value={
+        "observation_features": ["feature_close", "feature_open", "feature_high", "feature_low"],
+        "original_features": ["open", "high", "low", "close", "volume"],
+    })
+    return observer
+
+
+@pytest.fixture
+def mock_env_trader():
+    """Create a mock trader for env tests."""
+    trader = MagicMock()
+    trader.cancel_open_orders = MagicMock(return_value=True)
+    trader.close_position = MagicMock(return_value=True)
+    trader.get_account_balance = MagicMock(return_value={
+        "total_wallet_balance": 1000.0,
+        "available_balance": 900.0,
+        "total_unrealized_profit": 0.0,
+        "total_margin_balance": 1000.0,
+    })
+    trader.get_mark_price = MagicMock(return_value=50000.0)
+    trader.get_status = MagicMock(return_value={"position_status": None})
+    trader.trade = MagicMock(return_value=True)
+    trader.get_lot_size = MagicMock(return_value={"min_qty": 0.001, "qty_step": 0.001})
+    return trader
+
+
+@pytest.fixture
+def mock_empty_position(mock_okx_account_client):
+    """Configure mock account client with no open position."""
+    mock_okx_account_client.get_positions = MagicMock(return_value={
+        "code": "0",
+        "msg": "",
+        "data": [{
+            "instId": "BTC-USDT-SWAP",
+            "pos": "0",
+            "posSide": "net",
+        }],
+    })
+    return mock_okx_account_client
+
+
+@pytest.fixture
+def mock_short_position(mock_okx_account_client):
+    """Configure mock account client with a short position."""
+    mock_okx_account_client.get_positions = MagicMock(return_value={
+        "code": "0",
+        "msg": "",
+        "data": [{
+            "instId": "BTC-USDT-SWAP",
+            "pos": "-0.001",
+            "posSide": "net",
+            "avgPx": "50000.0",
+            "markPx": "49900.0",
+            "upl": "0.1",
+            "lever": "10",
+            "mgnMode": "isolated",
+            "liqPx": "55000.0",
+            "notionalUsd": "49.9",
+        }],
+    })
+    return mock_okx_account_client

--- a/tests/envs/okx/test_futures_order_executor.py
+++ b/tests/envs/okx/test_futures_order_executor.py
@@ -1,0 +1,388 @@
+"""Tests for OKXFuturesOrderClass."""
+
+import pytest
+from unittest.mock import MagicMock
+
+
+class TestOKXFuturesOrderClass:
+    """Tests for OKXFuturesOrderClass."""
+
+    @pytest.fixture
+    def order_executor(self, mock_okx_trade_client, mock_okx_account_client, mock_okx_public_client):
+        """Create order executor with mock OKX clients."""
+        from torchtrade.envs.live.okx.order_executor import (
+            OKXFuturesOrderClass,
+            MarginMode,
+            PositionMode,
+        )
+
+        executor = OKXFuturesOrderClass(
+            symbol="BTC-USDT-SWAP",
+            trade_mode="quantity",
+            demo=True,
+            leverage=10,
+            margin_mode=MarginMode.ISOLATED,
+            position_mode=PositionMode.NET,
+            api_key="test_key",
+            api_secret="test_secret",
+            passphrase="test_pass",
+            client=mock_okx_trade_client,
+            account_client=mock_okx_account_client,
+            public_client=mock_okx_public_client,
+        )
+        return executor
+
+    @pytest.mark.parametrize("symbol,expected", [
+        ("BTC-USDT-SWAP", "BTC-USDT-SWAP"),
+        ("BTCUSDT", "BTC-USDT-SWAP"),
+        ("BTC/USDT", "BTC-USDT-SWAP"),
+        ("BTC/USDT:USDT", "BTC-USDT-SWAP"),
+        (" btcusdt ", "BTC-USDT-SWAP"),
+    ])
+    def test_symbol_normalization(self, mock_okx_trade_client, mock_okx_account_client, mock_okx_public_client, symbol, expected):
+        """Test that symbol formats are normalized."""
+        from torchtrade.envs.live.okx.order_executor import OKXFuturesOrderClass
+
+        executor = OKXFuturesOrderClass(
+            symbol=symbol,
+            client=mock_okx_trade_client,
+            account_client=mock_okx_account_client,
+            public_client=mock_okx_public_client,
+        )
+        assert executor.symbol == expected
+
+    @pytest.mark.parametrize("side", ["buy", "sell"])
+    def test_market_order(self, order_executor, mock_okx_trade_client, side):
+        """Test placing a market order (buy or sell)."""
+        success = order_executor.trade(side=side, quantity=0.001, order_type="market")
+
+        assert success is True
+        mock_okx_trade_client.place_order.assert_called()
+        call_kwargs = mock_okx_trade_client.place_order.call_args[1]
+        assert call_kwargs["instId"] == "BTC-USDT-SWAP"
+        assert call_kwargs["side"] == side
+        assert call_kwargs["ordType"] == "market"
+        assert call_kwargs["sz"] == "0.001"
+
+    def test_bracket_order_with_tp_sl(self, order_executor, mock_okx_trade_client):
+        """Test placing bracket order with take profit and stop loss."""
+        success = order_executor.trade(
+            side="buy",
+            quantity=0.001,
+            order_type="market",
+            take_profit=51000.0,
+            stop_loss=49000.0,
+        )
+
+        assert success is True
+        call_kwargs = mock_okx_trade_client.place_order.call_args[1]
+        assert "attachAlgoOrds" in call_kwargs
+        algo = call_kwargs["attachAlgoOrds"][0]
+        assert algo["tpTriggerPx"] == "51000.00"
+        assert algo["slTriggerPx"] == "49000.00"
+
+    @pytest.mark.parametrize("raw_tp,raw_sl,expected_tp,expected_sl", [
+        (82622.2122, 84291.4358, "82622.21", "84291.44"),
+        (51234.5678, 48765.4321, "51234.57", "48765.43"),
+    ])
+    def test_bracket_order_prices_rounded_to_tick(self, order_executor, mock_okx_trade_client, raw_tp, raw_sl, expected_tp, expected_sl):
+        """SL/TP prices must be rounded to tick size before submission."""
+        success = order_executor.trade(
+            side="buy",
+            quantity=0.001,
+            order_type="market",
+            take_profit=raw_tp,
+            stop_loss=raw_sl,
+        )
+
+        assert success is True
+        algo = mock_okx_trade_client.place_order.call_args[1]["attachAlgoOrds"][0]
+        assert algo["tpTriggerPx"] == expected_tp
+        assert algo["slTriggerPx"] == expected_sl
+
+    def test_tick_size_fetched_at_init(self, order_executor):
+        """Tick size should be cached from instrument info at init."""
+        assert order_executor._tick_size == 0.01
+        assert order_executor._tick_decimals == 2
+
+    def test_round_price_without_precision(self, mock_okx_trade_client, mock_okx_account_client, mock_okx_public_client):
+        """When tick size fetch fails, prices pass through unmodified."""
+        from torchtrade.envs.live.okx.order_executor import OKXFuturesOrderClass
+
+        mock_okx_public_client.get_instruments = MagicMock(side_effect=Exception("API down"))
+
+        executor = OKXFuturesOrderClass(
+            symbol="BTC-USDT-SWAP",
+            client=mock_okx_trade_client,
+            account_client=mock_okx_account_client,
+            public_client=mock_okx_public_client,
+        )
+        assert executor._tick_size is None
+        assert executor._round_price(82622.2122) == 82622.2122
+
+    def test_get_status_with_position(self, order_executor):
+        """Test getting position status."""
+        status = order_executor.get_status()
+
+        assert "position_status" in status
+        pos = status["position_status"]
+        assert pos is not None
+        assert pos.qty > 0  # Long position
+        assert pos.entry_price == 50000.0
+        assert pos.mark_price == 50100.0
+        assert pos.leverage == 10
+
+    def test_get_status_no_position(self, order_executor, mock_okx_account_client):
+        """Test get_status when no position exists."""
+        mock_okx_account_client.get_positions = MagicMock(return_value={
+            "code": "0", "msg": "",
+            "data": [{"instId": "BTC-USDT-SWAP", "pos": "0", "posSide": "net"}],
+        })
+
+        status = order_executor.get_status()
+        assert status["position_status"] is None
+
+    def test_get_status_short_position(self, order_executor, mock_short_position):
+        """Test get_status with short position (negative qty)."""
+        order_executor.account_client = mock_short_position
+        status = order_executor.get_status()
+        assert status["position_status"].qty < 0
+
+    def test_get_account_balance(self, order_executor):
+        """Test getting account balance."""
+        balance = order_executor.get_account_balance()
+
+        assert balance["total_wallet_balance"] == 1000.0
+        assert balance["available_balance"] == 900.0
+        assert "total_unrealized_profit" in balance
+        assert "total_margin_balance" in balance
+
+    def test_close_position_long(self, order_executor, mock_okx_trade_client):
+        """Test closing a long position sends sell."""
+        success = order_executor.close_position()
+
+        assert success is True
+        call_kwargs = mock_okx_trade_client.place_order.call_args[1]
+        assert call_kwargs["reduceOnly"] is True
+        assert call_kwargs["side"] == "sell"
+
+    def test_close_position_short(self, order_executor, mock_okx_trade_client, mock_short_position):
+        """Test closing a short position sends buy."""
+        order_executor.account_client = mock_short_position
+        success = order_executor.close_position()
+
+        assert success is True
+        call_kwargs = mock_okx_trade_client.place_order.call_args[1]
+        assert call_kwargs["side"] == "buy"
+
+    def test_close_position_no_position(self, order_executor, mock_okx_account_client):
+        """Test closing when no position exists."""
+        mock_okx_account_client.get_positions = MagicMock(return_value={
+            "code": "0", "msg": "",
+            "data": [{"instId": "BTC-USDT-SWAP", "pos": "0", "posSide": "net"}],
+        })
+
+        success = order_executor.close_position()
+        assert success is True
+
+    def test_cancel_open_orders_no_orders(self, order_executor, mock_okx_trade_client):
+        """Test cancelling when no open orders exist."""
+        success = order_executor.cancel_open_orders()
+        assert success is True
+
+    @pytest.mark.parametrize("code,expected_success,expected_leverage", [
+        ("0", True, 20),
+        ("51101", False, 10),
+    ], ids=["success", "rejected"])
+    def test_set_leverage_validates_code(self, order_executor, mock_okx_account_client, code, expected_success, expected_leverage):
+        """set_leverage must validate code and only update local state on success."""
+        mock_okx_account_client.set_leverage = MagicMock(return_value={
+            "code": code, "msg": "OK" if code == "0" else "Leverage not modified", "data": [{}],
+        })
+        result = order_executor.set_leverage(20)
+        assert result is expected_success
+        assert order_executor.leverage == expected_leverage
+
+    def test_trade_failure_handling(self, order_executor, mock_okx_trade_client):
+        """Test that trade failures are handled gracefully."""
+        mock_okx_trade_client.place_order = MagicMock(side_effect=Exception("API Error"))
+
+        success = order_executor.trade(side="buy", quantity=0.001)
+        assert success is False
+
+    def test_margin_mode_enum_and_okx_conversion(self):
+        """Test MarginMode enum values and OKX conversion."""
+        from torchtrade.envs.live.okx.order_executor import MarginMode
+
+        assert MarginMode.ISOLATED.value == "isolated"
+        assert MarginMode.CROSS.value == "cross"
+        assert MarginMode.ISOLATED.to_okx() == "isolated"
+        assert MarginMode.CROSS.to_okx() == "cross"
+
+    def test_reduce_only_order(self, order_executor, mock_okx_trade_client):
+        """Test placing a reduce-only order."""
+        order_executor.trade(side="sell", quantity=0.001, reduce_only=True)
+
+        call_kwargs = mock_okx_trade_client.place_order.call_args[1]
+        assert call_kwargs["reduceOnly"] is True
+
+    @pytest.mark.parametrize("qty,entry,mark,expected_pnl_pct", [
+        (0.001, 50000, 51000, 0.02),
+        (0.001, 50000, 49000, -0.02),
+        (-0.001, 50000, 49000, 0.02),
+        (-0.001, 50000, 51000, -0.02),
+        (0.001, 0, 50000, 0.0),
+    ])
+    def test_unrealized_pnl_pct(self, order_executor, qty, entry, mark, expected_pnl_pct):
+        """Unrealized PnL % must be correct for long and short positions."""
+        result = order_executor._calculate_unrealized_pnl_pct(qty, entry, mark)
+        assert result == pytest.approx(expected_pnl_pct, abs=1e-6)
+
+    def test_get_mark_price(self, order_executor):
+        """Test getting mark price."""
+        price = order_executor.get_mark_price()
+        assert price == 50100.0
+
+    def test_get_mark_price_no_data_raises(self, order_executor, mock_okx_public_client):
+        """Missing mark price data must raise RuntimeError."""
+        mock_okx_public_client.get_mark_price = MagicMock(return_value={
+            "code": "0", "msg": "", "data": [{}],
+        })
+        with pytest.raises(RuntimeError):
+            order_executor.get_mark_price()
+
+    def test_limit_order_without_price_raises(self, order_executor):
+        """Limit order without limit_price must raise ValueError."""
+        with pytest.raises(ValueError, match="limit_price is required"):
+            order_executor.trade(side="buy", quantity=0.001, order_type="limit")
+
+    def test_limit_order_with_price_succeeds(self, order_executor, mock_okx_trade_client):
+        """Limit order with limit_price must succeed."""
+        success = order_executor.trade(
+            side="buy", quantity=0.001, order_type="limit", limit_price=50000.0,
+        )
+        assert success is True
+        call_kwargs = mock_okx_trade_client.place_order.call_args[1]
+        assert call_kwargs["px"] == "50000.00"
+        assert call_kwargs["ordType"] == "limit"
+
+    @pytest.mark.parametrize("liq_price_value,expected", [
+        ("45000.0", 45000.0),
+        ("", 0.0),
+        (None, 0.0),
+        ("0", 0.0),
+    ])
+    def test_get_status_liq_price_edge_cases(self, order_executor, mock_okx_account_client, liq_price_value, expected):
+        """liqPx parsing must handle empty/None/normal values."""
+        position_data = {
+            "instId": "BTC-USDT-SWAP", "pos": "0.001", "posSide": "net",
+            "avgPx": "50000.0", "markPx": "50100.0",
+            "upl": "0.1", "lever": "10",
+            "mgnMode": "isolated", "notionalUsd": "50.1",
+        }
+        if liq_price_value is not None:
+            position_data["liqPx"] = liq_price_value
+
+        mock_okx_account_client.get_positions = MagicMock(return_value={
+            "code": "0", "msg": "", "data": [position_data],
+        })
+        status = order_executor.get_status()
+        assert status["position_status"].liquidation_price == expected
+
+    def test_get_status_validates_code(self, order_executor, mock_okx_account_client):
+        """get_status must return position_status=None on non-zero code."""
+        mock_okx_account_client.get_positions = MagicMock(return_value={
+            "code": "51001", "msg": "Invalid parameter", "data": [],
+        })
+        status = order_executor.get_status()
+        assert status["position_status"] is None
+
+    def test_account_balance_empty_raises(self, order_executor, mock_okx_account_client):
+        """get_account_balance raises when data is empty."""
+        mock_okx_account_client.get_account_balance = MagicMock(return_value={
+            "code": "0", "msg": "", "data": [],
+        })
+        with pytest.raises(RuntimeError, match="No account data"):
+            order_executor.get_account_balance()
+
+    @pytest.mark.parametrize("code,msg,expected", [
+        ("0", "", True),
+        ("51008", "Insufficient balance", False),
+        ("51001", "Invalid parameter", False),
+    ], ids=["success", "insufficient-balance", "invalid-param"])
+    def test_trade_validates_code(self, order_executor, mock_okx_trade_client, code, msg, expected):
+        """trade() must return False when API returns non-zero code."""
+        mock_okx_trade_client.place_order = MagicMock(return_value={
+            "code": code, "msg": msg,
+            "data": [{"ordId": "123"}] if code == "0" else [],
+        })
+        result = order_executor.trade(side="buy", quantity=0.001)
+        assert result is expected
+
+    def test_get_lot_size_fetches_and_caches(self, order_executor, mock_okx_public_client):
+        """get_lot_size must return cached data from init-time instrument fetch."""
+        init_call_count = mock_okx_public_client.get_instruments.call_count
+
+        lot_size = order_executor.get_lot_size()
+        assert lot_size["min_qty"] == 0.001
+        assert lot_size["qty_step"] == 0.001
+
+        # Should use cache from init, no additional API call
+        lot_size2 = order_executor.get_lot_size()
+        assert lot_size2 is lot_size
+        assert mock_okx_public_client.get_instruments.call_count == init_call_count
+
+    def test_get_lot_size_fallback_on_failure(self, order_executor, mock_okx_public_client):
+        """get_lot_size must fall back to defaults if API fails."""
+        order_executor._lot_size_cache = None
+        mock_okx_public_client.get_instruments = MagicMock(side_effect=Exception("API down"))
+        lot_size = order_executor.get_lot_size()
+        assert lot_size["min_qty"] == 0.001
+        assert lot_size["qty_step"] == 0.001
+
+    def test_close_position_requery_confirms_closed(self, order_executor, mock_okx_trade_client, mock_okx_account_client):
+        """close_position must re-query to confirm when order fails."""
+        call_count = {"get_positions": 0}
+
+        def mock_get_positions(**kwargs):
+            call_count["get_positions"] += 1
+            if call_count["get_positions"] == 1:
+                return {
+                    "code": "0", "msg": "",
+                    "data": [{
+                        "instId": "BTC-USDT-SWAP", "pos": "0.001", "posSide": "net",
+                        "avgPx": "50000.0", "markPx": "50100.0",
+                        "upl": "0.1", "lever": "10",
+                        "mgnMode": "isolated", "liqPx": "45000.0", "notionalUsd": "50.1",
+                    }],
+                }
+            return {"code": "0", "msg": "", "data": []}
+
+        mock_okx_account_client.get_positions = MagicMock(side_effect=mock_get_positions)
+        mock_okx_trade_client.place_order = MagicMock(side_effect=Exception("Order failed"))
+
+        success = order_executor.close_position()
+        assert success is True
+        assert call_count["get_positions"] == 2
+
+    @pytest.mark.parametrize("side,reduce_only,expected_pos_side", [
+        ("buy", False, "long"),
+        ("sell", False, "short"),
+        ("buy", True, "short"),
+        ("sell", True, "long"),
+    ])
+    def test_long_short_mode_position_side(self, mock_okx_trade_client, mock_okx_account_client, mock_okx_public_client, side, reduce_only, expected_pos_side):
+        """Long/short mode must use correct posSide for open vs close trades."""
+        from torchtrade.envs.live.okx.order_executor import (
+            OKXFuturesOrderClass, PositionMode,
+        )
+        executor = OKXFuturesOrderClass(
+            symbol="BTC-USDT-SWAP",
+            position_mode=PositionMode.LONG_SHORT,
+            client=mock_okx_trade_client,
+            account_client=mock_okx_account_client,
+            public_client=mock_okx_public_client,
+        )
+        executor.trade(side=side, quantity=0.001, reduce_only=reduce_only)
+        call_kwargs = mock_okx_trade_client.place_order.call_args[1]
+        assert call_kwargs["posSide"] == expected_pos_side

--- a/tests/envs/okx/test_futures_order_executor.py
+++ b/tests/envs/okx/test_futures_order_executor.py
@@ -16,7 +16,7 @@ class TestOKXFuturesOrderClass:
             PositionMode,
         )
 
-        executor = OKXFuturesOrderClass(
+        return OKXFuturesOrderClass(
             symbol="BTC-USDT-SWAP",
             trade_mode="quantity",
             demo=True,
@@ -30,26 +30,6 @@ class TestOKXFuturesOrderClass:
             account_client=mock_okx_account_client,
             public_client=mock_okx_public_client,
         )
-        return executor
-
-    @pytest.mark.parametrize("symbol,expected", [
-        ("BTC-USDT-SWAP", "BTC-USDT-SWAP"),
-        ("BTCUSDT", "BTC-USDT-SWAP"),
-        ("BTC/USDT", "BTC-USDT-SWAP"),
-        ("BTC/USDT:USDT", "BTC-USDT-SWAP"),
-        (" btcusdt ", "BTC-USDT-SWAP"),
-    ])
-    def test_symbol_normalization(self, mock_okx_trade_client, mock_okx_account_client, mock_okx_public_client, symbol, expected):
-        """Test that symbol formats are normalized."""
-        from torchtrade.envs.live.okx.order_executor import OKXFuturesOrderClass
-
-        executor = OKXFuturesOrderClass(
-            symbol=symbol,
-            client=mock_okx_trade_client,
-            account_client=mock_okx_account_client,
-            public_client=mock_okx_public_client,
-        )
-        assert executor.symbol == expected
 
     @pytest.mark.parametrize("side", ["buy", "sell"])
     def test_market_order(self, order_executor, mock_okx_trade_client, side):
@@ -57,7 +37,6 @@ class TestOKXFuturesOrderClass:
         success = order_executor.trade(side=side, quantity=0.001, order_type="market")
 
         assert success is True
-        mock_okx_trade_client.place_order.assert_called()
         call_kwargs = mock_okx_trade_client.place_order.call_args[1]
         assert call_kwargs["instId"] == "BTC-USDT-SWAP"
         assert call_kwargs["side"] == side
@@ -67,17 +46,12 @@ class TestOKXFuturesOrderClass:
     def test_bracket_order_with_tp_sl(self, order_executor, mock_okx_trade_client):
         """Test placing bracket order with take profit and stop loss."""
         success = order_executor.trade(
-            side="buy",
-            quantity=0.001,
-            order_type="market",
-            take_profit=51000.0,
-            stop_loss=49000.0,
+            side="buy", quantity=0.001, order_type="market",
+            take_profit=51000.0, stop_loss=49000.0,
         )
 
         assert success is True
-        call_kwargs = mock_okx_trade_client.place_order.call_args[1]
-        assert "attachAlgoOrds" in call_kwargs
-        algo = call_kwargs["attachAlgoOrds"][0]
+        algo = mock_okx_trade_client.place_order.call_args[1]["attachAlgoOrds"][0]
         assert algo["tpTriggerPx"] == "51000.00"
         assert algo["slTriggerPx"] == "49000.00"
 
@@ -87,30 +61,16 @@ class TestOKXFuturesOrderClass:
     ])
     def test_bracket_order_prices_rounded_to_tick(self, order_executor, mock_okx_trade_client, raw_tp, raw_sl, expected_tp, expected_sl):
         """SL/TP prices must be rounded to tick size before submission."""
-        success = order_executor.trade(
-            side="buy",
-            quantity=0.001,
-            order_type="market",
-            take_profit=raw_tp,
-            stop_loss=raw_sl,
-        )
-
-        assert success is True
+        order_executor.trade(side="buy", quantity=0.001, take_profit=raw_tp, stop_loss=raw_sl)
         algo = mock_okx_trade_client.place_order.call_args[1]["attachAlgoOrds"][0]
         assert algo["tpTriggerPx"] == expected_tp
         assert algo["slTriggerPx"] == expected_sl
-
-    def test_tick_size_fetched_at_init(self, order_executor):
-        """Tick size should be cached from instrument info at init."""
-        assert order_executor._tick_size == 0.01
-        assert order_executor._tick_decimals == 2
 
     def test_round_price_without_precision(self, mock_okx_trade_client, mock_okx_account_client, mock_okx_public_client):
         """When tick size fetch fails, prices pass through unmodified."""
         from torchtrade.envs.live.okx.order_executor import OKXFuturesOrderClass
 
         mock_okx_public_client.get_instruments = MagicMock(side_effect=Exception("API down"))
-
         executor = OKXFuturesOrderClass(
             symbol="BTC-USDT-SWAP",
             client=mock_okx_trade_client,
@@ -120,75 +80,52 @@ class TestOKXFuturesOrderClass:
         assert executor._tick_size is None
         assert executor._round_price(82622.2122) == 82622.2122
 
-    def test_get_status_with_position(self, order_executor):
-        """Test getting position status."""
-        status = order_executor.get_status()
-
-        assert "position_status" in status
-        pos = status["position_status"]
-        assert pos is not None
-        assert pos.qty > 0  # Long position
-        assert pos.entry_price == 50000.0
-        assert pos.mark_price == 50100.0
-        assert pos.leverage == 10
-
-    def test_get_status_no_position(self, order_executor, mock_okx_account_client):
-        """Test get_status when no position exists."""
+    @pytest.mark.parametrize("pos_data,expected_qty", [
+        ({"pos": "0.001", "posSide": "net", "avgPx": "50000.0", "markPx": "50100.0",
+          "upl": "0.1", "lever": "10", "mgnMode": "isolated", "liqPx": "45000.0",
+          "notionalUsd": "50.1"}, 0.001),
+        ({"pos": "0", "posSide": "net"}, None),
+        ({"pos": "-0.001", "posSide": "net", "avgPx": "50000.0", "markPx": "49900.0",
+          "upl": "0.1", "lever": "10", "mgnMode": "isolated", "liqPx": "55000.0",
+          "notionalUsd": "49.9"}, -0.001),
+    ], ids=["long", "no-position", "short"])
+    def test_get_status(self, order_executor, mock_okx_account_client, pos_data, expected_qty):
+        """Test get_status for long, short, and no-position scenarios."""
         mock_okx_account_client.get_positions = MagicMock(return_value={
-            "code": "0", "msg": "",
-            "data": [{"instId": "BTC-USDT-SWAP", "pos": "0", "posSide": "net"}],
+            "code": "0", "msg": "", "data": [pos_data],
         })
-
         status = order_executor.get_status()
-        assert status["position_status"] is None
-
-    def test_get_status_short_position(self, order_executor, mock_short_position):
-        """Test get_status with short position (negative qty)."""
-        order_executor.account_client = mock_short_position
-        status = order_executor.get_status()
-        assert status["position_status"].qty < 0
+        if expected_qty is None:
+            assert status["position_status"] is None
+        else:
+            assert status["position_status"].qty == pytest.approx(expected_qty)
 
     def test_get_account_balance(self, order_executor):
         """Test getting account balance."""
         balance = order_executor.get_account_balance()
-
         assert balance["total_wallet_balance"] == 1000.0
         assert balance["available_balance"] == 900.0
-        assert "total_unrealized_profit" in balance
-        assert "total_margin_balance" in balance
 
-    def test_close_position_long(self, order_executor, mock_okx_trade_client):
-        """Test closing a long position sends sell."""
-        success = order_executor.close_position()
-
-        assert success is True
-        call_kwargs = mock_okx_trade_client.place_order.call_args[1]
-        assert call_kwargs["reduceOnly"] is True
-        assert call_kwargs["side"] == "sell"
-
-    def test_close_position_short(self, order_executor, mock_okx_trade_client, mock_short_position):
-        """Test closing a short position sends buy."""
-        order_executor.account_client = mock_short_position
-        success = order_executor.close_position()
-
-        assert success is True
-        call_kwargs = mock_okx_trade_client.place_order.call_args[1]
-        assert call_kwargs["side"] == "buy"
-
-    def test_close_position_no_position(self, order_executor, mock_okx_account_client):
-        """Test closing when no position exists."""
+    @pytest.mark.parametrize("pos_data,expected_side", [
+        ({"pos": "0.001", "posSide": "net", "avgPx": "50000.0", "markPx": "50100.0",
+          "upl": "0.1", "lever": "10", "mgnMode": "isolated", "liqPx": "45000.0",
+          "notionalUsd": "50.1"}, "sell"),
+        ({"pos": "-0.001", "posSide": "net", "avgPx": "50000.0", "markPx": "49900.0",
+          "upl": "0.1", "lever": "10", "mgnMode": "isolated", "liqPx": "55000.0",
+          "notionalUsd": "49.9"}, "buy"),
+        ({"pos": "0", "posSide": "net"}, None),
+    ], ids=["close-long", "close-short", "no-position"])
+    def test_close_position(self, order_executor, mock_okx_trade_client, mock_okx_account_client, pos_data, expected_side):
+        """Test closing long, short, and no-position scenarios."""
         mock_okx_account_client.get_positions = MagicMock(return_value={
-            "code": "0", "msg": "",
-            "data": [{"instId": "BTC-USDT-SWAP", "pos": "0", "posSide": "net"}],
+            "code": "0", "msg": "", "data": [pos_data],
         })
-
         success = order_executor.close_position()
         assert success is True
-
-    def test_cancel_open_orders_no_orders(self, order_executor, mock_okx_trade_client):
-        """Test cancelling when no open orders exist."""
-        success = order_executor.cancel_open_orders()
-        assert success is True
+        if expected_side is not None:
+            call_kwargs = mock_okx_trade_client.place_order.call_args[1]
+            assert call_kwargs["side"] == expected_side
+            assert call_kwargs["reduceOnly"] is True
 
     @pytest.mark.parametrize("code,expected_success,expected_leverage", [
         ("0", True, 20),
@@ -197,34 +134,40 @@ class TestOKXFuturesOrderClass:
     def test_set_leverage_validates_code(self, order_executor, mock_okx_account_client, code, expected_success, expected_leverage):
         """set_leverage must validate code and only update local state on success."""
         mock_okx_account_client.set_leverage = MagicMock(return_value={
-            "code": code, "msg": "OK" if code == "0" else "Leverage not modified", "data": [{}],
+            "code": code, "msg": "", "data": [{}],
         })
         result = order_executor.set_leverage(20)
         assert result is expected_success
         assert order_executor.leverage == expected_leverage
 
+    @pytest.mark.parametrize("code,expected_success,expect_mode_changed", [
+        ("0", True, True),
+        ("51101", False, False),
+    ], ids=["success", "rejected"])
+    def test_set_margin_mode_validates_code(self, order_executor, mock_okx_account_client, code, expected_success, expect_mode_changed):
+        """set_margin_mode must validate code and only update local state on success."""
+        from torchtrade.envs.live.okx.order_executor import MarginMode
+
+        original_mode = order_executor.margin_mode
+        mock_okx_account_client.set_leverage = MagicMock(return_value={
+            "code": code, "msg": "", "data": [{}],
+        })
+        result = order_executor.set_margin_mode(MarginMode.CROSS)
+        assert result is expected_success
+        if expect_mode_changed:
+            assert order_executor.margin_mode == MarginMode.CROSS
+        else:
+            assert order_executor.margin_mode == original_mode
+
     def test_trade_failure_handling(self, order_executor, mock_okx_trade_client):
         """Test that trade failures are handled gracefully."""
         mock_okx_trade_client.place_order = MagicMock(side_effect=Exception("API Error"))
-
-        success = order_executor.trade(side="buy", quantity=0.001)
-        assert success is False
-
-    def test_margin_mode_enum_and_okx_conversion(self):
-        """Test MarginMode enum values and OKX conversion."""
-        from torchtrade.envs.live.okx.order_executor import MarginMode
-
-        assert MarginMode.ISOLATED.value == "isolated"
-        assert MarginMode.CROSS.value == "cross"
-        assert MarginMode.ISOLATED.to_okx() == "isolated"
-        assert MarginMode.CROSS.to_okx() == "cross"
+        assert order_executor.trade(side="buy", quantity=0.001) is False
 
     def test_reduce_only_order(self, order_executor, mock_okx_trade_client):
         """Test placing a reduce-only order."""
         order_executor.trade(side="sell", quantity=0.001, reduce_only=True)
-
-        call_kwargs = mock_okx_trade_client.place_order.call_args[1]
-        assert call_kwargs["reduceOnly"] is True
+        assert mock_okx_trade_client.place_order.call_args[1]["reduceOnly"] is True
 
     @pytest.mark.parametrize("qty,entry,mark,expected_pnl_pct", [
         (0.001, 50000, 51000, 0.02),
@@ -237,11 +180,6 @@ class TestOKXFuturesOrderClass:
         """Unrealized PnL % must be correct for long and short positions."""
         result = order_executor._calculate_unrealized_pnl_pct(qty, entry, mark)
         assert result == pytest.approx(expected_pnl_pct, abs=1e-6)
-
-    def test_get_mark_price(self, order_executor):
-        """Test getting mark price."""
-        price = order_executor.get_mark_price()
-        assert price == 50100.0
 
     def test_get_mark_price_no_data_raises(self, order_executor, mock_okx_public_client):
         """Missing mark price data must raise RuntimeError."""
@@ -258,9 +196,7 @@ class TestOKXFuturesOrderClass:
 
     def test_limit_order_with_price_succeeds(self, order_executor, mock_okx_trade_client):
         """Limit order with limit_price must succeed."""
-        success = order_executor.trade(
-            side="buy", quantity=0.001, order_type="limit", limit_price=50000.0,
-        )
+        success = order_executor.trade(side="buy", quantity=0.001, order_type="limit", limit_price=50000.0)
         assert success is True
         call_kwargs = mock_okx_trade_client.place_order.call_args[1]
         assert call_kwargs["px"] == "50000.00"
@@ -277,12 +213,10 @@ class TestOKXFuturesOrderClass:
         position_data = {
             "instId": "BTC-USDT-SWAP", "pos": "0.001", "posSide": "net",
             "avgPx": "50000.0", "markPx": "50100.0",
-            "upl": "0.1", "lever": "10",
-            "mgnMode": "isolated", "notionalUsd": "50.1",
+            "upl": "0.1", "lever": "10", "mgnMode": "isolated", "notionalUsd": "50.1",
         }
         if liq_price_value is not None:
             position_data["liqPx"] = liq_price_value
-
         mock_okx_account_client.get_positions = MagicMock(return_value={
             "code": "0", "msg": "", "data": [position_data],
         })
@@ -294,8 +228,7 @@ class TestOKXFuturesOrderClass:
         mock_okx_account_client.get_positions = MagicMock(return_value={
             "code": "51001", "msg": "Invalid parameter", "data": [],
         })
-        status = order_executor.get_status()
-        assert status["position_status"] is None
+        assert order_executor.get_status()["position_status"] is None
 
     def test_account_balance_empty_raises(self, order_executor, mock_okx_account_client):
         """get_account_balance raises when data is empty."""
@@ -316,18 +249,13 @@ class TestOKXFuturesOrderClass:
             "code": code, "msg": msg,
             "data": [{"ordId": "123"}] if code == "0" else [],
         })
-        result = order_executor.trade(side="buy", quantity=0.001)
-        assert result is expected
+        assert order_executor.trade(side="buy", quantity=0.001) is expected
 
     def test_get_lot_size_fetches_and_caches(self, order_executor, mock_okx_public_client):
         """get_lot_size must return cached data from init-time instrument fetch."""
         init_call_count = mock_okx_public_client.get_instruments.call_count
-
         lot_size = order_executor.get_lot_size()
         assert lot_size["min_qty"] == 0.001
-        assert lot_size["qty_step"] == 0.001
-
-        # Should use cache from init, no additional API call
         lot_size2 = order_executor.get_lot_size()
         assert lot_size2 is lot_size
         assert mock_okx_public_client.get_instruments.call_count == init_call_count
@@ -340,6 +268,15 @@ class TestOKXFuturesOrderClass:
         assert lot_size["min_qty"] == 0.001
         assert lot_size["qty_step"] == 0.001
 
+    def test_get_lot_size_validates_code(self, order_executor, mock_okx_public_client):
+        """get_lot_size must fall back to defaults on non-zero code."""
+        order_executor._lot_size_cache = None
+        mock_okx_public_client.get_instruments = MagicMock(return_value={
+            "code": "51001", "msg": "Invalid parameter", "data": [],
+        })
+        lot_size = order_executor.get_lot_size()
+        assert lot_size["min_qty"] == 0.001
+
     def test_close_position_requery_confirms_closed(self, order_executor, mock_okx_trade_client, mock_okx_account_client):
         """close_position must re-query to confirm when order fails."""
         call_count = {"get_positions": 0}
@@ -347,23 +284,23 @@ class TestOKXFuturesOrderClass:
         def mock_get_positions(**kwargs):
             call_count["get_positions"] += 1
             if call_count["get_positions"] == 1:
-                return {
-                    "code": "0", "msg": "",
-                    "data": [{
-                        "instId": "BTC-USDT-SWAP", "pos": "0.001", "posSide": "net",
-                        "avgPx": "50000.0", "markPx": "50100.0",
-                        "upl": "0.1", "lever": "10",
-                        "mgnMode": "isolated", "liqPx": "45000.0", "notionalUsd": "50.1",
-                    }],
-                }
+                return {"code": "0", "msg": "", "data": [{
+                    "instId": "BTC-USDT-SWAP", "pos": "0.001", "posSide": "net",
+                    "avgPx": "50000.0", "markPx": "50100.0", "upl": "0.1",
+                    "lever": "10", "mgnMode": "isolated", "liqPx": "45000.0",
+                    "notionalUsd": "50.1",
+                }]}
             return {"code": "0", "msg": "", "data": []}
 
         mock_okx_account_client.get_positions = MagicMock(side_effect=mock_get_positions)
         mock_okx_trade_client.place_order = MagicMock(side_effect=Exception("Order failed"))
-
-        success = order_executor.close_position()
-        assert success is True
+        assert order_executor.close_position() is True
         assert call_count["get_positions"] == 2
+
+    def test_close_position_requery_still_open(self, order_executor, mock_okx_trade_client):
+        """close_position must return False when re-query shows position still open."""
+        mock_okx_trade_client.place_order = MagicMock(side_effect=Exception("Order failed"))
+        assert order_executor.close_position() is False
 
     @pytest.mark.parametrize("side,reduce_only,expected_pos_side", [
         ("buy", False, "long"),
@@ -373,9 +310,8 @@ class TestOKXFuturesOrderClass:
     ])
     def test_long_short_mode_position_side(self, mock_okx_trade_client, mock_okx_account_client, mock_okx_public_client, side, reduce_only, expected_pos_side):
         """Long/short mode must use correct posSide for open vs close trades."""
-        from torchtrade.envs.live.okx.order_executor import (
-            OKXFuturesOrderClass, PositionMode,
-        )
+        from torchtrade.envs.live.okx.order_executor import OKXFuturesOrderClass, PositionMode
+
         executor = OKXFuturesOrderClass(
             symbol="BTC-USDT-SWAP",
             position_mode=PositionMode.LONG_SHORT,
@@ -384,5 +320,4 @@ class TestOKXFuturesOrderClass:
             public_client=mock_okx_public_client,
         )
         executor.trade(side=side, quantity=0.001, reduce_only=reduce_only)
-        call_kwargs = mock_okx_trade_client.place_order.call_args[1]
-        assert call_kwargs["posSide"] == expected_pos_side
+        assert mock_okx_trade_client.place_order.call_args[1]["posSide"] == expected_pos_side

--- a/tests/envs/okx/test_obs_class.py
+++ b/tests/envs/okx/test_obs_class.py
@@ -1,0 +1,317 @@
+"""Tests for OKXObservationClass."""
+
+import pytest
+import numpy as np
+from unittest.mock import MagicMock
+from torchtrade.envs.utils.timeframe import TimeFrame, TimeFrameUnit
+
+
+class TestOKXObservationClass:
+    """Tests for OKXObservationClass."""
+
+    @pytest.fixture
+    def observer_single(self, mock_okx_market_client):
+        """Create observer with single timeframe."""
+        from torchtrade.envs.live.okx.observation import OKXObservationClass
+
+        observer = OKXObservationClass(
+            symbol="BTC-USDT-SWAP",
+            time_frames=TimeFrame(15, TimeFrameUnit.Minute),
+            window_sizes=10,
+            client=mock_okx_market_client,
+        )
+        return observer
+
+    @pytest.fixture
+    def observer_multi(self, mock_okx_market_client):
+        """Create observer with multiple timeframes."""
+        from torchtrade.envs.live.okx.observation import OKXObservationClass
+
+        observer = OKXObservationClass(
+            symbol="BTC-USDT-SWAP",
+            time_frames=[
+                TimeFrame(1, TimeFrameUnit.Minute),
+                TimeFrame(5, TimeFrameUnit.Minute),
+                TimeFrame(1, TimeFrameUnit.Hour),
+            ],
+            window_sizes=[10, 20, 15],
+            client=mock_okx_market_client,
+        )
+        return observer
+
+    def test_single_interval_initialization(self, observer_single):
+        """Test initialization with single timeframe."""
+        assert observer_single.symbol == "BTC-USDT-SWAP"
+        assert len(observer_single.time_frames) == 1
+        assert observer_single.time_frames[0].value == 15
+        assert observer_single.time_frames[0].unit == TimeFrameUnit.Minute
+        assert observer_single.window_sizes == [10]
+
+    def test_multi_interval_initialization(self, observer_multi):
+        """Test initialization with multiple timeframes."""
+        assert observer_multi.symbol == "BTC-USDT-SWAP"
+        assert len(observer_multi.time_frames) == 3
+        assert observer_multi.window_sizes == [10, 20, 15]
+
+    @pytest.mark.parametrize("symbol,expected", [
+        ("BTC-USDT-SWAP", "BTC-USDT-SWAP"),
+        ("BTC-USDT", "BTC-USDT-SWAP"),
+        ("BTCUSDT", "BTC-USDT-SWAP"),
+        ("BTC/USDT", "BTC-USDT-SWAP"),
+        ("BTC/USDT:USDT", "BTC-USDT-SWAP"),
+        (" btcusdt ", "BTC-USDT-SWAP"),
+    ])
+    def test_symbol_normalization(self, mock_okx_market_client, symbol, expected):
+        """Test that various symbol formats are normalized to OKX format."""
+        from torchtrade.envs.live.okx.observation import OKXObservationClass
+
+        observer = OKXObservationClass(
+            symbol=symbol,
+            time_frames=TimeFrame(1, TimeFrameUnit.Minute),
+            window_sizes=10,
+            client=mock_okx_market_client,
+        )
+        assert observer.symbol == expected
+
+    def test_invalid_interval_raises_error(self, mock_okx_market_client):
+        """Test that invalid timeframe raises ValueError."""
+        from torchtrade.envs.live.okx.observation import OKXObservationClass
+
+        with pytest.raises(ValueError, match="Unsupported timeframe"):
+            OKXObservationClass(
+                symbol="BTC-USDT-SWAP",
+                time_frames=TimeFrame(2, TimeFrameUnit.Minute),  # 2 minutes not supported
+                window_sizes=10,
+                client=mock_okx_market_client,
+            )
+
+    def test_mismatched_lengths_raises_error(self, mock_okx_market_client):
+        """Test that mismatched time_frames and window_sizes raises error."""
+        from torchtrade.envs.live.okx.observation import OKXObservationClass
+
+        with pytest.raises(ValueError, match="same length"):
+            OKXObservationClass(
+                symbol="BTC-USDT-SWAP",
+                time_frames=[
+                    TimeFrame(1, TimeFrameUnit.Minute),
+                    TimeFrame(5, TimeFrameUnit.Minute),
+                ],
+                window_sizes=[10],  # Mismatched length
+                client=mock_okx_market_client,
+            )
+
+    def test_get_keys_single(self, observer_single):
+        """Test get_keys with single timeframe."""
+        keys = observer_single.get_keys()
+        assert keys == ["15Minute_10"]
+
+    def test_get_keys_multi(self, observer_multi):
+        """Test get_keys with multiple timeframes."""
+        keys = observer_multi.get_keys()
+        assert keys == ["1Minute_10", "5Minute_20", "1Hour_15"]
+
+    def test_get_observations_single(self, observer_single):
+        """Test get_observations with single timeframe returns correct shape."""
+        observations = observer_single.get_observations()
+
+        assert "15Minute_10" in observations
+        assert observations["15Minute_10"].shape == (10, 4)  # window_size x num_features
+
+    def test_get_observations_multi(self, observer_multi):
+        """Test get_observations with multiple timeframes returns correct shapes."""
+        observations = observer_multi.get_observations()
+
+        assert observations["1Minute_10"].shape == (10, 4)
+        assert observations["5Minute_20"].shape == (20, 4)
+        assert observations["1Hour_15"].shape == (15, 4)
+
+    def test_get_observations_with_base_ohlc(self, observer_single):
+        """Test get_observations with return_base_ohlc=True."""
+        observations = observer_single.get_observations(return_base_ohlc=True)
+
+        assert "15Minute_10" in observations
+        assert "base_features" in observations
+        assert observations["base_features"].shape[1] == 4  # OHLC
+
+    def test_custom_preprocessing(self, mock_okx_market_client):
+        """Test custom preprocessing function."""
+        from torchtrade.envs.live.okx.observation import OKXObservationClass
+
+        def custom_preprocess(df):
+            df = df.copy()
+            df.dropna(inplace=True)
+            df.drop_duplicates(inplace=True)
+            df["feature_close"] = df["close"].pct_change().fillna(0)
+            df["feature_open"] = df["open"] / df["close"]
+            df["feature_high"] = df["high"] / df["close"]
+            df["feature_low"] = df["low"] / df["close"]
+            df["feature_custom"] = df["close"] * 2
+            df.dropna(inplace=True)
+            return df
+
+        observer = OKXObservationClass(
+            symbol="BTC-USDT-SWAP",
+            time_frames=TimeFrame(1, TimeFrameUnit.Minute),
+            window_sizes=10,
+            feature_preprocessing_fn=custom_preprocess,
+            client=mock_okx_market_client,
+        )
+
+        observations = observer.get_observations()
+        assert observations["1Minute_10"].shape[1] == 5  # 4 default + 1 custom
+
+    def test_api_call_parameters(self, observer_single, mock_okx_market_client):
+        """Test that OKX get_candlesticks is called with correct parameters."""
+        observer_single.get_observations()
+
+        mock_okx_market_client.get_candlesticks.assert_called()
+        call_kwargs = mock_okx_market_client.get_candlesticks.call_args[1]
+        assert call_kwargs["instId"] == "BTC-USDT-SWAP"
+
+    def test_empty_candles_raises_error(self, mock_okx_market_client):
+        """Test that empty candles raises RuntimeError."""
+        from torchtrade.envs.live.okx.observation import OKXObservationClass
+
+        mock_okx_market_client.get_candlesticks = MagicMock(return_value={
+            "code": "0",
+            "msg": "",
+            "data": [],
+        })
+
+        observer = OKXObservationClass(
+            symbol="BTC-USDT-SWAP",
+            time_frames=TimeFrame(1, TimeFrameUnit.Minute),
+            window_sizes=10,
+            client=mock_okx_market_client,
+        )
+
+        with pytest.raises(RuntimeError, match="No candle data"):
+            observer.get_observations()
+
+    def test_default_preprocessing_output(self, observer_single):
+        """Test that default preprocessing outputs valid data."""
+        observations = observer_single.get_observations()
+        data = observations["15Minute_10"]
+
+        assert not np.isnan(data).any(), "Data contains NaN values"
+        assert data.shape == (10, 4)
+
+    def test_fetch_klines_validates_code(self, mock_okx_market_client):
+        """_fetch_klines must raise RuntimeError on non-zero code."""
+        from torchtrade.envs.live.okx.observation import OKXObservationClass
+
+        mock_okx_market_client.get_candlesticks = MagicMock(return_value={
+            "code": "51001",
+            "msg": "Invalid parameter",
+            "data": [],
+        })
+
+        observer = OKXObservationClass(
+            symbol="BTC-USDT-SWAP",
+            time_frames=TimeFrame(1, TimeFrameUnit.Minute),
+            window_sizes=10,
+            client=mock_okx_market_client,
+        )
+
+        with pytest.raises(RuntimeError, match="code=51001"):
+            observer._fetch_klines("BTC-USDT-SWAP", "1m", 200)
+
+    def test_parse_klines_sorts_chronologically(self, mock_okx_market_client):
+        """Reverse-ordered klines from OKX must be sorted oldest-first."""
+        from torchtrade.envs.live.okx.observation import OKXObservationClass
+
+        observer = OKXObservationClass(
+            symbol="BTC-USDT-SWAP",
+            time_frames=TimeFrame(1, TimeFrameUnit.Minute),
+            window_sizes=5,
+            client=mock_okx_market_client,
+        )
+
+        # Feed reverse-chronological data (newest first, like OKX returns)
+        raw_klines = [
+            [str(1700000000000 + i * 60000), "50000", "50100", "49900", "50050", "100", "5000000", "5000000", "1"]
+            for i in [4, 3, 2, 1, 0]
+        ]
+        df = observer._parse_klines(raw_klines)
+        timestamps = df["timestamp"].tolist()
+        assert timestamps == sorted(timestamps), "Klines must be in chronological order"
+
+
+class TestOKXUtils:
+    """Tests for OKX utility functions."""
+
+    @pytest.mark.parametrize("tf,expected", [
+        (TimeFrame(1, TimeFrameUnit.Minute), "1m"),
+        (TimeFrame(15, TimeFrameUnit.Minute), "15m"),
+        (TimeFrame(1, TimeFrameUnit.Hour), "1H"),
+        (TimeFrame(4, TimeFrameUnit.Hour), "4H"),
+        (TimeFrame(1, TimeFrameUnit.Day), "1D"),
+    ])
+    def test_timeframe_to_okx(self, tf, expected):
+        """Test TimeFrame to OKX interval conversion."""
+        from torchtrade.envs.live.okx.utils import timeframe_to_okx
+        assert timeframe_to_okx(tf) == expected
+
+    @pytest.mark.parametrize("interval,expected_value,expected_unit", [
+        ("1m", 1, TimeFrameUnit.Minute),
+        ("15m", 15, TimeFrameUnit.Minute),
+        ("1H", 1, TimeFrameUnit.Hour),
+        ("4H", 4, TimeFrameUnit.Hour),
+        ("1D", 1, TimeFrameUnit.Day),
+    ])
+    def test_okx_to_timeframe(self, interval, expected_value, expected_unit):
+        """Test OKX interval string to TimeFrame conversion."""
+        from torchtrade.envs.live.okx.utils import okx_to_timeframe
+        tf = okx_to_timeframe(interval)
+        assert tf.value == expected_value
+        assert tf.unit == expected_unit
+
+    @pytest.mark.parametrize("bad_tf", [
+        TimeFrame(2, TimeFrameUnit.Minute),
+        TimeFrame(7, TimeFrameUnit.Hour),
+    ])
+    def test_timeframe_to_okx_invalid(self, bad_tf):
+        """Test that unsupported timeframes raise ValueError."""
+        from torchtrade.envs.live.okx.utils import timeframe_to_okx
+        with pytest.raises(ValueError):
+            timeframe_to_okx(bad_tf)
+
+    def test_okx_to_timeframe_invalid(self):
+        """Test that invalid interval string raises ValueError."""
+        from torchtrade.envs.live.okx.utils import okx_to_timeframe
+        with pytest.raises(ValueError):
+            okx_to_timeframe("99m")
+
+    @pytest.mark.parametrize("symbol,expected", [
+        ("BTC-USDT-SWAP", "BTC-USDT-SWAP"),
+        ("BTC-USDT", "BTC-USDT-SWAP"),
+        ("BTCUSDT", "BTC-USDT-SWAP"),
+        ("BTC/USDT", "BTC-USDT-SWAP"),
+        ("BTC/USDT:USDT", "BTC-USDT-SWAP"),
+        (" btcusdt ", "BTC-USDT-SWAP"),
+        ("ETH-USDT", "ETH-USDT-SWAP"),
+        ("ETHUSDT", "ETH-USDT-SWAP"),
+    ])
+    def test_normalize_symbol(self, symbol, expected):
+        """Test symbol normalization to OKX swap format."""
+        from torchtrade.envs.live.okx.utils import normalize_symbol
+        assert normalize_symbol(symbol) == expected
+
+    @pytest.mark.parametrize("bad_symbol", ["", "  "])
+    def test_normalize_symbol_empty_raises(self, bad_symbol):
+        """Empty or whitespace-only symbols must raise ValueError."""
+        from torchtrade.envs.live.okx.utils import normalize_symbol
+        with pytest.raises(ValueError):
+            normalize_symbol(bad_symbol)
+
+    @pytest.mark.parametrize("tf", [
+        TimeFrame(1, TimeFrameUnit.Minute),
+        TimeFrame(1, TimeFrameUnit.Hour),
+        TimeFrame(1, TimeFrameUnit.Day),
+    ])
+    def test_roundtrip_conversion(self, tf):
+        """Test that TimeFrame -> OKX -> TimeFrame is identity."""
+        from torchtrade.envs.live.okx.utils import timeframe_to_okx, okx_to_timeframe
+        result = okx_to_timeframe(timeframe_to_okx(tf))
+        assert result.value == tf.value
+        assert result.unit == tf.unit

--- a/tests/envs/okx/test_obs_class.py
+++ b/tests/envs/okx/test_obs_class.py
@@ -14,20 +14,19 @@ class TestOKXObservationClass:
         """Create observer with single timeframe."""
         from torchtrade.envs.live.okx.observation import OKXObservationClass
 
-        observer = OKXObservationClass(
+        return OKXObservationClass(
             symbol="BTC-USDT-SWAP",
             time_frames=TimeFrame(15, TimeFrameUnit.Minute),
             window_sizes=10,
             client=mock_okx_market_client,
         )
-        return observer
 
     @pytest.fixture
     def observer_multi(self, mock_okx_market_client):
         """Create observer with multiple timeframes."""
         from torchtrade.envs.live.okx.observation import OKXObservationClass
 
-        observer = OKXObservationClass(
+        return OKXObservationClass(
             symbol="BTC-USDT-SWAP",
             time_frames=[
                 TimeFrame(1, TimeFrameUnit.Minute),
@@ -37,41 +36,6 @@ class TestOKXObservationClass:
             window_sizes=[10, 20, 15],
             client=mock_okx_market_client,
         )
-        return observer
-
-    def test_single_interval_initialization(self, observer_single):
-        """Test initialization with single timeframe."""
-        assert observer_single.symbol == "BTC-USDT-SWAP"
-        assert len(observer_single.time_frames) == 1
-        assert observer_single.time_frames[0].value == 15
-        assert observer_single.time_frames[0].unit == TimeFrameUnit.Minute
-        assert observer_single.window_sizes == [10]
-
-    def test_multi_interval_initialization(self, observer_multi):
-        """Test initialization with multiple timeframes."""
-        assert observer_multi.symbol == "BTC-USDT-SWAP"
-        assert len(observer_multi.time_frames) == 3
-        assert observer_multi.window_sizes == [10, 20, 15]
-
-    @pytest.mark.parametrize("symbol,expected", [
-        ("BTC-USDT-SWAP", "BTC-USDT-SWAP"),
-        ("BTC-USDT", "BTC-USDT-SWAP"),
-        ("BTCUSDT", "BTC-USDT-SWAP"),
-        ("BTC/USDT", "BTC-USDT-SWAP"),
-        ("BTC/USDT:USDT", "BTC-USDT-SWAP"),
-        (" btcusdt ", "BTC-USDT-SWAP"),
-    ])
-    def test_symbol_normalization(self, mock_okx_market_client, symbol, expected):
-        """Test that various symbol formats are normalized to OKX format."""
-        from torchtrade.envs.live.okx.observation import OKXObservationClass
-
-        observer = OKXObservationClass(
-            symbol=symbol,
-            time_frames=TimeFrame(1, TimeFrameUnit.Minute),
-            window_sizes=10,
-            client=mock_okx_market_client,
-        )
-        assert observer.symbol == expected
 
     def test_invalid_interval_raises_error(self, mock_okx_market_client):
         """Test that invalid timeframe raises ValueError."""
@@ -80,7 +44,7 @@ class TestOKXObservationClass:
         with pytest.raises(ValueError, match="Unsupported timeframe"):
             OKXObservationClass(
                 symbol="BTC-USDT-SWAP",
-                time_frames=TimeFrame(2, TimeFrameUnit.Minute),  # 2 minutes not supported
+                time_frames=TimeFrame(2, TimeFrameUnit.Minute),
                 window_sizes=10,
                 client=mock_okx_market_client,
             )
@@ -96,31 +60,19 @@ class TestOKXObservationClass:
                     TimeFrame(1, TimeFrameUnit.Minute),
                     TimeFrame(5, TimeFrameUnit.Minute),
                 ],
-                window_sizes=[10],  # Mismatched length
+                window_sizes=[10],
                 client=mock_okx_market_client,
             )
-
-    def test_get_keys_single(self, observer_single):
-        """Test get_keys with single timeframe."""
-        keys = observer_single.get_keys()
-        assert keys == ["15Minute_10"]
-
-    def test_get_keys_multi(self, observer_multi):
-        """Test get_keys with multiple timeframes."""
-        keys = observer_multi.get_keys()
-        assert keys == ["1Minute_10", "5Minute_20", "1Hour_15"]
 
     def test_get_observations_single(self, observer_single):
         """Test get_observations with single timeframe returns correct shape."""
         observations = observer_single.get_observations()
-
         assert "15Minute_10" in observations
-        assert observations["15Minute_10"].shape == (10, 4)  # window_size x num_features
+        assert observations["15Minute_10"].shape == (10, 4)
 
     def test_get_observations_multi(self, observer_multi):
         """Test get_observations with multiple timeframes returns correct shapes."""
         observations = observer_multi.get_observations()
-
         assert observations["1Minute_10"].shape == (10, 4)
         assert observations["5Minute_20"].shape == (20, 4)
         assert observations["1Hour_15"].shape == (15, 4)
@@ -128,13 +80,12 @@ class TestOKXObservationClass:
     def test_get_observations_with_base_ohlc(self, observer_single):
         """Test get_observations with return_base_ohlc=True."""
         observations = observer_single.get_observations(return_base_ohlc=True)
-
         assert "15Minute_10" in observations
         assert "base_features" in observations
-        assert observations["base_features"].shape[1] == 4  # OHLC
+        assert observations["base_features"].shape[1] == 4
 
     def test_custom_preprocessing(self, mock_okx_market_client):
-        """Test custom preprocessing function."""
+        """Test custom preprocessing function changes feature count."""
         from torchtrade.envs.live.okx.observation import OKXObservationClass
 
         def custom_preprocess(df):
@@ -160,22 +111,12 @@ class TestOKXObservationClass:
         observations = observer.get_observations()
         assert observations["1Minute_10"].shape[1] == 5  # 4 default + 1 custom
 
-    def test_api_call_parameters(self, observer_single, mock_okx_market_client):
-        """Test that OKX get_candlesticks is called with correct parameters."""
-        observer_single.get_observations()
-
-        mock_okx_market_client.get_candlesticks.assert_called()
-        call_kwargs = mock_okx_market_client.get_candlesticks.call_args[1]
-        assert call_kwargs["instId"] == "BTC-USDT-SWAP"
-
     def test_empty_candles_raises_error(self, mock_okx_market_client):
         """Test that empty candles raises RuntimeError."""
         from torchtrade.envs.live.okx.observation import OKXObservationClass
 
         mock_okx_market_client.get_candlesticks = MagicMock(return_value={
-            "code": "0",
-            "msg": "",
-            "data": [],
+            "code": "0", "msg": "", "data": [],
         })
 
         observer = OKXObservationClass(
@@ -188,22 +129,12 @@ class TestOKXObservationClass:
         with pytest.raises(RuntimeError, match="No candle data"):
             observer.get_observations()
 
-    def test_default_preprocessing_output(self, observer_single):
-        """Test that default preprocessing outputs valid data."""
-        observations = observer_single.get_observations()
-        data = observations["15Minute_10"]
-
-        assert not np.isnan(data).any(), "Data contains NaN values"
-        assert data.shape == (10, 4)
-
     def test_fetch_klines_validates_code(self, mock_okx_market_client):
         """_fetch_klines must raise RuntimeError on non-zero code."""
         from torchtrade.envs.live.okx.observation import OKXObservationClass
 
         mock_okx_market_client.get_candlesticks = MagicMock(return_value={
-            "code": "51001",
-            "msg": "Invalid parameter",
-            "data": [],
+            "code": "51001", "msg": "Invalid parameter", "data": [],
         })
 
         observer = OKXObservationClass(
@@ -227,7 +158,6 @@ class TestOKXObservationClass:
             client=mock_okx_market_client,
         )
 
-        # Feed reverse-chronological data (newest first, like OKX returns)
         raw_klines = [
             [str(1700000000000 + i * 60000), "50000", "50100", "49900", "50050", "100", "5000000", "5000000", "1"]
             for i in [4, 3, 2, 1, 0]

--- a/tests/envs/okx/test_torch_env_futures.py
+++ b/tests/envs/okx/test_torch_env_futures.py
@@ -42,10 +42,8 @@ class TestOKXFuturesTorchTradingEnv:
         trader.cancel_open_orders = MagicMock(return_value=True)
         trader.close_position = MagicMock(return_value=True)
         trader.get_account_balance = MagicMock(return_value={
-            "total_wallet_balance": 1000.0,
-            "available_balance": 900.0,
-            "total_unrealized_profit": 0.0,
-            "total_margin_balance": 1000.0,
+            "total_wallet_balance": 1000.0, "available_balance": 900.0,
+            "total_unrealized_profit": 0.0, "total_margin_balance": 1000.0,
         })
         trader.get_mark_price = MagicMock(return_value=50000.0)
         trader.get_status = MagicMock(return_value={"position_status": None})
@@ -55,30 +53,21 @@ class TestOKXFuturesTorchTradingEnv:
 
     @pytest.fixture
     def env_config(self):
-        """Create environment configuration."""
         from torchtrade.envs.live.okx.env import OKXFuturesTradingEnvConfig
-
         return OKXFuturesTradingEnvConfig(
-            symbol="BTC-USDT-SWAP",
-            demo=True,
-            time_frames=["1m", "5m"],
-            window_sizes=[10, 10],
-            execute_on="1m",
-            leverage=5,
+            symbol="BTC-USDT-SWAP", demo=True,
+            time_frames=["1m", "5m"], window_sizes=[10, 10], execute_on="1m", leverage=5,
         )
 
     @pytest.fixture
     def env(self, env_config, mock_observer, mock_trader):
-        """Create environment with mocks."""
         from torchtrade.envs.live.okx.env import OKXFuturesTorchTradingEnv
 
-        with patch("time.sleep"):
-            with patch.object(OKXFuturesTorchTradingEnv, "_wait_for_next_timestamp"):
-                return OKXFuturesTorchTradingEnv(
-                    config=env_config,
-                    observer=mock_observer,
-                    trader=mock_trader,
-                )
+        with patch("time.sleep"), \
+             patch.object(OKXFuturesTorchTradingEnv, "_wait_for_next_timestamp"):
+            return OKXFuturesTorchTradingEnv(
+                config=env_config, observer=mock_observer, trader=mock_trader,
+            )
 
     def test_action_spec(self, env):
         """Test action spec and levels are correctly defined."""
@@ -96,44 +85,35 @@ class TestOKXFuturesTorchTradingEnv:
     def test_reset(self, env, mock_trader):
         """Test environment reset returns expected keys and shapes."""
         td = env.reset()
-
         assert "account_state" in td.keys()
-        assert "market_data_1Minute_10" in td.keys()
-        assert "market_data_5Minute_10" in td.keys()
         assert td["account_state"].shape == (6,)
         assert td["market_data_1Minute_10"].shape == (10, 4)
         mock_trader.cancel_open_orders.assert_called()
 
-    def test_step_hold_action(self, env, mock_trader):
-        """Test step with hold action."""
+    def test_step_hold_action(self, env):
+        """Test step with hold action produces valid output."""
         with patch.object(env, "_wait_for_next_timestamp"):
             env.reset()
             action_td = TensorDict({"action": torch.tensor(2)}, batch_size=())
             next_td = env.step(action_td)
-
             assert "reward" in next_td["next"].keys()
             assert "done" in next_td["next"].keys()
-            assert "account_state" in next_td["next"].keys()
 
     @pytest.mark.parametrize("action_idx,label", [
-        (4, "long"),
-        (0, "short"),
+        (4, "long"), (0, "short"),
     ], ids=["long", "short"])
     def test_step_trade_action(self, env, mock_trader, action_idx, label):
         """Test step with long/short action calls trade."""
         with patch.object(env, "_wait_for_next_timestamp"):
             env.reset()
-            action_td = TensorDict({"action": torch.tensor(action_idx)}, batch_size=())
-            env.step(action_td)
+            env.step(TensorDict({"action": torch.tensor(action_idx)}, batch_size=()))
             mock_trader.trade.assert_called()
 
     def test_reward_and_done_tensor_shapes(self, env):
         """Test that reward and done flags have correct tensor shapes."""
         with patch.object(env, "_wait_for_next_timestamp"):
             env.reset()
-            action_td = TensorDict({"action": torch.tensor(2)}, batch_size=())
-            next_td = env.step(action_td)
-
+            next_td = env.step(TensorDict({"action": torch.tensor(2)}, batch_size=()))
             assert next_td["next"]["reward"].shape == (1,)
             assert next_td["next"]["done"].shape == (1,)
             assert next_td["next"]["terminated"].shape == (1,)
@@ -142,14 +122,11 @@ class TestOKXFuturesTorchTradingEnv:
     def test_no_bankruptcy_when_disabled(self, env_config, mock_observer, mock_trader):
         """Test that bankruptcy check can be disabled."""
         from torchtrade.envs.live.okx.env import OKXFuturesTorchTradingEnv
-
         env_config.done_on_bankruptcy = False
 
         with patch("time.sleep"), \
              patch.object(OKXFuturesTorchTradingEnv, "_wait_for_next_timestamp"):
-            env = OKXFuturesTorchTradingEnv(
-                config=env_config, observer=mock_observer, trader=mock_trader,
-            )
+            env = OKXFuturesTorchTradingEnv(config=env_config, observer=mock_observer, trader=mock_trader)
 
         mock_trader.get_account_balance = MagicMock(return_value={
             "total_wallet_balance": 10.0, "available_balance": 10.0,
@@ -158,23 +135,8 @@ class TestOKXFuturesTorchTradingEnv:
 
         with patch.object(env, "_wait_for_next_timestamp"):
             env.reset()
-            action_td = TensorDict({"action": torch.tensor(2)}, batch_size=())
-            next_td = env.step(action_td)
+            next_td = env.step(TensorDict({"action": torch.tensor(2)}, batch_size=()))
             assert next_td["next"]["done"].item() is False
-
-    def test_config_post_init(self):
-        """Test config post_init normalization."""
-        from torchtrade.envs.live.okx.env import OKXFuturesTradingEnvConfig
-
-        config = OKXFuturesTradingEnvConfig(
-            symbol="BTC-USDT-SWAP",
-            time_frames="1m",
-            window_sizes=10,
-        )
-
-        assert isinstance(config.time_frames, list)
-        assert isinstance(config.window_sizes, list)
-        assert all(isinstance(tf, TimeFrame) for tf in config.time_frames)
 
 
 class TestOKXActionIndexClamping:
@@ -182,40 +144,22 @@ class TestOKXActionIndexClamping:
 
     @pytest.fixture
     def env(self, mock_env_observer, mock_env_trader):
-        from torchtrade.envs.live.okx.env import (
-            OKXFuturesTorchTradingEnv,
-            OKXFuturesTradingEnvConfig,
-        )
+        from torchtrade.envs.live.okx.env import OKXFuturesTorchTradingEnv, OKXFuturesTradingEnvConfig
 
         config = OKXFuturesTradingEnvConfig(
-            symbol="BTC-USDT-SWAP",
-            time_frames=["1m"],
-            window_sizes=[10],
-            execute_on="1m",
-            action_levels=[-1.0, 0.0, 1.0],
+            symbol="BTC-USDT-SWAP", time_frames=["1m"], window_sizes=[10],
+            execute_on="1m", action_levels=[-1.0, 0.0, 1.0],
         )
-
         with patch("time.sleep"), \
              patch.object(OKXFuturesTorchTradingEnv, "_wait_for_next_timestamp"):
-            return OKXFuturesTorchTradingEnv(
-                config=config, observer=mock_env_observer, trader=mock_env_trader,
-            )
+            return OKXFuturesTorchTradingEnv(config=config, observer=mock_env_observer, trader=mock_env_trader)
 
-    @pytest.mark.parametrize("action_idx", [-1, 5], ids=["negative", "too-high"])
-    def test_action_index_clamping(self, env, action_idx):
-        """Out-of-range action indices must be clamped with warning."""
+    @pytest.mark.parametrize("action_idx", [-1, 5, float("nan")], ids=["negative", "too-high", "nan"])
+    def test_invalid_action_index_handled(self, env, action_idx):
+        """Out-of-range and NaN action indices must be handled without crashing."""
         with patch.object(env, "_wait_for_next_timestamp"):
             env.reset()
-            action_td = TensorDict({"action": torch.tensor(action_idx)}, batch_size=())
-            next_td = env.step(action_td)
-            assert "reward" in next_td["next"].keys()
-
-    def test_nan_action_defaults_to_zero(self, env):
-        """NaN action must default to action index 0 without crashing."""
-        with patch.object(env, "_wait_for_next_timestamp"):
-            env.reset()
-            action_td = TensorDict({"action": torch.tensor(float("nan"))}, batch_size=())
-            next_td = env.step(action_td)
+            next_td = env.step(TensorDict({"action": torch.tensor(action_idx)}, batch_size=()))
             assert "reward" in next_td["next"].keys()
 
 
@@ -224,23 +168,14 @@ class TestOKXZeroLiquidationPrice:
 
     @pytest.fixture
     def env(self, mock_env_observer, mock_env_trader):
-        from torchtrade.envs.live.okx.env import (
-            OKXFuturesTorchTradingEnv,
-            OKXFuturesTradingEnvConfig,
-        )
+        from torchtrade.envs.live.okx.env import OKXFuturesTorchTradingEnv, OKXFuturesTradingEnvConfig
 
         config = OKXFuturesTradingEnvConfig(
-            symbol="BTC-USDT-SWAP",
-            time_frames=["1m"],
-            window_sizes=[10],
-            execute_on="1m",
+            symbol="BTC-USDT-SWAP", time_frames=["1m"], window_sizes=[10], execute_on="1m",
         )
-
         with patch("time.sleep"), \
              patch.object(OKXFuturesTorchTradingEnv, "_wait_for_next_timestamp"):
-            return OKXFuturesTorchTradingEnv(
-                config=config, observer=mock_env_observer, trader=mock_env_trader,
-            )
+            return OKXFuturesTorchTradingEnv(config=config, observer=mock_env_observer, trader=mock_env_trader)
 
     @pytest.mark.parametrize("qty,liq_price,expected_dtl", [
         (0.001, 45000.0, pytest.approx(0.1018, rel=1e-2)),
@@ -260,41 +195,25 @@ class TestOKXZeroLiquidationPrice:
                 liquidation_price=liq_price,
             )
         })
-
         td = env._get_observation()
-        distance_to_liq = td["account_state"][5].item()
-        assert distance_to_liq == expected_dtl
+        assert td["account_state"][5].item() == expected_dtl
 
 
 class TestOKXInitCleanup:
-    """Test that __init__ flattens by default and respects close_position_on_init."""
+    """Test init/reset cleanup behavior."""
 
-    @pytest.mark.parametrize("close_on_init,expect_close", [
-        (True, True),
-        (False, False),
-    ])
-    def test_init_close_position_configurable(
-        self, mock_env_observer, mock_env_trader, close_on_init, expect_close
-    ):
+    @pytest.mark.parametrize("close_on_init,expect_close", [(True, True), (False, False)])
+    def test_init_close_position_configurable(self, mock_env_observer, mock_env_trader, close_on_init, expect_close):
         """close_position_on_init controls whether positions are closed on startup."""
-        from torchtrade.envs.live.okx.env import (
-            OKXFuturesTorchTradingEnv,
-            OKXFuturesTradingEnvConfig,
-        )
+        from torchtrade.envs.live.okx.env import OKXFuturesTorchTradingEnv, OKXFuturesTradingEnvConfig
 
         config = OKXFuturesTradingEnvConfig(
-            symbol="BTC-USDT-SWAP",
-            time_frames=["1m"],
-            window_sizes=[10],
-            execute_on="1m",
-            close_position_on_init=close_on_init,
+            symbol="BTC-USDT-SWAP", time_frames=["1m"], window_sizes=[10],
+            execute_on="1m", close_position_on_init=close_on_init,
         )
-
         with patch("time.sleep"), \
              patch.object(OKXFuturesTorchTradingEnv, "_wait_for_next_timestamp"):
-            OKXFuturesTorchTradingEnv(
-                config=config, observer=mock_env_observer, trader=mock_env_trader,
-            )
+            OKXFuturesTorchTradingEnv(config=config, observer=mock_env_observer, trader=mock_env_trader)
 
         mock_env_trader.cancel_open_orders.assert_called_once()
         if expect_close:
@@ -303,33 +222,147 @@ class TestOKXInitCleanup:
             mock_env_trader.close_position.assert_not_called()
 
     @pytest.mark.parametrize("cancel_ok,close_ok", [
-        (False, True),
-        (True, False),
-        (False, False),
+        (False, True), (True, False), (False, False),
     ], ids=["cancel-fails", "close-fails", "both-fail"])
     def test_reset_logs_warning_on_cleanup_failure(self, mock_env_observer, mock_env_trader, cancel_ok, close_ok):
         """reset() must warn but not raise when cleanup calls return False."""
-        from torchtrade.envs.live.okx.env import (
-            OKXFuturesTorchTradingEnv,
-            OKXFuturesTradingEnvConfig,
-        )
+        from torchtrade.envs.live.okx.env import OKXFuturesTorchTradingEnv, OKXFuturesTradingEnvConfig
 
         config = OKXFuturesTradingEnvConfig(
-            symbol="BTC-USDT-SWAP",
-            time_frames=["1m"],
-            window_sizes=[10],
-            execute_on="1m",
-            close_position_on_reset=True,
+            symbol="BTC-USDT-SWAP", time_frames=["1m"], window_sizes=[10],
+            execute_on="1m", close_position_on_reset=True,
+        )
+        with patch("time.sleep"), \
+             patch.object(OKXFuturesTorchTradingEnv, "_wait_for_next_timestamp"):
+            env = OKXFuturesTorchTradingEnv(config=config, observer=mock_env_observer, trader=mock_env_trader)
+
+        mock_env_trader.cancel_open_orders = MagicMock(return_value=cancel_ok)
+        mock_env_trader.close_position = MagicMock(return_value=close_ok)
+        assert env.reset() is not None
+
+    def test_close_resilient_when_cancel_raises(self, mock_env_observer, mock_env_trader):
+        """close() must not raise even if cancel_open_orders fails."""
+        from torchtrade.envs.live.okx.env import OKXFuturesTorchTradingEnv, OKXFuturesTradingEnvConfig
+
+        config = OKXFuturesTradingEnvConfig(
+            symbol="BTC-USDT-SWAP", time_frames=["1m"], window_sizes=[10], execute_on="1m",
+        )
+        with patch("time.sleep"), \
+             patch.object(OKXFuturesTorchTradingEnv, "_wait_for_next_timestamp"):
+            env = OKXFuturesTorchTradingEnv(config=config, observer=mock_env_observer, trader=mock_env_trader)
+
+        mock_env_trader.cancel_open_orders = MagicMock(side_effect=Exception("API down"))
+        env.close()  # Must not raise
+
+
+class TestOKXObservationSpecsNoNetwork:
+    """Test that _build_observation_specs doesn't make live API calls."""
+
+    def test_build_specs_uses_get_features_not_get_observations(self, mock_env_observer, mock_env_trader):
+        """_build_observation_specs must use get_features() (dummy data), not get_observations()."""
+        from torchtrade.envs.live.okx.env import OKXFuturesTorchTradingEnv, OKXFuturesTradingEnvConfig
+
+        config = OKXFuturesTradingEnvConfig(
+            symbol="BTC-USDT-SWAP", time_frames=["1m"], window_sizes=[10], execute_on="1m",
+        )
+        with patch("time.sleep"), \
+             patch.object(OKXFuturesTorchTradingEnv, "_wait_for_next_timestamp"):
+            env = OKXFuturesTorchTradingEnv(config=config, observer=mock_env_observer, trader=mock_env_trader)
+
+        mock_env_observer.get_features.assert_called_once()
+        assert "account_state" in env.observation_spec.keys()
+        assert "market_data_1Minute_10" in env.observation_spec.keys()
+
+
+class TestOKXFractionalPositionResizing:
+    """Tests for fractional position resizing."""
+
+    @pytest.fixture
+    def env(self, mock_env_observer, mock_env_trader):
+        from torchtrade.envs.live.okx.env import OKXFuturesTorchTradingEnv, OKXFuturesTradingEnvConfig
+
+        config = OKXFuturesTradingEnvConfig(
+            symbol="BTC-USDT-SWAP", time_frames=["1m"], window_sizes=[10],
+            execute_on="1m", action_levels=[-1.0, -0.5, 0.0, 0.5, 1.0],
+        )
+        with patch("time.sleep"), \
+             patch.object(OKXFuturesTorchTradingEnv, "_wait_for_next_timestamp"):
+            return OKXFuturesTorchTradingEnv(config=config, observer=mock_env_observer, trader=mock_env_trader)
+
+    def test_qty_step_rounding_no_float_artifacts(self, env, mock_env_trader):
+        """Quantity must be rounded to avoid float artifacts like 0.00300000000003."""
+        from torchtrade.envs.live.okx.order_executor import PositionStatus
+
+        mock_env_trader.get_status = MagicMock(return_value={
+            "position_status": PositionStatus(
+                qty=0.0, notional_value=0, entry_price=0,
+                unrealized_pnl=0, unrealized_pnl_pct=0,
+                mark_price=50000.0, leverage=1, margin_mode="isolated",
+                liquidation_price=0,
+            )
+        })
+        mock_env_trader.get_mark_price = MagicMock(return_value=50000.0)
+        mock_env_trader.get_lot_size = MagicMock(return_value={"min_qty": 0.001, "qty_step": 0.001})
+        mock_env_trader.get_account_balance = MagicMock(return_value={
+            "total_wallet_balance": 1000.0, "available_balance": 900.0,
+            "total_unrealized_profit": 0.0, "total_margin_balance": 1000.0,
+        })
+
+        env.reset()
+        result = env._execute_fractional_action(1.0)
+        if result["executed"]:
+            qty = mock_env_trader.trade.call_args[1]["quantity"]
+            qty_str = str(qty)
+            assert len(qty_str.split('.')[-1]) <= 3, f"Float artifact in quantity: {qty}"
+
+
+class TestWithReplayData:
+    """Integration tests using ReplayObserver + ReplayOrderExecutor."""
+
+    @pytest.fixture
+    def replay_df(self):
+        import pandas as pd
+
+        n = 200
+        rng = np.random.default_rng(42)
+        base = 50000 + np.cumsum(rng.normal(0, 50, n))
+        return pd.DataFrame({
+            "timestamp": pd.date_range("2024-01-01", periods=n, freq="1min"),
+            "open": base,
+            "high": base + np.abs(rng.normal(30, 20, n)),
+            "low": base - np.abs(rng.normal(30, 20, n)),
+            "close": base + rng.normal(0, 20, n),
+            "volume": rng.uniform(100, 1000, n),
+        })
+
+    def test_multi_step_episode_with_replay(self, replay_df):
+        """Run a multi-step episode with realistic price data."""
+        from torchtrade.envs.live.okx.env import OKXFuturesTorchTradingEnv, OKXFuturesTradingEnvConfig
+        from torchtrade.envs.replay import ReplayObserver, ReplayOrderExecutor
+
+        config = OKXFuturesTradingEnvConfig(
+            symbol="BTC-USDT-SWAP", time_frames=["1m"], window_sizes=[10],
+            execute_on="1m", leverage=5, demo=True,
+        )
+        executor = ReplayOrderExecutor(initial_balance=10000.0, leverage=5)
+        observer = ReplayObserver(
+            df=replay_df, time_frames=config.time_frames,
+            window_sizes=config.window_sizes, execute_on=config.execute_on, executor=executor,
         )
 
         with patch("time.sleep"), \
              patch.object(OKXFuturesTorchTradingEnv, "_wait_for_next_timestamp"):
-            env = OKXFuturesTorchTradingEnv(
-                config=config, observer=mock_env_observer, trader=mock_env_trader,
-            )
+            env = OKXFuturesTorchTradingEnv(config=config, observer=observer, trader=executor)
 
-        mock_env_trader.cancel_open_orders = MagicMock(return_value=cancel_ok)
-        mock_env_trader.close_position = MagicMock(return_value=close_ok)
-
-        obs = env.reset()
-        assert obs is not None
+        with patch.object(env, "_wait_for_next_timestamp"):
+            td = env.reset()
+            for i in range(20):
+                action_idx = i % len(env.action_levels)
+                action_td = td.clone()
+                action_td["action"] = torch.tensor(action_idx)
+                result = env.step(action_td)
+                td = result["next"]
+                assert td["account_state"].shape == (6,)
+                if td["done"].item():
+                    break
+            assert executor.current_price > 0

--- a/tests/envs/okx/test_torch_env_futures.py
+++ b/tests/envs/okx/test_torch_env_futures.py
@@ -6,8 +6,6 @@ import numpy as np
 from unittest.mock import MagicMock, patch
 from tensordict import TensorDict
 
-from torchtrade.envs import TimeFrame
-
 
 class TestOKXFuturesTorchTradingEnv:
     """Tests for OKXFuturesTorchTradingEnv."""

--- a/tests/envs/okx/test_torch_env_futures.py
+++ b/tests/envs/okx/test_torch_env_futures.py
@@ -36,22 +36,6 @@ class TestOKXFuturesTorchTradingEnv:
         return observer
 
     @pytest.fixture
-    def mock_trader(self):
-        """Create a mock trader."""
-        trader = MagicMock()
-        trader.cancel_open_orders = MagicMock(return_value=True)
-        trader.close_position = MagicMock(return_value=True)
-        trader.get_account_balance = MagicMock(return_value={
-            "total_wallet_balance": 1000.0, "available_balance": 900.0,
-            "total_unrealized_profit": 0.0, "total_margin_balance": 1000.0,
-        })
-        trader.get_mark_price = MagicMock(return_value=50000.0)
-        trader.get_status = MagicMock(return_value={"position_status": None})
-        trader.trade = MagicMock(return_value=True)
-        trader.get_lot_size = MagicMock(return_value={"min_qty": 0.001, "qty_step": 0.001})
-        return trader
-
-    @pytest.fixture
     def env_config(self):
         from torchtrade.envs.live.okx.env import OKXFuturesTradingEnvConfig
         return OKXFuturesTradingEnvConfig(
@@ -60,13 +44,13 @@ class TestOKXFuturesTorchTradingEnv:
         )
 
     @pytest.fixture
-    def env(self, env_config, mock_observer, mock_trader):
+    def env(self, env_config, mock_observer, mock_env_trader):
         from torchtrade.envs.live.okx.env import OKXFuturesTorchTradingEnv
 
         with patch("time.sleep"), \
              patch.object(OKXFuturesTorchTradingEnv, "_wait_for_next_timestamp"):
             return OKXFuturesTorchTradingEnv(
-                config=env_config, observer=mock_observer, trader=mock_trader,
+                config=env_config, observer=mock_observer, trader=mock_env_trader,
             )
 
     def test_action_spec(self, env):
@@ -82,13 +66,13 @@ class TestOKXFuturesTorchTradingEnv:
         assert "market_data_5Minute_10" in obs_spec.keys()
         assert obs_spec["account_state"].shape == (6,)
 
-    def test_reset(self, env, mock_trader):
+    def test_reset(self, env, mock_env_trader):
         """Test environment reset returns expected keys and shapes."""
         td = env.reset()
         assert "account_state" in td.keys()
         assert td["account_state"].shape == (6,)
         assert td["market_data_1Minute_10"].shape == (10, 4)
-        mock_trader.cancel_open_orders.assert_called()
+        mock_env_trader.cancel_open_orders.assert_called()
 
     def test_step_hold_action(self, env):
         """Test step with hold action produces valid output."""
@@ -102,12 +86,12 @@ class TestOKXFuturesTorchTradingEnv:
     @pytest.mark.parametrize("action_idx,label", [
         (4, "long"), (0, "short"),
     ], ids=["long", "short"])
-    def test_step_trade_action(self, env, mock_trader, action_idx, label):
+    def test_step_trade_action(self, env, mock_env_trader, action_idx, label):
         """Test step with long/short action calls trade."""
         with patch.object(env, "_wait_for_next_timestamp"):
             env.reset()
             env.step(TensorDict({"action": torch.tensor(action_idx)}, batch_size=()))
-            mock_trader.trade.assert_called()
+            mock_env_trader.trade.assert_called()
 
     def test_reward_and_done_tensor_shapes(self, env):
         """Test that reward and done flags have correct tensor shapes."""
@@ -119,16 +103,16 @@ class TestOKXFuturesTorchTradingEnv:
             assert next_td["next"]["terminated"].shape == (1,)
             assert next_td["next"]["truncated"].shape == (1,)
 
-    def test_no_bankruptcy_when_disabled(self, env_config, mock_observer, mock_trader):
+    def test_no_bankruptcy_when_disabled(self, env_config, mock_observer, mock_env_trader):
         """Test that bankruptcy check can be disabled."""
         from torchtrade.envs.live.okx.env import OKXFuturesTorchTradingEnv
         env_config.done_on_bankruptcy = False
 
         with patch("time.sleep"), \
              patch.object(OKXFuturesTorchTradingEnv, "_wait_for_next_timestamp"):
-            env = OKXFuturesTorchTradingEnv(config=env_config, observer=mock_observer, trader=mock_trader)
+            env = OKXFuturesTorchTradingEnv(config=env_config, observer=mock_observer, trader=mock_env_trader)
 
-        mock_trader.get_account_balance = MagicMock(return_value={
+        mock_env_trader.get_account_balance = MagicMock(return_value={
             "total_wallet_balance": 10.0, "available_balance": 10.0,
             "total_unrealized_profit": 0.0, "total_margin_balance": 10.0,
         })
@@ -274,66 +258,8 @@ class TestOKXObservationSpecsNoNetwork:
         assert "market_data_1Minute_10" in env.observation_spec.keys()
 
 
-class TestOKXFractionalPositionResizing:
-    """Tests for fractional position resizing."""
-
-    @pytest.fixture
-    def env(self, mock_env_observer, mock_env_trader):
-        from torchtrade.envs.live.okx.env import OKXFuturesTorchTradingEnv, OKXFuturesTradingEnvConfig
-
-        config = OKXFuturesTradingEnvConfig(
-            symbol="BTC-USDT-SWAP", time_frames=["1m"], window_sizes=[10],
-            execute_on="1m", action_levels=[-1.0, -0.5, 0.0, 0.5, 1.0],
-        )
-        with patch("time.sleep"), \
-             patch.object(OKXFuturesTorchTradingEnv, "_wait_for_next_timestamp"):
-            return OKXFuturesTorchTradingEnv(config=config, observer=mock_env_observer, trader=mock_env_trader)
-
-    def test_qty_step_rounding_no_float_artifacts(self, env, mock_env_trader):
-        """Quantity must be rounded to avoid float artifacts like 0.00300000000003."""
-        from torchtrade.envs.live.okx.order_executor import PositionStatus
-
-        mock_env_trader.get_status = MagicMock(return_value={
-            "position_status": PositionStatus(
-                qty=0.0, notional_value=0, entry_price=0,
-                unrealized_pnl=0, unrealized_pnl_pct=0,
-                mark_price=50000.0, leverage=1, margin_mode="isolated",
-                liquidation_price=0,
-            )
-        })
-        mock_env_trader.get_mark_price = MagicMock(return_value=50000.0)
-        mock_env_trader.get_lot_size = MagicMock(return_value={"min_qty": 0.001, "qty_step": 0.001})
-        mock_env_trader.get_account_balance = MagicMock(return_value={
-            "total_wallet_balance": 1000.0, "available_balance": 900.0,
-            "total_unrealized_profit": 0.0, "total_margin_balance": 1000.0,
-        })
-
-        env.reset()
-        result = env._execute_fractional_action(1.0, current_qty=0.0, current_price=50000.0)
-        if result["executed"]:
-            qty = mock_env_trader.trade.call_args[1]["quantity"]
-            qty_str = str(qty)
-            assert len(qty_str.split('.')[-1]) <= 3, f"Float artifact in quantity: {qty}"
-
-
 class TestWithReplayData:
     """Integration tests using ReplayObserver + ReplayOrderExecutor."""
-
-    @pytest.fixture
-    def replay_df(self):
-        import pandas as pd
-
-        n = 200
-        rng = np.random.default_rng(42)
-        base = 50000 + np.cumsum(rng.normal(0, 50, n))
-        return pd.DataFrame({
-            "timestamp": pd.date_range("2024-01-01", periods=n, freq="1min"),
-            "open": base,
-            "high": base + np.abs(rng.normal(30, 20, n)),
-            "low": base - np.abs(rng.normal(30, 20, n)),
-            "close": base + rng.normal(0, 20, n),
-            "volume": rng.uniform(100, 1000, n),
-        })
 
     def test_multi_step_episode_with_replay(self, replay_df):
         """Run a multi-step episode with realistic price data."""

--- a/tests/envs/okx/test_torch_env_futures.py
+++ b/tests/envs/okx/test_torch_env_futures.py
@@ -1,0 +1,335 @@
+"""Tests for OKXFuturesTorchTradingEnv."""
+
+import pytest
+import torch
+import numpy as np
+from unittest.mock import MagicMock, patch
+from tensordict import TensorDict
+
+from torchtrade.envs import TimeFrame
+
+
+class TestOKXFuturesTorchTradingEnv:
+    """Tests for OKXFuturesTorchTradingEnv."""
+
+    @pytest.fixture
+    def mock_observer(self):
+        """Create a mock observer with two timeframes."""
+        observer = MagicMock()
+        observer.get_keys = MagicMock(return_value=["1Minute_10", "5Minute_10"])
+
+        def mock_observations(return_base_ohlc=False):
+            obs = {
+                "1Minute_10": np.random.randn(10, 4).astype(np.float32),
+                "5Minute_10": np.random.randn(10, 4).astype(np.float32),
+            }
+            if return_base_ohlc:
+                obs["base_features"] = np.random.randn(10, 4).astype(np.float32)
+                obs["base_timestamps"] = np.arange(10)
+            return obs
+
+        observer.get_observations = MagicMock(side_effect=mock_observations)
+        observer.get_features = MagicMock(return_value={
+            "observation_features": ["feature_close", "feature_open", "feature_high", "feature_low"],
+            "original_features": ["open", "high", "low", "close", "volume"],
+        })
+        return observer
+
+    @pytest.fixture
+    def mock_trader(self):
+        """Create a mock trader."""
+        trader = MagicMock()
+        trader.cancel_open_orders = MagicMock(return_value=True)
+        trader.close_position = MagicMock(return_value=True)
+        trader.get_account_balance = MagicMock(return_value={
+            "total_wallet_balance": 1000.0,
+            "available_balance": 900.0,
+            "total_unrealized_profit": 0.0,
+            "total_margin_balance": 1000.0,
+        })
+        trader.get_mark_price = MagicMock(return_value=50000.0)
+        trader.get_status = MagicMock(return_value={"position_status": None})
+        trader.trade = MagicMock(return_value=True)
+        trader.get_lot_size = MagicMock(return_value={"min_qty": 0.001, "qty_step": 0.001})
+        return trader
+
+    @pytest.fixture
+    def env_config(self):
+        """Create environment configuration."""
+        from torchtrade.envs.live.okx.env import OKXFuturesTradingEnvConfig
+
+        return OKXFuturesTradingEnvConfig(
+            symbol="BTC-USDT-SWAP",
+            demo=True,
+            time_frames=["1m", "5m"],
+            window_sizes=[10, 10],
+            execute_on="1m",
+            leverage=5,
+        )
+
+    @pytest.fixture
+    def env(self, env_config, mock_observer, mock_trader):
+        """Create environment with mocks."""
+        from torchtrade.envs.live.okx.env import OKXFuturesTorchTradingEnv
+
+        with patch("time.sleep"):
+            with patch.object(OKXFuturesTorchTradingEnv, "_wait_for_next_timestamp"):
+                return OKXFuturesTorchTradingEnv(
+                    config=env_config,
+                    observer=mock_observer,
+                    trader=mock_trader,
+                )
+
+    def test_action_spec(self, env):
+        """Test action spec and levels are correctly defined."""
+        assert env.action_spec.n == 5
+        assert env.action_levels == [-1.0, -0.5, 0.0, 0.5, 1.0]
+
+    def test_observation_spec(self, env):
+        """Test observation spec contains expected keys with correct shapes."""
+        obs_spec = env.observation_spec
+        assert "account_state" in obs_spec.keys()
+        assert "market_data_1Minute_10" in obs_spec.keys()
+        assert "market_data_5Minute_10" in obs_spec.keys()
+        assert obs_spec["account_state"].shape == (6,)
+
+    def test_reset(self, env, mock_trader):
+        """Test environment reset returns expected keys and shapes."""
+        td = env.reset()
+
+        assert "account_state" in td.keys()
+        assert "market_data_1Minute_10" in td.keys()
+        assert "market_data_5Minute_10" in td.keys()
+        assert td["account_state"].shape == (6,)
+        assert td["market_data_1Minute_10"].shape == (10, 4)
+        mock_trader.cancel_open_orders.assert_called()
+
+    def test_step_hold_action(self, env, mock_trader):
+        """Test step with hold action."""
+        with patch.object(env, "_wait_for_next_timestamp"):
+            env.reset()
+            action_td = TensorDict({"action": torch.tensor(2)}, batch_size=())
+            next_td = env.step(action_td)
+
+            assert "reward" in next_td["next"].keys()
+            assert "done" in next_td["next"].keys()
+            assert "account_state" in next_td["next"].keys()
+
+    @pytest.mark.parametrize("action_idx,label", [
+        (4, "long"),
+        (0, "short"),
+    ], ids=["long", "short"])
+    def test_step_trade_action(self, env, mock_trader, action_idx, label):
+        """Test step with long/short action calls trade."""
+        with patch.object(env, "_wait_for_next_timestamp"):
+            env.reset()
+            action_td = TensorDict({"action": torch.tensor(action_idx)}, batch_size=())
+            env.step(action_td)
+            mock_trader.trade.assert_called()
+
+    def test_reward_and_done_tensor_shapes(self, env):
+        """Test that reward and done flags have correct tensor shapes."""
+        with patch.object(env, "_wait_for_next_timestamp"):
+            env.reset()
+            action_td = TensorDict({"action": torch.tensor(2)}, batch_size=())
+            next_td = env.step(action_td)
+
+            assert next_td["next"]["reward"].shape == (1,)
+            assert next_td["next"]["done"].shape == (1,)
+            assert next_td["next"]["terminated"].shape == (1,)
+            assert next_td["next"]["truncated"].shape == (1,)
+
+    def test_no_bankruptcy_when_disabled(self, env_config, mock_observer, mock_trader):
+        """Test that bankruptcy check can be disabled."""
+        from torchtrade.envs.live.okx.env import OKXFuturesTorchTradingEnv
+
+        env_config.done_on_bankruptcy = False
+
+        with patch("time.sleep"), \
+             patch.object(OKXFuturesTorchTradingEnv, "_wait_for_next_timestamp"):
+            env = OKXFuturesTorchTradingEnv(
+                config=env_config, observer=mock_observer, trader=mock_trader,
+            )
+
+        mock_trader.get_account_balance = MagicMock(return_value={
+            "total_wallet_balance": 10.0, "available_balance": 10.0,
+            "total_unrealized_profit": 0.0, "total_margin_balance": 10.0,
+        })
+
+        with patch.object(env, "_wait_for_next_timestamp"):
+            env.reset()
+            action_td = TensorDict({"action": torch.tensor(2)}, batch_size=())
+            next_td = env.step(action_td)
+            assert next_td["next"]["done"].item() is False
+
+    def test_config_post_init(self):
+        """Test config post_init normalization."""
+        from torchtrade.envs.live.okx.env import OKXFuturesTradingEnvConfig
+
+        config = OKXFuturesTradingEnvConfig(
+            symbol="BTC-USDT-SWAP",
+            time_frames="1m",
+            window_sizes=10,
+        )
+
+        assert isinstance(config.time_frames, list)
+        assert isinstance(config.window_sizes, list)
+        assert all(isinstance(tf, TimeFrame) for tf in config.time_frames)
+
+
+class TestOKXActionIndexClamping:
+    """Tests for action index out-of-range clamping."""
+
+    @pytest.fixture
+    def env(self, mock_env_observer, mock_env_trader):
+        from torchtrade.envs.live.okx.env import (
+            OKXFuturesTorchTradingEnv,
+            OKXFuturesTradingEnvConfig,
+        )
+
+        config = OKXFuturesTradingEnvConfig(
+            symbol="BTC-USDT-SWAP",
+            time_frames=["1m"],
+            window_sizes=[10],
+            execute_on="1m",
+            action_levels=[-1.0, 0.0, 1.0],
+        )
+
+        with patch("time.sleep"), \
+             patch.object(OKXFuturesTorchTradingEnv, "_wait_for_next_timestamp"):
+            return OKXFuturesTorchTradingEnv(
+                config=config, observer=mock_env_observer, trader=mock_env_trader,
+            )
+
+    @pytest.mark.parametrize("action_idx", [-1, 5], ids=["negative", "too-high"])
+    def test_action_index_clamping(self, env, action_idx):
+        """Out-of-range action indices must be clamped with warning."""
+        with patch.object(env, "_wait_for_next_timestamp"):
+            env.reset()
+            action_td = TensorDict({"action": torch.tensor(action_idx)}, batch_size=())
+            next_td = env.step(action_td)
+            assert "reward" in next_td["next"].keys()
+
+    def test_nan_action_defaults_to_zero(self, env):
+        """NaN action must default to action index 0 without crashing."""
+        with patch.object(env, "_wait_for_next_timestamp"):
+            env.reset()
+            action_td = TensorDict({"action": torch.tensor(float("nan"))}, batch_size=())
+            next_td = env.step(action_td)
+            assert "reward" in next_td["next"].keys()
+
+
+class TestOKXZeroLiquidationPrice:
+    """Test distance_to_liquidation with zero/missing liquidation price."""
+
+    @pytest.fixture
+    def env(self, mock_env_observer, mock_env_trader):
+        from torchtrade.envs.live.okx.env import (
+            OKXFuturesTorchTradingEnv,
+            OKXFuturesTradingEnvConfig,
+        )
+
+        config = OKXFuturesTradingEnvConfig(
+            symbol="BTC-USDT-SWAP",
+            time_frames=["1m"],
+            window_sizes=[10],
+            execute_on="1m",
+        )
+
+        with patch("time.sleep"), \
+             patch.object(OKXFuturesTorchTradingEnv, "_wait_for_next_timestamp"):
+            return OKXFuturesTorchTradingEnv(
+                config=config, observer=mock_env_observer, trader=mock_env_trader,
+            )
+
+    @pytest.mark.parametrize("qty,liq_price,expected_dtl", [
+        (0.001, 45000.0, pytest.approx(0.1018, rel=1e-2)),
+        (0.001, 0.0, 1.0),
+        (-0.001, 55000.0, pytest.approx(0.0978, rel=1e-2)),
+        (-0.001, 0.0, 1.0),
+    ], ids=["long-normal", "long-zero-liq", "short-normal", "short-zero-liq"])
+    def test_distance_to_liquidation(self, env, mock_env_trader, qty, liq_price, expected_dtl):
+        """Zero liquidation price must return 1.0 (consistent with other exchanges)."""
+        from torchtrade.envs.live.okx.order_executor import PositionStatus
+
+        mock_env_trader.get_status = MagicMock(return_value={
+            "position_status": PositionStatus(
+                qty=qty, notional_value=50.1, entry_price=50000.0,
+                unrealized_pnl=0.1, unrealized_pnl_pct=0.002,
+                mark_price=50100.0, leverage=10, margin_mode="isolated",
+                liquidation_price=liq_price,
+            )
+        })
+
+        td = env._get_observation()
+        distance_to_liq = td["account_state"][5].item()
+        assert distance_to_liq == expected_dtl
+
+
+class TestOKXInitCleanup:
+    """Test that __init__ flattens by default and respects close_position_on_init."""
+
+    @pytest.mark.parametrize("close_on_init,expect_close", [
+        (True, True),
+        (False, False),
+    ])
+    def test_init_close_position_configurable(
+        self, mock_env_observer, mock_env_trader, close_on_init, expect_close
+    ):
+        """close_position_on_init controls whether positions are closed on startup."""
+        from torchtrade.envs.live.okx.env import (
+            OKXFuturesTorchTradingEnv,
+            OKXFuturesTradingEnvConfig,
+        )
+
+        config = OKXFuturesTradingEnvConfig(
+            symbol="BTC-USDT-SWAP",
+            time_frames=["1m"],
+            window_sizes=[10],
+            execute_on="1m",
+            close_position_on_init=close_on_init,
+        )
+
+        with patch("time.sleep"), \
+             patch.object(OKXFuturesTorchTradingEnv, "_wait_for_next_timestamp"):
+            OKXFuturesTorchTradingEnv(
+                config=config, observer=mock_env_observer, trader=mock_env_trader,
+            )
+
+        mock_env_trader.cancel_open_orders.assert_called_once()
+        if expect_close:
+            mock_env_trader.close_position.assert_called_once()
+        else:
+            mock_env_trader.close_position.assert_not_called()
+
+    @pytest.mark.parametrize("cancel_ok,close_ok", [
+        (False, True),
+        (True, False),
+        (False, False),
+    ], ids=["cancel-fails", "close-fails", "both-fail"])
+    def test_reset_logs_warning_on_cleanup_failure(self, mock_env_observer, mock_env_trader, cancel_ok, close_ok):
+        """reset() must warn but not raise when cleanup calls return False."""
+        from torchtrade.envs.live.okx.env import (
+            OKXFuturesTorchTradingEnv,
+            OKXFuturesTradingEnvConfig,
+        )
+
+        config = OKXFuturesTradingEnvConfig(
+            symbol="BTC-USDT-SWAP",
+            time_frames=["1m"],
+            window_sizes=[10],
+            execute_on="1m",
+            close_position_on_reset=True,
+        )
+
+        with patch("time.sleep"), \
+             patch.object(OKXFuturesTorchTradingEnv, "_wait_for_next_timestamp"):
+            env = OKXFuturesTorchTradingEnv(
+                config=config, observer=mock_env_observer, trader=mock_env_trader,
+            )
+
+        mock_env_trader.cancel_open_orders = MagicMock(return_value=cancel_ok)
+        mock_env_trader.close_position = MagicMock(return_value=close_ok)
+
+        obs = env.reset()
+        assert obs is not None

--- a/tests/envs/okx/test_torch_env_futures.py
+++ b/tests/envs/okx/test_torch_env_futures.py
@@ -309,7 +309,7 @@ class TestOKXFractionalPositionResizing:
         })
 
         env.reset()
-        result = env._execute_fractional_action(1.0)
+        result = env._execute_fractional_action(1.0, current_qty=0.0, current_price=50000.0)
         if result["executed"]:
             qty = mock_env_trader.trade.call_args[1]["quantity"]
             qty_str = str(qty)

--- a/tests/envs/okx/test_torch_env_futures_sltp.py
+++ b/tests/envs/okx/test_torch_env_futures_sltp.py
@@ -431,22 +431,6 @@ class TestOKXSLTPActionIndexClamping:
 class TestWithReplayData:
     """Integration tests using ReplayObserver + ReplayOrderExecutor."""
 
-    @pytest.fixture
-    def replay_df(self):
-        import pandas as pd
-
-        n = 200
-        rng = np.random.default_rng(42)
-        base = 50000 + np.cumsum(rng.normal(0, 50, n))
-        return pd.DataFrame({
-            "timestamp": pd.date_range("2024-01-01", periods=n, freq="1min"),
-            "open": base,
-            "high": base + np.abs(rng.normal(30, 20, n)),
-            "low": base - np.abs(rng.normal(30, 20, n)),
-            "close": base + rng.normal(0, 20, n),
-            "volume": rng.uniform(100, 1000, n),
-        })
-
     def test_multi_step_episode_with_replay(self, replay_df):
         """Run a full multi-step episode with realistic price data."""
         from torchtrade.envs.live.okx.env_sltp import OKXFuturesSLTPTorchTradingEnv, OKXFuturesSLTPTradingEnvConfig

--- a/tests/envs/okx/test_torch_env_futures_sltp.py
+++ b/tests/envs/okx/test_torch_env_futures_sltp.py
@@ -1,0 +1,486 @@
+"""Tests for OKXFuturesSLTPTorchTradingEnv."""
+
+import pytest
+import torch
+from unittest.mock import MagicMock, patch
+from tensordict import TensorDict
+
+from torchtrade.envs import TimeFrame
+
+
+class TestOKXFuturesSLTPTorchTradingEnv:
+    """Tests for OKXFuturesSLTPTorchTradingEnv."""
+
+    @pytest.fixture
+    def env_config(self):
+        """Create environment configuration."""
+        from torchtrade.envs.live.okx.env_sltp import OKXFuturesSLTPTradingEnvConfig
+
+        return OKXFuturesSLTPTradingEnvConfig(
+            symbol="BTC-USDT-SWAP",
+            demo=True,
+            time_frames=["1m"],
+            window_sizes=[10],
+            execute_on="1m",
+            leverage=5,
+            stoploss_levels=(-0.02, -0.05),
+            takeprofit_levels=(0.03, 0.06),
+            include_short_positions=True,
+            quantity_per_trade=0.001,
+        )
+
+    @pytest.fixture
+    def env(self, env_config, mock_env_observer, mock_env_trader):
+        """Create environment with mocks."""
+        from torchtrade.envs.live.okx.env_sltp import OKXFuturesSLTPTorchTradingEnv
+
+        with patch("time.sleep"):
+            with patch.object(OKXFuturesSLTPTorchTradingEnv, "_wait_for_next_timestamp"):
+                return OKXFuturesSLTPTorchTradingEnv(
+                    config=env_config,
+                    observer=mock_env_observer,
+                    trader=mock_env_trader,
+                )
+
+    def test_action_map_structure(self, env):
+        """Test action map: 1 HOLD + 4 LONG (2x2) + 4 SHORT (2x2) = 9 actions."""
+        assert len(env.action_map) == 9
+        assert env.action_spec.n == 9
+        assert env.action_map[0] == (None, None, None)  # HOLD
+
+    def test_action_map_long_actions(self, env):
+        """Test long actions have negative SL and positive TP."""
+        for i in range(1, 5):
+            side, sl, tp = env.action_map[i]
+            assert side == "long"
+            assert sl < 0
+            assert tp > 0
+
+    def test_action_map_short_actions(self, env):
+        """Test short actions have positive SL and negative TP."""
+        for i in range(5, 9):
+            side, sl, tp = env.action_map[i]
+            assert side == "short"
+            assert sl > 0
+            assert tp < 0
+
+    def test_action_spec_long_only(self, env_config, mock_env_observer, mock_env_trader):
+        """Test action spec when short positions disabled: 1 HOLD + 4 LONG = 5."""
+        from torchtrade.envs.live.okx.env_sltp import OKXFuturesSLTPTorchTradingEnv
+
+        env_config.include_short_positions = False
+
+        with patch("time.sleep"), \
+             patch.object(OKXFuturesSLTPTorchTradingEnv, "_wait_for_next_timestamp"):
+            env = OKXFuturesSLTPTorchTradingEnv(
+                config=env_config, observer=mock_env_observer, trader=mock_env_trader,
+            )
+
+        assert env.action_spec.n == 5
+
+    def test_observation_spec(self, env):
+        """Test observation spec contains expected keys with correct shapes."""
+        assert "account_state" in env.observation_spec.keys()
+        assert "market_data_1Minute_10" in env.observation_spec.keys()
+        assert env.observation_spec["account_state"].shape == (6,)
+
+    def test_reset(self, env, mock_env_trader):
+        """Test environment reset returns expected keys and resets SLTP state."""
+        td = env.reset()
+
+        assert "account_state" in td.keys()
+        assert "market_data_1Minute_10" in td.keys()
+        assert td["account_state"].shape == (6,)
+        assert env.active_stop_loss == 0.0
+        assert env.active_take_profit == 0.0
+        mock_env_trader.cancel_open_orders.assert_called()
+
+    def test_step_hold_action(self, env, mock_env_trader):
+        """Test step with HOLD action does not trade."""
+        with patch.object(env, "_wait_for_next_timestamp"):
+            env.reset()
+            action_td = TensorDict({"action": torch.tensor(0)}, batch_size=())
+            next_td = env.step(action_td)
+
+            mock_env_trader.trade.assert_not_called()
+            assert "reward" in next_td["next"].keys()
+
+    @pytest.mark.parametrize("action_idx,expected_side", [
+        (1, "buy"),
+        (5, "sell"),
+    ])
+    def test_step_bracket_order(self, env, mock_env_trader, action_idx, expected_side):
+        """Test step with LONG/SHORT action places bracket order with SL/TP."""
+        with patch.object(env, "_wait_for_next_timestamp"):
+            env.reset()
+            action_td = TensorDict({"action": torch.tensor(action_idx)}, batch_size=())
+            env.step(action_td)
+
+            mock_env_trader.trade.assert_called()
+            call_kwargs = mock_env_trader.trade.call_args[1]
+            assert call_kwargs["side"] == expected_side
+            assert "take_profit" in call_kwargs
+            assert "stop_loss" in call_kwargs
+
+    def test_sltp_prices_calculated_correctly(self, env, mock_env_trader):
+        """Test that SL/TP prices are calculated from percentages."""
+        with patch.object(env, "_wait_for_next_timestamp"):
+            env.reset()
+            action_td = TensorDict({"action": torch.tensor(1)}, batch_size=())
+            env._step(action_td)
+
+            call_kwargs = mock_env_trader.trade.call_args[1]
+            mark_price = 50000.0
+
+            expected_sl = mark_price * (1 - 0.02)
+            expected_tp = mark_price * (1 + 0.03)
+
+            assert call_kwargs["stop_loss"] == pytest.approx(expected_sl, rel=1e-4)
+            assert call_kwargs["take_profit"] == pytest.approx(expected_tp, rel=1e-4)
+
+    def test_active_sltp_tracking(self, env, mock_env_trader):
+        """Test that active SL/TP levels are tracked after order."""
+        with patch.object(env, "_wait_for_next_timestamp"):
+            env.reset()
+            action_td = TensorDict({"action": torch.tensor(1)}, batch_size=())
+            env._step(action_td)
+
+            assert env.active_stop_loss > 0
+            assert env.active_take_profit > 0
+
+    def test_position_closed_resets_sltp(self, env, mock_env_trader):
+        """Test that position closure resets SL/TP tracking."""
+        with patch.object(env, "_wait_for_next_timestamp"):
+            env.reset()
+
+            action_td = TensorDict({"action": torch.tensor(1)}, batch_size=())
+            env._step(action_td)
+
+            env.active_stop_loss = 49000.0
+            env.active_take_profit = 51000.0
+            env.position.current_position = 1
+
+            mock_env_trader.get_status = MagicMock(return_value={"position_status": None})
+
+            action_td = TensorDict({"action": torch.tensor(0)}, batch_size=())
+            env._step(action_td)
+
+            assert env.active_stop_loss == 0.0
+            assert env.active_take_profit == 0.0
+            assert env.position.current_position == 0
+
+    def test_reward_and_done_tensor_shapes(self, env):
+        """Test that reward and done flags have correct shapes."""
+        with patch.object(env, "_wait_for_next_timestamp"):
+            env.reset()
+            action_td = TensorDict({"action": torch.tensor(0)}, batch_size=())
+            next_td = env.step(action_td)
+
+            assert next_td["next"]["reward"].shape == (1,)
+            assert next_td["next"]["done"].shape == (1,)
+            assert next_td["next"]["terminated"].shape == (1,)
+            assert next_td["next"]["truncated"].shape == (1,)
+
+    def test_bankruptcy_termination(self, env, mock_env_trader):
+        """Test that environment terminates on bankruptcy."""
+        mock_env_trader.get_account_balance = MagicMock(return_value={
+            "total_wallet_balance": 50.0, "available_balance": 50.0,
+            "total_unrealized_profit": 0.0, "total_margin_balance": 50.0,
+        })
+
+        with patch.object(env, "_wait_for_next_timestamp"):
+            env.reset()
+            action_td = TensorDict({"action": torch.tensor(0)}, batch_size=())
+            next_td = env.step(action_td)
+            assert next_td["next"]["done"].item() is True
+
+    def test_no_trade_when_position_exists(self, env, mock_env_trader):
+        """Test that no trade is placed when already in same position."""
+        from torchtrade.envs.live.okx.order_executor import PositionStatus
+
+        mock_env_trader.get_status = MagicMock(return_value={
+            "position_status": PositionStatus(
+                qty=0.001, notional_value=50.0, entry_price=50000.0,
+                unrealized_pnl=0.5, unrealized_pnl_pct=0.01, mark_price=50500.0,
+                leverage=5, margin_mode="isolated", liquidation_price=45000.0,
+            )
+        })
+
+        with patch.object(env, "_wait_for_next_timestamp"):
+            env.reset()
+            env.position.current_position = 1
+
+            action_td = TensorDict({"action": torch.tensor(1)}, batch_size=())
+            env._step(action_td)
+
+            mock_env_trader.trade.assert_not_called()
+
+    def test_config_post_init(self):
+        """Test config post_init normalization."""
+        from torchtrade.envs.live.okx.env_sltp import OKXFuturesSLTPTradingEnvConfig
+
+        config = OKXFuturesSLTPTradingEnvConfig(
+            symbol="BTC-USDT-SWAP",
+            time_frames="1m",
+            window_sizes=10,
+        )
+
+        assert isinstance(config.time_frames, list)
+        assert isinstance(config.window_sizes, list)
+        assert all(isinstance(tf, TimeFrame) for tf in config.time_frames)
+
+
+class TestOKXDuplicateActionPrevention:
+    """Test duplicate action prevention and position switch logic."""
+
+    @pytest.fixture
+    def env_with_mocks(self, mock_env_observer, mock_env_trader):
+        from torchtrade.envs.live.okx.env_sltp import (
+            OKXFuturesSLTPTorchTradingEnv,
+            OKXFuturesSLTPTradingEnvConfig,
+        )
+
+        config = OKXFuturesSLTPTradingEnvConfig(
+            symbol="BTC-USDT-SWAP",
+            time_frames=["1m"],
+            window_sizes=[10],
+            stoploss_levels=(-0.02,),
+            takeprofit_levels=(0.03,),
+            include_short_positions=True,
+        )
+
+        with patch("time.sleep"), \
+             patch.object(OKXFuturesSLTPTorchTradingEnv, "_wait_for_next_timestamp"):
+            env = OKXFuturesSLTPTorchTradingEnv(
+                config=config, observer=mock_env_observer, trader=mock_env_trader,
+            )
+            return env, mock_env_trader
+
+    @pytest.mark.parametrize("position,action_tuple,should_trade", [
+        (1, ("long", -0.02, 0.03), False),
+        (-1, ("short", 0.03, -0.02), False),
+        (0, (None, None, None), False),
+        (1, (None, None, None), False),
+    ])
+    def test_duplicate_and_hold_actions(self, env_with_mocks, position, action_tuple, should_trade):
+        """Test that duplicate and hold actions don't trigger trades."""
+        env, mock_trader = env_with_mocks
+        env.reset()
+        mock_trader.reset_mock()
+
+        env.position.current_position = position
+        trade_info = env._execute_trade_if_needed(action_tuple)
+
+        assert trade_info["executed"] is should_trade
+        mock_trader.trade.assert_not_called()
+        mock_trader.close_position.assert_not_called()
+
+    @pytest.mark.parametrize("initial_pos,action_tuple,expected_side", [
+        (1, ("short", 0.03, -0.02), "sell"),
+        (-1, ("long", -0.02, 0.03), "buy"),
+    ])
+    def test_position_switch(self, env_with_mocks, initial_pos, action_tuple, expected_side):
+        """Test position switching closes old and opens new."""
+        env, mock_trader = env_with_mocks
+        env.reset()
+        mock_trader.reset_mock()
+        env.position.current_position = initial_pos
+
+        env._execute_trade_if_needed(action_tuple)
+
+        mock_trader.close_position.assert_called_once()
+        mock_trader.trade.assert_called_once()
+        assert mock_trader.trade.call_args.kwargs["side"] == expected_side
+
+
+class TestOKXSLTPCloseAction:
+    """Tests for close action when include_close_action=True."""
+
+    @pytest.fixture
+    def env_with_close(self, mock_env_observer, mock_env_trader):
+        from torchtrade.envs.live.okx.env_sltp import (
+            OKXFuturesSLTPTorchTradingEnv,
+            OKXFuturesSLTPTradingEnvConfig,
+        )
+
+        config = OKXFuturesSLTPTradingEnvConfig(
+            symbol="BTC-USDT-SWAP",
+            time_frames=["1m"],
+            window_sizes=[10],
+            stoploss_levels=(-0.02,),
+            takeprofit_levels=(0.03,),
+            include_close_action=True,
+        )
+
+        with patch("time.sleep"), \
+             patch.object(OKXFuturesSLTPTorchTradingEnv, "_wait_for_next_timestamp"):
+            env = OKXFuturesSLTPTorchTradingEnv(
+                config=config, observer=mock_env_observer, trader=mock_env_trader,
+            )
+
+        mock_env_trader.reset_mock()
+        return env
+
+    def test_close_action_in_action_map(self, env_with_close):
+        """Close action must be present in action map at index 1."""
+        assert env_with_close.action_map[0] == (None, None, None)
+        assert env_with_close.action_map[1] == ("close", None, None)
+
+    def test_close_action_closes_position(self, env_with_close, mock_env_trader):
+        """Close action must close an existing position."""
+        env_with_close.position.current_position = 1
+
+        trade_info = env_with_close._execute_trade_if_needed(("close", None, None))
+
+        assert trade_info["executed"] is True
+        assert trade_info["closed_position"] is True
+        mock_env_trader.close_position.assert_called_once()
+        assert env_with_close.position.current_position == 0
+
+    def test_close_action_no_position(self, env_with_close, mock_env_trader):
+        """Close action with no position should be a no-op."""
+        env_with_close.position.current_position = 0
+
+        trade_info = env_with_close._execute_trade_if_needed(("close", None, None))
+
+        assert trade_info["executed"] is False
+        mock_env_trader.close_position.assert_not_called()
+
+
+class TestOKXSLTPNotionalTradeMode:
+    """Test notional (USD) trade mode for OKX SLTP environment."""
+
+    @pytest.fixture
+    def notional_env(self, mock_env_observer, mock_env_trader):
+        from torchtrade.envs.live.okx.env_sltp import (
+            OKXFuturesSLTPTorchTradingEnv,
+            OKXFuturesSLTPTradingEnvConfig,
+        )
+
+        config = OKXFuturesSLTPTradingEnvConfig(
+            symbol="BTC-USDT-SWAP",
+            time_frames=["1m"],
+            window_sizes=[10],
+            stoploss_levels=(-0.02,),
+            takeprofit_levels=(0.03,),
+            include_short_positions=True,
+            trade_mode="notional",
+            quantity_per_trade=500.0,
+        )
+
+        with patch("time.sleep"), \
+             patch.object(OKXFuturesSLTPTorchTradingEnv, "_wait_for_next_timestamp"):
+            return OKXFuturesSLTPTorchTradingEnv(
+                config=config, observer=mock_env_observer, trader=mock_env_trader,
+            )
+
+    @pytest.mark.parametrize("action_tuple,expected_side", [
+        (("long", -0.02, 0.03), "buy"),
+        (("short", 0.02, -0.03), "sell"),
+    ], ids=["long-buy", "short-sell"])
+    def test_notional_converts_usd_to_quantity(self, notional_env, mock_env_trader, action_tuple, expected_side):
+        """Notional mode must convert USD to base-asset quantity using current price."""
+        mock_env_trader.get_mark_price = MagicMock(return_value=50000.0)
+
+        with patch.object(notional_env, "_wait_for_next_timestamp"):
+            notional_env.reset()
+            notional_env._execute_trade_if_needed(action_tuple)
+
+            call_kwargs = mock_env_trader.trade.call_args[1]
+            assert call_kwargs["side"] == expected_side
+            assert call_kwargs["quantity"] == pytest.approx(0.01, rel=1e-6)
+
+
+class TestOKXSLTPLockPosition:
+    """Test lock_position_until_sltp for OKX SLTP environment."""
+
+    @pytest.fixture
+    def locked_env(self, mock_env_observer, mock_env_trader):
+        from torchtrade.envs.live.okx.env_sltp import (
+            OKXFuturesSLTPTorchTradingEnv,
+            OKXFuturesSLTPTradingEnvConfig,
+        )
+
+        config = OKXFuturesSLTPTradingEnvConfig(
+            symbol="BTC-USDT-SWAP",
+            time_frames=["1m"],
+            window_sizes=[10],
+            stoploss_levels=(-0.02,),
+            takeprofit_levels=(0.03,),
+            include_short_positions=True,
+            lock_position_until_sltp=True,
+        )
+
+        with patch("time.sleep"), \
+             patch.object(OKXFuturesSLTPTorchTradingEnv, "_wait_for_next_timestamp"):
+            return OKXFuturesSLTPTorchTradingEnv(
+                config=config, observer=mock_env_observer, trader=mock_env_trader,
+            )
+
+    def test_locked_ignores_switch_action(self, locked_env, mock_env_trader):
+        """With lock=True, a short action while long should be ignored."""
+        with patch.object(locked_env, "_wait_for_next_timestamp"):
+            locked_env.reset()
+
+            locked_env._execute_trade_if_needed(("long", -0.02, 0.03))
+            mock_env_trader.trade.assert_called_once()
+            locked_env.position.current_position = 1
+
+            mock_env_trader.reset_mock()
+
+            trade_info = locked_env._execute_trade_if_needed(("short", 0.02, -0.03))
+
+            assert trade_info["executed"] is False
+            mock_env_trader.trade.assert_not_called()
+            mock_env_trader.close_position.assert_not_called()
+
+    def test_locked_allows_open_from_flat(self, locked_env, mock_env_trader):
+        """With lock=True, opening a position from flat should still work."""
+        with patch.object(locked_env, "_wait_for_next_timestamp"):
+            locked_env.reset()
+            assert locked_env.position.current_position == 0
+
+            locked_env._execute_trade_if_needed(("long", -0.02, 0.03))
+            mock_env_trader.trade.assert_called_once()
+
+
+class TestOKXSLTPActionIndexClamping:
+    """Test SLTP action index clamping."""
+
+    @pytest.fixture
+    def env(self, mock_env_observer, mock_env_trader):
+        from torchtrade.envs.live.okx.env_sltp import (
+            OKXFuturesSLTPTorchTradingEnv,
+            OKXFuturesSLTPTradingEnvConfig,
+        )
+
+        config = OKXFuturesSLTPTradingEnvConfig(
+            symbol="BTC-USDT-SWAP",
+            time_frames=["1m"],
+            window_sizes=[10],
+            stoploss_levels=(-0.02,),
+            takeprofit_levels=(0.03,),
+        )
+
+        with patch("time.sleep"), \
+             patch.object(OKXFuturesSLTPTorchTradingEnv, "_wait_for_next_timestamp"):
+            return OKXFuturesSLTPTorchTradingEnv(
+                config=config, observer=mock_env_observer, trader=mock_env_trader,
+            )
+
+    @pytest.mark.parametrize("action_idx", [-1, 99], ids=["negative", "too-high"])
+    def test_action_index_clamping(self, env, action_idx):
+        """Out-of-range SLTP action indices must be clamped without error."""
+        with patch.object(env, "_wait_for_next_timestamp"):
+            env.reset()
+            action_td = TensorDict({"action": torch.tensor(action_idx)}, batch_size=())
+            next_td = env.step(action_td)
+            assert "reward" in next_td["next"].keys()
+
+    def test_nan_action_defaults_to_zero(self, env):
+        """NaN action must default to action index 0 (HOLD) without crashing."""
+        with patch.object(env, "_wait_for_next_timestamp"):
+            env.reset()
+            action_td = TensorDict({"action": torch.tensor(float("nan"))}, batch_size=())
+            next_td = env.step(action_td)
+            assert "reward" in next_td["next"].keys()

--- a/tests/envs/okx/test_torch_env_futures_sltp.py
+++ b/tests/envs/okx/test_torch_env_futures_sltp.py
@@ -2,6 +2,7 @@
 
 import pytest
 import torch
+import numpy as np
 from unittest.mock import MagicMock, patch
 from tensordict import TensorDict
 
@@ -13,34 +14,23 @@ class TestOKXFuturesSLTPTorchTradingEnv:
 
     @pytest.fixture
     def env_config(self):
-        """Create environment configuration."""
         from torchtrade.envs.live.okx.env_sltp import OKXFuturesSLTPTradingEnvConfig
-
         return OKXFuturesSLTPTradingEnvConfig(
-            symbol="BTC-USDT-SWAP",
-            demo=True,
-            time_frames=["1m"],
-            window_sizes=[10],
-            execute_on="1m",
-            leverage=5,
-            stoploss_levels=(-0.02, -0.05),
-            takeprofit_levels=(0.03, 0.06),
-            include_short_positions=True,
+            symbol="BTC-USDT-SWAP", demo=True, time_frames=["1m"], window_sizes=[10],
+            execute_on="1m", leverage=5, stoploss_levels=(-0.02, -0.05),
+            takeprofit_levels=(0.03, 0.06), include_short_positions=True,
             quantity_per_trade=0.001,
         )
 
     @pytest.fixture
     def env(self, env_config, mock_env_observer, mock_env_trader):
-        """Create environment with mocks."""
         from torchtrade.envs.live.okx.env_sltp import OKXFuturesSLTPTorchTradingEnv
 
-        with patch("time.sleep"):
-            with patch.object(OKXFuturesSLTPTorchTradingEnv, "_wait_for_next_timestamp"):
-                return OKXFuturesSLTPTorchTradingEnv(
-                    config=env_config,
-                    observer=mock_env_observer,
-                    trader=mock_env_trader,
-                )
+        with patch("time.sleep"), \
+             patch.object(OKXFuturesSLTPTorchTradingEnv, "_wait_for_next_timestamp"):
+            return OKXFuturesSLTPTorchTradingEnv(
+                config=env_config, observer=mock_env_observer, trader=mock_env_trader,
+            )
 
     def test_action_map_structure(self, env):
         """Test action map: 1 HOLD + 4 LONG (2x2) + 4 SHORT (2x2) = 9 actions."""
@@ -48,26 +38,9 @@ class TestOKXFuturesSLTPTorchTradingEnv:
         assert env.action_spec.n == 9
         assert env.action_map[0] == (None, None, None)  # HOLD
 
-    def test_action_map_long_actions(self, env):
-        """Test long actions have negative SL and positive TP."""
-        for i in range(1, 5):
-            side, sl, tp = env.action_map[i]
-            assert side == "long"
-            assert sl < 0
-            assert tp > 0
-
-    def test_action_map_short_actions(self, env):
-        """Test short actions have positive SL and negative TP."""
-        for i in range(5, 9):
-            side, sl, tp = env.action_map[i]
-            assert side == "short"
-            assert sl > 0
-            assert tp < 0
-
     def test_action_spec_long_only(self, env_config, mock_env_observer, mock_env_trader):
         """Test action spec when short positions disabled: 1 HOLD + 4 LONG = 5."""
         from torchtrade.envs.live.okx.env_sltp import OKXFuturesSLTPTorchTradingEnv
-
         env_config.include_short_positions = False
 
         with patch("time.sleep"), \
@@ -75,95 +48,60 @@ class TestOKXFuturesSLTPTorchTradingEnv:
             env = OKXFuturesSLTPTorchTradingEnv(
                 config=env_config, observer=mock_env_observer, trader=mock_env_trader,
             )
-
         assert env.action_spec.n == 5
-
-    def test_observation_spec(self, env):
-        """Test observation spec contains expected keys with correct shapes."""
-        assert "account_state" in env.observation_spec.keys()
-        assert "market_data_1Minute_10" in env.observation_spec.keys()
-        assert env.observation_spec["account_state"].shape == (6,)
 
     def test_reset(self, env, mock_env_trader):
         """Test environment reset returns expected keys and resets SLTP state."""
         td = env.reset()
-
         assert "account_state" in td.keys()
         assert "market_data_1Minute_10" in td.keys()
         assert td["account_state"].shape == (6,)
         assert env.active_stop_loss == 0.0
         assert env.active_take_profit == 0.0
-        mock_env_trader.cancel_open_orders.assert_called()
 
     def test_step_hold_action(self, env, mock_env_trader):
         """Test step with HOLD action does not trade."""
         with patch.object(env, "_wait_for_next_timestamp"):
             env.reset()
-            action_td = TensorDict({"action": torch.tensor(0)}, batch_size=())
-            next_td = env.step(action_td)
-
+            next_td = env.step(TensorDict({"action": torch.tensor(0)}, batch_size=()))
             mock_env_trader.trade.assert_not_called()
             assert "reward" in next_td["next"].keys()
 
-    @pytest.mark.parametrize("action_idx,expected_side", [
-        (1, "buy"),
-        (5, "sell"),
-    ])
+    @pytest.mark.parametrize("action_idx,expected_side", [(1, "buy"), (5, "sell")])
     def test_step_bracket_order(self, env, mock_env_trader, action_idx, expected_side):
         """Test step with LONG/SHORT action places bracket order with SL/TP."""
         with patch.object(env, "_wait_for_next_timestamp"):
             env.reset()
-            action_td = TensorDict({"action": torch.tensor(action_idx)}, batch_size=())
-            env.step(action_td)
-
-            mock_env_trader.trade.assert_called()
+            env.step(TensorDict({"action": torch.tensor(action_idx)}, batch_size=()))
             call_kwargs = mock_env_trader.trade.call_args[1]
             assert call_kwargs["side"] == expected_side
             assert "take_profit" in call_kwargs
             assert "stop_loss" in call_kwargs
 
-    def test_sltp_prices_calculated_correctly(self, env, mock_env_trader):
-        """Test that SL/TP prices are calculated from percentages."""
+    def test_bracket_uses_mark_price(self, env, mock_env_trader):
+        """Bracket order SL/TP must be calculated from mark price, not candle close."""
+        mock_env_trader.get_mark_price = MagicMock(return_value=51000.0)
+
         with patch.object(env, "_wait_for_next_timestamp"):
             env.reset()
-            action_td = TensorDict({"action": torch.tensor(1)}, batch_size=())
-            env._step(action_td)
-
+            env._execute_trade_if_needed(("long", -0.02, 0.03))
             call_kwargs = mock_env_trader.trade.call_args[1]
-            mark_price = 50000.0
-
-            expected_sl = mark_price * (1 - 0.02)
-            expected_tp = mark_price * (1 + 0.03)
-
-            assert call_kwargs["stop_loss"] == pytest.approx(expected_sl, rel=1e-4)
-            assert call_kwargs["take_profit"] == pytest.approx(expected_tp, rel=1e-4)
-
-    def test_active_sltp_tracking(self, env, mock_env_trader):
-        """Test that active SL/TP levels are tracked after order."""
-        with patch.object(env, "_wait_for_next_timestamp"):
-            env.reset()
-            action_td = TensorDict({"action": torch.tensor(1)}, batch_size=())
-            env._step(action_td)
-
-            assert env.active_stop_loss > 0
-            assert env.active_take_profit > 0
+            # SL/TP should be based on mark price (51000), not candle close (50050)
+            assert call_kwargs["stop_loss"] == pytest.approx(51000.0 * (1 - 0.02), rel=1e-4)
+            assert call_kwargs["take_profit"] == pytest.approx(51000.0 * (1 + 0.03), rel=1e-4)
 
     def test_position_closed_resets_sltp(self, env, mock_env_trader):
         """Test that position closure resets SL/TP tracking."""
         with patch.object(env, "_wait_for_next_timestamp"):
             env.reset()
-
-            action_td = TensorDict({"action": torch.tensor(1)}, batch_size=())
-            env._step(action_td)
+            env._step(TensorDict({"action": torch.tensor(1)}, batch_size=()))
 
             env.active_stop_loss = 49000.0
             env.active_take_profit = 51000.0
             env.position.current_position = 1
 
             mock_env_trader.get_status = MagicMock(return_value={"position_status": None})
-
-            action_td = TensorDict({"action": torch.tensor(0)}, batch_size=())
-            env._step(action_td)
+            env._step(TensorDict({"action": torch.tensor(0)}, batch_size=()))
 
             assert env.active_stop_loss == 0.0
             assert env.active_take_profit == 0.0
@@ -173,9 +111,7 @@ class TestOKXFuturesSLTPTorchTradingEnv:
         """Test that reward and done flags have correct shapes."""
         with patch.object(env, "_wait_for_next_timestamp"):
             env.reset()
-            action_td = TensorDict({"action": torch.tensor(0)}, batch_size=())
-            next_td = env.step(action_td)
-
+            next_td = env.step(TensorDict({"action": torch.tensor(0)}, batch_size=()))
             assert next_td["next"]["reward"].shape == (1,)
             assert next_td["next"]["done"].shape == (1,)
             assert next_td["next"]["terminated"].shape == (1,)
@@ -187,11 +123,9 @@ class TestOKXFuturesSLTPTorchTradingEnv:
             "total_wallet_balance": 50.0, "available_balance": 50.0,
             "total_unrealized_profit": 0.0, "total_margin_balance": 50.0,
         })
-
         with patch.object(env, "_wait_for_next_timestamp"):
             env.reset()
-            action_td = TensorDict({"action": torch.tensor(0)}, batch_size=())
-            next_td = env.step(action_td)
+            next_td = env.step(TensorDict({"action": torch.tensor(0)}, batch_size=()))
             assert next_td["next"]["done"].item() is True
 
     def test_no_trade_when_position_exists(self, env, mock_env_trader):
@@ -205,29 +139,11 @@ class TestOKXFuturesSLTPTorchTradingEnv:
                 leverage=5, margin_mode="isolated", liquidation_price=45000.0,
             )
         })
-
         with patch.object(env, "_wait_for_next_timestamp"):
             env.reset()
             env.position.current_position = 1
-
-            action_td = TensorDict({"action": torch.tensor(1)}, batch_size=())
-            env._step(action_td)
-
+            env._step(TensorDict({"action": torch.tensor(1)}, batch_size=()))
             mock_env_trader.trade.assert_not_called()
-
-    def test_config_post_init(self):
-        """Test config post_init normalization."""
-        from torchtrade.envs.live.okx.env_sltp import OKXFuturesSLTPTradingEnvConfig
-
-        config = OKXFuturesSLTPTradingEnvConfig(
-            symbol="BTC-USDT-SWAP",
-            time_frames="1m",
-            window_sizes=10,
-        )
-
-        assert isinstance(config.time_frames, list)
-        assert isinstance(config.window_sizes, list)
-        assert all(isinstance(tf, TimeFrame) for tf in config.time_frames)
 
 
 class TestOKXDuplicateActionPrevention:
@@ -235,20 +151,12 @@ class TestOKXDuplicateActionPrevention:
 
     @pytest.fixture
     def env_with_mocks(self, mock_env_observer, mock_env_trader):
-        from torchtrade.envs.live.okx.env_sltp import (
-            OKXFuturesSLTPTorchTradingEnv,
-            OKXFuturesSLTPTradingEnvConfig,
-        )
+        from torchtrade.envs.live.okx.env_sltp import OKXFuturesSLTPTorchTradingEnv, OKXFuturesSLTPTradingEnvConfig
 
         config = OKXFuturesSLTPTradingEnvConfig(
-            symbol="BTC-USDT-SWAP",
-            time_frames=["1m"],
-            window_sizes=[10],
-            stoploss_levels=(-0.02,),
-            takeprofit_levels=(0.03,),
-            include_short_positions=True,
+            symbol="BTC-USDT-SWAP", time_frames=["1m"], window_sizes=[10],
+            stoploss_levels=(-0.02,), takeprofit_levels=(0.03,), include_short_positions=True,
         )
-
         with patch("time.sleep"), \
              patch.object(OKXFuturesSLTPTorchTradingEnv, "_wait_for_next_timestamp"):
             env = OKXFuturesSLTPTorchTradingEnv(
@@ -267,13 +175,9 @@ class TestOKXDuplicateActionPrevention:
         env, mock_trader = env_with_mocks
         env.reset()
         mock_trader.reset_mock()
-
         env.position.current_position = position
         trade_info = env._execute_trade_if_needed(action_tuple)
-
         assert trade_info["executed"] is should_trade
-        mock_trader.trade.assert_not_called()
-        mock_trader.close_position.assert_not_called()
 
     @pytest.mark.parametrize("initial_pos,action_tuple,expected_side", [
         (1, ("short", 0.03, -0.02), "sell"),
@@ -285,9 +189,7 @@ class TestOKXDuplicateActionPrevention:
         env.reset()
         mock_trader.reset_mock()
         env.position.current_position = initial_pos
-
         env._execute_trade_if_needed(action_tuple)
-
         mock_trader.close_position.assert_called_once()
         mock_trader.trade.assert_called_once()
         assert mock_trader.trade.call_args.kwargs["side"] == expected_side
@@ -298,26 +200,17 @@ class TestOKXSLTPCloseAction:
 
     @pytest.fixture
     def env_with_close(self, mock_env_observer, mock_env_trader):
-        from torchtrade.envs.live.okx.env_sltp import (
-            OKXFuturesSLTPTorchTradingEnv,
-            OKXFuturesSLTPTradingEnvConfig,
-        )
+        from torchtrade.envs.live.okx.env_sltp import OKXFuturesSLTPTorchTradingEnv, OKXFuturesSLTPTradingEnvConfig
 
         config = OKXFuturesSLTPTradingEnvConfig(
-            symbol="BTC-USDT-SWAP",
-            time_frames=["1m"],
-            window_sizes=[10],
-            stoploss_levels=(-0.02,),
-            takeprofit_levels=(0.03,),
-            include_close_action=True,
+            symbol="BTC-USDT-SWAP", time_frames=["1m"], window_sizes=[10],
+            stoploss_levels=(-0.02,), takeprofit_levels=(0.03,), include_close_action=True,
         )
-
         with patch("time.sleep"), \
              patch.object(OKXFuturesSLTPTorchTradingEnv, "_wait_for_next_timestamp"):
             env = OKXFuturesSLTPTorchTradingEnv(
                 config=config, observer=mock_env_observer, trader=mock_env_trader,
             )
-
         mock_env_trader.reset_mock()
         return env
 
@@ -329,22 +222,15 @@ class TestOKXSLTPCloseAction:
     def test_close_action_closes_position(self, env_with_close, mock_env_trader):
         """Close action must close an existing position."""
         env_with_close.position.current_position = 1
-
         trade_info = env_with_close._execute_trade_if_needed(("close", None, None))
-
         assert trade_info["executed"] is True
         assert trade_info["closed_position"] is True
-        mock_env_trader.close_position.assert_called_once()
-        assert env_with_close.position.current_position == 0
 
     def test_close_action_no_position(self, env_with_close, mock_env_trader):
         """Close action with no position should be a no-op."""
         env_with_close.position.current_position = 0
-
         trade_info = env_with_close._execute_trade_if_needed(("close", None, None))
-
         assert trade_info["executed"] is False
-        mock_env_trader.close_position.assert_not_called()
 
 
 class TestOKXSLTPNotionalTradeMode:
@@ -352,22 +238,13 @@ class TestOKXSLTPNotionalTradeMode:
 
     @pytest.fixture
     def notional_env(self, mock_env_observer, mock_env_trader):
-        from torchtrade.envs.live.okx.env_sltp import (
-            OKXFuturesSLTPTorchTradingEnv,
-            OKXFuturesSLTPTradingEnvConfig,
-        )
+        from torchtrade.envs.live.okx.env_sltp import OKXFuturesSLTPTorchTradingEnv, OKXFuturesSLTPTradingEnvConfig
 
         config = OKXFuturesSLTPTradingEnvConfig(
-            symbol="BTC-USDT-SWAP",
-            time_frames=["1m"],
-            window_sizes=[10],
-            stoploss_levels=(-0.02,),
-            takeprofit_levels=(0.03,),
-            include_short_positions=True,
-            trade_mode="notional",
-            quantity_per_trade=500.0,
+            symbol="BTC-USDT-SWAP", time_frames=["1m"], window_sizes=[10],
+            stoploss_levels=(-0.02,), takeprofit_levels=(0.03,),
+            include_short_positions=True, trade_mode="notional", quantity_per_trade=500.0,
         )
-
         with patch("time.sleep"), \
              patch.object(OKXFuturesSLTPTorchTradingEnv, "_wait_for_next_timestamp"):
             return OKXFuturesSLTPTorchTradingEnv(
@@ -381,14 +258,66 @@ class TestOKXSLTPNotionalTradeMode:
     def test_notional_converts_usd_to_quantity(self, notional_env, mock_env_trader, action_tuple, expected_side):
         """Notional mode must convert USD to base-asset quantity using current price."""
         mock_env_trader.get_mark_price = MagicMock(return_value=50000.0)
-
         with patch.object(notional_env, "_wait_for_next_timestamp"):
             notional_env.reset()
             notional_env._execute_trade_if_needed(action_tuple)
-
             call_kwargs = mock_env_trader.trade.call_args[1]
             assert call_kwargs["side"] == expected_side
             assert call_kwargs["quantity"] == pytest.approx(0.01, rel=1e-6)
+
+    def test_notional_zero_price_aborts_trade(self, notional_env, mock_env_trader):
+        """Zero mark price must abort trade without calling trader.trade()."""
+        mock_env_trader.get_mark_price = MagicMock(return_value=0.0)
+        with patch.object(notional_env, "_wait_for_next_timestamp"):
+            notional_env.reset()
+            trade_info = notional_env._execute_trade_if_needed(("long", -0.02, 0.03))
+            mock_env_trader.trade.assert_not_called()
+            assert trade_info["success"] is False
+
+    def test_quantity_mode_passes_raw_value(self, mock_env_observer, mock_env_trader):
+        """Quantity mode must pass quantity_per_trade directly without conversion."""
+        from torchtrade.envs.live.okx.env_sltp import OKXFuturesSLTPTorchTradingEnv, OKXFuturesSLTPTradingEnvConfig
+
+        config = OKXFuturesSLTPTradingEnvConfig(
+            symbol="BTC-USDT-SWAP", time_frames=["1m"], window_sizes=[10],
+            stoploss_levels=(-0.02,), takeprofit_levels=(0.03,),
+            trade_mode="quantity", quantity_per_trade=0.001,
+        )
+        with patch("time.sleep"), \
+             patch.object(OKXFuturesSLTPTorchTradingEnv, "_wait_for_next_timestamp"):
+            env = OKXFuturesSLTPTorchTradingEnv(
+                config=config, observer=mock_env_observer, trader=mock_env_trader,
+            )
+        with patch.object(env, "_wait_for_next_timestamp"):
+            env.reset()
+            env._execute_trade_if_needed(("long", -0.02, 0.03))
+            assert mock_env_trader.trade.call_args[1]["quantity"] == pytest.approx(0.001, rel=1e-6)
+
+    def test_fractional_converts_balance_to_quantity(self, mock_env_observer, mock_env_trader):
+        """Fractional mode must compute quantity from balance * fraction * leverage / price."""
+        from torchtrade.envs.live.okx.env_sltp import OKXFuturesSLTPTorchTradingEnv, OKXFuturesSLTPTradingEnvConfig
+
+        config = OKXFuturesSLTPTradingEnvConfig(
+            symbol="BTC-USDT-SWAP", time_frames=["1m"], window_sizes=[10],
+            stoploss_levels=(-0.02,), takeprofit_levels=(0.03,),
+            trade_mode="fractional", position_fraction=0.1, leverage=5,
+        )
+        with patch("time.sleep"), \
+             patch.object(OKXFuturesSLTPTorchTradingEnv, "_wait_for_next_timestamp"):
+            env = OKXFuturesSLTPTorchTradingEnv(
+                config=config, observer=mock_env_observer, trader=mock_env_trader,
+            )
+
+        mock_env_trader.get_mark_price = MagicMock(return_value=50000.0)
+        mock_env_trader.get_account_balance = MagicMock(return_value={
+            "total_wallet_balance": 1000.0, "available_balance": 900.0,
+            "total_unrealized_profit": 0.0, "total_margin_balance": 1000.0,
+        })
+        with patch.object(env, "_wait_for_next_timestamp"):
+            env.reset()
+            env._execute_trade_if_needed(("long", -0.02, 0.03))
+            # balance=1000 * fraction=0.1 * leverage=5 / price=50000 = 0.01
+            assert mock_env_trader.trade.call_args[1]["quantity"] == pytest.approx(0.01, rel=1e-4)
 
 
 class TestOKXSLTPLockPosition:
@@ -396,21 +325,13 @@ class TestOKXSLTPLockPosition:
 
     @pytest.fixture
     def locked_env(self, mock_env_observer, mock_env_trader):
-        from torchtrade.envs.live.okx.env_sltp import (
-            OKXFuturesSLTPTorchTradingEnv,
-            OKXFuturesSLTPTradingEnvConfig,
-        )
+        from torchtrade.envs.live.okx.env_sltp import OKXFuturesSLTPTorchTradingEnv, OKXFuturesSLTPTradingEnvConfig
 
         config = OKXFuturesSLTPTradingEnvConfig(
-            symbol="BTC-USDT-SWAP",
-            time_frames=["1m"],
-            window_sizes=[10],
-            stoploss_levels=(-0.02,),
-            takeprofit_levels=(0.03,),
-            include_short_positions=True,
-            lock_position_until_sltp=True,
+            symbol="BTC-USDT-SWAP", time_frames=["1m"], window_sizes=[10],
+            stoploss_levels=(-0.02,), takeprofit_levels=(0.03,),
+            include_short_positions=True, lock_position_until_sltp=True,
         )
-
         with patch("time.sleep"), \
              patch.object(OKXFuturesSLTPTorchTradingEnv, "_wait_for_next_timestamp"):
             return OKXFuturesSLTPTorchTradingEnv(
@@ -421,17 +342,23 @@ class TestOKXSLTPLockPosition:
         """With lock=True, a short action while long should be ignored."""
         with patch.object(locked_env, "_wait_for_next_timestamp"):
             locked_env.reset()
-
             locked_env._execute_trade_if_needed(("long", -0.02, 0.03))
-            mock_env_trader.trade.assert_called_once()
             locked_env.position.current_position = 1
-
             mock_env_trader.reset_mock()
 
             trade_info = locked_env._execute_trade_if_needed(("short", 0.02, -0.03))
-
             assert trade_info["executed"] is False
             mock_env_trader.trade.assert_not_called()
+
+    def test_locked_ignores_close_action(self, locked_env, mock_env_trader):
+        """With lock=True, close action while in position should be ignored."""
+        with patch.object(locked_env, "_wait_for_next_timestamp"):
+            locked_env.reset()
+            locked_env.position.current_position = 1
+            mock_env_trader.reset_mock()
+
+            trade_info = locked_env._execute_trade_if_needed(("close", None, None))
+            assert trade_info["executed"] is False
             mock_env_trader.close_position.assert_not_called()
 
     def test_locked_allows_open_from_flat(self, locked_env, mock_env_trader):
@@ -439,9 +366,40 @@ class TestOKXSLTPLockPosition:
         with patch.object(locked_env, "_wait_for_next_timestamp"):
             locked_env.reset()
             assert locked_env.position.current_position == 0
-
             locked_env._execute_trade_if_needed(("long", -0.02, 0.03))
             mock_env_trader.trade.assert_called_once()
+
+
+class TestOKXSLTPPositionClosedClobber:
+    """Regression: position_closed must not overwrite a newly-opened position."""
+
+    @pytest.fixture
+    def env(self, mock_env_observer, mock_env_trader):
+        from torchtrade.envs.live.okx.env_sltp import OKXFuturesSLTPTorchTradingEnv, OKXFuturesSLTPTradingEnvConfig
+
+        config = OKXFuturesSLTPTradingEnvConfig(
+            symbol="BTC-USDT-SWAP", time_frames=["1m"], window_sizes=[10],
+            stoploss_levels=(-0.02,), takeprofit_levels=(0.03,), include_short_positions=True,
+        )
+        with patch("time.sleep"), \
+             patch.object(OKXFuturesSLTPTorchTradingEnv, "_wait_for_next_timestamp"):
+            return OKXFuturesSLTPTorchTradingEnv(
+                config=config, observer=mock_env_observer, trader=mock_env_trader,
+            )
+
+    def test_new_trade_after_sltp_close_preserves_position(self, env, mock_env_trader):
+        """When SL/TP closes a position and a new trade opens in the same step,
+        the new position state must be preserved (not overwritten to 0)."""
+        with patch.object(env, "_wait_for_next_timestamp"):
+            env.reset()
+            env.position.current_position = 1  # Was long
+
+            mock_env_trader.get_status = MagicMock(return_value={"position_status": None})
+            mock_env_trader.get_mark_price = MagicMock(return_value=50000.0)
+
+            short_action_idx = len(env.action_map) - 1
+            env._step(TensorDict({"action": torch.tensor(short_action_idx)}, batch_size=()))
+            assert env.position.current_position == -1
 
 
 class TestOKXSLTPActionIndexClamping:
@@ -449,38 +407,74 @@ class TestOKXSLTPActionIndexClamping:
 
     @pytest.fixture
     def env(self, mock_env_observer, mock_env_trader):
-        from torchtrade.envs.live.okx.env_sltp import (
-            OKXFuturesSLTPTorchTradingEnv,
-            OKXFuturesSLTPTradingEnvConfig,
-        )
+        from torchtrade.envs.live.okx.env_sltp import OKXFuturesSLTPTorchTradingEnv, OKXFuturesSLTPTradingEnvConfig
 
         config = OKXFuturesSLTPTradingEnvConfig(
-            symbol="BTC-USDT-SWAP",
-            time_frames=["1m"],
-            window_sizes=[10],
-            stoploss_levels=(-0.02,),
-            takeprofit_levels=(0.03,),
+            symbol="BTC-USDT-SWAP", time_frames=["1m"], window_sizes=[10],
+            stoploss_levels=(-0.02,), takeprofit_levels=(0.03,),
         )
-
         with patch("time.sleep"), \
              patch.object(OKXFuturesSLTPTorchTradingEnv, "_wait_for_next_timestamp"):
             return OKXFuturesSLTPTorchTradingEnv(
                 config=config, observer=mock_env_observer, trader=mock_env_trader,
             )
 
-    @pytest.mark.parametrize("action_idx", [-1, 99], ids=["negative", "too-high"])
-    def test_action_index_clamping(self, env, action_idx):
-        """Out-of-range SLTP action indices must be clamped without error."""
+    @pytest.mark.parametrize("action_idx", [-1, 99, float("nan")], ids=["negative", "too-high", "nan"])
+    def test_invalid_action_index_handled(self, env, action_idx):
+        """Out-of-range and NaN SLTP action indices must be handled without crashing."""
         with patch.object(env, "_wait_for_next_timestamp"):
             env.reset()
-            action_td = TensorDict({"action": torch.tensor(action_idx)}, batch_size=())
-            next_td = env.step(action_td)
+            next_td = env.step(TensorDict({"action": torch.tensor(action_idx)}, batch_size=()))
             assert "reward" in next_td["next"].keys()
 
-    def test_nan_action_defaults_to_zero(self, env):
-        """NaN action must default to action index 0 (HOLD) without crashing."""
+
+class TestWithReplayData:
+    """Integration tests using ReplayObserver + ReplayOrderExecutor."""
+
+    @pytest.fixture
+    def replay_df(self):
+        import pandas as pd
+
+        n = 200
+        rng = np.random.default_rng(42)
+        base = 50000 + np.cumsum(rng.normal(0, 50, n))
+        return pd.DataFrame({
+            "timestamp": pd.date_range("2024-01-01", periods=n, freq="1min"),
+            "open": base,
+            "high": base + np.abs(rng.normal(30, 20, n)),
+            "low": base - np.abs(rng.normal(30, 20, n)),
+            "close": base + rng.normal(0, 20, n),
+            "volume": rng.uniform(100, 1000, n),
+        })
+
+    def test_multi_step_episode_with_replay(self, replay_df):
+        """Run a full multi-step episode with realistic price data."""
+        from torchtrade.envs.live.okx.env_sltp import OKXFuturesSLTPTorchTradingEnv, OKXFuturesSLTPTradingEnvConfig
+        from torchtrade.envs.replay import ReplayObserver, ReplayOrderExecutor
+
+        config = OKXFuturesSLTPTradingEnvConfig(
+            symbol="BTC-USDT-SWAP", time_frames=["1m"], window_sizes=[10],
+            execute_on="1m", stoploss_levels=(-0.02,), takeprofit_levels=(0.03,),
+            leverage=5, trade_mode="quantity", quantity_per_trade=0.01,
+        )
+        executor = ReplayOrderExecutor(initial_balance=10000.0, leverage=5)
+        observer = ReplayObserver(
+            df=replay_df, time_frames=config.time_frames,
+            window_sizes=config.window_sizes, execute_on=config.execute_on, executor=executor,
+        )
+
+        with patch("time.sleep"), \
+             patch.object(OKXFuturesSLTPTorchTradingEnv, "_wait_for_next_timestamp"):
+            env = OKXFuturesSLTPTorchTradingEnv(config=config, observer=observer, trader=executor)
+
         with patch.object(env, "_wait_for_next_timestamp"):
-            env.reset()
-            action_td = TensorDict({"action": torch.tensor(float("nan"))}, batch_size=())
-            next_td = env.step(action_td)
-            assert "reward" in next_td["next"].keys()
+            td = env.reset()
+            for i in range(50):
+                action = [0, 1, 0, 0, len(env.action_map) - 1, 0][i % 6]
+                action_td = td.clone()
+                action_td["action"] = torch.tensor(action)
+                result = env.step(action_td)
+                td = result["next"]
+                assert td["account_state"].shape == (6,)
+                if td["done"].item():
+                    break

--- a/tests/envs/okx/test_torch_env_futures_sltp.py
+++ b/tests/envs/okx/test_torch_env_futures_sltp.py
@@ -2,11 +2,8 @@
 
 import pytest
 import torch
-import numpy as np
 from unittest.mock import MagicMock, patch
 from tensordict import TensorDict
-
-from torchtrade.envs import TimeFrame
 
 
 class TestOKXFuturesSLTPTorchTradingEnv:

--- a/torchtrade/envs/live/__init__.py
+++ b/torchtrade/envs/live/__init__.py
@@ -39,7 +39,7 @@ from torchtrade.envs.live.bybit import (
     PositionMode,
 )
 
-# OKX
+# OKX (use qualified imports to avoid shadowing Bybit's MarginMode/PositionMode)
 from torchtrade.envs.live.okx import (
     OKXObservationClass,
     OKXFuturesOrderClass,
@@ -47,6 +47,8 @@ from torchtrade.envs.live.okx import (
     OKXFuturesTradingEnvConfig,
     OKXFuturesSLTPTorchTradingEnv,
     OKXFuturesSLTPTradingEnvConfig,
+    MarginMode as OKXMarginMode,
+    PositionMode as OKXPositionMode,
 )
 
 __all__ = [
@@ -84,4 +86,6 @@ __all__ = [
     "OKXFuturesTradingEnvConfig",
     "OKXFuturesSLTPTorchTradingEnv",
     "OKXFuturesSLTPTradingEnvConfig",
+    "OKXMarginMode",
+    "OKXPositionMode",
 ]

--- a/torchtrade/envs/live/__init__.py
+++ b/torchtrade/envs/live/__init__.py
@@ -39,6 +39,16 @@ from torchtrade.envs.live.bybit import (
     PositionMode,
 )
 
+# OKX
+from torchtrade.envs.live.okx import (
+    OKXObservationClass,
+    OKXFuturesOrderClass,
+    OKXFuturesTorchTradingEnv,
+    OKXFuturesTradingEnvConfig,
+    OKXFuturesSLTPTorchTradingEnv,
+    OKXFuturesSLTPTradingEnvConfig,
+)
+
 __all__ = [
     # Alpaca
     "AlpacaObservationClass",
@@ -67,4 +77,11 @@ __all__ = [
     "BybitFuturesSLTPTradingEnvConfig",
     "MarginMode",
     "PositionMode",
+    # OKX
+    "OKXObservationClass",
+    "OKXFuturesOrderClass",
+    "OKXFuturesTorchTradingEnv",
+    "OKXFuturesTradingEnvConfig",
+    "OKXFuturesSLTPTorchTradingEnv",
+    "OKXFuturesSLTPTradingEnvConfig",
 ]

--- a/torchtrade/envs/live/okx/__init__.py
+++ b/torchtrade/envs/live/okx/__init__.py
@@ -1,0 +1,29 @@
+"""OKX Futures live trading environments."""
+
+from torchtrade.envs.live.okx.observation import OKXObservationClass
+from torchtrade.envs.live.okx.order_executor import (
+    OKXFuturesOrderClass,
+    MarginMode,
+    PositionMode,
+    PositionStatus,
+)
+from torchtrade.envs.live.okx.env import (
+    OKXFuturesTorchTradingEnv,
+    OKXFuturesTradingEnvConfig,
+)
+from torchtrade.envs.live.okx.env_sltp import (
+    OKXFuturesSLTPTorchTradingEnv,
+    OKXFuturesSLTPTradingEnvConfig,
+)
+
+__all__ = [
+    "OKXObservationClass",
+    "OKXFuturesOrderClass",
+    "MarginMode",
+    "PositionMode",
+    "PositionStatus",
+    "OKXFuturesTorchTradingEnv",
+    "OKXFuturesTradingEnvConfig",
+    "OKXFuturesSLTPTorchTradingEnv",
+    "OKXFuturesSLTPTradingEnvConfig",
+]

--- a/torchtrade/envs/live/okx/base.py
+++ b/torchtrade/envs/live/okx/base.py
@@ -83,9 +83,18 @@ class OKXBaseTorchTradingEnv(TorchTradeLiveEnv):
         self.execute_on_unit = str(config.execute_on.unit)
 
         # Flatten on startup for a clean state (configurable, default: True)
-        self.trader.cancel_open_orders()
+        try:
+            if not self.trader.cancel_open_orders():
+                logger.warning("cancel_open_orders failed during init")
+        except Exception as e:
+            logger.warning(f"cancel_open_orders raised during init: {e}")
+
         if config.close_position_on_init:
-            self.trader.close_position()
+            try:
+                if not self.trader.close_position():
+                    logger.warning("close_position failed during init")
+            except Exception as e:
+                logger.warning(f"close_position raised during init: {e}")
 
         # Get initial portfolio value
         balance = self.trader.get_account_balance()
@@ -167,6 +176,14 @@ class OKXBaseTorchTradingEnv(TorchTradeLiveEnv):
             )
             self.observation_spec.set(market_data_key, market_data_spec)
             self.market_data_keys.append(market_data_key)
+
+        # Base features spec (raw OHLC from first timeframe)
+        if self.config.include_base_features:
+            base_ws = window_sizes[0]
+            self.observation_spec.set(
+                "base_features",
+                Bounded(low=-torch.inf, high=torch.inf, shape=(base_ws, 4), dtype=torch.float),
+            )
 
     def _get_observation(self) -> TensorDictBase:
         """Get the current observation state."""

--- a/torchtrade/envs/live/okx/base.py
+++ b/torchtrade/envs/live/okx/base.py
@@ -269,13 +269,19 @@ class OKXBaseTorchTradingEnv(TorchTradeLiveEnv):
 
     def _reset(self, tensordict: TensorDictBase, **kwargs) -> TensorDictBase:
         """Reset the environment."""
-        if not self.trader.cancel_open_orders():
-            logger.warning("cancel_open_orders failed during reset; proceeding with potentially stale orders")
+        try:
+            if not self.trader.cancel_open_orders():
+                logger.warning("cancel_open_orders failed during reset; proceeding with potentially stale orders")
+        except Exception as e:
+            logger.warning(f"cancel_open_orders raised during reset: {e}")
         self.history.reset()
 
         if self.config.close_position_on_reset:
-            if not self.trader.close_position():
-                logger.warning("close_position failed during reset; proceeding with residual exposure")
+            try:
+                if not self.trader.close_position():
+                    logger.warning("close_position failed during reset; proceeding with residual exposure")
+            except Exception as e:
+                logger.warning(f"close_position raised during reset: {e}")
 
         balance = self.trader.get_account_balance()
         self.balance = balance.get("available_balance", 0)

--- a/torchtrade/envs/live/okx/base.py
+++ b/torchtrade/envs/live/okx/base.py
@@ -1,0 +1,315 @@
+"""Base class for OKX live trading environments."""
+import logging
+
+from abc import abstractmethod
+from typing import Callable, List, Optional
+
+import torch
+from tensordict import TensorDict, TensorDictBase
+from torchrl.data import Bounded
+from torchrl.data.tensor_specs import Composite
+
+from torchtrade.envs.live.okx.observation import OKXObservationClass
+from torchtrade.envs.live.okx.order_executor import OKXFuturesOrderClass
+from torchtrade.envs.core.live import TorchTradeLiveEnv
+from torchtrade.envs.core.state import HistoryTracker
+
+logger = logging.getLogger(__name__)
+
+
+class OKXBaseTorchTradingEnv(TorchTradeLiveEnv):
+    """
+    Base class for OKX trading environments.
+
+    Provides common functionality for all OKX environments:
+    - OKXObservationClass and OKXFuturesOrderClass initialization
+    - Observation spec construction (account state + market data)
+    - Common observation gathering logic
+    - Portfolio value calculation
+
+    Standard account state (6 elements):
+    [exposure_pct, position_direction, unrealized_pnl_pct,
+     holding_time, leverage, distance_to_liquidation]
+
+    Subclasses must implement:
+    - Action space definition
+    - _execute_trade_if_needed(): Trade execution logic
+    - _check_termination(): Episode termination logic
+    """
+
+    ACCOUNT_STATE = [
+        "exposure_pct", "position_direction", "unrealized_pnlpct",
+        "holding_time", "leverage", "distance_to_liquidation"
+    ]
+
+    def __init__(
+        self,
+        config,
+        api_key: str = "",
+        api_secret: str = "",
+        passphrase: str = "",
+        feature_preprocessing_fn: Optional[Callable] = None,
+        observer: Optional[OKXObservationClass] = None,
+        trader: Optional[OKXFuturesOrderClass] = None,
+    ):
+        """
+        Initialize OKX trading environment.
+
+        Args:
+            config: Environment configuration
+            api_key: OKX API key
+            api_secret: OKX API secret key
+            passphrase: OKX API passphrase
+            feature_preprocessing_fn: Optional custom preprocessing function
+            observer: Optional pre-configured OKXObservationClass
+            trader: Optional pre-configured OKXFuturesOrderClass
+        """
+        self._feature_preprocessing_fn = feature_preprocessing_fn
+        self._passphrase = passphrase
+
+        # Initialize base class (will call _init_trading_clients)
+        super().__init__(
+            config=config,
+            api_key=api_key,
+            api_secret=api_secret,
+            observer=observer,
+            trader=trader,
+            timezone="UTC"
+        )
+
+        # Extract execute timeframe (already normalized to TimeFrame in config.__post_init__)
+        self.execute_on = config.execute_on
+        self.execute_on_value = config.execute_on.value
+        self.execute_on_unit = str(config.execute_on.unit)
+
+        # Flatten on startup for a clean state (configurable, default: True)
+        self.trader.cancel_open_orders()
+        if config.close_position_on_init:
+            self.trader.close_position()
+
+        # Get initial portfolio value
+        balance = self.trader.get_account_balance()
+        self.initial_portfolio_value = balance.get("total_wallet_balance", 0)
+
+        # Build observation specs
+        self._build_observation_specs()
+
+        # Initialize history tracking
+        self.history = HistoryTracker()
+
+    def _init_trading_clients(
+        self,
+        api_key: str,
+        api_secret: str,
+        observer: Optional[OKXObservationClass],
+        trader: Optional[OKXFuturesOrderClass]
+    ):
+        """Initialize OKX observer and trader clients."""
+        time_frames = self.config.time_frames
+        window_sizes = self.config.window_sizes
+        demo = getattr(self.config, 'demo', True)
+
+        # Initialize trader first (observer may reuse its client)
+        self.trader = trader if trader is not None else OKXFuturesOrderClass(
+            symbol=self.config.symbol,
+            api_key=api_key,
+            api_secret=api_secret,
+            passphrase=self._passphrase,
+            demo=demo,
+            leverage=self.config.leverage,
+            margin_mode=self.config.margin_mode,
+            position_mode=self.config.position_mode,
+        )
+
+        # Initialize observer
+        if observer is not None:
+            self.observer = observer
+        else:
+            self.observer = OKXObservationClass(
+                symbol=self.config.symbol,
+                time_frames=time_frames,
+                window_sizes=window_sizes,
+                feature_preprocessing_fn=self._feature_preprocessing_fn,
+                demo=demo,
+            )
+
+    def _build_observation_specs(self):
+        """Build observation specs for account state and market data (no network calls)."""
+        features_info = self.observer.get_features()
+        num_features = len(features_info["observation_features"])
+        market_data_names = self.observer.get_keys()
+
+        window_sizes = self.config.window_sizes if isinstance(self.config.window_sizes, list) else [self.config.window_sizes]
+
+        self.observation_spec = Composite(shape=())
+        self.market_data_key = "market_data"
+        self.account_state_key = "account_state"
+
+        # Account state spec (6 elements)
+        account_state_spec = Bounded(
+            low=-torch.inf,
+            high=torch.inf,
+            shape=(len(self.ACCOUNT_STATE),),
+            dtype=torch.float
+        )
+        self.observation_spec.set(self.account_state_key, account_state_spec)
+
+        # Market data specs (one per interval/timeframe)
+        self.market_data_keys = []
+        for i, market_data_name in enumerate(market_data_names):
+            market_data_key = "market_data_" + market_data_name
+            ws = window_sizes[i] if i < len(window_sizes) else window_sizes[0]
+            market_data_spec = Bounded(
+                low=-torch.inf,
+                high=torch.inf,
+                shape=(ws, num_features),
+                dtype=torch.float
+            )
+            self.observation_spec.set(market_data_key, market_data_spec)
+            self.market_data_keys.append(market_data_key)
+
+    def _get_observation(self) -> TensorDictBase:
+        """Get the current observation state."""
+        obs_dict = self.observer.get_observations(
+            return_base_ohlc=self.config.include_base_features
+        )
+
+        if self.config.include_base_features:
+            base_features = obs_dict.get("base_features")
+
+        market_data = [obs_dict[features_name] for features_name in self.observer.get_keys()]
+
+        # Get account state from trader
+        status = self.trader.get_status()
+        balance = self.trader.get_account_balance()
+
+        total_balance = balance.get("total_wallet_balance", 0)
+        position_status = status.get("position_status", None)
+
+        if position_status is None:
+            self.position.hold_counter = 0
+            position_size = 0.0
+            position_value = 0.0
+            current_price = self.trader.get_mark_price()
+            unrealized_pnl_pct = 0.0
+            leverage = float(self.config.leverage)
+            liquidation_price = 0.0
+            holding_time = 0.0
+        else:
+            self.position.hold_counter += 1
+            position_size = position_status.qty
+            position_value = abs(position_status.notional_value)
+            current_price = position_status.mark_price
+            unrealized_pnl_pct = position_status.unrealized_pnl_pct
+            leverage = float(position_status.leverage)
+            liquidation_price = position_status.liquidation_price
+            holding_time = float(self.position.hold_counter)
+
+        # Build 6-element account state
+        exposure_pct = position_value / total_balance if total_balance > 0 else 0.0
+
+        if position_size > 0:
+            position_direction = 1.0
+        elif position_size < 0:
+            position_direction = -1.0
+        else:
+            position_direction = 0.0
+
+        if position_size == 0 or current_price == 0 or liquidation_price <= 0:
+            distance_to_liquidation = 1.0
+        else:
+            if position_size > 0:
+                distance_to_liquidation = (current_price - liquidation_price) / current_price
+            else:
+                distance_to_liquidation = (liquidation_price - current_price) / current_price
+            distance_to_liquidation = max(0.0, distance_to_liquidation)
+
+        account_state = torch.tensor(
+            [
+                exposure_pct,
+                position_direction,
+                unrealized_pnl_pct,
+                holding_time,
+                leverage,
+                distance_to_liquidation,
+            ],
+            dtype=torch.float,
+        )
+
+        out_td = TensorDict({self.account_state_key: account_state}, batch_size=())
+        for market_data_name, data in zip(self.market_data_keys, market_data):
+            out_td.set(market_data_name, torch.from_numpy(data))
+
+        if self.config.include_base_features and base_features is not None:
+            out_td.set("base_features", torch.from_numpy(base_features))
+
+        return out_td
+
+    def _get_portfolio_value(self) -> float:
+        """Calculate total portfolio value (includes unrealized PnL)."""
+        balance = self.trader.get_account_balance()
+        return balance.get("total_margin_balance", 0)
+
+    def _reset(self, tensordict: TensorDictBase, **kwargs) -> TensorDictBase:
+        """Reset the environment."""
+        if not self.trader.cancel_open_orders():
+            logger.warning("cancel_open_orders failed during reset; proceeding with potentially stale orders")
+        self.history.reset()
+
+        if self.config.close_position_on_reset:
+            if not self.trader.close_position():
+                logger.warning("close_position failed during reset; proceeding with residual exposure")
+
+        balance = self.trader.get_account_balance()
+        self.balance = balance.get("available_balance", 0)
+        self.last_portfolio_value = self._get_portfolio_value()
+
+        status = self.trader.get_status()
+        position_status = status.get("position_status")
+        self.position.hold_counter = 0
+
+        if position_status is None:
+            self.position.current_position = 0
+        elif position_status.qty > 0:
+            self.position.current_position = 1
+        elif position_status.qty < 0:
+            self.position.current_position = -1
+        else:
+            self.position.current_position = 0
+
+        return self._get_observation()
+
+    @abstractmethod
+    def _execute_trade_if_needed(self, action) -> dict:
+        """Execute trade if position change is needed."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def _check_termination(self, portfolio_value: float) -> bool:
+        """Check if episode should terminate."""
+        raise NotImplementedError
+
+    def get_market_data_keys(self) -> List[str]:
+        """Return the list of market data keys."""
+        return self.market_data_keys
+
+    def get_account_state(self) -> List[str]:
+        """Return the list of account state field names."""
+        return self.ACCOUNT_STATE
+
+    def close(self):
+        """Clean up resources."""
+        try:
+            status = self.trader.get_status()
+            if status.get("position_status") and status["position_status"].qty != 0:
+                logger.warning(
+                    "Closing environment with open position! "
+                    "Call env.trader.close_position() before env.close() if needed."
+                )
+        except Exception:
+            pass
+
+        try:
+            self.trader.cancel_open_orders()
+        except Exception as e:
+            logger.error(f"Failed to cancel open orders on close(): {e}")

--- a/torchtrade/envs/live/okx/base.py
+++ b/torchtrade/envs/live/okx/base.py
@@ -83,18 +83,9 @@ class OKXBaseTorchTradingEnv(TorchTradeLiveEnv):
         self.execute_on_unit = str(config.execute_on.unit)
 
         # Flatten on startup for a clean state (configurable, default: True)
-        try:
-            if not self.trader.cancel_open_orders():
-                logger.warning("cancel_open_orders failed during init")
-        except Exception as e:
-            logger.warning(f"cancel_open_orders raised during init: {e}")
-
+        self.trader.cancel_open_orders()
         if config.close_position_on_init:
-            try:
-                if not self.trader.close_position():
-                    logger.warning("close_position failed during init")
-            except Exception as e:
-                logger.warning(f"close_position raised during init: {e}")
+            self.trader.close_position()
 
         # Get initial portfolio value
         balance = self.trader.get_account_balance()
@@ -269,19 +260,13 @@ class OKXBaseTorchTradingEnv(TorchTradeLiveEnv):
 
     def _reset(self, tensordict: TensorDictBase, **kwargs) -> TensorDictBase:
         """Reset the environment."""
-        try:
-            if not self.trader.cancel_open_orders():
-                logger.warning("cancel_open_orders failed during reset; proceeding with potentially stale orders")
-        except Exception as e:
-            logger.warning(f"cancel_open_orders raised during reset: {e}")
+        if not self.trader.cancel_open_orders():
+            logger.warning("cancel_open_orders failed during reset; proceeding with potentially stale orders")
         self.history.reset()
 
         if self.config.close_position_on_reset:
-            try:
-                if not self.trader.close_position():
-                    logger.warning("close_position failed during reset; proceeding with residual exposure")
-            except Exception as e:
-                logger.warning(f"close_position raised during reset: {e}")
+            if not self.trader.close_position():
+                logger.warning("close_position failed during reset; proceeding with residual exposure")
 
         balance = self.trader.get_account_balance()
         self.balance = balance.get("available_balance", 0)

--- a/torchtrade/envs/live/okx/env.py
+++ b/torchtrade/envs/live/okx/env.py
@@ -1,6 +1,7 @@
 """OKX Futures TorchRL trading environment with fractional position sizing."""
 import math
 from dataclasses import dataclass
+from decimal import Decimal, ROUND_DOWN
 from typing import List, Optional, Union, Callable, Dict
 import logging
 
@@ -129,7 +130,9 @@ class OKXFuturesTorchTradingEnv(OKXBaseTorchTradingEnv):
             action_idx = max(0, min(action_idx, len(self.action_levels) - 1))
         desired_action = self.action_levels[action_idx]
 
-        trade_info = self._execute_trade_if_needed(desired_action)
+        trade_info = self._execute_trade_if_needed(
+            desired_action, current_qty=position_size, current_price=current_price,
+        )
 
         if trade_info["executed"] and trade_info.get("success") is not False:
             if trade_info.get("closed_position"):
@@ -248,11 +251,10 @@ class OKXFuturesTorchTradingEnv(OKXBaseTorchTradingEnv):
         )
         return calculate_fractional_position(params)
 
-    def _execute_fractional_action(self, action_value: float) -> Dict:
+    def _execute_fractional_action(
+        self, action_value: float, *, current_qty: float, current_price: float,
+    ) -> Dict:
         """Execute action using fractional position sizing."""
-        current_qty = self._get_current_position_quantity()
-        current_price = self.trader.get_mark_price()
-
         if action_value == 0.0:
             if abs(current_qty) > 0:
                 return self._handle_close_action(current_qty)
@@ -262,25 +264,25 @@ class OKXFuturesTorchTradingEnv(OKXBaseTorchTradingEnv):
         delta_qty = target_qty - current_qty
 
         lot_size = self.trader.get_lot_size()
-        min_qty = lot_size["min_qty"]
-        qty_step = lot_size["qty_step"]
+        min_qty = Decimal(str(lot_size["min_qty"]))
+        qty_step = Decimal(str(lot_size["qty_step"]))
 
-        if abs(delta_qty) < min_qty:
+        delta_d = Decimal(str(abs(delta_qty)))
+        amount_d = (delta_d / qty_step).to_integral_value(rounding=ROUND_DOWN) * qty_step
+
+        if amount_d < min_qty:
             return self._create_trade_info(executed=False)
 
         side = "buy" if delta_qty > 0 else "sell"
-        # Use round() to avoid float artifacts (e.g., 0.003000000000003)
-        step_decimals = len(str(qty_step).rstrip('0').split('.')[-1]) if '.' in str(qty_step) else 0
-        amount = round(int(abs(delta_qty) / qty_step) * qty_step, step_decimals)
+        return self._execute_market_order(side, float(amount_d))
 
-        if amount < min_qty:
-            return self._create_trade_info(executed=False)
-
-        return self._execute_market_order(side, amount)
-
-    def _execute_trade_if_needed(self, desired_action: float) -> Dict:
+    def _execute_trade_if_needed(
+        self, desired_action: float, *, current_qty: float = 0.0, current_price: float = 0.0,
+    ) -> Dict:
         """Execute trade based on desired action value."""
-        return self._execute_fractional_action(desired_action)
+        return self._execute_fractional_action(
+            desired_action, current_qty=current_qty, current_price=current_price,
+        )
 
     def _check_termination(self, portfolio_value: float) -> bool:
         """Check if episode should terminate."""

--- a/torchtrade/envs/live/okx/env.py
+++ b/torchtrade/envs/live/okx/env.py
@@ -132,10 +132,10 @@ class OKXFuturesTorchTradingEnv(OKXBaseTorchTradingEnv):
         trade_info = self._execute_trade_if_needed(desired_action)
 
         if trade_info["executed"] and trade_info.get("success") is not False:
-            if trade_info["side"] == "buy":
-                self.position.current_position = 1
-            elif trade_info["side"] == "sell" and trade_info.get("closed_position"):
+            if trade_info.get("closed_position"):
                 self.position.current_position = 0
+            elif trade_info["side"] == "buy":
+                self.position.current_position = 1
             elif trade_info["side"] == "sell":
                 self.position.current_position = -1
             self.position.current_action_level = desired_action

--- a/torchtrade/envs/live/okx/env.py
+++ b/torchtrade/envs/live/okx/env.py
@@ -1,7 +1,6 @@
 """OKX Futures TorchRL trading environment with fractional position sizing."""
 import math
 from dataclasses import dataclass
-from decimal import Decimal, ROUND_DOWN
 from typing import List, Optional, Union, Callable, Dict
 import logging
 
@@ -168,12 +167,6 @@ class OKXFuturesTorchTradingEnv(OKXBaseTorchTradingEnv):
 
         return next_tensordict
 
-    def _get_current_position_quantity(self) -> float:
-        """Get current position quantity from trader status."""
-        status = self.trader.get_status()
-        position = status.get("position_status")
-        return position.qty if position is not None else 0.0
-
     def _create_trade_info(self, executed=False, **kwargs) -> Dict:
         """Create trade info dictionary with defaults."""
         info = {
@@ -264,17 +257,12 @@ class OKXFuturesTorchTradingEnv(OKXBaseTorchTradingEnv):
         delta_qty = target_qty - current_qty
 
         lot_size = self.trader.get_lot_size()
-        min_qty = Decimal(str(lot_size["min_qty"]))
-        qty_step = Decimal(str(lot_size["qty_step"]))
-
-        delta_d = Decimal(str(abs(delta_qty)))
-        amount_d = (delta_d / qty_step).to_integral_value(rounding=ROUND_DOWN) * qty_step
-
-        if amount_d < min_qty:
+        if abs(delta_qty) < lot_size["min_qty"]:
             return self._create_trade_info(executed=False)
 
         side = "buy" if delta_qty > 0 else "sell"
-        return self._execute_market_order(side, float(amount_d))
+        # _format_size() in trade() handles lot-step quantization
+        return self._execute_market_order(side, abs(delta_qty))
 
     def _execute_trade_if_needed(
         self, desired_action: float, *, current_qty: float = 0.0, current_price: float = 0.0,

--- a/torchtrade/envs/live/okx/env.py
+++ b/torchtrade/envs/live/okx/env.py
@@ -1,0 +1,291 @@
+"""OKX Futures TorchRL trading environment with fractional position sizing."""
+import math
+from dataclasses import dataclass
+from typing import List, Optional, Union, Callable, Dict
+import logging
+
+import torch
+from tensordict import TensorDictBase
+from torchrl.data import Categorical
+
+from torchtrade.envs.live.okx.observation import OKXObservationClass
+from torchtrade.envs.live.okx.order_executor import (
+    OKXFuturesOrderClass,
+    MarginMode,
+    PositionMode,
+)
+from torchtrade.envs.live.okx.base import OKXBaseTorchTradingEnv
+from torchtrade.envs.utils.fractional_sizing import (
+    calculate_fractional_position,
+    PositionCalculationParams,
+)
+
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class OKXFuturesTradingEnvConfig:
+    """Configuration for OKX Futures Trading Environment."""
+
+    symbol: str = "BTC-USDT-SWAP"
+
+    # Timeframes and windows
+    time_frames: Union[List[Union[str, "TimeFrame"]], Union[str, "TimeFrame"]] = "1Hour"
+    window_sizes: Union[List[int], int] = 10
+    execute_on: Union[str, "TimeFrame"] = "1Hour"
+
+    # Trading parameters
+    leverage: int = 1
+    margin_mode: MarginMode = MarginMode.ISOLATED
+    position_mode: PositionMode = PositionMode.NET
+
+    # Action space configuration
+    action_levels: List[float] = None
+
+    # Termination settings
+    done_on_bankruptcy: bool = True
+    bankrupt_threshold: float = 0.1
+
+    # Environment settings
+    demo: bool = True
+    seed: Optional[int] = 42
+    include_base_features: bool = False
+    close_position_on_init: bool = True
+    close_position_on_reset: bool = False
+
+    def __post_init__(self):
+        from torchtrade.envs.live.okx.utils import normalize_okx_timeframe_config
+        self.execute_on, self.time_frames, self.window_sizes = normalize_okx_timeframe_config(
+            self.execute_on, self.time_frames, self.window_sizes
+        )
+
+        if self.action_levels is None:
+            self.action_levels = [-1.0, -0.5, 0.0, 0.5, 1.0]
+
+
+class OKXFuturesTorchTradingEnv(OKXBaseTorchTradingEnv):
+    """
+    TorchRL environment for OKX Futures live trading.
+
+    Supports:
+    - Long and short positions
+    - Configurable leverage (1x-125x)
+    - Multiple timeframe observations
+    - Demo trading
+    - Fractional position sizing
+
+    Action Space (Fractional Mode - Default):
+    - action = -1.0: 100% short (all-in short)
+    - action = -0.5: 50% short
+    - action = 0.0: Market neutral (close all positions)
+    - action = 0.5: 50% long
+    - action = 1.0: 100% long (all-in long)
+
+    Default action_levels: [-1.0, -0.5, 0.0, 0.5, 1.0]
+    """
+
+    def __init__(
+        self,
+        config: OKXFuturesTradingEnvConfig,
+        api_key: str = "",
+        api_secret: str = "",
+        passphrase: str = "",
+        feature_preprocessing_fn: Optional[Callable] = None,
+        reward_function: Optional[Callable] = None,
+        observer: Optional[OKXObservationClass] = None,
+        trader: Optional[OKXFuturesOrderClass] = None,
+    ):
+        super().__init__(config, api_key, api_secret, passphrase, feature_preprocessing_fn, observer, trader)
+
+        from torchtrade.envs.core.default_rewards import log_return_reward
+        self.reward_function = reward_function or log_return_reward
+
+        self.action_levels = config.action_levels
+        self.action_spec = Categorical(len(self.action_levels))
+
+    def _step(self, tensordict: TensorDictBase) -> TensorDictBase:
+        """Execute one environment step."""
+        status = self.trader.get_status()
+        position_status = status.get("position_status", None)
+        if position_status:
+            current_price = position_status.mark_price
+            position_size = position_status.qty
+        else:
+            current_price = self.trader.get_mark_price()
+            position_size = 0.0
+
+        action_idx = tensordict.get("action", 0)
+        if isinstance(action_idx, torch.Tensor):
+            action_idx = action_idx.item()
+        if not isinstance(action_idx, int):
+            if isinstance(action_idx, float) and math.isfinite(action_idx):
+                action_idx = int(action_idx)
+            else:
+                logger.warning(f"Invalid action index {action_idx}, defaulting to 0")
+                action_idx = 0
+        if action_idx < 0 or action_idx >= len(self.action_levels):
+            logger.warning(f"Action index {action_idx} out of range [0, {len(self.action_levels) - 1}], clamping")
+            action_idx = max(0, min(action_idx, len(self.action_levels) - 1))
+        desired_action = self.action_levels[action_idx]
+
+        trade_info = self._execute_trade_if_needed(desired_action)
+
+        if trade_info["executed"] and trade_info.get("success") is not False:
+            if trade_info["side"] == "buy":
+                self.position.current_position = 1
+            elif trade_info["side"] == "sell" and trade_info.get("closed_position"):
+                self.position.current_position = 0
+            elif trade_info["side"] == "sell":
+                self.position.current_position = -1
+            self.position.current_action_level = desired_action
+
+        self._wait_for_next_timestamp()
+
+        new_portfolio_value = self._get_portfolio_value()
+        next_tensordict = self._get_observation()
+
+        self.history.record_step(
+            price=current_price,
+            action=desired_action,
+            reward=0.0,
+            portfolio_value=new_portfolio_value,
+            position=position_size
+        )
+
+        reward = float(self.reward_function(self.history))
+        self.history.rewards[-1] = reward
+
+        done = self._check_termination(new_portfolio_value)
+
+        next_tensordict.set("reward", torch.tensor([reward], dtype=torch.float))
+        next_tensordict.set("done", torch.tensor([done], dtype=torch.bool))
+        next_tensordict.set("truncated", torch.tensor([False], dtype=torch.bool))
+        next_tensordict.set("terminated", torch.tensor([done], dtype=torch.bool))
+
+        return next_tensordict
+
+    def _get_current_position_quantity(self) -> float:
+        """Get current position quantity from trader status."""
+        status = self.trader.get_status()
+        position = status.get("position_status")
+        return position.qty if position is not None else 0.0
+
+    def _create_trade_info(self, executed=False, **kwargs) -> Dict:
+        """Create trade info dictionary with defaults."""
+        info = {
+            "executed": executed,
+            "quantity": 0,
+            "side": None,
+            "success": None,
+            "closed_position": False,
+        }
+        info.update(kwargs)
+        return info
+
+    def _execute_market_order(self, side: str, quantity: float) -> Dict:
+        """Execute a market order with error handling."""
+        try:
+            success = self.trader.trade(
+                side=side,
+                quantity=quantity,
+                order_type="market",
+            )
+            return self._create_trade_info(
+                executed=True,
+                quantity=quantity,
+                side=side,
+                success=success,
+            )
+        except Exception as e:
+            logger.error(f"{side.capitalize()} trade failed for {self.config.symbol}: quantity={quantity}, error={e}")
+            return self._create_trade_info(executed=False, success=False)
+
+    def _handle_close_action(self, current_qty: float) -> Dict:
+        """Handle close position action."""
+        if current_qty == 0:
+            return self._create_trade_info(executed=False)
+
+        try:
+            success = self.trader.close_position()
+        except Exception as e:
+            logger.error(f"Close position failed for {self.config.symbol}: {e}")
+            return self._create_trade_info(executed=False, success=False)
+
+        side = "sell" if current_qty > 0 else "buy"
+
+        if success:
+            self.position.current_position = 0
+
+        return self._create_trade_info(
+            executed=True,
+            quantity=abs(current_qty),
+            side=side,
+            success=success,
+            closed_position=True,
+        )
+
+    def _calculate_fractional_position(self, action_value: float, current_price: float) -> tuple[float, float, str]:
+        """Calculate target position size from fractional action."""
+        if action_value == 0.0:
+            return 0.0, 0.0, "flat"
+
+        balance_info = self.trader.get_account_balance()
+        total_balance = balance_info.get('total_margin_balance', 0.0)
+
+        if total_balance <= 0:
+            logger.warning("No balance for fractional position sizing")
+            return 0.0, 0.0, "flat"
+
+        effective_balance = total_balance * 0.98
+        fee_rate = 0.0005  # OKX futures taker fee
+        params = PositionCalculationParams(
+            balance=effective_balance,
+            action_value=action_value,
+            current_price=current_price,
+            leverage=self.config.leverage,
+            transaction_fee=fee_rate,
+        )
+        return calculate_fractional_position(params)
+
+    def _execute_fractional_action(self, action_value: float) -> Dict:
+        """Execute action using fractional position sizing."""
+        current_qty = self._get_current_position_quantity()
+        current_price = self.trader.get_mark_price()
+
+        if action_value == 0.0:
+            if abs(current_qty) > 0:
+                return self._handle_close_action(current_qty)
+            return self._create_trade_info(executed=False)
+
+        target_qty, _, _ = self._calculate_fractional_position(action_value, current_price)
+        delta_qty = target_qty - current_qty
+
+        lot_size = self.trader.get_lot_size()
+        min_qty = lot_size["min_qty"]
+        qty_step = lot_size["qty_step"]
+
+        if abs(delta_qty) < min_qty:
+            return self._create_trade_info(executed=False)
+
+        side = "buy" if delta_qty > 0 else "sell"
+        # Use round() to avoid float artifacts (e.g., 0.003000000000003)
+        step_decimals = len(str(qty_step).rstrip('0').split('.')[-1]) if '.' in str(qty_step) else 0
+        amount = round(int(abs(delta_qty) / qty_step) * qty_step, step_decimals)
+
+        if amount < min_qty:
+            return self._create_trade_info(executed=False)
+
+        return self._execute_market_order(side, amount)
+
+    def _execute_trade_if_needed(self, desired_action: float) -> Dict:
+        """Execute trade based on desired action value."""
+        return self._execute_fractional_action(desired_action)
+
+    def _check_termination(self, portfolio_value: float) -> bool:
+        """Check if episode should terminate."""
+        if not self.config.done_on_bankruptcy:
+            return False
+
+        bankruptcy_threshold = self.config.bankrupt_threshold * self.initial_portfolio_value
+        return portfolio_value < bankruptcy_threshold

--- a/torchtrade/envs/live/okx/env_sltp.py
+++ b/torchtrade/envs/live/okx/env_sltp.py
@@ -276,6 +276,15 @@ class OKXFuturesSLTPTorchTradingEnv(SLTPMixin, OKXBaseTorchTradingEnv):
         else:
             raise ValueError(f"Unsupported trade_mode={self.config.trade_mode!r}")
 
+        # Quantize to lot size constraints
+        lot = self.trader.get_lot_size()
+        min_qty, qty_step = lot["min_qty"], lot["qty_step"]
+        quantity = math.floor(quantity / qty_step) * qty_step
+        if quantity < min_qty:
+            logger.warning(f"Quantity {quantity} below min_qty {min_qty} for {self.config.symbol}")
+            trade_info["success"] = False
+            return trade_info
+
         # Close opposite position if switching directions
         if self.position.current_position != 0:
             try:

--- a/torchtrade/envs/live/okx/env_sltp.py
+++ b/torchtrade/envs/live/okx/env_sltp.py
@@ -304,8 +304,10 @@ class OKXFuturesSLTPTorchTradingEnv(SLTPMixin, OKXBaseTorchTradingEnv):
             )
 
             if success:
-                self.active_stop_loss = stop_loss_price
-                self.active_take_profit = take_profit_price
+                # Only record SL/TP levels that actually placed on-exchange
+                bs = getattr(self.trader, 'bracket_status', {"tp_placed": True, "sl_placed": True})
+                self.active_stop_loss = stop_loss_price if bs["sl_placed"] else 0.0
+                self.active_take_profit = take_profit_price if bs["tp_placed"] else 0.0
 
             trade_info.update({
                 "executed": True,

--- a/torchtrade/envs/live/okx/env_sltp.py
+++ b/torchtrade/envs/live/okx/env_sltp.py
@@ -1,0 +1,335 @@
+"""OKX Futures TorchRL trading environment with Stop Loss and Take Profit."""
+import math
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Tuple, Union, Callable
+import logging
+
+import torch
+from tensordict import TensorDictBase
+from torchrl.data import Categorical
+
+from torchtrade.envs.live.okx.observation import OKXObservationClass
+from torchtrade.envs.live.okx.order_executor import (
+    OKXFuturesOrderClass,
+    MarginMode,
+    PositionMode,
+)
+from torchtrade.envs.live.okx.base import OKXBaseTorchTradingEnv
+from torchtrade.envs.utils.action_maps import create_sltp_action_map
+from torchtrade.envs.utils.sltp_mixin import SLTPMixin
+from torchtrade.envs.utils.sltp_helpers import calculate_bracket_prices
+from torchtrade.envs.core.common import TradeMode
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class OKXFuturesSLTPTradingEnvConfig:
+    """Configuration for OKX Futures SLTP Trading Environment.
+
+    Uses a combinatorial action space where each action represents a
+    (side, stop_loss_pct, take_profit_pct) tuple for bracket orders.
+    """
+    symbol: str = "BTC-USDT-SWAP"
+
+    # Timeframes and windows
+    time_frames: Union[List[Union[str, "TimeFrame"]], Union[str, "TimeFrame"]] = "1Hour"
+    window_sizes: Union[List[int], int] = 10
+    execute_on: Union[str, "TimeFrame"] = "1Hour"
+
+    # Trading parameters
+    leverage: int = 1
+    margin_mode: MarginMode = MarginMode.ISOLATED
+    position_mode: PositionMode = PositionMode.NET
+    quantity_per_trade: float = 0.001
+    trade_mode: TradeMode = "quantity"
+    position_fraction: float = 1.0  # Used when trade_mode="fractional"
+    lock_position_until_sltp: bool = False  # If True, ignore actions while in position
+
+    # Stop loss levels as percentages (negative values, e.g., -0.025 = -2.5%)
+    stoploss_levels: Tuple[float, ...] = (-0.025, -0.05, -0.1)
+    # Take profit levels as percentages (positive values, e.g., 0.05 = 5%)
+    takeprofit_levels: Tuple[float, ...] = (0.05, 0.1, 0.2)
+    # Include short positions in action space
+    include_short_positions: bool = True
+    # Include HOLD action (index 0)
+    include_hold_action: bool = True
+    # Include CLOSE action for manual position exit
+    include_close_action: bool = False
+
+    # Termination settings
+    done_on_bankruptcy: bool = True
+    bankrupt_threshold: float = 0.1
+
+    # Environment settings
+    demo: bool = True
+    seed: Optional[int] = 42
+    include_base_features: bool = False
+    close_position_on_init: bool = True
+    close_position_on_reset: bool = False
+
+    def __post_init__(self):
+        from torchtrade.envs.live.okx.utils import normalize_okx_timeframe_config
+        from torchtrade.envs.core.common import validate_trade_mode
+
+        self.trade_mode = validate_trade_mode(self.trade_mode)
+        if self.trade_mode == "fractional":
+            if not (0 < self.position_fraction <= 1.0):
+                raise ValueError(f"position_fraction must be in (0, 1.0], got {self.position_fraction}")
+        elif self.trade_mode in ("notional", "quantity"):
+            if self.quantity_per_trade <= 0:
+                raise ValueError(f"quantity_per_trade must be positive, got {self.quantity_per_trade}")
+        self.execute_on, self.time_frames, self.window_sizes = normalize_okx_timeframe_config(
+            self.execute_on, self.time_frames, self.window_sizes
+        )
+
+
+class OKXFuturesSLTPTorchTradingEnv(SLTPMixin, OKXBaseTorchTradingEnv):
+    """
+    OKX Futures trading environment with Stop Loss and Take Profit action spec.
+
+    Uses bracket orders via OKX's attachAlgoOrds parameter.
+
+    Action mapping:
+        - 0: HOLD (do nothing)
+        - 1..N: LONG with specific (stop_loss_pct, take_profit_pct) combination
+        - N+1..M: SHORT with specific SL/TP combination (if enabled)
+    """
+
+    def __init__(
+        self,
+        config: OKXFuturesSLTPTradingEnvConfig,
+        api_key: str = "",
+        api_secret: str = "",
+        passphrase: str = "",
+        feature_preprocessing_fn: Optional[Callable] = None,
+        reward_function: Optional[Callable] = None,
+        observer: Optional[OKXObservationClass] = None,
+        trader: Optional[OKXFuturesOrderClass] = None,
+    ):
+        super().__init__(config, api_key, api_secret, passphrase, feature_preprocessing_fn, observer, trader)
+
+        from torchtrade.envs.core.default_rewards import log_return_reward
+        self.reward_function = reward_function or log_return_reward
+
+        self.stoploss_levels = list(config.stoploss_levels)
+        self.takeprofit_levels = list(config.takeprofit_levels)
+        self.action_map = create_sltp_action_map(
+            self.stoploss_levels,
+            self.takeprofit_levels,
+            include_short_positions=config.include_short_positions,
+            include_hold_action=config.include_hold_action,
+            include_close_action=config.include_close_action
+        )
+
+        self.action_spec = Categorical(len(self.action_map))
+
+        self.active_stop_loss = 0.0
+        self.active_take_profit = 0.0
+
+    def _reset(self, tensordict: TensorDictBase, **kwargs) -> TensorDictBase:
+        """Reset the environment, including SLTP-specific state."""
+        result = super()._reset(tensordict, **kwargs)
+        self._reset_sltp_state()
+        return result
+
+    def _step(self, tensordict: TensorDictBase) -> TensorDictBase:
+        """Execute one environment step."""
+        status = self.trader.get_status()
+        position_status = status.get("position_status", None)
+        if position_status:
+            current_price = position_status.mark_price
+            position_size = position_status.qty
+        else:
+            current_price = self.trader.get_mark_price()
+            position_size = 0.0
+
+        # Sync position state from exchange — this is the source of truth.
+        position_closed = self._sync_position_from_exchange(position_status)
+
+        action_idx = tensordict.get("action", 0)
+        if isinstance(action_idx, torch.Tensor):
+            action_idx = action_idx.item()
+        if not isinstance(action_idx, int):
+            if isinstance(action_idx, float) and math.isfinite(action_idx):
+                action_idx = int(action_idx)
+            else:
+                logger.warning(f"Invalid action index {action_idx}, defaulting to 0")
+                action_idx = 0
+        if action_idx < 0 or action_idx >= len(self.action_map):
+            logger.warning(f"Action index {action_idx} out of range [0, {len(self.action_map) - 1}], clamping")
+            action_idx = max(0, min(action_idx, len(self.action_map) - 1))
+        action_tuple = self.action_map[action_idx]
+
+        # Execute trade if needed (duplicate guard uses synced state)
+        trade_info = self._execute_trade_if_needed(action_tuple)
+        trade_info["position_closed"] = position_closed
+
+        # Eagerly update position from trade result
+        if trade_info["executed"] and trade_info.get("success") is not False:
+            if trade_info.get("closed_position"):
+                self.position.current_position = 0
+            elif trade_info["side"] == "buy":
+                self.position.current_position = 1
+            elif trade_info["side"] == "sell":
+                self.position.current_position = -1
+
+        self._wait_for_next_timestamp()
+
+        new_portfolio_value = self._get_portfolio_value()
+        next_tensordict = self._get_observation()
+
+        side, _, _ = action_tuple
+        if side == "long":
+            action_value = 1.0
+        elif side == "short":
+            action_value = -1.0
+        else:
+            action_value = 0.0
+
+        self.history.record_step(
+            price=current_price,
+            action=action_value,
+            reward=0.0,
+            portfolio_value=new_portfolio_value,
+            position=position_size
+        )
+
+        reward = float(self.reward_function(self.history))
+        self.history.rewards[-1] = reward
+
+        done = self._check_termination(new_portfolio_value)
+
+        next_tensordict.set("reward", torch.tensor([reward], dtype=torch.float))
+        next_tensordict.set("done", torch.tensor([done], dtype=torch.bool))
+        next_tensordict.set("truncated", torch.tensor([False], dtype=torch.bool))
+        next_tensordict.set("terminated", torch.tensor([done], dtype=torch.bool))
+
+        return next_tensordict
+
+    def _execute_trade_if_needed(
+        self, action_tuple: Tuple[Optional[str], Optional[float], Optional[float]]
+    ) -> Dict:
+        """Execute trade if position change is needed."""
+        trade_info = {
+            "executed": False,
+            "quantity": 0,
+            "side": None,
+            "success": None,
+            "closed_position": False,
+        }
+
+        side, stop_loss_pct, take_profit_pct = action_tuple
+
+        # HOLD action
+        if side is None:
+            return trade_info
+
+        # Position locking: ignore all actions while in position
+        if self.config.lock_position_until_sltp and self.position.current_position != 0:
+            return trade_info
+
+        # CLOSE action - close any open position
+        if side == "close":
+            if self.position.current_position == 0:
+                return trade_info
+            try:
+                success = self.trader.close_position()
+            except Exception as e:
+                logger.error(f"Close position failed for {self.config.symbol}: {e}")
+                return trade_info
+            if success:
+                close_side = "sell" if self.position.current_position > 0 else "buy"
+                self.position.current_position = 0
+                self.active_stop_loss = 0.0
+                self.active_take_profit = 0.0
+                trade_info.update({
+                    "executed": True, "side": close_side,
+                    "success": True, "closed_position": True,
+                })
+            return trade_info
+
+        # Check if already in same position
+        position_map = {"long": 1, "short": -1}
+        if side in position_map and self.position.current_position == position_map[side]:
+            return trade_info
+
+        # Get current mark price (more accurate than candle close for bracket orders)
+        current_price = float(self.trader.get_mark_price())
+
+        # Resolve quantity based on trade_mode
+        if self.config.trade_mode == "fractional":
+            balance = float(self.trader.get_account_balance()["total_wallet_balance"])
+            if current_price <= 0 or balance <= 0:
+                logger.error(f"Invalid price={current_price} or balance={balance} for {self.config.symbol}")
+                trade_info["success"] = False
+                return trade_info
+            quantity = balance * self.config.position_fraction * self.config.leverage / current_price
+        elif self.config.trade_mode == "notional":
+            if current_price <= 0:
+                logger.error(f"Invalid current_price={current_price} for {self.config.symbol}")
+                trade_info["success"] = False
+                return trade_info
+            quantity = float(self.config.quantity_per_trade) / current_price
+        elif self.config.trade_mode == "quantity":
+            quantity = float(self.config.quantity_per_trade)
+        else:
+            raise ValueError(f"Unsupported trade_mode={self.config.trade_mode!r}")
+
+        # Close opposite position if switching directions
+        if self.position.current_position != 0:
+            try:
+                close_success = self.trader.close_position()
+            except Exception as e:
+                logger.error(f"Close position failed for {self.config.symbol}: {e}")
+                return trade_info
+            if not close_success:
+                return trade_info
+            self.position.current_position = 0
+
+        # Map position side to trade side
+        trade_side = "buy" if side == "long" else "sell"
+
+        stop_loss_price, take_profit_price = calculate_bracket_prices(
+            side, current_price, stop_loss_pct, take_profit_pct
+        )
+
+        try:
+            success = self.trader.trade(
+                side=trade_side,
+                quantity=quantity,
+                order_type="market",
+                take_profit=take_profit_price,
+                stop_loss=stop_loss_price,
+            )
+
+            if success:
+                self.active_stop_loss = stop_loss_price
+                self.active_take_profit = take_profit_price
+
+            trade_info.update({
+                "executed": True,
+                "quantity": quantity,
+                "side": trade_side,
+                "success": success,
+                "stop_loss": stop_loss_price,
+                "take_profit": take_profit_price,
+            })
+        except Exception as e:
+            logger.error(
+                f"{side.capitalize()} trade failed for {self.config.symbol}: "
+                f"quantity={quantity}, "
+                f"SL={stop_loss_price:.2f}, TP={take_profit_price:.2f}, error={e}"
+            )
+            trade_info["success"] = False
+            return trade_info
+
+        return trade_info
+
+    def _check_termination(self, portfolio_value: float) -> bool:
+        """Check if episode should terminate."""
+        if not self.config.done_on_bankruptcy:
+            return False
+
+        bankruptcy_threshold = self.config.bankrupt_threshold * self.initial_portfolio_value
+        return portfolio_value < bankruptcy_threshold

--- a/torchtrade/envs/live/okx/env_sltp.py
+++ b/torchtrade/envs/live/okx/env_sltp.py
@@ -276,6 +276,12 @@ class OKXFuturesSLTPTorchTradingEnv(SLTPMixin, OKXBaseTorchTradingEnv):
         else:
             raise ValueError(f"Unsupported trade_mode={self.config.trade_mode!r}")
 
+        # Short-circuit if quantity is below exchange minimum
+        lot = self.trader.get_lot_size()
+        if quantity < lot["min_qty"]:
+            trade_info["success"] = False
+            return trade_info
+
         # Close opposite position if switching directions
         if self.position.current_position != 0:
             try:

--- a/torchtrade/envs/live/okx/env_sltp.py
+++ b/torchtrade/envs/live/okx/env_sltp.py
@@ -276,15 +276,6 @@ class OKXFuturesSLTPTorchTradingEnv(SLTPMixin, OKXBaseTorchTradingEnv):
         else:
             raise ValueError(f"Unsupported trade_mode={self.config.trade_mode!r}")
 
-        # Quantize to lot size constraints
-        lot = self.trader.get_lot_size()
-        min_qty, qty_step = lot["min_qty"], lot["qty_step"]
-        quantity = math.floor(quantity / qty_step) * qty_step
-        if quantity < min_qty:
-            logger.warning(f"Quantity {quantity} below min_qty {min_qty} for {self.config.symbol}")
-            trade_info["success"] = False
-            return trade_info
-
         # Close opposite position if switching directions
         if self.position.current_position != 0:
             try:

--- a/torchtrade/envs/live/okx/env_sltp.py
+++ b/torchtrade/envs/live/okx/env_sltp.py
@@ -295,6 +295,8 @@ class OKXFuturesSLTPTorchTradingEnv(SLTPMixin, OKXBaseTorchTradingEnv):
             if not close_success:
                 return trade_info
             self.position.current_position = 0
+            self.active_stop_loss = 0.0
+            self.active_take_profit = 0.0
 
         # Map position side to trade side
         trade_side = "buy" if side == "long" else "sell"
@@ -314,9 +316,9 @@ class OKXFuturesSLTPTorchTradingEnv(SLTPMixin, OKXBaseTorchTradingEnv):
 
             if success:
                 # Only record SL/TP levels that actually placed on-exchange
-                bs = getattr(self.trader, 'bracket_status', {"tp_placed": True, "sl_placed": True})
-                self.active_stop_loss = stop_loss_price if bs["sl_placed"] else 0.0
-                self.active_take_profit = take_profit_price if bs["tp_placed"] else 0.0
+                bs = getattr(self.trader, 'bracket_status', None) or {}
+                self.active_stop_loss = stop_loss_price if bs.get("sl_placed", True) else 0.0
+                self.active_take_profit = take_profit_price if bs.get("tp_placed", True) else 0.0
 
             trade_info.update({
                 "executed": True,

--- a/torchtrade/envs/live/okx/env_sltp.py
+++ b/torchtrade/envs/live/okx/env_sltp.py
@@ -315,10 +315,9 @@ class OKXFuturesSLTPTorchTradingEnv(SLTPMixin, OKXBaseTorchTradingEnv):
             )
 
             if success:
-                # Only record SL/TP levels that actually placed on-exchange
-                bs = getattr(self.trader, 'bracket_status', None) or {}
-                self.active_stop_loss = stop_loss_price if bs.get("sl_placed", True) else 0.0
-                self.active_take_profit = take_profit_price if bs.get("tp_placed", True) else 0.0
+                # OKX attachAlgoOrds is atomic — SL/TP succeed or fail with the main order
+                self.active_stop_loss = stop_loss_price
+                self.active_take_profit = take_profit_price
 
             trade_info.update({
                 "executed": True,

--- a/torchtrade/envs/live/okx/observation.py
+++ b/torchtrade/envs/live/okx/observation.py
@@ -1,0 +1,127 @@
+"""Observation class for fetching market data from OKX."""
+from typing import Union, List, Optional, Callable
+import pandas as pd
+
+from torchtrade.envs.live.shared.futures_base_obs import BaseFuturesObservationClass
+from torchtrade.envs.utils.timeframe import TimeFrame
+from torchtrade.envs.live.okx.utils import timeframe_to_okx, normalize_symbol
+
+
+class OKXObservationClass(BaseFuturesObservationClass):
+    """
+    Observation class for fetching market data from OKX.
+
+    Inherits common functionality from BaseFuturesObservationClass.
+    Implements OKX-specific API interaction using python-okx for futures market data.
+    """
+
+    def __init__(
+        self,
+        symbol: str,
+        time_frames: Union[List[TimeFrame], TimeFrame],
+        window_sizes: Union[List[int], int] = 10,
+        feature_preprocessing_fn: Optional[Callable] = None,
+        client: Optional[object] = None,
+        demo: bool = True,
+    ):
+        """
+        Initialize the OKXObservationClass.
+
+        Args:
+            symbol: The trading symbol (e.g., "BTC-USDT-SWAP")
+            time_frames: Single TimeFrame or list of TimeFrame objects
+            window_sizes: Single integer or list of integers specifying window sizes
+            feature_preprocessing_fn: Optional custom preprocessing function
+            client: Optional pre-configured OKX MarketData client for dependency injection
+            demo: Whether to use demo trading environment (default: True)
+        """
+        symbol = normalize_symbol(symbol)
+        super().__init__(
+            symbol=symbol,
+            time_frames=time_frames,
+            window_sizes=window_sizes,
+            feature_preprocessing_fn=feature_preprocessing_fn,
+            client=client,
+            demo=demo,
+        )
+
+    def _create_client(self) -> object:
+        """Create OKX MarketData API client (public endpoints, no keys needed)."""
+        import okx.MarketData as MarketData
+
+        flag = "1" if self.demo else "0"
+        return MarketData.MarketAPI(flag=flag)
+
+    def _validate_timeframe(self, timeframe: TimeFrame) -> None:
+        """Validate that a timeframe is supported by OKX."""
+        timeframe_to_okx(timeframe)
+
+    def _fetch_klines(self, symbol: str, interval: str, limit: int) -> list:
+        """
+        Fetch raw kline data from OKX API.
+
+        Args:
+            symbol: Trading symbol (e.g., "BTC-USDT-SWAP")
+            interval: OKX-specific interval string (e.g., "1m", "1H", "1D")
+            limit: Number of candles to fetch
+
+        Returns:
+            Raw kline data from OKX: result["data"] (reverse chronological order)
+        """
+        response = self.client.get_candlesticks(
+            instId=symbol,
+            bar=interval,
+            limit=str(limit),
+        )
+        code = response.get("code", "-1")
+        if str(code) != "0":
+            msg = response.get("msg", "unknown error")
+            raise RuntimeError(f"get_candlesticks failed (code={code}): {msg}")
+        return response["data"]
+
+    def _parse_klines(self, raw_klines: list) -> pd.DataFrame:
+        """
+        Parse raw OKX kline data into standardized DataFrame.
+
+        OKX kline format: [ts, o, h, l, c, vol, volCcy, volCcyQuote, confirm]
+        Note: OKX returns data in reverse chronological order (newest first).
+
+        Args:
+            raw_klines: Raw kline data from OKX
+
+        Returns:
+            DataFrame with columns: timestamp, open, high, low, close, volume
+        """
+        ohlcv_cols = ['open', 'high', 'low', 'close', 'volume']
+        df = pd.DataFrame(raw_klines, columns=[
+            'timestamp', *ohlcv_cols, 'vol_ccy', 'vol_ccy_quote', 'confirm'
+        ])
+
+        # Convert types (OKX returns strings)
+        df[ohlcv_cols] = df[ohlcv_cols].astype(float)
+        df['timestamp'] = pd.to_datetime(df['timestamp'].astype(int), unit='ms')
+
+        # Ensure chronological order (OKX returns newest first)
+        df = df.sort_values('timestamp', ascending=True, kind='stable').reset_index(drop=True)
+
+        return df[['timestamp', *ohlcv_cols]]
+
+    def _convert_timeframe(self, timeframe: TimeFrame) -> str:
+        """
+        Convert TimeFrame to OKX-specific interval format.
+
+        Args:
+            timeframe: TimeFrame object
+
+        Returns:
+            OKX interval string (e.g., "1m", "1H", "1D")
+        """
+        return timeframe_to_okx(timeframe)
+
+    def _get_default_lookback(self) -> int:
+        """Get the default number of candles to fetch (OKX max per request is 300)."""
+        return 200
+
+    def _get_timestamp_column(self) -> str:
+        """Get the name of the timestamp column."""
+        return "timestamp"

--- a/torchtrade/envs/live/okx/order_executor.py
+++ b/torchtrade/envs/live/okx/order_executor.py
@@ -1,6 +1,5 @@
 """Order executor for OKX Futures trading using python-okx."""
 import logging
-import math
 from dataclasses import dataclass
 from decimal import Decimal, ROUND_DOWN
 from enum import Enum
@@ -34,14 +33,6 @@ class MarginMode(Enum):
     """
     ISOLATED = "isolated"
     CROSS = "cross"
-
-    def to_okx(self) -> str:
-        """Convert to OKX tdMode string.
-
-        Returns:
-            "isolated" or "cross"
-        """
-        return self.value
 
 
 @dataclass
@@ -235,7 +226,7 @@ class OKXFuturesOrderClass:
             res = self.account_client.set_leverage(
                 instId=self.symbol,
                 lever=str(self.leverage),
-                mgnMode=self.margin_mode.to_okx(),
+                mgnMode=self.margin_mode.value,
             )
             if str(res.get("code", "-1")) != "0":
                 logger.warning(f"Failed to set leverage: code={res.get('code')} msg={res.get('msg')}")
@@ -273,7 +264,7 @@ class OKXFuturesOrderClass:
         try:
             params = {
                 "instId": self.symbol,
-                "tdMode": self.margin_mode.to_okx(),
+                "tdMode": self.margin_mode.value,
                 "side": side.lower(),
                 "ordType": order_type.lower(),
                 "sz": self._format_size(quantity),
@@ -384,7 +375,7 @@ class OKXFuturesOrderClass:
                     unrealized_pnl_pct=unrealized_pnl_pct,
                     mark_price=mark_price,
                     leverage=int(float(pos.get("lever") or str(self.leverage))),
-                    margin_mode=pos.get("mgnMode", self.margin_mode.to_okx()),
+                    margin_mode=pos.get("mgnMode", self.margin_mode.value),
                     liquidation_price=liq_price,
                 )
             else:
@@ -600,7 +591,7 @@ class OKXFuturesOrderClass:
 
                 params = {
                     "instId": self.symbol,
-                    "tdMode": self.margin_mode.to_okx(),
+                    "tdMode": self.margin_mode.value,
                     "side": close_side,
                     "ordType": "market",
                     "sz": self._format_size(abs(raw_pos)),
@@ -649,7 +640,7 @@ class OKXFuturesOrderClass:
             response = self.account_client.set_leverage(
                 instId=self.symbol,
                 lever=str(leverage),
-                mgnMode=self.margin_mode.to_okx(),
+                mgnMode=self.margin_mode.value,
             )
             code = response.get("code", "-1")
             if str(code) != "0":
@@ -677,7 +668,7 @@ class OKXFuturesOrderClass:
             response = self.account_client.set_leverage(
                 instId=self.symbol,
                 lever=str(self.leverage),
-                mgnMode=mode.to_okx(),
+                mgnMode=mode.value,
             )
             code = response.get("code", "-1")
             if str(code) != "0":

--- a/torchtrade/envs/live/okx/order_executor.py
+++ b/torchtrade/envs/live/okx/order_executor.py
@@ -1,0 +1,664 @@
+"""Order executor for OKX Futures trading using python-okx."""
+import logging
+from dataclasses import dataclass
+from enum import Enum
+from typing import Dict, List, Optional
+
+from torchtrade.envs.live.okx.utils import normalize_symbol
+from torchtrade.envs.core.common import TradeMode
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_LOT_SIZE = {"min_qty": 0.001, "qty_step": 0.001}
+
+
+class PositionMode(Enum):
+    """
+    Position mode for OKX Futures.
+
+    - NET: Net mode — single position per instrument (mgnMode determines margin).
+    - LONG_SHORT: Long/short mode — separate long and short positions simultaneously.
+    """
+    NET = "net_mode"
+    LONG_SHORT = "long_short_mode"
+
+
+class MarginMode(Enum):
+    """
+    Margin mode for OKX Futures positions.
+
+    - ISOLATED: Margin is isolated per position. tdMode="isolated" in OKX API.
+    - CROSS: Margin is shared across all positions. tdMode="cross" in OKX API.
+    """
+    ISOLATED = "isolated"
+    CROSS = "cross"
+
+    def to_okx(self) -> str:
+        """Convert to OKX tdMode string.
+
+        Returns:
+            "isolated" or "cross"
+        """
+        return self.value
+
+
+@dataclass
+class PositionStatus:
+    qty: float  # Positive for long, negative for short
+    notional_value: float
+    entry_price: float
+    unrealized_pnl: float
+    unrealized_pnl_pct: float
+    mark_price: float
+    leverage: int
+    margin_mode: str
+    liquidation_price: float
+
+
+class OKXFuturesOrderClass:
+    """
+    Order executor for OKX Futures trading using python-okx.
+
+    Supports:
+    - Long and short positions
+    - Configurable leverage (1x-125x)
+    - Market orders
+    - Bracket orders with stop-loss and take-profit (via attachAlgoOrds)
+    - Demo and production modes
+    """
+
+    def __init__(
+        self,
+        symbol: str,
+        trade_mode: TradeMode = "quantity",
+        api_key: str = "",
+        api_secret: str = "",
+        passphrase: str = "",
+        demo: bool = True,
+        leverage: int = 1,
+        margin_mode: MarginMode = MarginMode.ISOLATED,
+        position_mode: PositionMode = PositionMode.NET,
+        client=None,
+        account_client=None,
+        public_client=None,
+    ):
+        """
+        Initialize the OKXFuturesOrderClass.
+
+        Args:
+            symbol: The trading symbol (e.g., "BTC-USDT-SWAP")
+            trade_mode: "quantity" for unit-based orders
+            api_key: OKX API key
+            api_secret: OKX API secret key
+            passphrase: OKX API passphrase
+            demo: Whether to use demo trading (default: True for safety)
+            leverage: Leverage to use (1-125, default: 1)
+            margin_mode: ISOLATED or CROSS
+            position_mode: NET or LONG_SHORT
+            client: Optional pre-configured Trade client for dependency injection
+            account_client: Optional pre-configured Account client
+            public_client: Optional pre-configured PublicData client
+        """
+        self.symbol = normalize_symbol(symbol)
+        self.trade_mode = trade_mode
+        self.demo = demo
+        self.leverage = leverage
+        self.margin_mode = margin_mode
+        self.position_mode = position_mode
+        self.last_order_id = None
+        self._lot_size_cache: Optional[Dict[str, float]] = None
+        self._tick_size: Optional[float] = None
+        self._tick_decimals: int = 0
+
+        flag = "1" if demo else "0"
+
+        # Initialize OKX clients
+        if client is not None:
+            self.client = client
+        else:
+            import okx.Trade as Trade
+            self.client = Trade.TradeAPI(api_key, api_secret, passphrase, False, flag)
+
+        if account_client is not None:
+            self.account_client = account_client
+        else:
+            import okx.Account as Account
+            self.account_client = Account.AccountAPI(api_key, api_secret, passphrase, False, flag)
+
+        if public_client is not None:
+            self.public_client = public_client
+        else:
+            import okx.PublicData as PublicData
+            self.public_client = PublicData.PublicAPI(flag=flag)
+
+        # Setup futures account and fetch price precision
+        self._setup_futures_account()
+        self._fetch_price_precision()
+
+    def _fetch_price_precision(self):
+        """Fetch and cache tick size (and lot size) from OKX instruments info.
+
+        Populates both _tick_size and _lot_size_cache from a single API call.
+        """
+        try:
+            response = self.public_client.get_instruments(
+                instType="SWAP", instId=self.symbol,
+            )
+            code = response.get("code", "-1")
+            if str(code) != "0":
+                logger.warning("get_instruments failed, prices will not be rounded")
+                return
+            instruments = response.get("data", [])
+            if instruments:
+                instrument = instruments[0]
+                # Tick size for price quantization
+                tick_str = instrument.get("tickSz", "0")
+                tick_size = float(tick_str)
+                if tick_size > 0:
+                    self._tick_size = tick_size
+                    if '.' in tick_str:
+                        decimal_part = tick_str.rstrip('0').split('.')[1]
+                        self._tick_decimals = len(decimal_part) if decimal_part else 0
+                    logger.info(f"Tick size for {self.symbol}: {self._tick_size} ({self._tick_decimals} decimals)")
+
+                # Cache lot size
+                self._lot_size_cache = {
+                    "min_qty": float(instrument.get("minSz", 0.001)),
+                    "qty_step": float(instrument.get("lotSz", 0.001)),
+                }
+        except Exception as e:
+            logger.warning(f"Could not fetch tick size for {self.symbol}: {e}")
+
+    def _round_price(self, price: float) -> float:
+        """Round a price to the nearest tick size."""
+        if self._tick_size is not None:
+            rounded = round(price / self._tick_size) * self._tick_size
+            return round(rounded, self._tick_decimals)
+        return price
+
+    def _format_price(self, price: float) -> str:
+        """Round price to tick size and format as deterministic string."""
+        rounded = self._round_price(price)
+        if self._tick_size is not None:
+            return f"{rounded:.{self._tick_decimals}f}"
+        return str(rounded)
+
+    def _calculate_unrealized_pnl_pct(self, qty: float, entry_price: float, mark_price: float) -> float:
+        """Calculate unrealized PnL percentage."""
+        if entry_price <= 0:
+            return 0.0
+        if qty > 0:
+            return (mark_price - entry_price) / entry_price
+        else:
+            return (entry_price - mark_price) / entry_price
+
+    def _setup_futures_account(self):
+        """Configure futures account settings."""
+        # Set position mode
+        pos_mode = self.position_mode.value
+        try:
+            self.account_client.set_position_mode(posMode=pos_mode)
+            logger.info(f"Position mode set to {pos_mode}")
+        except Exception as e:
+            logger.warning(f"Could not set position mode (may already be configured): {e}")
+
+        # Set leverage
+        try:
+            self.account_client.set_leverage(
+                instId=self.symbol,
+                lever=str(self.leverage),
+                mgnMode=self.margin_mode.to_okx(),
+            )
+        except Exception as e:
+            logger.warning(f"Could not set leverage (may already be configured): {e}")
+
+    def trade(
+        self,
+        side: str,
+        quantity: float,
+        order_type: str = "market",
+        limit_price: Optional[float] = None,
+        take_profit: Optional[float] = None,
+        stop_loss: Optional[float] = None,
+        reduce_only: bool = False,
+    ) -> bool:
+        """
+        Execute a futures trade using OKX API.
+
+        Args:
+            side: "buy" or "sell"
+            quantity: Amount to trade in contracts/base asset units
+            order_type: "market" or "limit"
+            limit_price: Required for limit orders
+            take_profit: Take profit price
+            stop_loss: Stop loss price
+            reduce_only: If True, only reduce position
+
+        Returns:
+            bool: True if order was submitted successfully
+        """
+        if order_type.lower() == "limit" and limit_price is None:
+            raise ValueError("limit_price is required for limit orders")
+
+        try:
+            params = {
+                "instId": self.symbol,
+                "tdMode": self.margin_mode.to_okx(),
+                "side": side.lower(),
+                "ordType": order_type.lower(),
+                "sz": str(quantity),
+            }
+
+            if limit_price is not None:
+                params["px"] = self._format_price(limit_price)
+
+            if reduce_only:
+                params["reduceOnly"] = True
+
+            # Position side for long/short mode
+            if self.position_mode == PositionMode.LONG_SHORT:
+                if reduce_only:
+                    params["posSide"] = "short" if side.lower() == "buy" else "long"
+                else:
+                    params["posSide"] = "long" if side.lower() == "buy" else "short"
+
+            # Attach SL/TP as algo orders
+            if take_profit is not None or stop_loss is not None:
+                attach_algo = []
+                if take_profit is not None:
+                    attach_algo.append({
+                        "tpTriggerPx": self._format_price(take_profit),
+                        "tpOrdPx": "-1",  # Market price
+                    })
+                if stop_loss is not None:
+                    # If we already have a TP entry, add SL to it
+                    if attach_algo:
+                        attach_algo[0]["slTriggerPx"] = self._format_price(stop_loss)
+                        attach_algo[0]["slOrdPx"] = "-1"
+                    else:
+                        attach_algo.append({
+                            "slTriggerPx": self._format_price(stop_loss),
+                            "slOrdPx": "-1",
+                        })
+                params["attachAlgoOrds"] = attach_algo
+
+            response = self.client.place_order(**params)
+
+            code = response.get("code", "-1")
+            if str(code) != "0":
+                msg = response.get("msg", "unknown error")
+                logger.error(f"Order rejected (code={code}): {msg}")
+                return False
+
+            # Extract order ID
+            data = response.get("data", [])
+            if data and isinstance(data[0], dict):
+                order_id = data[0].get("ordId")
+                if order_id:
+                    self.last_order_id = order_id
+                    logger.info(f"Order executed: {side} {quantity} @ {order_type} (ID: {order_id})")
+                else:
+                    logger.info(f"Order executed: {side} {quantity} @ {order_type}")
+            else:
+                logger.info(f"Order executed: {side} {quantity} @ {order_type}")
+
+            return True
+
+        except Exception as e:
+            logger.error(f"Error executing trade: {str(e)}")
+            return False
+
+    def get_status(self) -> Dict[str, Optional[PositionStatus]]:
+        """
+        Get current position status.
+
+        Returns:
+            Dictionary containing position_status
+        """
+        status = {}
+
+        try:
+            response = self.account_client.get_positions(
+                instType="SWAP",
+                instId=self.symbol,
+            )
+
+            code = response.get("code", "-1")
+            if str(code) != "0":
+                msg = response.get("msg", "unknown error")
+                logger.error(f"get_positions failed (code={code}): {msg}")
+                status["position_status"] = None
+                return status
+
+            positions = response.get("data", [])
+
+            # Find non-zero positions
+            non_zero = [p for p in positions if float(p.get("pos", 0)) != 0]
+            if len(non_zero) > 1:
+                logger.warning("Multiple open positions detected (long/short mode); using first non-zero")
+            pos = non_zero[0] if non_zero else None
+
+            if pos is not None:
+                raw_pos = float(pos.get("pos", 0))
+                pos_side = pos.get("posSide", "net")
+
+                # Determine signed quantity
+                if pos_side == "short":
+                    qty = -abs(raw_pos)
+                elif pos_side == "long":
+                    qty = abs(raw_pos)
+                else:
+                    # Net mode: sign from pos field
+                    qty = raw_pos
+
+                entry_price = float(pos.get("avgPx") or "0")
+                mark_price = float(pos.get("markPx") or str(entry_price))
+                unrealized_pnl = float(pos.get("upl") or "0")
+                unrealized_pnl_pct = self._calculate_unrealized_pnl_pct(qty, entry_price, mark_price)
+                notional_value = float(pos.get("notionalUsd") or str(abs(qty * mark_price)))
+                liq_price = float(pos.get("liqPx") or "0")
+
+                status["position_status"] = PositionStatus(
+                    qty=qty,
+                    notional_value=notional_value,
+                    entry_price=entry_price,
+                    unrealized_pnl=unrealized_pnl,
+                    unrealized_pnl_pct=unrealized_pnl_pct,
+                    mark_price=mark_price,
+                    leverage=int(float(pos.get("lever") or str(self.leverage))),
+                    margin_mode=pos.get("mgnMode", self.margin_mode.to_okx()),
+                    liquidation_price=liq_price,
+                )
+            else:
+                status["position_status"] = None
+
+        except Exception as e:
+            logger.error(f"Error getting status: {str(e)}")
+            status["position_status"] = None
+
+        return status
+
+    def get_account_balance(self) -> Dict[str, float]:
+        """
+        Get futures account balance using OKX API.
+
+        Returns:
+            Dictionary with balance information
+
+        Raises:
+            RuntimeError: If balance cannot be retrieved
+        """
+        try:
+            response = self.account_client.get_account_balance()
+            code = response.get("code", "-1")
+            if str(code) != "0":
+                msg = response.get("msg", "unknown error")
+                raise RuntimeError(f"get_account_balance failed (code={code}): {msg}")
+
+            data = response.get("data", [])
+            if not data:
+                raise RuntimeError("No account data returned from OKX")
+
+            account = data[0]
+            total_equity = float(account.get("totalEq") or "0")
+            # Available equity for trading
+            details = account.get("details", [])
+            available = 0.0
+            for detail in details:
+                if detail.get("ccy") == "USDT":
+                    available = float(detail.get("availBal") or "0")
+                    break
+
+            total_pnl = float(account.get("upl") or "0")
+
+            result = {
+                "total_wallet_balance": total_equity,
+                "available_balance": available,
+                "total_unrealized_profit": total_pnl,
+                "total_margin_balance": total_equity,
+            }
+
+            logger.debug(f"Account balance: total={total_equity:.2f}, available={available:.2f}, pnl={total_pnl:.4f}")
+
+            if self.demo and total_equity == 0:
+                logger.warning(
+                    "Demo account balance is 0 USDT! "
+                    "Please fund your OKX demo account at: "
+                    "https://www.okx.com (Demo Trading)"
+                )
+
+            return result
+
+        except RuntimeError:
+            raise
+        except Exception as e:
+            logger.error(f"Error getting account balance: {str(e)}")
+            raise RuntimeError(f"Failed to get account balance: {e}") from e
+
+    def get_mark_price(self) -> float:
+        """
+        Get current mark price for the symbol.
+
+        Returns:
+            Current mark price
+
+        Raises:
+            RuntimeError: If mark price cannot be retrieved
+        """
+        response = self.public_client.get_mark_price(
+            instType="SWAP",
+            instId=self.symbol,
+        )
+
+        code = response.get("code", "-1")
+        if str(code) != "0":
+            msg = response.get("msg", "unknown error")
+            raise RuntimeError(f"get_mark_price failed (code={code}): {msg}")
+
+        data = response.get("data", [])
+        if data:
+            mark_price = data[0].get("markPx")
+            if mark_price:
+                return float(mark_price)
+
+        raise RuntimeError(f"No mark price data for {self.symbol}")
+
+    def get_lot_size(self) -> Dict[str, float]:
+        """
+        Get and cache lot size constraints for the symbol.
+
+        Returns:
+            Dictionary with 'min_qty' and 'qty_step' for the symbol.
+        """
+        if self._lot_size_cache is not None:
+            return self._lot_size_cache
+
+        try:
+            response = self.public_client.get_instruments(
+                instType="SWAP", instId=self.symbol,
+            )
+            code = response.get("code", "-1")
+            if str(code) != "0":
+                msg = response.get("msg", "unknown error")
+                logger.warning(f"get_instruments failed (code={code}): {msg}, using defaults")
+                self._lot_size_cache = _DEFAULT_LOT_SIZE.copy()
+                return self._lot_size_cache
+            instruments = response.get("data", [])
+            if instruments:
+                instrument = instruments[0]
+                self._lot_size_cache = {
+                    "min_qty": float(instrument.get("minSz", 0.001)),
+                    "qty_step": float(instrument.get("lotSz", 0.001)),
+                }
+            else:
+                logger.warning(f"No instrument info for {self.symbol}, using defaults")
+                self._lot_size_cache = _DEFAULT_LOT_SIZE.copy()
+        except Exception as e:
+            logger.warning(f"Failed to fetch lot size for {self.symbol}: {e}, using defaults")
+            self._lot_size_cache = _DEFAULT_LOT_SIZE.copy()
+
+        return self._lot_size_cache
+
+    def get_open_orders(self) -> List[Dict]:
+        """Get all open orders for the symbol."""
+        try:
+            response = self.client.get_order_list(
+                instType="SWAP",
+                instId=self.symbol,
+            )
+            return response.get("data", [])
+        except Exception as e:
+            logger.error(f"Error getting open orders: {str(e)}")
+            return []
+
+    def cancel_open_orders(self) -> bool:
+        """Cancel all open orders for the symbol."""
+        try:
+            orders = self.get_open_orders()
+            if not orders:
+                logger.debug(f"No open orders to cancel for {self.symbol}")
+                return True
+
+            for order in orders:
+                order_id = order.get("ordId")
+                if order_id:
+                    response = self.client.cancel_order(
+                        instId=self.symbol,
+                        ordId=order_id,
+                    )
+                    code = response.get("code", "-1")
+                    if str(code) != "0":
+                        msg = response.get("msg", "unknown error")
+                        logger.error(f"Cancel order {order_id} rejected (code={code}): {msg}")
+                        return False
+
+            logger.debug(f"Cancelled all open orders for {self.symbol}")
+            return True
+        except Exception as e:
+            logger.error(f"Error cancelling open orders: {str(e)}")
+            return False
+
+    def close_position(self) -> bool:
+        """
+        Close all open positions for the symbol.
+
+        Returns:
+            bool: True if all positions were closed successfully
+        """
+        try:
+            response = self.account_client.get_positions(
+                instType="SWAP", instId=self.symbol,
+            )
+            code = response.get("code", "-1")
+            if str(code) != "0":
+                msg = response.get("msg", "unknown error")
+                logger.error(f"get_positions failed in close_position (code={code}): {msg}")
+                return False
+            positions = response.get("data", [])
+            non_zero = [p for p in positions if float(p.get("pos", 0)) != 0]
+
+            if not non_zero:
+                logger.debug("No open position to close")
+                return True
+
+            all_closed = True
+            for pos in non_zero:
+                raw_pos = float(pos.get("pos", 0))
+                pos_side = pos.get("posSide", "net")
+
+                if pos_side in ("long", "net") and raw_pos > 0:
+                    close_side = "sell"
+                else:
+                    close_side = "buy"
+
+                params = {
+                    "instId": self.symbol,
+                    "tdMode": self.margin_mode.to_okx(),
+                    "side": close_side,
+                    "ordType": "market",
+                    "sz": str(abs(raw_pos)),
+                    "reduceOnly": True,
+                }
+
+                if self.position_mode == PositionMode.LONG_SHORT:
+                    params["posSide"] = pos_side
+
+                response = self.client.place_order(**params)
+                code = response.get("code", "-1")
+                if str(code) != "0":
+                    msg = response.get("msg", "unknown error")
+                    logger.error(f"Close order rejected (code={code}): {msg}")
+                    all_closed = False
+                else:
+                    logger.info(f"Position closed: {abs(raw_pos)} {close_side}")
+
+            return all_closed
+
+        except Exception as e:
+            logger.warning(f"close_position order failed: {e}; re-querying position")
+            try:
+                status = self.get_status()
+                pos = status.get("position_status")
+                if pos is None or pos.qty == 0:
+                    logger.debug("Position confirmed closed after failed order")
+                    return True
+            except Exception:
+                pass
+            logger.error(f"Error closing position: {e}")
+            return False
+
+    def set_leverage(self, leverage: int) -> bool:
+        """
+        Change leverage for the symbol.
+
+        Args:
+            leverage: New leverage value (1-125)
+
+        Returns:
+            bool: True if successful
+        """
+        try:
+            response = self.account_client.set_leverage(
+                instId=self.symbol,
+                lever=str(leverage),
+                mgnMode=self.margin_mode.to_okx(),
+            )
+            code = response.get("code", "-1")
+            if str(code) != "0":
+                msg = response.get("msg", "unknown error")
+                logger.error(f"set_leverage rejected (code={code}): {msg}")
+                return False
+            self.leverage = leverage
+            logger.debug(f"Leverage set to {leverage}x for {self.symbol}")
+            return True
+        except Exception as e:
+            logger.error(f"Error setting leverage: {str(e)}")
+            return False
+
+    def set_margin_mode(self, mode: MarginMode) -> bool:
+        """
+        Change margin mode for the symbol.
+
+        Args:
+            mode: New margin mode (ISOLATED or CROSS)
+
+        Returns:
+            bool: True if successful
+        """
+        try:
+            response = self.account_client.set_leverage(
+                instId=self.symbol,
+                lever=str(self.leverage),
+                mgnMode=mode.to_okx(),
+            )
+            code = response.get("code", "-1")
+            if str(code) != "0":
+                msg = response.get("msg", "unknown error")
+                logger.error(f"set_margin_mode rejected (code={code}): {msg}")
+                return False
+            self.margin_mode = mode
+            logger.info(f"Margin mode set to {mode.value} for {self.symbol}")
+            return True
+        except Exception as e:
+            logger.error(f"Error setting margin mode: {str(e)}")
+            return False

--- a/torchtrade/envs/live/okx/order_executor.py
+++ b/torchtrade/envs/live/okx/order_executor.py
@@ -1,7 +1,7 @@
 """Order executor for OKX Futures trading using python-okx."""
 import logging
+import math
 from dataclasses import dataclass
-from decimal import Decimal, ROUND_DOWN
 from enum import Enum
 from typing import Dict, List, Optional
 
@@ -177,27 +177,14 @@ class OKXFuturesOrderClass:
         return str(rounded)
 
     def _format_size(self, qty: float) -> str:
-        """Quantize quantity to lot size constraints and format as string.
-
-        Rounds down to nearest lot step and validates against min size.
-
-        Args:
-            qty: Raw quantity to quantize
-
-        Returns:
-            Formatted quantity string
-
-        Raises:
-            ValueError: If quantized quantity is below min_qty
-        """
+        """Quantize quantity to lot size step and format as string."""
         lot = self.get_lot_size()
-        step = Decimal(str(lot["qty_step"]))
-        min_qty = Decimal(str(lot["min_qty"]))
-        q = Decimal(str(qty))
-        q = (q / step).to_integral_value(rounding=ROUND_DOWN) * step
-        if q < min_qty:
-            raise ValueError(f"qty {qty} below min_qty {min_qty} after quantizing to step {step}")
-        return format(q, "f")
+        step = lot["qty_step"]
+        quantized = math.floor(qty / step) * step
+        # Derive decimal places from step for clean formatting
+        step_str = str(step)
+        decimals = len(step_str.rstrip('0').split('.')[-1]) if '.' in step_str else 0
+        return f"{quantized:.{decimals}f}"
 
     def _calculate_unrealized_pnl_pct(self, qty: float, entry_price: float, mark_price: float) -> float:
         """Calculate unrealized PnL percentage."""

--- a/torchtrade/envs/live/okx/order_executor.py
+++ b/torchtrade/envs/live/okx/order_executor.py
@@ -570,18 +570,20 @@ class OKXFuturesOrderClass:
             for pos in non_zero:
                 raw_pos = float(pos.get("pos", 0))
                 pos_side = pos.get("posSide", "net")
-
                 if pos_side in ("long", "net") and raw_pos > 0:
                     close_side = "sell"
                 else:
                     close_side = "buy"
+
+                # Use raw string from exchange (strip sign) to avoid float artifacts
+                size_str = pos.get("pos", "0").lstrip("-")
 
                 params = {
                     "instId": self.symbol,
                     "tdMode": self.margin_mode.value,
                     "side": close_side,
                     "ordType": "market",
-                    "sz": self._format_size(abs(raw_pos)),
+                    "sz": size_str,
                     "reduceOnly": True,
                 }
 

--- a/torchtrade/envs/live/okx/order_executor.py
+++ b/torchtrade/envs/live/okx/order_executor.py
@@ -100,6 +100,7 @@ class OKXFuturesOrderClass:
         self.position_mode = position_mode
         self.last_order_id = None
         self._lot_size_cache: Optional[Dict[str, float]] = None
+        self._lot_size_decimals: int = 3  # Default; updated from instrument data
         self._tick_size: Optional[float] = None
         self._tick_decimals: int = 0
 
@@ -154,10 +155,14 @@ class OKXFuturesOrderClass:
                         self._tick_decimals = len(decimal_part) if decimal_part else 0
                     logger.info(f"Tick size for {self.symbol}: {self._tick_size} ({self._tick_decimals} decimals)")
 
-                # Cache lot size
+                # Cache lot size and derive decimal places from raw string
+                lot_sz_str = instrument.get("lotSz", "0.001")
+                if '.' in lot_sz_str:
+                    decimal_part = lot_sz_str.rstrip('0').split('.')[1]
+                    self._lot_size_decimals = len(decimal_part) if decimal_part else 0
                 self._lot_size_cache = {
                     "min_qty": float(instrument.get("minSz", 0.001)),
-                    "qty_step": float(instrument.get("lotSz", 0.001)),
+                    "qty_step": float(lot_sz_str),
                 }
         except Exception as e:
             logger.warning(f"Could not fetch tick size for {self.symbol}: {e}")
@@ -177,14 +182,16 @@ class OKXFuturesOrderClass:
         return str(rounded)
 
     def _format_size(self, qty: float) -> str:
-        """Quantize quantity to lot size step and format as string."""
+        """Quantize quantity to lot size step, enforce minimum, and format as string."""
         lot = self.get_lot_size()
         step = lot["qty_step"]
+        min_qty = lot["min_qty"]
         quantized = math.floor(qty / step) * step
-        # Derive decimal places from step for clean formatting
-        step_str = str(step)
-        decimals = len(step_str.rstrip('0').split('.')[-1]) if '.' in step_str else 0
-        return f"{quantized:.{decimals}f}"
+        if quantized < min_qty:
+            quantized = min_qty
+        # Use _lot_size_decimals derived from instrument data, not str(float) which
+        # can produce scientific notation for small steps (e.g. 1e-05 → decimals=0)
+        return f"{quantized:.{self._lot_size_decimals}f}"
 
     def _calculate_unrealized_pnl_pct(self, qty: float, entry_price: float, mark_price: float) -> float:
         """Calculate unrealized PnL percentage."""

--- a/torchtrade/envs/live/okx/order_executor.py
+++ b/torchtrade/envs/live/okx/order_executor.py
@@ -264,23 +264,14 @@ class OKXFuturesOrderClass:
 
             # Attach SL/TP as algo orders
             if take_profit is not None or stop_loss is not None:
-                attach_algo = []
+                algo_ord = {}
                 if take_profit is not None:
-                    attach_algo.append({
-                        "tpTriggerPx": self._format_price(take_profit),
-                        "tpOrdPx": "-1",  # Market price
-                    })
+                    algo_ord["tpTriggerPx"] = self._format_price(take_profit)
+                    algo_ord["tpOrdPx"] = "-1"  # Market price
                 if stop_loss is not None:
-                    # If we already have a TP entry, add SL to it
-                    if attach_algo:
-                        attach_algo[0]["slTriggerPx"] = self._format_price(stop_loss)
-                        attach_algo[0]["slOrdPx"] = "-1"
-                    else:
-                        attach_algo.append({
-                            "slTriggerPx": self._format_price(stop_loss),
-                            "slOrdPx": "-1",
-                        })
-                params["attachAlgoOrds"] = attach_algo
+                    algo_ord["slTriggerPx"] = self._format_price(stop_loss)
+                    algo_ord["slOrdPx"] = "-1"
+                params["attachAlgoOrds"] = [algo_ord]
 
             response = self.client.place_order(**params)
 
@@ -293,14 +284,9 @@ class OKXFuturesOrderClass:
             # Extract order ID
             data = response.get("data", [])
             if data and isinstance(data[0], dict):
-                order_id = data[0].get("ordId")
-                if order_id:
-                    self.last_order_id = order_id
-                    logger.info(f"Order executed: {side} {quantity} @ {order_type} (ID: {order_id})")
-                else:
-                    logger.info(f"Order executed: {side} {quantity} @ {order_type}")
-            else:
-                logger.info(f"Order executed: {side} {quantity} @ {order_type}")
+                self.last_order_id = data[0].get("ordId")
+            order_id_str = f" (ID: {self.last_order_id})" if self.last_order_id else ""
+            logger.info(f"Order executed: {side} {quantity} @ {order_type}{order_id_str}")
 
             return True
 
@@ -429,8 +415,6 @@ class OKXFuturesOrderClass:
 
             return result
 
-        except RuntimeError:
-            raise
         except Exception as e:
             logger.error(f"Error getting account balance: {str(e)}")
             raise RuntimeError(f"Failed to get account balance: {e}") from e

--- a/torchtrade/envs/live/okx/order_executor.py
+++ b/torchtrade/envs/live/okx/order_executor.py
@@ -222,18 +222,23 @@ class OKXFuturesOrderClass:
         # Set position mode
         pos_mode = self.position_mode.value
         try:
-            self.account_client.set_position_mode(posMode=pos_mode)
-            logger.info(f"Position mode set to {pos_mode}")
+            res = self.account_client.set_position_mode(posMode=pos_mode)
+            if str(res.get("code", "-1")) == "0":
+                logger.info(f"Position mode set to {pos_mode}")
+            else:
+                logger.warning(f"Failed to set position mode: code={res.get('code')} msg={res.get('msg')}")
         except Exception as e:
             logger.warning(f"Could not set position mode (may already be configured): {e}")
 
         # Set leverage
         try:
-            self.account_client.set_leverage(
+            res = self.account_client.set_leverage(
                 instId=self.symbol,
                 lever=str(self.leverage),
                 mgnMode=self.margin_mode.to_okx(),
             )
+            if str(res.get("code", "-1")) != "0":
+                logger.warning(f"Failed to set leverage: code={res.get('code')} msg={res.get('msg')}")
         except Exception as e:
             logger.warning(f"Could not set leverage (may already be configured): {e}")
 
@@ -510,22 +515,33 @@ class OKXFuturesOrderClass:
 
         return self._lot_size_cache
 
-    def get_open_orders(self) -> List[Dict]:
-        """Get all open orders for the symbol."""
+    def get_open_orders(self) -> Optional[List[Dict]]:
+        """Get all open orders for the symbol.
+
+        Returns:
+            List of open orders, or None if the API call failed.
+        """
         try:
             response = self.client.get_order_list(
                 instType="SWAP",
                 instId=self.symbol,
             )
+            code = response.get("code", "-1")
+            if str(code) != "0":
+                msg = response.get("msg", "unknown error")
+                logger.error(f"get_order_list failed (code={code}): {msg}")
+                return None
             return response.get("data", [])
         except Exception as e:
             logger.error(f"Error getting open orders: {str(e)}")
-            return []
+            return None
 
     def cancel_open_orders(self) -> bool:
         """Cancel all open orders for the symbol."""
         try:
             orders = self.get_open_orders()
+            if orders is None:
+                return False
             if not orders:
                 logger.debug(f"No open orders to cancel for {self.symbol}")
                 return True
@@ -587,7 +603,7 @@ class OKXFuturesOrderClass:
                     "tdMode": self.margin_mode.to_okx(),
                     "side": close_side,
                     "ordType": "market",
-                    "sz": str(abs(raw_pos)),
+                    "sz": self._format_size(abs(raw_pos)),
                     "reduceOnly": True,
                 }
 
@@ -608,11 +624,12 @@ class OKXFuturesOrderClass:
         except Exception as e:
             logger.warning(f"close_position order failed: {e}; re-querying position")
             try:
-                status = self.get_status()
-                pos = status.get("position_status")
-                if pos is None or pos.qty == 0:
-                    logger.debug("Position confirmed closed after failed order")
-                    return True
+                resp = self.account_client.get_positions(instType="SWAP", instId=self.symbol)
+                if str(resp.get("code", "-1")) == "0":
+                    still_open = any(float(p.get("pos", 0)) != 0 for p in resp.get("data", []))
+                    if not still_open:
+                        logger.debug("Position confirmed closed after failed order")
+                        return True
             except Exception:
                 pass
             logger.error(f"Error closing position: {e}")

--- a/torchtrade/envs/live/okx/order_executor.py
+++ b/torchtrade/envs/live/okx/order_executor.py
@@ -1,6 +1,8 @@
 """Order executor for OKX Futures trading using python-okx."""
 import logging
+import math
 from dataclasses import dataclass
+from decimal import Decimal, ROUND_DOWN
 from enum import Enum
 from typing import Dict, List, Optional
 
@@ -183,6 +185,29 @@ class OKXFuturesOrderClass:
             return f"{rounded:.{self._tick_decimals}f}"
         return str(rounded)
 
+    def _format_size(self, qty: float) -> str:
+        """Quantize quantity to lot size constraints and format as string.
+
+        Rounds down to nearest lot step and validates against min size.
+
+        Args:
+            qty: Raw quantity to quantize
+
+        Returns:
+            Formatted quantity string
+
+        Raises:
+            ValueError: If quantized quantity is below min_qty
+        """
+        lot = self.get_lot_size()
+        step = Decimal(str(lot["qty_step"]))
+        min_qty = Decimal(str(lot["min_qty"]))
+        q = Decimal(str(qty))
+        q = (q / step).to_integral_value(rounding=ROUND_DOWN) * step
+        if q < min_qty:
+            raise ValueError(f"qty {qty} below min_qty {min_qty} after quantizing to step {step}")
+        return format(q, "f")
+
     def _calculate_unrealized_pnl_pct(self, qty: float, entry_price: float, mark_price: float) -> float:
         """Calculate unrealized PnL percentage."""
         if entry_price <= 0:
@@ -246,7 +271,7 @@ class OKXFuturesOrderClass:
                 "tdMode": self.margin_mode.to_okx(),
                 "side": side.lower(),
                 "ordType": order_type.lower(),
-                "sz": str(quantity),
+                "sz": self._format_size(quantity),
             }
 
             if limit_price is not None:
@@ -321,7 +346,9 @@ class OKXFuturesOrderClass:
             # Find non-zero positions
             non_zero = [p for p in positions if float(p.get("pos", 0)) != 0]
             if len(non_zero) > 1:
-                logger.warning("Multiple open positions detected (long/short mode); using first non-zero")
+                logger.error("Multiple open positions in LONG_SHORT mode are not supported by this env")
+                status["position_status"] = None
+                return status
             pos = non_zero[0] if non_zero else None
 
             if pos is not None:

--- a/torchtrade/envs/live/okx/utils.py
+++ b/torchtrade/envs/live/okx/utils.py
@@ -1,0 +1,156 @@
+"""Utility functions for OKX environments."""
+from functools import partial
+
+from torchtrade.envs.utils.timeframe import (
+    TimeFrame,
+    TimeFrameUnit,
+    normalize_timeframe_config,
+    create_provider_parser,
+)
+
+
+# OKX interval mapping
+OKX_INTERVAL_MAP = {
+    TimeFrameUnit.Minute: {
+        1: "1m",
+        3: "3m",
+        5: "5m",
+        15: "15m",
+        30: "30m",
+    },
+    TimeFrameUnit.Hour: {
+        1: "1H",
+        2: "2H",
+        4: "4H",
+        6: "6H",
+        12: "12H",
+    },
+    TimeFrameUnit.Day: {
+        1: "1D",
+        3: "3D",
+    },
+}
+
+# Pre-computed reverse mapping for efficient lookups
+_OKX_REVERSE_MAP = {
+    interval_str: (value, unit)
+    for unit, value_map in OKX_INTERVAL_MAP.items()
+    for value, interval_str in value_map.items()
+}
+
+
+def timeframe_to_okx(tf: TimeFrame) -> str:
+    """Convert TimeFrame to OKX interval string.
+
+    Args:
+        tf: Custom TimeFrame object
+
+    Returns:
+        OKX interval string (e.g., "1m", "15m", "1H", "1D")
+
+    Raises:
+        ValueError: If timeframe is not supported by OKX
+
+    Examples:
+        >>> tf = TimeFrame(5, TimeFrameUnit.Minute)
+        >>> timeframe_to_okx(tf)
+        '5m'
+        >>> tf = TimeFrame(1, TimeFrameUnit.Hour)
+        >>> timeframe_to_okx(tf)
+        '1H'
+    """
+    if tf.unit not in OKX_INTERVAL_MAP:
+        raise ValueError(f"Unsupported TimeFrameUnit for OKX: {tf.unit}")
+
+    unit_map = OKX_INTERVAL_MAP[tf.unit]
+    if tf.value not in unit_map:
+        raise ValueError(
+            f"Unsupported timeframe value for OKX: {tf.value}{tf.unit.value}. "
+            f"Valid values for {tf.unit.value}: {list(unit_map.keys())}"
+        )
+
+    return unit_map[tf.value]
+
+
+def okx_to_timeframe(interval: str) -> TimeFrame:
+    """Convert OKX interval string to custom TimeFrame.
+
+    Args:
+        interval: OKX interval string (e.g., "1m", "15m", "1H", "1D")
+
+    Returns:
+        Custom TimeFrame object
+
+    Raises:
+        ValueError: If interval is not valid for OKX
+
+    Examples:
+        >>> okx_to_timeframe("5m")
+        TimeFrame(5, TimeFrameUnit.Minute)
+        >>> okx_to_timeframe("1H")
+        TimeFrame(1, TimeFrameUnit.Hour)
+    """
+    if interval not in _OKX_REVERSE_MAP:
+        raise ValueError(
+            f"Invalid OKX interval: {interval}. "
+            f"Valid intervals: {list(_OKX_REVERSE_MAP.keys())}"
+        )
+
+    value, unit = _OKX_REVERSE_MAP[interval]
+    return TimeFrame(value, unit)
+
+
+# Create OKX-specific parser using factory (tries OKX format first, then standard format)
+parse_okx_timeframe_string = create_provider_parser(okx_to_timeframe)
+
+# Convenience wrapper: normalize_timeframe_config with OKX-specific parsing
+# Accepts OKX interval strings ("1m", "1H"), standard strings ("1Min"), or TimeFrame objects
+normalize_okx_timeframe_config = partial(
+    normalize_timeframe_config,
+    parse_fn=parse_okx_timeframe_string
+)
+
+
+def normalize_symbol(symbol: str) -> str:
+    """Normalize symbol to OKX perpetual swap format.
+
+    OKX uses dash-separated symbols with product suffix for perpetual futures:
+    "BTC-USDT-SWAP"
+
+    Args:
+        symbol: Trading symbol in various formats:
+                - "BTC-USDT-SWAP" -> "BTC-USDT-SWAP" (no change)
+                - "BTC-USDT" -> "BTC-USDT-SWAP"
+                - "BTCUSDT" -> "BTC-USDT-SWAP"
+                - "BTC/USDT" -> "BTC-USDT-SWAP"
+                - "BTC/USDT:USDT" -> "BTC-USDT-SWAP"
+
+    Returns:
+        Normalized symbol in OKX swap format (e.g., "BTC-USDT-SWAP")
+    """
+    symbol = symbol.strip().upper()
+
+    # Already in OKX swap format
+    if symbol.endswith("-SWAP"):
+        return symbol
+
+    # Strip CCXT settlement suffix (e.g., ":USDT")
+    if ":" in symbol:
+        symbol = symbol.split(":")[0]
+
+    # Handle slash-separated (e.g., "BTC/USDT")
+    if "/" in symbol:
+        symbol = symbol.replace("/", "-")
+    # Handle concatenated (e.g., "BTCUSDT") — insert dash before quote currency
+    elif "-" not in symbol:
+        # Common quote currencies in order of specificity
+        for quote in ("USDT", "USDC", "USD"):
+            if symbol.endswith(quote):
+                base = symbol[:-len(quote)]
+                symbol = f"{base}-{quote}"
+                break
+
+    if not symbol or "-" not in symbol:
+        raise ValueError(f"Symbol cannot be parsed into OKX format: '{symbol}'")
+
+    return f"{symbol}-SWAP"


### PR DESCRIPTION
## Summary

- Adds full **OKX** support as the 5th exchange integration (alongside Alpaca, Binance, Bitget, Bybit)
- Follows the established exchange integration pattern using shared abstractions (`BaseFuturesObservationClass`, `SLTPMixin`, `TorchTradeLiveEnv`)
- Uses the official `python-okx` SDK for API interaction

### New Files

**Source** (`torchtrade/envs/live/okx/`):
| File | Description |
|---|---|
| `utils.py` | Symbol normalization (`BTC-USDT-SWAP` format), OKX-specific timeframe mapping |
| `observation.py` | `OKXObservationClass` — market data fetching via `get_candlesticks` |
| `order_executor.py` | `OKXFuturesOrderClass` — orders, positions, balances, bracket orders via `attachAlgoOrds` |
| `base.py` | `OKXBaseTorchTradingEnv` — shared env logic with 6-element account state |
| `env.py` | `OKXFuturesTorchTradingEnv` — fractional position sizing environment |
| `env_sltp.py` | `OKXFuturesSLTPTorchTradingEnv` — bracket orders with SL/TP levels |

### Features
- **Position modes**: NET (one-way) and LONG_SHORT (hedge)
- **Margin modes**: ISOLATED and CROSS
- **Leverage**: 1x–125x
- **Demo trading**: Full support via OKX demo trading API
- **Trade modes**: `fractional`, `notional`, `quantity`
- **Bracket orders**: Native SL/TP via OKX's `attachAlgoOrds`
- **Position locking**: `lock_position_until_sltp` support
- **Symbol normalization**: Handles `BTCUSDT`, `BTC/USDT`, `BTC-USDT`, `BTC/USDT:USDT` → `BTC-USDT-SWAP`

### OKX-Specific Differences from Other Exchanges
- Symbol format: `BTC-USDT-SWAP` (dash-separated with product suffix)
- Response codes: String `"0"` for success (vs integer `0` in Bybit)
- SL/TP: Via `attachAlgoOrds` parameter on order placement
- 3 separate API clients: Trade, Account, PublicData

## Test plan
- [x] 150 new tests covering utils, observation, order execution, env, and SLTP
- [x] Full test suite passes: **1594 passed, 5 skipped** (no regressions)
- [ ] Manual testing with OKX demo account (requires API credentials)

Closes #212

🤖 Generated with [Claude Code](https://claude.com/claude-code)