### PR TITLE
refactor(actor): formalize <answer> parsing + add tool-call seam to LLM actor

### DIFF
--- a/docs/components/actors.md
+++ b/docs/components/actors.md
@@ -125,6 +125,39 @@ existing offline/live scripts require no changes. `generate_batch` is the
 extension point for adding batched generation to new backends. See
 `examples/llm/local/parallel.py` for a full example.
 
+### Action Extraction
+
+Both LLM actors parse the model's chosen action from a `<answer>N</answer>` tag.
+That logic lives in one reusable pure function:
+
+```python
+from torchtrade.actor.parsers import extract_action
+
+idx = extract_action("<think>...</think><answer>2</answer>", num_actions=3)  # -> 2
+```
+
+It returns the integer `N` when `0 <= N < num_actions`, and falls back to action
+`0` (logging a warning) when the tag is missing or out of range — a trading agent
+must always emit a valid action.
+
+### Extending: the tool-use seam
+
+`BaseLLMActor.forward()` calls a `_resolve_tools(system_prompt, user_prompts,
+responses)` hook between generation and action extraction. The default is a no-op
+(returns `responses` unchanged), so standard single-shot actors are unaffected.
+To add tool use, override it:
+
+```python
+class ToolAugmentedActor(LocalLLMActor):
+    def _resolve_tools(self, system_prompt, user_prompts, responses):
+        # detect <tool>...</tool> in each response, execute the tool, append the
+        # result to the conversation, and re-generate the ones that called a tool
+        return self._run_tool_loop(system_prompt, user_prompts, responses)
+```
+
+The multi-turn tool-execution loop itself (parsing `<tool>` calls, dispatching to
+broker/data APIs, re-prompting) ships with the upcoming tool-use feature.
+
 ---
 
 ## See Also

