### PR TITLE
fix(llm-train): bound guided-decoding inter-tag gap to kill whitespace-dump no-answers

### DIFF
--- a/docs/guides/llm-grpo-training.md
+++ b/docs/guides/llm-grpo-training.md
@@ -117,16 +117,27 @@ the time), so set `constrain_actions=True` (recommended; the parameter defaults 
 vLLM **guided decoding**: a regex forces every completion to `<think>…</think><answer>N</answer>`
 with an in-range index → parseable → the model's genuine action variety becomes real learning signal.
 
-The regex is `<think>[^<]{40,600}</think>\s*<answer>(0|…)</answer>`. The bounded, `<`-free think body
-is deliberate: a permissive `[\s\S]*?` body is **not actually enforced** by the decoding FSM (it can
-absorb the closing tags as free text), which lets the model emit an empty `<think></think>`, ramble
-past `max_tokens` with no answer, or add text after `</answer>`. Forbidding `<` forces the only way to
-produce `<` to be `</think>`, and `{40,600}` makes a minimum of real reasoning while forcing the close
-(then the answer) before the token cap. Keep `max_tokens` at roughly 2× the think token budget so the
-forced answer always fits. Reasoning can't contain a literal `<` (the decoder rejects the lookahead
-that would allow it), so the model uses `>` / "above" / "below" naturally. Set `constrain_actions=False`
-only with a strong instruction-tuned model where you want fully free-form reasoning and accept the
-occasional unparseable completion (which scores as hold).
+The regex is `<think>[^<]{40,600}</think>\s{0,2}<answer>(0|…)</answer>`. Two bounds are load-bearing:
+
+- **The `<`-free think body `[^<]{40,600}`.** A permissive `[\s\S]*?` body is **not actually enforced**
+  by the decoding FSM (it can absorb the closing tags as free text), which lets the model emit an empty
+  `<think></think>`, ramble past `max_tokens` with no answer, or add text after `</answer>`. Forbidding
+  `<` forces the only way to produce `<` to be `</think>`, and `{40,600}` requires a minimum of real
+  reasoning while forcing the close (then the answer). Reasoning can't contain a literal `<` (the decoder
+  rejects the lookahead that would allow it), so the model uses `>` / "above" / "below" naturally.
+- **The bounded inter-tag gap `\s{0,2}`, not `\s*`.** This one is subtle and only bites *thinking*
+  models (Qwen3.5, Qwen3-\*-Thinking). An unbounded `\s*` is an escape hatch: once the char bound forces
+  the model to close `<think>` while it still "wants" to reason, it dumps whitespace into the gap until
+  the token cap and never emits `<answer>`. Measured on Qwen3-4B-Thinking, `\s*` gave **16–35% no-answer
+  flat across every (think-bound × max_tokens) cell** — raising `max_tokens` did *not* help, it just fed
+  the dump — while `\s{0,2}` took it to **0%**. (A plain-English base model like Qwen3-8B-Base reasons in
+  ~130 tokens and never triggers this, so it was already ~0% either way.)
+
+`max_tokens` is therefore not a reliability knob for the answer format — the regex bounds are. Keep
+`max_tokens` comfortably above the think token budget (the 1024 default is ample for a 600-char body),
+and prefer a higher value only if *you* want longer reasoning, not to "fix" missing answers. Set
+`constrain_actions=False` only with a strong instruction-tuned model where you want fully free-form
+reasoning and accept the occasional unparseable completion (which scores as hold).
 
 ## The stack (hybrid torchrl-native)
 

