### PR TITLE
Remove PPOLoss copy-paste cruft from GroupRelativePGLoss

### DIFF
--- a/tests/losses/test_group_relative_pg_loss.py
+++ b/tests/losses/test_group_relative_pg_loss.py
@@ -237,21 +237,6 @@ class TestGroupRelativePGLoss:
         loss = GroupRelativePGLoss(actor_network=actor_network, entropy_coeff=coeff_map)
         assert loss._entropy_coeff_map == coeff_map
 
-    def test_deprecated_entropy_coef_warning(self, actor_network):
-        """Test that deprecated entropy_coef parameter raises warning."""
-        with pytest.warns(DeprecationWarning, match="entropy_coef.*deprecated"):
-            loss = GroupRelativePGLoss(actor_network=actor_network, entropy_coef=0.05)
-            assert loss.entropy_coeff.item() == pytest.approx(0.05)
-
-    def test_entropy_coef_and_coeff_conflict(self, actor_network):
-        """Test that using both entropy_coef and entropy_coeff raises error."""
-        with pytest.raises(ValueError, match="Cannot specify both"):
-            GroupRelativePGLoss(
-                actor_network=actor_network,
-                entropy_coeff=0.01,
-                entropy_coef=0.02,
-            )
-
     def test_functional_mode(self, actor_network):
         """Test that functional mode works correctly."""
         loss = GroupRelativePGLoss(actor_network=actor_network, functional=True)
@@ -333,14 +318,6 @@ class TestGroupRelativePGLoss:
         output = loss(sample_data)
         assert "entropy" in output.keys()
         assert torch.isfinite(output["entropy"])
-
-    def test_loss_log_explained_variance(self, actor_network):
-        """Test log_explained_variance parameter."""
-        loss = GroupRelativePGLoss(actor_network=actor_network, log_explained_variance=True)
-        assert loss.log_explained_variance is True
-
-        loss = GroupRelativePGLoss(actor_network=actor_network, log_explained_variance=False)
-        assert loss.log_explained_variance is False
 
     def test_loss_with_cuda_if_available(self, actor_network, sample_data):
         """Test loss computation on CUDA if available."""

--- a/torchtrade/losses/ctrl.py
+++ b/torchtrade/losses/ctrl.py
@@ -54,7 +54,7 @@ class CTRLLoss(LossModule):
         >>> import torch
         >>> from tensordict import TensorDict
         >>> from tensordict.nn import TensorDictModule
-        >>> from torchrl.objectives.ctrl import CTRLLoss
+        >>> from torchtrade.losses import CTRLLoss
         >>> # Create a simple encoder
         >>> encoder = TensorDictModule(
         ...     nn.Sequential(nn.Linear(64, 256), nn.ReLU(), nn.Linear(256, 128)),
@@ -428,7 +428,7 @@ class CTRLPPOLoss(LossModule):
 
     Examples:
         >>> from torchrl.objectives import ClipPPOLoss
-        >>> from torchrl.objectives.ctrl import CTRLLoss, CTRLPPOLoss
+        >>> from torchtrade.losses import CTRLLoss, CTRLPPOLoss
         >>> # Create PPO and CTRL losses
         >>> ppo_loss = ClipPPOLoss(actor, critic)
         >>> ctrl_loss = CTRLLoss(encoder, embedding_dim=128)

--- a/torchtrade/losses/dg_loss.py
+++ b/torchtrade/losses/dg_loss.py
@@ -96,7 +96,6 @@ class DGLoss(LossModule):
         samples_mc_entropy: int = 1,
         reduction: str | None = None,
         functional: bool = True,
-        device: torch.device | None = None,
     ):
         if actor_network is None:
             raise TypeError("Missing positional argument actor_network.")

--- a/torchtrade/losses/group_relative_pg_loss.py
+++ b/torchtrade/losses/group_relative_pg_loss.py
@@ -43,12 +43,6 @@ class GroupRelativePGLoss(LossModule):
         default values
 
         Attributes:
-            advantage (NestedKey): The input tensordict key where the advantage is expected.
-                Will be used for the underlying value estimator. Defaults to ``"advantage"``.
-            value_target (NestedKey): The input tensordict key where the target state value is expected.
-                Will be used for the underlying value estimator Defaults to ``"value_target"``.
-            value (NestedKey): The input tensordict key where the state value is expected.
-                Will be used for the underlying value estimator. Defaults to ``"state_value"``.
             sample_log_prob (NestedKey or list of nested keys): The input tensordict key where the
                sample log probability is expected.
                Defaults to ``"sample_log_prob"`` when :func:`~tensordict.nn.composite_lp_aggregate` returns `True`,