--- a/docs/environments/online.md
+++ b/docs/environments/online.md
@@ -610,7 +610,7 @@ while not bool(td.get("done", torch.zeros(1, dtype=torch.bool)).item()):
 env.close()
 ```
 
-The actor expects responses in `<answer>N</answer>` format (handled by `BaseLLMActor._extract_action`); models that don't follow it default to action 0. Set `debug=True` on the actor to print the system prompt, user prompt, and raw model response each step, useful while tuning.
+The actor expects responses in `<answer>N</answer>` format (handled by `torchtrade.actor.parsers.extract_action`); models that don't follow it default to action 0. Set `debug=True` on the actor to print the system prompt, user prompt, and raw model response each step, useful while tuning.
 
 #### Combining with `BinanceOHLCVTransform`
 

--- a/tests/actor/test_local_llm_actor.py
+++ b/tests/actor/test_local_llm_actor.py
@@ -79,30 +79,6 @@ def sample_td():
 # ============================================================================
 
 
-@pytest.mark.parametrize("response,expected_idx", [
-    ("<think>go long</think><answer>2</answer>", 2),
-    ("<answer>0</answer>", 0),
-    ("<ANSWER> 1 </ANSWER>", 1),  # case-insensitive, whitespace
-    ("<answer>99</answer>", 0),   # out of range → default 0
-    ("no tags here", 0),          # missing tag → default 0
-], ids=["valid-long", "valid-short", "case-whitespace", "out-of-range", "no-tag"])
-def test_extract_action(actor, response, expected_idx):
-    """Action extraction maps <answer>N</answer> to correct index, with safe fallbacks."""
-    assert actor._extract_action(response) == expected_idx
-
-
-@pytest.mark.parametrize("response,expected_msg_fragment", [
-    ("<answer>99</answer>", "out of range"),
-    ("no tag", "No <answer> tag"),
-], ids=["out-of-range", "no-tag"])
-def test_extract_action_warns_unconditionally(actor, caplog, response, expected_msg_fragment):
-    """Warnings on bad responses are emitted regardless of debug flag."""
-    assert actor.debug is False
-    with caplog.at_level("WARNING", logger="torchtrade.actor.base_llm_actor"):
-        actor._extract_action(response)
-    assert any(expected_msg_fragment in r.message for r in caplog.records)
-
-
 @pytest.mark.parametrize("bad_shape", [
     (48, 4),       # 2D with wrong feature count
     (2, 48, 5),    # 3D with leading dim != 1 (squeeze(0) is a no-op)

--- a/tests/actor/test_local_llm_actor.py
+++ b/tests/actor/test_local_llm_actor.py
@@ -126,9 +126,10 @@ def test_forward_produces_required_keys(actor, sample_td):
 
 
 def test_forward_clamps_out_of_range_action(actor, sample_td):
-    """Actor passes num_actions=len(action_levels) to the parser, so an
-    out-of-range model answer clamps to 0 — pins the actor->parser wiring."""
-    with patch.object(actor, "generate_batch", return_value=["<answer>9</answer>"]):
+    """Actor passes num_actions=len(action_levels) to the parser, so the first
+    out-of-range index (3 for a 3-action actor) clamps to 0 — pins the
+    actor->parser wiring to exactly len(action_levels)."""
+    with patch.object(actor, "generate_batch", return_value=["<answer>3</answer>"]):
         result = actor.forward(sample_td)
     assert result["action"].item() == 0
 

--- a/tests/actor/test_local_llm_actor.py
+++ b/tests/actor/test_local_llm_actor.py
@@ -125,6 +125,14 @@ def test_forward_produces_required_keys(actor, sample_td):
     assert "exposure_pct" in result["user_prompt"]
 
 
+def test_forward_clamps_out_of_range_action(actor, sample_td):
+    """Actor passes num_actions=len(action_levels) to the parser, so an
+    out-of-range model answer clamps to 0 — pins the actor->parser wiring."""
+    with patch.object(actor, "generate_batch", return_value=["<answer>9</answer>"]):
+        result = actor.forward(sample_td)
+    assert result["action"].item() == 0
+
+
 def test_system_prompt_reflects_action_levels(actor):
     """System prompt describes actions from action_levels, not hardcoded buy/sell/hold."""
     prompt = actor._build_system_prompt()

--- a/tests/actor/test_parsers.py
+++ b/tests/actor/test_parsers.py
@@ -1,0 +1,28 @@
+"""Tests for the standalone LLM action-extraction parser."""
+import pytest
+
+from torchtrade.actor.parsers import extract_action
+
+
+@pytest.mark.parametrize("response,expected", [
+    ("<think>go long</think><answer>2</answer>", 2),   # normal
+    ("<answer>0</answer>", 0),                          # boundary low
+    ("<ANSWER> 1 </ANSWER>", 1),                        # case-insensitive + whitespace
+    ("<answer>99</answer>", 0),                         # out of range -> 0
+    ("no tags here", 0),                                # missing tag -> 0
+    ("<answer>-1</answer>", 0),                         # negative not matched -> 0 (no accidental short)
+    ("<answer>1</answer> <answer>2</answer>", 1),       # first match wins
+], ids=["normal", "low", "case-ws", "out-of-range", "no-tag", "negative", "first-wins"])
+def test_extract_action(response, expected):
+    assert extract_action(response, num_actions=3) == expected
+
+
+@pytest.mark.parametrize("response,fragment", [
+    ("<answer>99</answer>", "out of range"),
+    ("no tag", "No <answer> tag"),
+], ids=["out-of-range", "no-tag"])
+def test_extract_action_warns(caplog, response, fragment):
+    """The silent fallback-to-0 must be observable via a WARNING."""
+    with caplog.at_level("WARNING", logger="torchtrade.actor.parsers"):
+        extract_action(response, num_actions=3)
+    assert any(fragment in r.message for r in caplog.records)

--- a/torchtrade/actor/base_llm_actor.py
+++ b/torchtrade/actor/base_llm_actor.py
@@ -1,5 +1,4 @@
 """Base LLM Actor with environment-driven prompt construction and action extraction."""
-import logging
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Callable, List, Optional, Union
 
@@ -9,8 +8,6 @@ from torchtrade.actor.parsers import extract_action
 
 if TYPE_CHECKING:
     from tensordict import TensorDict
-
-logger = logging.getLogger(__name__)
 
 SystemPrompt = Union[str, Callable[["BaseLLMActor"], str]]
 UserPromptFn = Callable[["BaseLLMActor", "TensorDict"], str]

--- a/torchtrade/actor/base_llm_actor.py
+++ b/torchtrade/actor/base_llm_actor.py
@@ -1,10 +1,11 @@
 """Base LLM Actor with environment-driven prompt construction and action extraction."""
 import logging
-import re
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Callable, List, Optional, Union
 
 import torch
+
+from torchtrade.actor.parsers import extract_action
 
 if TYPE_CHECKING:
     from tensordict import TensorDict
@@ -79,9 +80,6 @@ class BaseLLMActor(ABC):
             if action_descriptions is not None
             else self._build_action_descriptions()
         )
-
-        # Pre-compile regex
-        self._answer_pattern = re.compile(r"<answer>\s*(\d+)\s*</answer>", re.IGNORECASE | re.DOTALL)
 
     def _build_action_descriptions(self) -> List[str]:
         """Build human-readable descriptions for each action index."""
@@ -159,7 +157,9 @@ class BaseLLMActor(ABC):
         responses = self.generate_batch(system_prompt, user_prompts)
         self._debug("RESPONSES", "\n---\n".join(responses))
 
-        actions = [self._extract_action(r) for r in responses]
+        responses = self._resolve_tools(system_prompt, user_prompts, responses)
+
+        actions = [extract_action(r, len(self.action_levels)) for r in responses]
 
         if batched:
             tensordict.set("action", torch.tensor(actions, dtype=torch.long))
@@ -173,6 +173,16 @@ class BaseLLMActor(ABC):
             tensordict.set("user_prompt", user_prompts[0])
 
         return tensordict
+
+    def _resolve_tools(self, system_prompt, user_prompts, responses):
+        """Extension point for tool-augmented multi-turn resolution.
+
+        Default: no tools — returns responses unchanged (single-shot, batched).
+        Group C overrides this to detect <tool>...</tool> in a response, execute
+        the tool, append the result to the conversation, and re-generate the
+        conversations that made a tool call — returning the final responses.
+        """
+        return responses
 
     def _debug(self, label: str, content: str) -> None:
         if self.debug:
@@ -246,18 +256,3 @@ class BaseLLMActor(ABC):
             out += "\n"
 
         return out
-
-    # --- Action extraction ---
-
-    def _extract_action(self, response: str) -> int:
-        """Extract action index from <answer>N</answer> tag."""
-        match = self._answer_pattern.search(response)
-        if match:
-            idx = int(match.group(1))
-            if 0 <= idx < len(self.action_levels):
-                return idx
-            logger.warning("Action %d out of range [0, %d); defaulting to 0", idx, len(self.action_levels))
-            return 0
-
-        logger.warning("No <answer> tag found in response; defaulting to action 0")
-        return 0

--- a/torchtrade/actor/base_llm_actor.py
+++ b/torchtrade/actor/base_llm_actor.py
@@ -159,7 +159,7 @@ class BaseLLMActor(ABC):
 
         responses = self._resolve_tools(system_prompt, user_prompts, responses)
 
-        actions = [extract_action(r, len(self.action_levels)) for r in responses]
+        actions = [extract_action(r, num_actions=len(self.action_levels)) for r in responses]
 
         if batched:
             tensordict.set("action", torch.tensor(actions, dtype=torch.long))

--- a/torchtrade/actor/base_llm_actor.py
+++ b/torchtrade/actor/base_llm_actor.py
@@ -174,13 +174,16 @@ class BaseLLMActor(ABC):
 
         return tensordict
 
-    def _resolve_tools(self, system_prompt, user_prompts, responses):
+    def _resolve_tools(
+        self, system_prompt: str, user_prompts: List[str], responses: List[str]
+    ) -> List[str]:
         """Extension point for tool-augmented multi-turn resolution.
 
         Default: no tools — returns responses unchanged (single-shot, batched).
-        Group C overrides this to detect <tool>...</tool> in a response, execute
-        the tool, append the result to the conversation, and re-generate the
-        conversations that made a tool call — returning the final responses.
+        A tool-augmented subclass overrides this to detect <tool>...</tool> in a
+        response, execute the tool, append the result to the conversation, and
+        re-generate the conversations that made a tool call — returning the final
+        responses.
         """
         return responses
 

--- a/torchtrade/actor/parsers.py
+++ b/torchtrade/actor/parsers.py
@@ -1,0 +1,26 @@
+"""Standalone parsers for LLM trading-actor responses."""
+import logging
+import re
+
+logger = logging.getLogger(__name__)
+
+_ANSWER_PATTERN = re.compile(r"<answer>\s*(\d+)\s*</answer>", re.IGNORECASE | re.DOTALL)
+
+
+def extract_action(response: str, num_actions: int) -> int:
+    """Parse the chosen action index from an LLM response's <answer>N</answer> tag.
+
+    Returns N when a tag is found and 0 <= N < num_actions. Falls back to 0
+    (logging a warning) when no tag is present or N is out of range — a trading
+    agent must always emit a valid action.
+    """
+    match = _ANSWER_PATTERN.search(response)
+    if match:
+        idx = int(match.group(1))
+        if 0 <= idx < num_actions:
+            return idx
+        logger.warning("Action %d out of range [0, %d); defaulting to 0", idx, num_actions)
+        return 0
+
+    logger.warning("No <answer> tag found in response; defaulting to action 0")
+    return 0


### PR DESCRIPTION
## Summary

Formalizes the LLM trading actor's `<answer>N</answer>` action extraction and defines a clean, no-op **tool-call seam** — the substrate for upcoming tool-use features — as a small, behavior-preserving refactor. No new dependency; the batched single-shot inference path is byte-identical.

This is backlog item **B1**. Research against the installed torchrl 0.13.2 established that a full ChatEnv/ChatHistory migration is **not** justified for a single-shot per-bar trading agent (it only pays off if the RL formulation later makes the conversation itself the training object). The salvageable, high-value part is done here instead.

## What changed

1. **New `torchtrade/actor/parsers.py`** — a standalone, unit-tested pure function `extract_action(response, num_actions)`, lifted verbatim from the old inline `BaseLLMActor._extract_action` (same regex, range-check, and warn-and-default-to-0 fallback). Modeled on torchrl's own `GSM8KRewardParser.extract_tags`.
2. **Tool-call seam in `BaseLLMActor.forward()`** — a single overridable `_resolve_tools(system_prompt, user_prompts, responses)` hook between generation and extraction. The default is pure identity, so single-shot behavior and the batched fast path are unchanged. A future tool-use feature overrides this one method — without touching `forward()`.
3. **Dead-code removal** — deleted the inline `_extract_action`, `self._answer_pattern`, and the now-unused `import re` / `import logging` + module `logger` from `base_llm_actor.py`.
4. **Tests** — new `tests/actor/test_parsers.py` (parser unit + warning coverage, incl. two new edge cases: a `-1` must never parse as a short, and first-match-wins); migrated the two old extraction tests out of `test_local_llm_actor.py`; added `test_forward_clamps_out_of_range_action` pinning the actor→parser `num_actions` wiring at the exact boundary.
5. **Docs** — `docs/components/actors.md` gets the reusable-parser note + an "Extending: the tool-use seam" subsection with an override snippet; fixed a stray `_extract_action` reference in `docs/environments/online.md`.

## Explicitly deferred (to the tool-use feature)

No multi-turn tool-execution loop, no ChatEnv/ChatHistory/vLLMWrapper adoption, no tool registry, no generic tag extractor. The seam is defined; the loop lands against a real broker tool.

## Verification

- Full suite green on torchrl 0.13.2: **1732 passed, 15 skipped, 0 failures**.
- Behavior byte-identical: the existing `forward()`/integration tests (which run through the new parser + no-op seam) are the regression guarantee.
- Full 3-round review (test-justification, code-simplifier, pr-test-analyzer, torchrl-engineer): the only substantive finding was a dead `logger` left after the refactor — fixed. torchrl-engineer confirmed the seam signature does not foreclose the future multi-turn loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