--- a/tests/llm/train/test_llm_trainer.py
+++ b/tests/llm/train/test_llm_trainer.py
@@ -60,15 +60,19 @@ def test_build_action_regex_index_range(n, good_idx, bad_idx):
 
 def test_build_action_regex_structure_is_enforceable():
     """The regex must be guided-decoding-enforceable: reasoning REQUIRED and non-empty, nothing after
-    </answer>, and the {40,600} think bounds are load-bearing. Regression for the old [\\s\\S]*? regex
-    that let the model emit empty think, ramble with no answer, or add text after the answer."""
+    </answer>, the {40,600} think bounds are load-bearing, and the inter-tag gap is BOUNDED. Regression
+    for the old [\\s\\S]*? regex (empty think / no answer / trailing text) AND the unbounded \\s* gap
+    that let thinking models dump whitespace to the token cap instead of answering (16-35% no-answer)."""
     rx = LLMTrainer._build_action_regex(3)
-    assert re.fullmatch(rx, f"<think>{_THINK}</think>\n<answer>2</answer>")   # \\s* between tags
     assert not re.fullmatch(rx, "<answer>2</answer>")            # missing <think>: reasoning enforced
     assert not re.fullmatch(rx, f"<think>{_THINK}</think>")      # missing answer
     assert not re.fullmatch(rx, "<think></think><answer>1</answer>")     # empty think rejected
     assert not re.fullmatch(rx, _fmt(_THINK) + " extra")                 # no trailing text
     assert not re.fullmatch(rx, _fmt(f"has a < bracket {_THINK}"))       # '<' banned in think body
+    # inter-tag gap is bounded to \\s{0,2}: 0-2 whitespace OK, 3+ rejected (kills the whitespace-dump
+    # escape hatch). Pinning the upper bound fails a regression back to \\s* / \\s+.
+    for gap, ok in [("", True), ("\n", True), ("\n\n", True), ("\n\n\n", False), ("   ", False)]:
+        assert bool(re.fullmatch(rx, f"<think>{_THINK}</think>{gap}<answer>2</answer>")) is ok, repr(gap)
     # pin BOTH think-length bounds so a widening to {40,} or {1,600} fails here:
     for length, ok in [(39, False), (40, True), (600, True), (601, False)]:
         assert bool(re.fullmatch(rx, _fmt("a" * length))) is ok, length

--- a/torchtrade/llm/train/llm_trainer.py
+++ b/torchtrade/llm/train/llm_trainer.py
@@ -104,10 +104,18 @@ class LLMTrainer:
         in the body so the only way to produce `<` is to start `</think>`; `{40,600}` makes min-40
         kill empty think and max-600 force `</think>` (then the answer) well before a typical
         max_tokens cap. Reasoning can't contain a literal `<` (xgrammar rejects the lookahead that
-        would allow it) — the model uses `>`/"above"/"below" fine. Keep max_tokens >= ~2x the think
-        token budget so the forced answer always fits."""
+        would allow it) — the model uses `>`/"above"/"below" fine.
+
+        The inter-tag gap is `\s{0,2}`, NOT `\s*`. An unbounded `\s*` is an escape hatch: a
+        reasoning-hungry model (any *thinking* model — Qwen3.5, Qwen3-*-Thinking), once the char
+        bound forces it to close `<think>` while it still "wants" to reason, dumps whitespace into
+        the gap until the token cap and never emits `<answer>`. Measured on Qwen3-4B-Thinking: `\s*`
+        gave 16-35% no-answer FLAT across every (think-bound x max_tokens) cell (raising max_tokens
+        did NOT help — it just fed the dump); `\s{0,2}` took it to 0% (the base Qwen3-8B, an English
+        reasoner, was already 0% either way). 0-2 whitespace covers the natural `</think>\n<answer>`
+        without leaving room to escape."""
         indices = "|".join(str(i) for i in range(num_actions))
-        return r"<think>[^<]{40,600}</think>\s*<answer>(" + indices + r")</answer>"
+        return r"<think>[^<]{40,600}</think>\s{0,2}<answer>(" + indices + r")</answer>"
 
     def _build_prompt_actor(self, env):
         num_actions = env.action_spec.n


### PR DESCRIPTION
## Problem

The GRPO trainer's guided-decoding regex had an **unbounded whitespace gap**: `<think>…</think>\s*<answer>N</answer>`. A reasoning-hungry *thinking* model (Qwen3.5, Qwen3-\*-Thinking), once the `{40,600}` char bound forces it to close `<think>` while it still "wants" to keep reasoning, dumps whitespace into that `\s*` hole until the token cap and **never emits `<answer>`**. The parser then falls back to hold → degenerate all-hold GRPO groups → no within-group reward variance → **no gradient**.

This is the "~15% no-answer residual" noted after the original trainer PR. It was **misdiagnosed as a `max_tokens`/think-bound budget issue** — it is not.

## Evidence (Spark, real vLLM guided decoding, `Qwen/Qwen3-4B-Thinking-2507`)

A pure-generation sweep over `(think-bound ∈ {200…600}) × (max_tokens ∈ {384…1024})` on real trading prompts:

| Regex gap | no-answer rate | notes |
|---|---|---|
| `\s*` (before) | **16–35%, flat across every cell** | raising `max_tokens` did **not** help — `mean_tok` just grew with the budget = more whitespace dumped; `at_cap=1.0` everywhere |
| `\s{0,2}` (after) | **0.0%** at mt=384 and mt=512 | model-agnostic; also reduces token waste |

A completion inspector confirmed **16/16** truncated completions ended past `</think>` in pure `\t\r\n` whitespace. The default `unsloth/Qwen3-8B-Base-bnb-4bit` (plain-English reasoner, ~130 tok per 600-char body) was already ~0% either way — this only bit thinking models.

## Fix

One character-class edit in `LLMTrainer._build_action_regex`:

```diff
- r"<think>[^<]{40,600}</think>\s*<answer>(" + indices + r")</answer>"
+ r"<think>[^<]{40,600}</think>\s{0,2}<answer>(" + indices + r")</answer>"
```

0–2 whitespace covers the natural `</think>\n<answer>` / `</think>\n\n<answer>` without leaving room to escape. `max_tokens` default is left at 1024 — the finding is that it was never the reliability lever; the regex structure is.

## Changes
- `torchtrade/llm/train/llm_trainer.py` — the regex + a docstring explaining the escape hatch and the measured 16–35% → 0%.
- `tests/llm/train/test_llm_trainer.py` — regression assertion pinning the gap to ≤2 whitespace (3+ rejected); catches a revert to `\s*`/`\s+`/`\s{0,3}` *and* an over-tighten to `\s{0,1}`.
- `docs/guides/llm-grpo-training.md` — rewrote the guided-decoding section; corrected the "raise max_tokens" framing.

## Review
Full mandated review (test-justification, code-simplifier, pr-test-analyzer, torchrl-engineer) — all clean; torchrl-engineer confirmed no interaction with rlhf masking / log-prob / MCAdvantage / `input_mode="tokens"` replay. Full suite: **1808 passed, 15 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)