### PR TITLE
Reconcile offline config validation (bankrupt_threshold / maintenance_margin_rate)

### DIFF
--- a/tests/envs/offline/test_sequential.py
+++ b/tests/envs/offline/test_sequential.py
@@ -102,6 +102,23 @@ class TestSequentialEnvInitialization:
             config = SequentialTradingEnvConfig(leverage=0.5)
             SequentialTradingEnv(sample_ohlcv_df, config)
 
+    @pytest.mark.parametrize("field,value", [
+        ("bankrupt_threshold", 1.0),          # >=1 terminates immediately: rejected
+        ("bankrupt_threshold", 5.0),          # was silently accepted before the fix
+        ("bankrupt_threshold", -0.1),
+        ("maintenance_margin_rate", 1.0),
+        ("maintenance_margin_rate", -0.1),
+    ])
+    def test_termination_threshold_out_of_range_raises(self, field, value):
+        """bankrupt_threshold / maintenance_margin_rate must be in [0, 1) (was unvalidated)."""
+        with pytest.raises(ValueError, match=field):
+            SequentialTradingEnvConfig(**{field: value})
+
+    @pytest.mark.parametrize("field", ["bankrupt_threshold", "maintenance_margin_rate"])
+    def test_termination_threshold_zero_disables(self, field):
+        """0.0 is a valid 'disabled' value and must not raise (parity with vectorized)."""
+        SequentialTradingEnvConfig(**{field: 0.0})
+
     @pytest.mark.parametrize("action_levels,leverage,should_warn", [
         ([-1, 0, 1], 1, True),   # Negative actions + spot = warn
         ([-1, 0, 1], 2, False),  # Negative actions + futures = no warn

--- a/tests/envs/offline/test_vectorized_sequential.py
+++ b/tests/envs/offline/test_vectorized_sequential.py
@@ -263,11 +263,21 @@ class TestVecEnvEdgeCases:
         ({"transaction_fee": 1.5}, "Transaction fee"),
         ({"slippage": -0.1}, "Slippage"),
         ({"slippage": 1.5}, "Slippage"),
-    ], ids=["fee-negative", "fee-over-1", "slip-negative", "slip-over-1"])
+        ({"bankrupt_threshold": 1.0}, "bankrupt_threshold"),
+        ({"bankrupt_threshold": -0.1}, "bankrupt_threshold"),
+        ({"maintenance_margin_rate": 1.0}, "maintenance_margin_rate"),
+    ], ids=["fee-negative", "fee-over-1", "slip-negative", "slip-over-1",
+            "bankrupt-1", "bankrupt-negative", "mmr-1"])
     def test_invalid_config_raises(self, kwargs, match):
-        """Should raise ValueError for out-of-range fee or slippage."""
+        """Should raise ValueError for out-of-range fee/slippage/threshold."""
         with pytest.raises(ValueError, match=match):
             VectorizedSequentialTradingEnvConfig(**kwargs)
+
+    @pytest.mark.parametrize("field", ["bankrupt_threshold", "maintenance_margin_rate"])
+    def test_termination_threshold_zero_accepted(self, field):
+        """0.0 must be accepted (disabled-floor), matching the scalar config parity
+        this PR reconciled (the vectorized config previously rejected 0.0)."""
+        VectorizedSequentialTradingEnvConfig(**{field: 0.0})
 
     @pytest.mark.parametrize("leverage,expected_first", [
         (1, 0.0),    # Spot: negative clamped to 0

--- a/torchtrade/envs/offline/sequential.py
+++ b/torchtrade/envs/offline/sequential.py
@@ -86,6 +86,19 @@ class SequentialTradingEnvConfig:
                 f"Leverage must be between 1 and 125, got {self.leverage}"
             )
 
+        # Termination thresholds, range mirrors the vectorized config.
+        # bankrupt_threshold=0.0 removes the positive termination floor (spot positions
+        # never hit it; leveraged positions can still terminate on portfolio_value <= 0).
+        # maintenance_margin_rate=0.0 = no maintenance-margin buffer. >=1 is nonsensical.
+        if not (0 <= self.bankrupt_threshold < 1):
+            raise ValueError(
+                f"bankrupt_threshold must be in [0, 1), got {self.bankrupt_threshold}"
+            )
+        if not (0 <= self.maintenance_margin_rate < 1):
+            raise ValueError(
+                f"maintenance_margin_rate must be in [0, 1), got {self.maintenance_margin_rate}"
+            )
+
         # Validate action levels
         validate_action_levels(self.action_levels)
 

--- a/torchtrade/envs/offline/vectorized_sequential.py
+++ b/torchtrade/envs/offline/vectorized_sequential.py
@@ -87,13 +87,15 @@ class VectorizedSequentialTradingEnvConfig:
             raise ValueError(
                 f"Leverage must be between 1 and 125, got {self.leverage}"
             )
-        if not (0 < self.bankrupt_threshold < 1):
+        # [0, 1) mirrors the scalar config: 0.0 removes the positive termination floor
+        # (env math floor = bankrupt_threshold * initial_pv). >=1 is nonsensical.
+        if not (0 <= self.bankrupt_threshold < 1):
             raise ValueError(
-                f"Bankrupt threshold must be between 0 and 1, got {self.bankrupt_threshold}"
+                f"bankrupt_threshold must be in [0, 1), got {self.bankrupt_threshold}"
             )
-        if not (0 < self.maintenance_margin_rate < 1):
+        if not (0 <= self.maintenance_margin_rate < 1):
             raise ValueError(
-                f"Maintenance margin rate must be between 0 and 1, got {self.maintenance_margin_rate}"
+                f"maintenance_margin_rate must be in [0, 1), got {self.maintenance_margin_rate}"
             )
 
 


### PR DESCRIPTION
Reconciles numeric-range validation for two offline-env config fields that had diverged. Reviewed by `torchrl-engineer` (offline-env correctness, mandated) + `pr-test-analyzer`.

## Problem
- Scalar `SequentialTradingEnvConfig` validated **neither** `bankrupt_threshold` nor `maintenance_margin_rate` — silently accepted e.g. `bankrupt_threshold=5.0` (instant termination).
- Vectorized config used `0 < x < 1`, which **rejected the valid `0.0`** value the scalar allows and both envs' math supports (termination floor = `bankrupt_threshold * initial_pv`). `test_bankruptcy.py` and `test_margin_accounting.py` both intentionally use `0.0`.

## Fix
- Scalar config now validates both fields to `[0, 1)` (inherited by SLTP/OneStep via `super().__post_init__`).
- Vectorized config loosened from `(0,1)` to `[0, 1)` for parity.
- Comments state the exact semantics — per torchrl-engineer, `bankrupt_threshold=0.0` removes the *positive* floor but a **leveraged** position can still terminate on `portfolio_value <= 0`, so it's not a blanket "disable" (comment corrected to avoid overclaiming).

## Tests
Scalar out-of-range rejection + `0.0`-accepted, and the matching vectorized rejection + `0.0`-accepted cases (the vectorized loosening previously had no test). Full suite: **1820 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)