@@ -65,7 +59,6 @@ class GroupRelativePGLoss(LossModule):
                 Defaults to ``"terminated"``.
         """
 
-        advantage: NestedKey = "advantage"
         sample_log_prob: NestedKey | list[NestedKey] | None = None
         action: NestedKey | list[NestedKey] = "action"
         reward: NestedKey | list[NestedKey] = "reward"
@@ -93,12 +86,9 @@ class GroupRelativePGLoss(LossModule):
         epsilon_high: float = 0.2,
         samples_mc_entropy: int = 1,
         entropy_coeff: float | Mapping[NestedKey, float] | None = None,
-        log_explained_variance: bool = True,
         actor: ProbabilisticTensorDictSequential = None,
         reduction: str | None = None,
         functional: bool = True,
-        device: torch.device | None = None,
-        **kwargs,
     ):
         if actor is not None:
             actor_network = actor
@@ -121,32 +111,11 @@ class GroupRelativePGLoss(LossModule):
             self.actor_network = actor_network
             self.actor_network_params = None
 
-        self.log_explained_variance = log_explained_variance
         self.samples_mc_entropy = samples_mc_entropy
         self.entropy_bonus = entropy_bonus
         self.reduction = reduction
         self.epsilon_low = epsilon_low
         self.epsilon_high = epsilon_high
-
-        if device is None:
-            try:
-                device = next(self.parameters()).device
-            except (AttributeError, StopIteration):
-                device = getattr(
-                    torch, "get_default_device", lambda: torch.device("cpu")
-                )()
-
-        # Handle deprecated entropy_coef argument
-        if "entropy_coef" in kwargs:
-            if entropy_coeff is not None:  # Check if entropy_coeff was explicitly set
-                raise ValueError(
-                    "Cannot specify both 'entropy_coef' and 'entropy_coeff'"
-                )
-            warnings.warn(
-                "'entropy_coef' is deprecated and will be removed in torchrl v0.11. Please use 'entropy_coeff' instead.",
-                DeprecationWarning,
-            )
-            entropy_coeff = kwargs.pop("entropy_coef")
 
         # Set default value if None
         if entropy_coeff is None:
@@ -290,9 +259,9 @@ class GroupRelativePGLoss(LossModule):
         else:
             raise NotImplementedError(
                 "Only probabilistic modules from tensordict.nn are currently supported. "
-                "If you need to implement a custom logic to retrieve the log-probs (to compute "
-                "the PPO objective) or the distribution (for the PPO entropy), please augment "
-                f"the {type(self).__class__} by implementing your own logic in _get_cur_log_prob."
+                "If you need custom logic to retrieve the log-probs (for the policy-gradient "
+                "objective) or the distribution (for the entropy bonus), please augment "
+                f"{type(self).__name__} by implementing your own logic in _get_cur_log_prob."
             )
         return log_prob, dist, is_composite
 


### PR DESCRIPTION
Strips dead code copy-pasted from torchrl's `PPOLoss` into the custom `GroupRelativePGLoss` (a group-relative PG loss with **no value network**). Every removal was validated against the installed torchrl 0.13.2 `LossModule` base by a `torchrl-engineer` review (all GO), and re-reviewed by `code-simplifier` + `pr-test-analyzer` (clean).

## Removed (all verified unused across `torchtrade/`, `tests/`, `examples/`)
- `device` ctor param + its compute block — `LossModule.__init__` takes no device; `self.device` is a computed `TensorDictModule` property, never an ivar.
- `log_explained_variance` param + attr — stored, never read (no value net → no explained variance).
- `entropy_coef` deprecation shim + the now-orphaned `**kwargs` sink (unknown kwargs now raise `TypeError` instead of silently vanishing).
- `_AcceptedKeys.advantage` — `forward` computes advantage inline; the base `_AcceptedKeys` is empty, nothing requires it. Also pruned the stale `value_target`/`value` docstring (never fields).
- Reworded the copied-from-PPOLoss `NotImplementedError` and fixed `type(self).__class__` → `type(self).__name__` (the old form printed `<class 'type'>`).

Also drops `dg_loss.py`'s unused `device` param and fixes `ctrl.py` docstrings that imported from `torchrl.objectives.ctrl` instead of `torchtrade.losses`.

## Tests
Removes 3 tests that only asserted the deleted params were stored (`test-analyzer` confirmed the surviving `entropy_coeff` behavior stays covered). Full loss suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)