### PR TITLE
fix(actor): live vLLM actor silently defaulted to action 0 (stop string stripped)

### DIFF
--- a/tests/actor/test_local_llm_actor.py
+++ b/tests/actor/test_local_llm_actor.py
@@ -134,6 +134,30 @@ def test_forward_clamps_out_of_range_action(actor, sample_td):
     assert result["action"].item() == 0
 
 
+def test_vllm_sampling_includes_stop_str_in_output():
+    """Regression: vLLM defaults include_stop_str_in_output=False, which strips the
+    '</answer>' stop string from output — but the parser regex requires the closing
+    tag, so without this flag every live response fails to parse and defaults to 0."""
+    captured = {}
+
+    class CapturingSamplingParams:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    sys.modules["vllm"].SamplingParams = CapturingSamplingParams
+
+    from torchtrade.actor import LocalLLMActor
+    LocalLLMActor(
+        model="test-model",
+        backend="vllm",
+        market_data_keys=MARKET_DATA_KEYS,
+        account_state_labels=ACCOUNT_STATE_LABELS,
+        action_levels=ACTION_LEVELS_FUTURES,
+    )
+    assert captured["include_stop_str_in_output"] is True
+    assert "</answer>" in captured["stop"]
+
+
 def test_system_prompt_reflects_action_levels(actor):
     """System prompt describes actions from action_levels, not hardcoded buy/sell/hold."""
     prompt = actor._build_system_prompt()

--- a/torchtrade/actor/local_llm_actor.py
+++ b/torchtrade/actor/local_llm_actor.py
@@ -55,10 +55,15 @@ class LocalLLMActor(BaseLLMActor):
 
     def _initialize_vllm(self):
         from vllm import LLM, SamplingParams
+        # include_stop_str_in_output=True is REQUIRED: vLLM defaults it to False,
+        # which strips the "</answer>" stop string from the returned text — but the
+        # action parser's regex requires the closing tag, so without this every live
+        # response fails to parse and silently defaults to action 0.
         self.sampling_params = SamplingParams(
             temperature=self.temperature,
             max_tokens=self.max_tokens,
             stop=["</answer>"],
+            include_stop_str_in_output=True,
         )
         kwargs = {
             "model": self.model_name,


### PR DESCRIPTION
## Summary

Fixes a latent correctness bug in the **live vLLM** `LocalLLMActor`: it never parsed the model's action and silently defaulted to **action 0** on every step.

## Root cause

`_initialize_vllm` builds `SamplingParams(..., stop=["</answer>"])`. vLLM defaults `include_stop_str_in_output=False`, so it **strips** the `</answer>` stop string from the returned text. But the action parser's regex (`torchtrade/actor/parsers.py`) requires the closing tag:

```python
_ANSWER_PATTERN = re.compile(r"<answer>\s*(\d+)\s*</answer>", ...)
```

With the tag stripped, the regex never matches → `extract_action` hits its fallback and returns `0` with a warning, on every live response. The unit tests didn't catch it because they mock `generate_batch` with complete strings that already include `</answer>` — the mock was more correct than the live sampler.

## Fix

One line: `include_stop_str_in_output=True` in the vLLM `SamplingParams`. Now `</answer>` is retained and the parser matches.

## Test

Added `test_vllm_sampling_includes_stop_str_in_output` — asserts the `SamplingParams` construction sets `include_stop_str_in_output=True` and keeps `</answer>` in `stop`. The config can't be exercised without a GPU, so the test pins the flag directly (verified it fails against the pre-fix construction). Only the vLLM backend is affected; the transformers and OpenAI (`FrontierLLMActor`) paths return full text and were never broken.

Full suite: **1733 passed, 15 skipped** on torchrl 0.13.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
