### PR TITLE
build: upgrade RL stack to torchrl 0.13.2 / tensordict 0.13 (lockstep pins)

### DIFF
--- a/docs/components/transforms.md
+++ b/docs/components/transforms.md
@@ -24,12 +24,12 @@ Tracks which portions of the dataset are visited during training with random epi
 
 ```python
 from torchtrade.envs.transforms import CoverageTracker
-from torchrl.collectors import SyncDataCollector
+from torchrl.collectors import Collector
 
 # Use as postproc in collector (NOT in environment transform chain)
 coverage_tracker = CoverageTracker()
 
-collector = SyncDataCollector(
+collector = Collector(
     env, policy,
     frames_per_batch=1000,
     total_frames=100000,

--- a/docs/environments/offline-rl.md
+++ b/docs/environments/offline-rl.md
@@ -24,7 +24,7 @@ TorchTrade provides an example implementation of offline RL using **Implicit Q-L
 ```python
 # Example: Training IQL on pre-collected dataset
 from torchtrade.envs.offline import SequentialTradingEnv, SequentialTradingEnvConfig
-from torchrl.collectors import SyncDataCollector
+from torchrl.collectors import Collector
 from torchrl.data import LazyTensorStorage, TensorDictReplayBuffer
 
 # 1. Create environment (for evaluation only)
