### PR TITLE
feat(actor): news/sentiment tool loop for the LLM actor (Google News)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ TorchTrade provides modular environments for both live trading with major exchan
 - 📊 **Feature Engineering** - Add technical indicators and custom features
 - 🔴 **Live Trading** - Direct Alpaca, Binance, Bitget, Bybit, OKX, and Polymarket integrations
 - 🧠 **LLM Integration** - Use GPT-4o-mini or local LLMs as trading agents
+- 🔧 **LLM Tool Use** - Let LLM agents call tools mid-reasoning (e.g. live Google News for sentiment) before choosing an action
 - 📐 **Rule-Based Actors** - Hard-coded strategies for imitation learning and baselines
 - 🔮 **Pretrained Encoder Transforms** - Foundation model embeddings for time series
 - 📦 **Ready-to-Use Datasets** - Pre-processed OHLCV data at [HuggingFace/Torch-Trade](https://huggingface.co/Torch-Trade)

--- a/docs/components/actors.md
+++ b/docs/components/actors.md
@@ -140,23 +140,32 @@ It returns the integer `N` when `0 <= N < num_actions`, and falls back to action
 `0` (logging a warning) when the tag is missing or out of range — a trading agent
 must always emit a valid action.
 
-### Extending: the tool-use seam
+### Tool use
 
-`BaseLLMActor.forward()` calls a `_resolve_tools(system_prompt, user_prompts,
-responses)` hook between generation and action extraction. The default is a no-op
-(returns `responses` unchanged), so standard single-shot actors are unaffected.
-To add tool use, override it:
+Configure `tools=[...]` to let the actor call tools before deciding. Tools run
+only when configured (live path); without them the actor is single-shot as before.
 
 ```python
-class ToolAugmentedActor(LocalLLMActor):
-    def _resolve_tools(self, system_prompt, user_prompts, responses):
-        # detect <tool>...</tool> in each response, execute the tool, append the
-        # result to the conversation, and re-generate the ones that called a tool
-        return self._run_tool_loop(system_prompt, user_prompts, responses)
+from torchtrade.actor import LocalLLMActor
+from torchtrade.actor.tools import GoogleNewsTool
+
+actor = LocalLLMActor(
+    model="Qwen/Qwen2.5-0.5B-Instruct", backend="vllm",
+    market_data_keys=env.market_data_keys,
+    account_state_labels=env.account_state,
+    action_levels=env.action_levels,
+    symbol="BTC/USD",
+    tools=[GoogleNewsTool(symbol="BTC/USD")],
+    max_tool_iters=3,
+)
 ```
 
-The multi-turn tool-execution loop itself (parsing `<tool>` calls, dispatching to
-broker/data APIs, re-prompting) ships with the upcoming tool-use feature.
+The model calls a tool with `<tool name="google_news">{"query": "Bitcoin"}</tool>`
+(torchrl `XMLBlockParser` convention) and receives a `<tool_results>...</tool_results>`
+block, then continues until it emits `<answer>N</answer>`. Only conversations that
+call a tool are re-generated, so batched multi-symbol inference stays efficient.
+Tool use requires `backend="vllm"` (the transformers backend can't halt at
+`</tool>`) and the `[llm]` extra (adds `feedparser`).
 
 ---
 

--- a/examples/llm/tools/news_decision.py
+++ b/examples/llm/tools/news_decision.py
@@ -1,0 +1,45 @@
+"""LocalLLMActor with the Google News tool making one decision with news context.
+
+Requires: pip install -e ".[llm]"  (adds feedparser) + network access.
+Run:      python examples/llm/tools/news_decision.py
+"""
+import os
+os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
+
+import torch
+from tensordict import TensorDict
+
+from torchtrade.actor import LocalLLMActor
+from torchtrade.actor.tools import GoogleNewsTool
+
+SYMBOL = "BTC/USD"
+
+
+def main():
+    actor = LocalLLMActor(
+        model="Qwen/Qwen2.5-0.5B-Instruct",
+        backend="vllm",
+        device="cuda" if torch.cuda.is_available() else "cpu",
+        debug=True,
+        market_data_keys=["market_data_1Hour_48"],
+        account_state_labels=[
+            "exposure_pct", "position_direction", "unrealized_pnl_pct",
+            "holding_time", "leverage", "distance_to_liquidation",
+        ],
+        action_levels=[-1, 0, 1],
+        symbol=SYMBOL,
+        execute_on="1Hour",
+        tools=[GoogleNewsTool(symbol=SYMBOL)],
+        max_tool_iters=3,
+    )
+    td = TensorDict({
+        "market_data_1Hour_48": torch.randn(1, 48, 5),
+        "account_state": torch.tensor([[0.0, 0.0, 0.0, 0.0, 1.0, 1.0]]),
+    }, batch_size=[])
+    out = actor(td)
+    print(f"\nDecision: action={out['action'].item()} "
+          f"(target {actor.action_levels[out['action'].item()] * 100:+.0f}%)")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ llm = [
     "transformers>=4.30.0",
     "accelerate>=0.20.0",
     "bitsandbytes>=0.41.0",
+    "feedparser>=6.0.0",
 ]
 chronos = [
     "chronos-forecasting",

--- a/tests/actor/test_local_llm_actor.py
+++ b/tests/actor/test_local_llm_actor.py
@@ -494,3 +494,55 @@ def test_run_tool_calls_success_and_errors(tool_actor):
 def test_no_tools_actor_prompt_unchanged(actor):
     # actor fixture has no tools -> system prompt has no tool section
     assert "<tool name=" not in actor._resolve_system_prompt()
+
+
+# ============================================================================
+# Multi-turn tool loop (C1, Task 4)
+# ============================================================================
+
+
+def test_tool_loop_call_then_answer(tool_actor, sample_td):
+    """A tool call is executed, its result injected, then the model answers."""
+    calls = [
+        ['<tool name="echo">{"text": "news"}</tool>'],   # round 1: tool call
+        ["<answer>2</answer>"],                            # round 2: final answer
+    ]
+    with patch.object(tool_actor, "generate_batch", side_effect=calls) as gen:
+        result = tool_actor.forward(sample_td)
+    assert result["action"].item() == 2
+    assert gen.call_count == 2                            # one extra generation for the tool round
+
+
+def test_tool_loop_batching_only_regenerates_pending(tool_actor):
+    """A1 preservation: only the tool-calling conversation is re-generated."""
+    td = TensorDict({
+        "market_data_1Hour_48": torch.randn(3, 48, 5),
+        "account_state": torch.zeros(3, 6),
+    }, batch_size=[3])
+    round1 = ['<answer>0</answer>', '<tool name="echo">{}</tool>', '<answer>1</answer>']
+    round2 = ['<answer>2</answer>']                       # only the 1 pending conv
+    seen = []
+    def fake_gen(system, prompts):
+        seen.append(list(prompts))
+        return round1 if len(seen) == 1 else round2
+    with patch.object(tool_actor, "generate_batch", side_effect=fake_gen):
+        result = tool_actor.forward(td)
+    assert len(seen) == 2
+    assert len(seen[1]) == 1                              # 2nd call regenerates ONLY the pending one
+    assert result["action"].tolist() == [0, 2, 1]
+
+
+def test_tool_loop_max_iters_defaults_to_zero(tool_actor, sample_td):
+    """Runaway tool caller hits the cap and safely defaults to action 0."""
+    with patch.object(tool_actor, "generate_batch",
+                      return_value=['<tool name="echo">{}</tool>']) as gen:
+        result = tool_actor.forward(sample_td)
+    assert result["action"].item() == 0                  # never emitted <answer>
+    assert gen.call_count == 1 + tool_actor.max_tool_iters
+
+
+def test_tool_loop_tool_failure_does_not_crash(tool_actor, sample_td):
+    calls = [['<tool name="boom">{}</tool>'], ["<answer>1</answer>"]]
+    with patch.object(tool_actor, "generate_batch", side_effect=calls):
+        result = tool_actor.forward(sample_td)            # must not raise
+    assert result["action"].item() == 1

--- a/tests/actor/test_local_llm_actor.py
+++ b/tests/actor/test_local_llm_actor.py
@@ -134,10 +134,14 @@ def test_forward_clamps_out_of_range_action(actor, sample_td):
     assert result["action"].item() == 0
 
 
-def test_vllm_sampling_includes_stop_str_in_output():
-    """Regression: vLLM defaults include_stop_str_in_output=False, which strips the
-    '</answer>' stop string from output — but the parser regex requires the closing
-    tag, so without this flag every live response fails to parse and defaults to 0."""
+def test_vllm_stop_includes_tool_tag():
+    """The tool loop needs generation to halt at </tool> as well as </answer>.
+
+    Also pins include_stop_str_in_output=True: vLLM defaults it to False, which
+    strips the stop string from the returned text — but the action/tool parsers'
+    regexes require the closing tag, so without this flag every live response
+    fails to parse and silently defaults to action 0.
+    """
     captured = {}
 
     class CapturingSamplingParams:
@@ -148,14 +152,29 @@ def test_vllm_sampling_includes_stop_str_in_output():
 
     from torchtrade.actor import LocalLLMActor
     LocalLLMActor(
-        model="test-model",
-        backend="vllm",
+        model="test-model", backend="vllm",
         market_data_keys=MARKET_DATA_KEYS,
         account_state_labels=ACCOUNT_STATE_LABELS,
         action_levels=ACTION_LEVELS_FUTURES,
     )
-    assert captured["include_stop_str_in_output"] is True
+    assert "</tool>" in captured["stop"]
     assert "</answer>" in captured["stop"]
+    assert captured["include_stop_str_in_output"] is True
+
+
+def test_tools_with_transformers_backend_raises():
+    """Tool use requires vLLM's </tool> stop; the transformers backend can't halt
+    there, so configuring tools with it must fail loud rather than degrade silently."""
+    from torchtrade.actor import LocalLLMActor
+    from torchtrade.actor.tools import GoogleNewsTool
+    with pytest.raises(ValueError, match="Tool use requires backend='vllm'"):
+        LocalLLMActor(
+            model="test-model", backend="transformers",
+            market_data_keys=MARKET_DATA_KEYS,
+            account_state_labels=ACCOUNT_STATE_LABELS,
+            action_levels=ACTION_LEVELS_FUTURES,
+            tools=[GoogleNewsTool(symbol="BTC/USD")],
+        )
 
 
 def test_system_prompt_reflects_action_levels(actor):

--- a/tests/actor/test_local_llm_actor.py
+++ b/tests/actor/test_local_llm_actor.py
@@ -434,3 +434,63 @@ def test_batched_forward_end_to_end_vllm(actor):
     assert result["action"].shape == torch.Size([3])
     assert result["action"].tolist() == [0, 1, 2]   # distinct -> proves per-element mapping
     assert len(result["thinking"]) == 3
+
+
+# ============================================================================
+# Tool config, system-prompt tools block, dispatch helpers (C1, Task 3)
+# ============================================================================
+
+
+from torchtrade.actor.tools import Tool
+
+
+class _EchoTool(Tool):
+    name = "echo"
+    description = "echo(text): returns the text"
+    def run(self, text="hi", **kw):
+        return f"echoed: {text}"
+
+
+class _BoomTool(Tool):
+    name = "boom"
+    description = "boom(): always fails"
+    def run(self, **kw):
+        raise RuntimeError("kaboom")
+
+
+@pytest.fixture
+def tool_actor():
+    from torchtrade.actor import LocalLLMActor
+    return LocalLLMActor(
+        model="test-model", backend="vllm",
+        market_data_keys=MARKET_DATA_KEYS,
+        account_state_labels=ACCOUNT_STATE_LABELS,
+        action_levels=ACTION_LEVELS_FUTURES,
+        symbol="BTC/USD",
+        tools=[_EchoTool(), _BoomTool()],
+        max_tool_iters=2,
+    )
+
+
+def test_tools_prompt_lists_tools_and_protocol(tool_actor):
+    prompt = tool_actor._resolve_system_prompt()
+    assert "echo(text)" in prompt                 # tool description present
+    assert '<tool name=' in prompt                # protocol shown
+    assert "<answer>" in prompt                   # base contract retained
+
+
+def test_run_tool_calls_success_and_errors(tool_actor):
+    out = tool_actor._run_tool_calls([
+        {"name": "echo", "args": {"text": "yo"}, "tag": None},
+        {"name": "nope", "args": {}, "tag": None},     # unknown tool
+        {"name": "boom", "args": {}, "tag": None},     # raises
+    ])
+    assert out.startswith("<tool_results>") and out.rstrip().endswith("</tool_results>")
+    assert "echoed: yo" in out
+    assert "Tool nope (call 2) failed" in out and "unknown tool" in out.lower()
+    assert "Tool boom (call 3) failed" in out and "kaboom" in out
+
+
+def test_no_tools_actor_prompt_unchanged(actor):
+    # actor fixture has no tools -> system prompt has no tool section
+    assert "<tool name=" not in actor._resolve_system_prompt()

--- a/tests/actor/test_local_llm_actor.py
+++ b/tests/actor/test_local_llm_actor.py
@@ -565,3 +565,25 @@ def test_tool_loop_tool_failure_does_not_crash(tool_actor, sample_td):
     with patch.object(tool_actor, "generate_batch", side_effect=calls):
         result = tool_actor.forward(sample_td)            # must not raise
     assert result["action"].item() == 1
+
+
+def test_tool_loop_accumulates_context_across_rounds(tool_actor, sample_td):
+    """Round N's prompt must carry ALL prior <tool_results>, not just the base
+    prompt — pins that _linearize threads the growing conversation (convo[i])."""
+    scripts = [
+        ['<tool name="echo">{"text": "first"}</tool>'],   # round 1: tool call
+        ['<tool name="echo">{"text": "second"}</tool>'],  # round 2: tool call
+        ["<answer>1</answer>"],                            # round 3: answer
+    ]
+    prompts_seen = []
+
+    def fake_gen(system, prompts):
+        prompts_seen.append(prompts[0])
+        return scripts[len(prompts_seen) - 1]
+
+    with patch.object(tool_actor, "generate_batch", side_effect=fake_gen):
+        result = tool_actor.forward(sample_td)
+    assert result["action"].item() == 1
+    # the final regeneration prompt must contain BOTH prior tool results
+    assert "echoed: first" in prompts_seen[-1]
+    assert "echoed: second" in prompts_seen[-1]

--- a/tests/actor/test_parsers.py
+++ b/tests/actor/test_parsers.py
@@ -1,7 +1,7 @@
 """Tests for the standalone LLM action-extraction parser."""
 import pytest
 
-from torchtrade.actor.parsers import extract_action
+from torchtrade.actor.parsers import extract_action, parse_tool_calls
 
 
 @pytest.mark.parametrize("response,expected", [
@@ -26,3 +26,28 @@ def test_extract_action_warns(caplog, response, fragment):
     with caplog.at_level("WARNING", logger="torchtrade.actor.parsers"):
         extract_action(response, num_actions=3)
     assert any(fragment in r.message for r in caplog.records)
+
+
+@pytest.mark.parametrize("response,expected_calls,expected_text", [
+    # single call, JSON body
+    ('<tool name="google_news">{"query": "Bitcoin"}</tool>\nSome text.',
+     [{"name": "google_news", "args": {"query": "Bitcoin"}, "tag": None}], "Some text."),
+    # tag attribute
+    ('<tool name="search" tag="A">{"q": 1}</tool>',
+     [{"name": "search", "args": {"q": 1}, "tag": "A"}], ""),
+    # empty body -> {}
+    ('<tool name="google_news"></tool>',
+     [{"name": "google_news", "args": {}, "tag": None}], ""),
+    # malformed JSON -> {"raw": body}
+    ('<tool name="x">not json</tool>',
+     [{"name": "x", "args": {"raw": "not json"}, "tag": None}], ""),
+    # multiple calls
+    ('<tool name="a">{}</tool> mid <tool name="b">{}</tool>',
+     [{"name": "a", "args": {}, "tag": None}, {"name": "b", "args": {}, "tag": None}], "mid"),
+    # no tag
+    ("just an answer <answer>1</answer>", [], "just an answer <answer>1</answer>"),
+], ids=["single", "tag", "empty-body", "malformed", "multiple", "none"])
+def test_parse_tool_calls(response, expected_calls, expected_text):
+    text, calls = parse_tool_calls(response)
+    assert calls == expected_calls
+    assert text == expected_text

--- a/tests/actor/test_tools.py
+++ b/tests/actor/test_tools.py
@@ -45,3 +45,45 @@ def test_google_news_fetch_failure_returns_error_string(monkeypatch):
     monkeypatch.setattr(tool, "_fetch", boom)
     out = tool.run()                          # must NOT raise
     assert "error" in out.lower()
+
+
+def _fake_feedparser(monkeypatch):
+    """Inject a stub feedparser so _fetch's lazy import works without the real dep."""
+    import sys
+    import types
+    fake = types.ModuleType("feedparser")
+    fake.parse = lambda data: types.SimpleNamespace(entries=[])
+    monkeypatch.setitem(sys.modules, "feedparser", fake)
+
+
+def test_google_news_fetch_enforces_timeout(monkeypatch):
+    """_fetch must bound the request with self.timeout so a hung RSS connection
+    cannot block a live trading decision indefinitely."""
+    _fake_feedparser(monkeypatch)
+    captured = {}
+
+    class _Resp:
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+        def read(self): return b"<rss></rss>"
+
+    def fake_urlopen(url, timeout=None):
+        captured["timeout"] = timeout
+        return _Resp()
+
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+    GoogleNewsTool(symbol="BTC/USD", timeout=3.0)._fetch("Bitcoin")
+    assert captured["timeout"] == 3.0
+
+
+def test_google_news_timeout_returns_error_string(monkeypatch):
+    """A network stall (urlopen raises after the timeout) degrades to an error
+    string via run()'s guard — never hangs or raises into forward()."""
+    _fake_feedparser(monkeypatch)
+
+    def stall(url, timeout=None):
+        raise TimeoutError("timed out")
+
+    monkeypatch.setattr("urllib.request.urlopen", stall)
+    out = GoogleNewsTool(symbol="BTC/USD", timeout=0.01).run()
+    assert "error" in out.lower()

--- a/tests/actor/test_tools.py
+++ b/tests/actor/test_tools.py
@@ -1,0 +1,47 @@
+"""Tests for LLM actor tools."""
+import pytest
+
+from torchtrade.actor.tools import GoogleNewsTool, symbol_to_query
+
+
+@pytest.mark.parametrize("symbol,expected", [
+    ("BTC/USD", "Bitcoin"), ("ETH/USD", "Ethereum"), ("DOGE/USD", "DOGE"),
+], ids=["btc", "eth", "fallback"])
+def test_symbol_to_query(symbol, expected):
+    assert symbol_to_query(symbol) == expected
+
+
+def _entries(n):
+    return [{"title": f"headline {i}", "source": "Reuters", "published": "2h ago"} for i in range(n)]
+
+
+def test_google_news_formats_top_n(monkeypatch):
+    tool = GoogleNewsTool(symbol="BTC/USD", top_n=2)
+    monkeypatch.setattr(tool, "_fetch", lambda query: _entries(5))
+    out = tool.run()
+    assert "headline 0" in out and "headline 1" in out
+    assert "headline 2" not in out            # capped at top_n
+    assert "Reuters" in out
+
+
+def test_google_news_default_query_uses_symbol(monkeypatch):
+    tool = GoogleNewsTool(symbol="ETH/USD")
+    seen = {}
+    monkeypatch.setattr(tool, "_fetch", lambda query: (seen.update({"q": query}), [])[1])
+    tool.run()
+    assert seen["q"] == "Ethereum"
+
+
+def test_google_news_empty_results(monkeypatch):
+    tool = GoogleNewsTool(symbol="BTC/USD")
+    monkeypatch.setattr(tool, "_fetch", lambda query: [])
+    assert "no recent news" in tool.run().lower()
+
+
+def test_google_news_fetch_failure_returns_error_string(monkeypatch):
+    tool = GoogleNewsTool(symbol="BTC/USD")
+    def boom(query):
+        raise ConnectionError("network down")
+    monkeypatch.setattr(tool, "_fetch", boom)
+    out = tool.run()                          # must NOT raise
+    assert "error" in out.lower()

--- a/torchtrade/actor/base_llm_actor.py
+++ b/torchtrade/actor/base_llm_actor.py
@@ -1,10 +1,12 @@
 """Base LLM Actor with environment-driven prompt construction and action extraction."""
+import json
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Callable, List, Optional, Union
 
 import torch
 
-from torchtrade.actor.parsers import extract_action
+from torchtrade.actor.parsers import extract_action, parse_tool_calls
+from torchtrade.actor.tools import Tool
 
 if TYPE_CHECKING:
     from tensordict import TensorDict
@@ -40,6 +42,13 @@ class BaseLLMActor(ABC):
             state + market data tables) is used. The callable receives the
             live tensordict for the current step — read freely, but do NOT
             mutate it (writes will leak into observation/action keys).
+        tools: Optional list of `Tool` instances the LLM may call mid-reasoning
+            (e.g. `GoogleNewsTool`). When non-empty, the system prompt gains a
+            tool-calling protocol block. If None/empty, prompt behavior is
+            unchanged (no-tools path).
+        max_tool_iters: Maximum number of tool-call round-trips per step
+            (advertised in the prompt; enforced by the tool-loop, added in a
+            later task).
     """
 
     def __init__(
@@ -54,6 +63,8 @@ class BaseLLMActor(ABC):
         debug: bool = False,
         system_prompt: Optional[SystemPrompt] = None,
         user_prompt_fn: Optional[UserPromptFn] = None,
+        tools: Optional[List[Tool]] = None,
+        max_tool_iters: int = 3,
     ):
         self.market_data_keys = market_data_keys
         self.account_state_labels = account_state_labels
@@ -69,6 +80,9 @@ class BaseLLMActor(ABC):
         self.debug = debug
         self._system_prompt_override = system_prompt
         self._user_prompt_fn = user_prompt_fn
+        self.tools = list(tools) if tools else []
+        self._tools_by_name = {t.name: t for t in self.tools}
+        self.max_tool_iters = max_tool_iters
 
         # Action descriptions: explicit override (e.g. for binary up/down envs)
         # falls back to the auto-generated "target exposure" language.
@@ -184,6 +198,41 @@ class BaseLLMActor(ABC):
         """
         return responses
 
+    def _build_tools_prompt(self) -> str:
+        tool_list = "\n".join(f"  - {t.description}" for t in self.tools)
+        return (
+            "You may call tools before deciding. Available tools:\n"
+            f"{tool_list}\n\n"
+            'To call a tool, output exactly: <tool name="<tool>">{"arg": "value"}</tool> '
+            "and stop. You will receive a <tool_results>...</tool_results> block, then continue.\n"
+            f"You may call tools up to {self.max_tool_iters} times. Finish with <answer>N</answer>."
+        )
+
+    def _run_tool_calls(self, calls: List[dict]) -> str:
+        lines = ["<tool_results>"]
+        for idx, call in enumerate(calls, 1):
+            name = call["name"]
+            tool = self._tools_by_name.get(name)
+            if tool is None:
+                lines.append(f"Tool {name} (call {idx}) failed:")
+                lines.append(f"  Error: unknown tool '{name}'")
+                continue
+            try:
+                result = tool.run(**call["args"])
+                lines.append(f"Tool {name} (call {idx}) succeeded:")
+                lines.append(f"  Result: {json.dumps(result)}")
+            except Exception as exc:  # per-tool guard; never crash a live step
+                lines.append(f"Tool {name} (call {idx}) failed:")
+                lines.append(f"  Error: {exc}")
+        lines.append("</tool_results>")
+        return "\n".join(lines)
+
+    def _linearize(self, base_prompt: str, response: str, results: str) -> str:
+        return (
+            f"{base_prompt}\n\n{response}\n{results}\n\n"
+            "Continue your analysis. When ready, respond with <answer>N</answer>."
+        )
+
     def _debug(self, label: str, content: str) -> None:
         if self.debug:
             print(f"{'=' * 80}\n{label}:\n{content}")
@@ -191,10 +240,14 @@ class BaseLLMActor(ABC):
     def _resolve_system_prompt(self) -> str:
         override = self._system_prompt_override
         if override is None:
-            return self._build_system_prompt()
-        if callable(override):
-            return override(self)
-        return override
+            base = self._build_system_prompt()
+        elif callable(override):
+            base = override(self)
+        else:
+            base = override
+        if self.tools:
+            base = base + "\n\n" + self._build_tools_prompt()
+        return base
 
     # --- Prompt construction ---
 

--- a/torchtrade/actor/base_llm_actor.py
+++ b/torchtrade/actor/base_llm_actor.py
@@ -188,14 +188,32 @@ class BaseLLMActor(ABC):
     def _resolve_tools(
         self, system_prompt: str, user_prompts: List[str], responses: List[str]
     ) -> List[str]:
-        """Extension point for tool-augmented multi-turn resolution.
+        """Run the multi-turn tool loop when tools are configured.
 
-        Default: no tools — returns responses unchanged (single-shot, batched).
-        A tool-augmented subclass overrides this to detect <tool>...</tool> in a
-        response, execute the tool, append the result to the conversation, and
-        re-generate the conversations that made a tool call — returning the final
-        responses.
+        Default (no tools): returns responses unchanged. Otherwise, each round
+        finds responses containing a <tool> call, executes the tools, injects a
+        <tool_results> block, and RE-GENERATES only those conversations in one
+        batched call — preserving the single-batched-call throughput for the
+        conversations that answered directly.
         """
+        if not self.tools:
+            return responses
+        convo = dict(enumerate(user_prompts))
+        for _ in range(self.max_tool_iters):
+            pending = {}
+            for i, resp in enumerate(responses):
+                _, calls = parse_tool_calls(resp)
+                if not calls:
+                    continue
+                results = self._run_tool_calls(calls)
+                convo[i] = self._linearize(convo[i], resp, results)
+                pending[i] = convo[i]
+            if not pending:
+                break
+            idx = list(pending)
+            regen = self.generate_batch(system_prompt, [pending[i] for i in idx])
+            for j, i in enumerate(idx):
+                responses[i] = regen[j]
         return responses
 
     def _build_tools_prompt(self) -> str:

--- a/torchtrade/actor/base_llm_actor.py
+++ b/torchtrade/actor/base_llm_actor.py
@@ -1,5 +1,4 @@
 """Base LLM Actor with environment-driven prompt construction and action extraction."""
-import json
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Callable, List, Optional, Union
 
@@ -47,8 +46,7 @@ class BaseLLMActor(ABC):
             tool-calling protocol block. If None/empty, prompt behavior is
             unchanged (no-tools path).
         max_tool_iters: Maximum number of tool-call round-trips per step
-            (advertised in the prompt; enforced by the tool-loop, added in a
-            later task).
+            (advertised in the prompt and enforced by the tool loop).
     """
 
     def __init__(
@@ -198,21 +196,20 @@ class BaseLLMActor(ABC):
         """
         if not self.tools:
             return responses
-        convo = dict(enumerate(user_prompts))
+        convo = list(user_prompts)
         for _ in range(self.max_tool_iters):
-            pending = {}
+            pending = []
             for i, resp in enumerate(responses):
                 _, calls = parse_tool_calls(resp)
                 if not calls:
                     continue
                 results = self._run_tool_calls(calls)
                 convo[i] = self._linearize(convo[i], resp, results)
-                pending[i] = convo[i]
+                pending.append(i)
             if not pending:
                 break
-            idx = list(pending)
-            regen = self.generate_batch(system_prompt, [pending[i] for i in idx])
-            for j, i in enumerate(idx):
+            regen = self.generate_batch(system_prompt, [convo[i] for i in pending])
+            for j, i in enumerate(pending):
                 responses[i] = regen[j]
         return responses
 
@@ -238,7 +235,7 @@ class BaseLLMActor(ABC):
             try:
                 result = tool.run(**call["args"])
                 lines.append(f"Tool {name} (call {idx}) succeeded:")
-                lines.append(f"  Result: {json.dumps(result)}")
+                lines.append(f"  Result: {result}")
             except Exception as exc:  # per-tool guard; never crash a live step
                 lines.append(f"Tool {name} (call {idx}) failed:")
                 lines.append(f"  Error: {exc}")

--- a/torchtrade/actor/local_llm_actor.py
+++ b/torchtrade/actor/local_llm_actor.py
@@ -33,6 +33,13 @@ class LocalLLMActor(BaseLLMActor):
         **kwargs,
     ):
         super().__init__(**kwargs)
+        # transformers has no stop-string mechanism to halt at </tool>, so tools would
+        # degrade silently. Fail loud on a live (real-money) path instead.
+        if self.tools and backend == "transformers":
+            raise ValueError(
+                "Tool use requires backend='vllm'; the transformers backend does not "
+                "halt generation at </tool>."
+            )
         self.model_name = model
         self.backend = backend
         self.device = device
@@ -56,13 +63,14 @@ class LocalLLMActor(BaseLLMActor):
     def _initialize_vllm(self):
         from vllm import LLM, SamplingParams
         # include_stop_str_in_output=True is REQUIRED: vLLM defaults it to False,
-        # which strips the "</answer>" stop string from the returned text — but the
-        # action parser's regex requires the closing tag, so without this every live
-        # response fails to parse and silently defaults to action 0.
+        # which strips the matched stop string ("</tool>" / "</answer>") from the
+        # returned text — but the tool/action parsers' regexes require the closing
+        # tag, so without this every live response fails to parse and silently
+        # defaults to action 0.
         self.sampling_params = SamplingParams(
             temperature=self.temperature,
             max_tokens=self.max_tokens,
-            stop=["</answer>"],
+            stop=["</tool>", "</answer>"],
             include_stop_str_in_output=True,
         )
         kwargs = {

--- a/torchtrade/actor/parsers.py
+++ b/torchtrade/actor/parsers.py
@@ -1,4 +1,5 @@
 """Standalone parsers for LLM trading-actor responses."""
+import json
 import logging
 import re
 
@@ -24,3 +25,31 @@ def extract_action(response: str, num_actions: int) -> int:
 
     logger.warning("No <answer> tag found in response; defaulting to action 0")
     return 0
+
+
+_TOOL_PATTERN = re.compile(
+    r'<tool\s+name="(?P<name>[^"]+)"(?:\s+tag="(?P<tag>[^"]+)")?\s*>\s*(?P<body>.*?)\s*</tool>',
+    re.DOTALL,
+)
+
+
+def parse_tool_calls(response: str) -> tuple[str, list[dict]]:
+    """Parse torchrl-style <tool name="..."[ tag="..."]>{json}</tool> blocks.
+
+    Mirrors torchrl's XMLBlockParser: name/tag are attributes, the body is the
+    args JSON (empty body -> {}, JSON error -> {"raw": body}). Returns the text
+    with tool blocks removed, and the list of parsed calls (possibly empty).
+    """
+    calls: list[dict] = []
+
+    def repl(m: re.Match) -> str:
+        body = m.group("body")
+        try:
+            args = json.loads(body) if body.strip() else {}
+        except json.JSONDecodeError:
+            args = {"raw": body}
+        calls.append({"name": m.group("name"), "args": args, "tag": m.group("tag")})
+        return ""
+
+    cleaned = _TOOL_PATTERN.sub(repl, response).strip()
+    return cleaned, calls

--- a/torchtrade/actor/tools.py
+++ b/torchtrade/actor/tools.py
@@ -1,0 +1,68 @@
+"""External information tools the LLM trading actor can call mid-reasoning."""
+from typing import Optional
+from urllib.parse import quote_plus
+
+SYMBOL_QUERY_MAP = {
+    "BTC": "Bitcoin", "ETH": "Ethereum", "SOL": "Solana",
+    "XRP": "XRP", "ADA": "Cardano",
+}
+
+
+def symbol_to_query(symbol: str) -> str:
+    """Map a trading symbol to a news search term ('BTC/USD' -> 'Bitcoin')."""
+    base = symbol.split("/")[0].split("-")[0].upper()
+    return SYMBOL_QUERY_MAP.get(base, base)
+
+
+class Tool:
+    """Minimal tool interface: a name, a one-line description, and run(**args)->str."""
+
+    name: str = ""
+    description: str = ""
+
+    def run(self, **kwargs) -> str:
+        raise NotImplementedError
+
+
+class GoogleNewsTool(Tool):
+    """Top-N recent Google News headlines for the traded symbol (free RSS)."""
+
+    name = "google_news"
+    description = "google_news(query?: str): recent news headlines (defaults to the traded symbol)"
+
+    def __init__(self, symbol: str, top_n: int = 5, timeout: float = 5.0):
+        self.symbol = symbol
+        self.top_n = top_n
+        self.timeout = timeout
+
+    def _fetch(self, query: str) -> list[dict]:
+        """Fetch + normalize Google News RSS entries. Thin network seam (mocked in tests)."""
+        import feedparser  # lazy: torchtrade.actor.tools imports without feedparser
+        url = (
+            "https://news.google.com/rss/search?q="
+            + quote_plus(query)
+            + "&hl=en-US&gl=US&ceid=US:en"
+        )
+        feed = feedparser.parse(url)
+        entries = []
+        for e in feed.entries:
+            entries.append({
+                "title": getattr(e, "title", ""),
+                "source": getattr(getattr(e, "source", None), "title", "") or "",
+                "published": getattr(e, "published", ""),
+            })
+        return entries
+
+    def run(self, query: Optional[str] = None, as_of=None) -> str:
+        # as_of accepted for a future offline point-in-time mode; unused for now.
+        q = query or symbol_to_query(self.symbol)
+        try:
+            entries = self._fetch(q)
+        except Exception as exc:  # never raise into a live trading step
+            return f"error: google_news unavailable ({exc})"
+        if not entries:
+            return f"No recent news for '{q}'."
+        lines = [f"Top news for '{q}':"]
+        for i, e in enumerate(entries[: self.top_n], 1):
+            lines.append(f"{i}. {e['title']} — {e['source']} · {e['published']}".rstrip(" ·"))
+        return "\n".join(lines)

--- a/torchtrade/actor/tools.py
+++ b/torchtrade/actor/tools.py
@@ -38,12 +38,20 @@ class GoogleNewsTool(Tool):
     def _fetch(self, query: str) -> list[dict]:
         """Fetch + normalize Google News RSS entries. Thin network seam (mocked in tests)."""
         import feedparser  # lazy: torchtrade.actor.tools imports without feedparser
+        from urllib.request import urlopen
+
         url = (
             "https://news.google.com/rss/search?q="
             + quote_plus(query)
             + "&hl=en-US&gl=US&ceid=US:en"
         )
-        feed = feedparser.parse(url)
+        # Bound the network request: feedparser.parse(url) would fetch with no
+        # timeout, so a hung RSS connection could block a live trading decision
+        # indefinitely. Fetch the bytes ourselves with self.timeout — a stall then
+        # raises and run()'s guard degrades it to an error string.
+        with urlopen(url, timeout=self.timeout) as resp:
+            raw = resp.read()
+        feed = feedparser.parse(raw)
         entries = []
         for e in feed.entries:
             entries.append({

--- a/torchtrade/actor/tools.py
+++ b/torchtrade/actor/tools.py
@@ -64,5 +64,8 @@ class GoogleNewsTool(Tool):
             return f"No recent news for '{q}'."
         lines = [f"Top news for '{q}':"]
         for i, e in enumerate(entries[: self.top_n], 1):
-            lines.append(f"{i}. {e['title']} — {e['source']} · {e['published']}".rstrip(" ·"))
+            title = e.get("title", "")
+            source = e.get("source", "")
+            published = e.get("published", "")
+            lines.append(f"{i}. {title} — {source} · {published}".rstrip(" ·"))
         return "\n".join(lines)


### PR DESCRIPTION
## Summary

Lets the LLM trading actor call **external information tools mid-reasoning** — first tool: a **Google News** search returning top-N recent headlines for the traded symbol — via a multi-turn loop that overrides B1's no-op `_resolve_tools` seam. Preserves the batched single-shot throughput and is byte-identical when no tools are configured. No ChatEnv adoption; mirrors torchrl's tool-call convention.

This is backlog item **C1**. Broker/microstructure data is already in the observation, so tools surface what the model can't otherwise see (news/sentiment). Live-only for now; the tool signature carries an `as_of` hook for a future offline point-in-time mode.

## What's included

- **`parse_tool_calls`** (`parsers.py`) — mirrors torchrl's `XMLBlockParser` exactly: `<tool name="X" tag="Y">{json}</tool>`, empty body → `{}`, JSON error → `{"raw": body}`, multiple calls.
- **`tools.py`** — a minimal `Tool` interface + `GoogleNewsTool` (free RSS via lazily-imported `feedparser`, bounded timeout, **never raises**) + `symbol_to_query` (BTC/USD → "Bitcoin").
- **Tool loop** in `BaseLLMActor._resolve_tools` — gated on `self.tools`; each round finds `<tool>` calls, executes only those, re-generates **only that subset** in one batched call, splices back by index, ≤ `max_tool_iters`. Tool results injected in torchrl's `<tool_results>` format. Budget exhaustion / no `<answer>` → safe action 0.
- **Config**: `tools=[...]`, `max_tool_iters=3` on `BaseLLMActor`; both `LocalLLMActor` and `FrontierLLMActor` inherit the loop.
- **vLLM** `stop=["</tool>","</answer>"]` (keeps `include_stop_str_in_output=True`); a **fail-loud guard** rejecting `tools=` with the transformers backend (it can't halt at `</tool>`, so it would degrade silently).
- Docs "Tool use" section + a runnable `examples/llm/tools/news_decision.py`.

## Correctness / batching

- **A1 batching preserved** — no-tool conversations are never re-generated; only the tool-calling subset is, in one `generate_batch` call. `_resolve_tools` returns a same-length `list[str]`, so `forward()`'s action tensor / TensorDict writes are byte-identical for the no-tool case (torchrl-engineer confirmed the collector contract is untouched).
- Error handling never crashes a live step: per-tool `try/except`, unknown-tool / malformed-JSON degrade to error lines, budget exhaustion → action 0.

## Deferred (interface-ready)

X/Twitter tool (write `XTool`, add to `tools=[...]`), offline point-in-time (`as_of` hook), C2 (PythonInterpreter, needs sandboxing), C3 (Browser).

## Verification

- Full suite **1755 passed, 15 skipped** on torchrl 0.13.2.
- Consolidated 4-agent review: code-simplifier caught a real tool-result rendering bug (`json.dumps` escaping the human-readable string the model reads) — fixed; pr-test-analyzer flagged the multi-round-accumulation gap — test added; torchrl-engineer verified batching/format/index-alignment; hand-traced batching-subset test pins the A1 property.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