@@ -51,11 +51,11 @@ For a complete implementation, see [examples/offline/iql/](https://github.com/To
 
 ```python
 from torchtrade.envs.offline import SequentialTradingEnv, SequentialTradingEnvConfig
-from torchrl.collectors import SyncDataCollector
+from torchrl.collectors import Collector
 from torchrl.data import LazyTensorStorage, TensorDictReplayBuffer
 
 # Collect trajectories with any policy (random, rule-based, pre-trained)
-collector = SyncDataCollector(
+collector = Collector(
     env,
     policy,
     frames_per_batch=10000,

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -25,7 +25,7 @@ from torchrl.envs import GymEnv
 env = GymEnv("CartPole-v1")
 
 # Everything else stays the same
-collector = SyncDataCollector(env, policy, ...)
+collector = Collector(env, policy, ...)
 loss_module = A2CLoss(actor, critic, ...)
 optimizer = torch.optim.Adam(loss_module.parameters(), lr=1e-3)
 
@@ -43,7 +43,7 @@ from torchtrade.envs.offline import SequentialTradingEnv, SequentialTradingEnvCo
 env = SequentialTradingEnv(df, SequentialTradingEnvConfig(...))
 
 # Everything else stays EXACTLY the same
-collector = SyncDataCollector(env, policy, ...)
+collector = Collector(env, policy, ...)
 loss_module = A2CLoss(actor, critic, ...)
 optimizer = torch.optim.Adam(loss_module.parameters(), lr=1e-3)
 

--- a/examples/llm/frontier/live.py
+++ b/examples/llm/frontier/live.py
@@ -22,7 +22,7 @@ from dotenv import load_dotenv
 
 from torchtrade.actor import FrontierLLMActor
 from torchtrade.envs.live.alpaca.env import AlpacaTorchTradingEnv, AlpacaTradingEnvConfig
-from torchrl.collectors import SyncDataCollector
+from torchrl.collectors import Collector
 from torchrl.data import LazyTensorStorage, TensorDictReplayBuffer
 from torchrl.envs import Compose, DoubleToFloat, TransformedEnv
 from torchrl.envs.transforms import InitTracker, RewardSum, StepCounter, UnsqueezeTransform
@@ -98,7 +98,7 @@ def main():
     )
 
     # Create collector and replay buffer
-    collector = SyncDataCollector(
+    collector = Collector(
         transformed_env,
         policy,
         init_random_frames=0,

--- a/examples/llm/local/live.py
+++ b/examples/llm/local/live.py
@@ -23,7 +23,7 @@ from dotenv import load_dotenv
 
 from torchtrade.actor import LocalLLMActor
 from torchtrade.envs.live.alpaca.env import AlpacaTorchTradingEnv, AlpacaTradingEnvConfig
-from torchrl.collectors import SyncDataCollector
+from torchrl.collectors import Collector
 from torchrl.data import LazyTensorStorage, TensorDictReplayBuffer
 from torchrl.envs import Compose, DoubleToFloat, TransformedEnv
 from torchrl.envs.transforms import InitTracker, RewardSum, StepCounter, UnsqueezeTransform
@@ -101,7 +101,7 @@ def main():
     )
 
     # Create collector and replay buffer
-    collector = SyncDataCollector(
+    collector = Collector(
         env,
         policy,
         init_random_frames=0,

--- a/examples/online_rl/dqn/live.py
+++ b/examples/online_rl/dqn/live.py
@@ -26,7 +26,7 @@ import torch
 import tqdm
 from dotenv import load_dotenv
 from sklearn.preprocessing import StandardScaler
-from torchrl.collectors import SyncDataCollector
+from torchrl.collectors import Collector
 from torchrl.data import LazyTensorStorage, TensorDictReplayBuffer
 from torchrl.envs import (
     Compose,
@@ -199,7 +199,7 @@ def main():
     )
 
     # Run live
-    collector = SyncDataCollector(
+    collector = Collector(
         env,
         policy,
         frames_per_batch=1,

--- a/examples/online_rl/dqn/utils.py
+++ b/examples/online_rl/dqn/utils.py
@@ -16,7 +16,7 @@ from torchrl.envs import (
 )
 
 from torchtrade.envs.transforms import CoverageTracker
-from torchrl.collectors import SyncDataCollector
+from torchrl.collectors import Collector
 from torchrl.data import LazyTensorStorage, TensorDictReplayBuffer
 
 from torchrl.modules import (
@@ -197,7 +197,7 @@ def make_collector(cfg, train_env, policy, compile_mode=None, postproc=None):
     """Make data collector."""
     device = cfg.collector.device or ("cuda:0" if torch.cuda.is_available() else "cpu")
 
-    collector = SyncDataCollector(
+    collector = Collector(
         train_env,
         policy,
         frames_per_batch=cfg.collector.frames_per_batch,

--- a/examples/online_rl/dsac/utils.py
+++ b/examples/online_rl/dsac/utils.py
@@ -8,7 +8,7 @@ import torch
 from tensordict.nn import InteractionType
 
 from torch import optim
-from torchrl.collectors import SyncDataCollector
+from torchrl.collectors import Collector
 from torchrl.data import (
     Composite,
     TensorDictPrioritizedReplayBuffer,
@@ -219,7 +219,7 @@ def make_collector(cfg, train_env, actor_model_explore, compile_mode, device="cp
         device: Device for data collection (default: "cpu", can use "cuda" now that VecNormV2 is removed)
         postproc: Optional postprocessing transform (e.g., CoverageTracker)
     """
-    collector = SyncDataCollector(
+    collector = Collector(
         train_env,
         actor_model_explore,
         frames_per_batch=cfg.collector.frames_per_batch,

--- a/examples/online_rl/grpo/utils.py
+++ b/examples/online_rl/grpo/utils.py
@@ -17,7 +17,7 @@ from torchrl.envs import (
 )
 
 from torchtrade.envs.transforms import CoverageTracker
-from torchrl.collectors import SyncDataCollector
+from torchrl.collectors import Collector
 
 from torchrl.modules import (
     MLP,
@@ -421,7 +421,7 @@ def make_collector(cfg, train_env, actor_model_explore, compile_mode, postproc=N
     Args:
         device: Device for data collection (default: "cpu", can use "cuda" now that VecNormV2 is removed)
     """
-    collector = SyncDataCollector(
+    collector = Collector(
         train_env,
         actor_model_explore,
         frames_per_batch=cfg.collector.frames_per_batch,

--- a/examples/online_rl/iql/utils.py
+++ b/examples/online_rl/iql/utils.py
@@ -8,7 +8,7 @@ from tensordict.nn import InteractionType
 from torch.distributions import Categorical
 
 
-from torchrl.collectors import SyncDataCollector
+from torchrl.collectors import Collector
 from torchrl.data import (
     Composite,
     LazyMemmapStorage,
@@ -178,7 +178,7 @@ def make_collector(cfg, train_env, actor_model_explore, compile_mode, postproc=N
     Args:
         device: Device for data collection (default: "cpu", can use "cuda" now that VecNormV2 is removed)
     """
-    collector = SyncDataCollector(
+    collector = Collector(
         train_env,
         actor_model_explore,
         frames_per_batch=cfg.collector.frames_per_batch,

--- a/examples/online_rl/ppo/live.py
+++ b/examples/online_rl/ppo/live.py
@@ -26,7 +26,7 @@ import torch
 import tqdm
 from dotenv import load_dotenv
 from sklearn.preprocessing import StandardScaler
-from torchrl.collectors import SyncDataCollector
+from torchrl.collectors import Collector
 from torchrl.data import LazyTensorStorage, TensorDictReplayBuffer
 from torchrl.envs import (
     Compose,
@@ -188,7 +188,7 @@ def main():
     )
 
     # Run live
-    collector = SyncDataCollector(
+    collector = Collector(
         env,
         policy,
         frames_per_batch=1,

--- a/examples/online_rl/ppo/utils.py
+++ b/examples/online_rl/ppo/utils.py
@@ -14,7 +14,7 @@ from torchrl.envs import (
     TransformedEnv,
     StepCounter,
 )
-from torchrl.collectors import SyncDataCollector
+from torchrl.collectors import Collector
 
 from torchrl.modules import (
     ActorValueOperator,
@@ -424,7 +424,7 @@ def make_collector(cfg, train_env, actor_model_explore, compile_mode, device="cp
         compile_mode: Compilation mode for the policy
         device: Device for data collection (default: "cpu", can use "cuda" now that VecNormV2 is removed)
     """
-    collector = SyncDataCollector(
+    collector = Collector(
         train_env,
         actor_model_explore,
         frames_per_batch=cfg.collector.frames_per_batch,

--- a/examples/online_rl/ppo_chronos/utils.py
+++ b/examples/online_rl/ppo_chronos/utils.py
@@ -16,7 +16,7 @@ from torchrl.envs import (
 )
 
 from torchtrade.envs.transforms import CoverageTracker, ChronosEmbeddingTransform
-from torchrl.collectors import SyncDataCollector
+from torchrl.collectors import Collector
 
 from torchrl.modules import (
     ActorValueOperator,
@@ -363,7 +363,7 @@ def make_collector(cfg, train_env, actor_model_explore, compile_mode, postproc=N
     Args:
         device: Device for data collection (default: "cpu", can use "cuda" now that VecNormV2 is removed)
     """
-    collector = SyncDataCollector(
+    collector = Collector(
         train_env,
         actor_model_explore,
         frames_per_batch=cfg.collector.frames_per_batch,

--- a/examples/online_rl/ppo_vectorized/utils.py
+++ b/examples/online_rl/ppo_vectorized/utils.py
@@ -10,7 +10,7 @@ from torchrl.envs import (
     TransformedEnv,
     StepCounter,
 )
-from torchrl.collectors import SyncDataCollector
+from torchrl.collectors import Collector
 import torchrl
 import torch
 from torchrl.modules import (
@@ -411,7 +411,7 @@ def make_collector(cfg, train_env, actor_model_explore, compile_mode, device="cp
         compile_mode: Compilation mode for the policy
         device: Device for data collection (default: "cpu", can use "cuda" now that VecNormV2 is removed)
     """
-    collector = SyncDataCollector(
+    collector = Collector(
         train_env,
         actor_model_explore,
         frames_per_batch=cfg.collector.frames_per_batch,

--- a/examples/rule_based/live.py
+++ b/examples/rule_based/live.py
@@ -22,7 +22,7 @@ from dotenv import load_dotenv
 from torchtrade.actor import MeanReversionActor
 from torchtrade.envs.live.alpaca.env import AlpacaTorchTradingEnv, AlpacaTradingEnvConfig
 from torchtrade.envs.utils.timeframe import TimeFrame, TimeFrameUnit
-from torchrl.collectors import SyncDataCollector
+from torchrl.collectors import Collector
 from torchrl.data import LazyTensorStorage, TensorDictReplayBuffer
 from torchrl.envs import Compose, DoubleToFloat, TransformedEnv
 from torchrl.envs.transforms import InitTracker, RewardSum, StepCounter, UnsqueezeTransform
@@ -90,7 +90,7 @@ def main():
     )
 
     # Create collector and replay buffer
-    collector = SyncDataCollector(
+    collector = Collector(
         env,
         actor,
         init_random_frames=0,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,11 +24,11 @@ dependencies = [
     "pybit>=5.0.0",
     "python-okx>=0.3.0",
     "python-dotenv",
-    # Pin the RL stack to the 0.10 line: torchrl 0.11 dropped the top-level
-    # `from torchrl.collectors import SyncDataCollector` import path this repo
-    # relies on in ~18 places. tensordict is pinned in lockstep to avoid skew.
-    "torchrl>=0.10,<0.11",
-    "tensordict>=0.10,<0.11",
+    # RL stack pinned in lockstep (torchrl + tensordict MUST move together — a
+    # skew is what silently broke CI before this pin). torchrl 0.13 removed the
+    # `SyncDataCollector` alias (use `Collector`); torch floor (2.1.0) is met by 2.9.0.
+    "torchrl>=0.13,<0.14",
+    "tensordict>=0.13,<0.14",
     "wandb",
     "tqdm",
     "hydra-core",

--- a/tests/envs/offline/test_history_tracking.py
+++ b/tests/envs/offline/test_history_tracking.py
@@ -23,16 +23,8 @@ from torchtrade.envs.offline import (
 from torchtrade.envs.utils.timeframe import TimeFrame, TimeFrameUnit
 
 # Import TorchRL testing utilities
-try:
-    from torchrl.testing import get_default_devices
-    from torchrl.envs.utils import check_env_specs
-    HAS_TORCHRL_TESTING = True
-except ImportError:
-    HAS_TORCHRL_TESTING = False
-
-    def get_default_devices():
-        """Fallback if torchrl.testing not available."""
-        return [torch.device("cpu")]
+from torchrl.testing import get_default_devices
+from torchrl.envs.utils import check_env_specs
 
 
 def simple_feature_fn(df: pd.DataFrame) -> pd.DataFrame:
@@ -66,8 +58,7 @@ class TestSequentialTradingEnvHistory:
         )
 
         # Validate environment specs
-        if HAS_TORCHRL_TESTING:
-            check_env_specs(env)
+        check_env_specs(env)
 
         td = env.reset()
 
@@ -182,8 +173,7 @@ class TestSequentialTradingEnvHistoryFutures:
         )
 
         # Validate specs
-        if HAS_TORCHRL_TESTING:
-            check_env_specs(env)
+        check_env_specs(env)
 
         td = env.reset()
 
@@ -231,8 +221,7 @@ class TestSequentialTradingEnvSLTPHistory:
         )
 
         # Validate specs
-        if HAS_TORCHRL_TESTING:
-            check_env_specs(env)
+        check_env_specs(env)
 
         td = env.reset()
 
@@ -332,8 +321,7 @@ class TestOneStepTradingEnvHistory:
         )
 
         # Validate specs
-        if HAS_TORCHRL_TESTING:
-            check_env_specs(env)
+        check_env_specs(env)
 
         td = env.reset()
 

--- a/tests/envs/offline/test_onestep.py
+++ b/tests/envs/offline/test_onestep.py
@@ -467,7 +467,7 @@ class TestOneStepIntegration:
     """Integration tests with TorchRL ecosystem."""
 
     def test_compatible_with_collector(self, onestep_env):
-        """Should work with SyncDataCollector."""
+        """Should work with Collector."""
         # This is a conceptual test - actual collector integration
         # would require imports and more setup
         td = onestep_env.reset()

--- a/tests/envs/offline/test_vectorized_sequential.py
+++ b/tests/envs/offline/test_vectorized_sequential.py
@@ -5,7 +5,7 @@ Verifies:
 - TorchRL spec compliance (check_env_specs)
 - Truncation and done signal correctness
 - Transaction fee accounting
-- SyncDataCollector integration
+- Collector integration
 - Partial reset behavior
 - Futures position mechanics
 """
@@ -369,11 +369,11 @@ class TestVecEnvFees:
 
 
 class TestVecEnvCollector:
-    """Tests for TorchRL SyncDataCollector integration."""
+    """Tests for TorchRL Collector integration."""
 
     @pytest.mark.parametrize("leverage", [1, 10], ids=["spot", "futures"])
     def test_collector_collects_frames(self, sample_ohlcv_df, leverage):
-        """SyncDataCollector should collect expected number of frames."""
+        """Collector should collect expected number of frames."""
         config = VectorizedSequentialTradingEnvConfig(
             num_envs=8,
             leverage=leverage,

--- a/tests/envs/offline/test_vectorized_sequential.py
+++ b/tests/envs/offline/test_vectorized_sequential.py
@@ -14,7 +14,7 @@ import pytest
 import torch
 
 from torchrl.envs.utils import check_env_specs
-from torchrl.collectors import SyncDataCollector
+from torchrl.collectors import Collector
 
 from torchtrade.envs.offline import (
     VectorizedSequentialTradingEnv,
@@ -387,7 +387,7 @@ class TestVecEnvCollector:
         env = VectorizedSequentialTradingEnv(sample_ohlcv_df, config, simple_feature_fn)
 
         total_frames = 200
-        collector = SyncDataCollector(
+        collector = Collector(
             env,
             policy=None,
             frames_per_batch=80,

--- a/tests/envs/transforms/test_coverage_tracker.py
+++ b/tests/envs/transforms/test_coverage_tracker.py
@@ -820,7 +820,7 @@ class TestParallelEnvironmentCoverage:
 
         The recommended pattern is shown in examples/online/ppo_futures/:
         - Create coverage_tracker = CoverageTracker()
-        - Pass as postproc to SyncDataCollector
+        - Pass as postproc to Collector
         - Do NOT add to environment transforms
 
         Direct reset() calls on ParallelEnv don't work because ParallelEnv's
@@ -847,7 +847,7 @@ class TestCollectorPostproc:
 
     def test_collector_postproc_integration(self, simple_df):
         """Test CoverageTracker as collector postproc (recommended pattern)."""
-        from torchrl.collectors import SyncDataCollector
+        from torchrl.collectors import Collector
 
         # Create env with random_start
         def make_env(df):
@@ -894,7 +894,7 @@ class TestCollectorPostproc:
 
         # Create collector with coverage tracker as postproc
         # Use large total_frames to avoid auto-close
-        collector = SyncDataCollector(
+        collector = Collector(
             transformed_env,
             policy,
             frames_per_batch=100,

--- a/tests/losses/test_group_relative_pg_loss.py
+++ b/tests/losses/test_group_relative_pg_loss.py
@@ -12,7 +12,7 @@ from tensordict.nn import (
 )
 from torch import nn
 from torch.distributions import Categorical
-from torchrl.collectors import SyncDataCollector
+from torchrl.collectors import Collector
 from torchrl.envs import (
     Compose,
     EnvCreator,
@@ -449,7 +449,7 @@ class TestGroupRelativePGLossGroupingInvariant:
         )
 
         t_steps = 3
-        collector = SyncDataCollector(
+        collector = Collector(
             env, actor, frames_per_batch=n_group * t_steps, total_frames=n_group * t_steps, device="cpu"
         )
         data = next(iter(collector))

--- a/torchtrade/envs/transforms/coverage_tracker.py
+++ b/torchtrade/envs/transforms/coverage_tracker.py
@@ -32,7 +32,7 @@ class CoverageTracker(Transform):
     - Detecting overfitting to specific market conditions
 
     Usage:
-        from torchrl.collectors import SyncDataCollector
+        from torchrl.collectors import Collector
         from torchrl.envs import TransformedEnv, Compose, InitTracker, DoubleToFloat, RewardSum
         from torchtrade.envs.transforms import CoverageTracker
 
@@ -50,7 +50,7 @@ class CoverageTracker(Transform):
         coverage_tracker = CoverageTracker()
 
         # Use coverage tracker as postproc in collector
-        collector = SyncDataCollector(
+        collector = Collector(
             env,
             policy,
             frames_per_batch=1000,
@@ -80,7 +80,7 @@ class CoverageTracker(Transform):
     def __init__(self):
         """Initialize the CoverageTracker transform.
 
-        CoverageTracker should be used as a postproc in SyncDataCollector.
+        CoverageTracker should be used as a postproc in Collector.
         It reads reset_index and state_index from collected batches and aggregates coverage statistics.
         """
         super().__init__()
@@ -242,7 +242,7 @@ class CoverageTracker(Transform):
     def forward(self, tensordict: TensorDictBase) -> TensorDictBase:
         """Process collected batch and aggregate coverage from reset and state indices.
 
-        This method is called by SyncDataCollector's postproc after data collection.
+        This method is called by Collector's postproc after data collection.
         It reads both reset_index and state_index from the batch and updates coverage statistics.
 
         Args:


### PR DESCRIPTION
## Summary

Upgrades the RL stack off the stopgap pin (`torchrl>=0.10,<0.11`) to **torchrl 0.13.2 + tensordict 0.13.0** with bounded lockstep pins. torch 2.9.0 is unchanged (satisfies torchrl 0.13's `>=2.1.0` floor). No new features and **no intended behavior change** — this is a dependency bump plus one mechanical rename.

This is backlog item **E1**: it fixes the CI-drift risk properly (the deps were unpinned before #229, which let CI silently drift into a broken torchrl/tensordict combo) and unblocks the newer torchrl LLM stack needed for future work.

## What changed

1. **Pins** (`pyproject.toml`): `torchrl>=0.13,<0.14`, `tensordict>=0.13,<0.14`, lockstep comment corrected. torchrl and tensordict **must** move together — a version skew was the original silent CI break, not the `SyncDataCollector` import.
2. **`SyncDataCollector` → `Collector`** across 18 tracked files (1 production: `coverage_tracker.py`; examples; tests; **and 3 docs code-samples**). torchrl 0.13 **removed** the `SyncDataCollector` name (it survived through 0.12); `Collector` is a verified drop-in — same constructor kwargs, same iteration protocol, same per-batch TensorDict. Clean rename, no back-compat alias (matches the project's no-shim convention).
3. **Dead-code removal** (`tests/envs/offline/test_history_tracking.py`): dropped a now-obsolete `try/except ImportError` fallback for `torchrl.testing.get_default_devices` + the `HAS_TORCHRL_TESTING` flag. Side effect: `check_env_specs()` on the four offline envs now runs **unconditionally** instead of being silently skippable — a coverage gain.

## Correctness verification (offline-env-correctness mandate)

- **Golden numeric gate:** a one-time seeded `env.reset`/`step` sequence through `SequentialTradingEnv`, `SequentialTradingEnvSLTP`, `OneStepTradingEnv` + a `GroupRelativePGLoss` forward, captured on 0.10.1 and re-run on 0.13.2 → **byte-identical (GOLDEN MATCH)**. (Throwaway, not committed — a permanent test can't hold two torchrl versions.)
- **Full suite on 0.13.2:** `1729 passed, 15 skipped` — same pass count as pre-upgrade.
- `check_env_specs` passes on all offline envs.

## Review notes (from the mandated review agents)

Non-blocking residuals, recorded for transparency:
- The golden gate covered the 3 scalar offline envs but **not** the 2 vectorized envs; their committed tests pass on 0.13.2 but assert directionally, not byte-exact. Low residual risk on the batched path.
- `Collector`'s `compile_policy` / `cudagraph_policy` truthy branches and the `trust_policy=True` live-script path are not exercised by the automated suite (all example configs ship `compile: False`; live scripts need broker/LLM creds). Pre-existing coverage gap, not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
