### PR TITLE
Consolidate exchange obs-class tests onto BaseObservationClassTests

### DIFF
--- a/tests/envs/alpaca/test_obs_class.py
+++ b/tests/envs/alpaca/test_obs_class.py
@@ -1,267 +1,82 @@
-"""
-Unit tests for AlpacaObservationClass.
+"""Unit tests for AlpacaObservationClass.
 
-Tests observation fetching, preprocessing, and feature extraction using mock clients.
+Common observation-class behavior (init, keys, shapes, float32, no-NaN, features,
+window sizes, custom preprocessing) is inherited from BaseObservationClassTests.
+Only Alpaca-specific tests (client injection, data integrity, feature semantics)
+and stricter assertions live here.
 """
 
-import pytest
 import numpy as np
 from torchtrade.envs.utils.timeframe import TimeFrame, TimeFrameUnit
 
 from torchtrade.envs.live.alpaca.observation import AlpacaObservationClass
+from tests.envs.base_exchange_tests import BaseObservationClassTests
 from .mocks import MockCryptoHistoricalDataClient
 
 
-class TestAlpacaObservationClassInitialization:
-    """Tests for AlpacaObservationClass initialization."""
+class TestAlpacaObservationClass(BaseObservationClassTests):
+    """Alpaca observation class — common tests inherited from the base."""
+
+    def create_observer(self, symbol, timeframes, window_sizes, **kwargs):
+        # num_bars generous so the base's window=100 test is fully populated.
+        client = kwargs.pop("client", None) or MockCryptoHistoricalDataClient(num_bars=600)
+        return AlpacaObservationClass(
+            symbol=symbol, timeframes=timeframes, window_sizes=window_sizes,
+            client=client, **kwargs,
+        )
+
+    def get_expected_symbol_format(self, symbol):
+        return symbol  # Alpaca stores the symbol unchanged
+
+    # --- Alpaca-specific / stricter tests ---
 
     def test_init_with_mock_client(self):
-        """Test initialization with injected mock client."""
+        """Injected client is stored as-is."""
         mock_client = MockCryptoHistoricalDataClient()
-        obs_class = AlpacaObservationClass(
-            symbol="BTC/USD",
-            timeframes=TimeFrame(1, TimeFrameUnit.Minute),
-            window_sizes=10,
-            client=mock_client,
-        )
-
-        assert obs_class.symbol == "BTC/USD"
-        assert len(obs_class.timeframes) == 1
-        assert len(obs_class.window_sizes) == 1
-        assert obs_class.client is mock_client
-
-    def test_init_single_timeframe(self):
-        """Test initialization with single timeframe."""
-        mock_client = MockCryptoHistoricalDataClient()
-        obs_class = AlpacaObservationClass(
-            symbol="BTC/USD",
-            timeframes=TimeFrame(15, TimeFrameUnit.Minute),
-            window_sizes=20,
-            client=mock_client,
-        )
-
-        assert len(obs_class.timeframes) == 1
-        assert obs_class.timeframes[0].value == 15
-        assert len(obs_class.window_sizes) == 1
-        assert obs_class.window_sizes[0] == 20
-
-    def test_init_multiple_timeframes(self):
-        """Test initialization with multiple timeframes."""
-        mock_client = MockCryptoHistoricalDataClient()
-        obs_class = AlpacaObservationClass(
-            symbol="BTC/USD",
-            timeframes=[
-                TimeFrame(1, TimeFrameUnit.Minute),
-                TimeFrame(5, TimeFrameUnit.Minute),
-                TimeFrame(1, TimeFrameUnit.Hour),
-            ],
-            window_sizes=[10, 20, 30],
-            client=mock_client,
-        )
-
-        assert len(obs_class.timeframes) == 3
-        assert len(obs_class.window_sizes) == 3
-
-    def test_init_mismatched_lengths_raises_error(self):
-        """Test that mismatched timeframes and window_sizes raises ValueError."""
-        mock_client = MockCryptoHistoricalDataClient()
-
-        with pytest.raises(ValueError, match="must have the same length"):
-            AlpacaObservationClass(
-                symbol="BTC/USD",
-                timeframes=[
-                    TimeFrame(1, TimeFrameUnit.Minute),
-                    TimeFrame(5, TimeFrameUnit.Minute),
-                ],
-                window_sizes=[10, 20, 30],  # 3 sizes for 2 timeframes
-                client=mock_client,
-            )
-
-
-class TestAlpacaObservationClassGetKeys:
-    """Tests for get_keys method."""
-
-    def test_get_keys_single_timeframe(self):
-        """Test get_keys with single timeframe."""
-        mock_client = MockCryptoHistoricalDataClient()
-        obs_class = AlpacaObservationClass(
-            symbol="BTC/USD",
-            timeframes=TimeFrame(15, TimeFrameUnit.Minute),
-            window_sizes=10,
-            client=mock_client,
-        )
-
-        keys = obs_class.get_keys()
-        assert len(keys) == 1
-        assert keys[0] == "15Minute_10"
+        obs = AlpacaObservationClass(
+            symbol="BTC/USD", timeframes=TimeFrame(1, TimeFrameUnit.Minute),
+            window_sizes=10, client=mock_client)
+        assert obs.symbol == "BTC/USD"
+        assert obs.client is mock_client
 
     def test_get_keys_multiple_timeframes(self):
-        """Test get_keys with multiple timeframes."""
-        mock_client = MockCryptoHistoricalDataClient()
-        obs_class = AlpacaObservationClass(
+        obs = self.create_observer(
             symbol="BTC/USD",
-            timeframes=[
-                TimeFrame(1, TimeFrameUnit.Minute),
-                TimeFrame(1, TimeFrameUnit.Hour),
-            ],
-            window_sizes=[10, 20],
-            client=mock_client,
-        )
+            timeframes=[TimeFrame(1, TimeFrameUnit.Minute), TimeFrame(1, TimeFrameUnit.Hour)],
+            window_sizes=[10, 20])
+        keys = obs.get_keys()
+        assert "1Minute_10" in keys and "1Hour_20" in keys
 
-        keys = obs_class.get_keys()
-        assert len(keys) == 2
-        assert "1Minute_10" in keys
-        assert "1Hour_20" in keys
-
-
-class TestAlpacaObservationClassGetObservations:
-    """Tests for get_observations method."""
-
-    def test_get_observations_single_timeframe(self):
-        """Test getting observations for single timeframe."""
-        mock_client = MockCryptoHistoricalDataClient(num_bars=100)
-        obs_class = AlpacaObservationClass(
+    def test_get_observations_exact_shapes(self):
+        """Alpaca observations have exact (window, 4) shapes (stricter than base >=4)."""
+        obs = self.create_observer(
             symbol="BTC/USD",
-            timeframes=TimeFrame(1, TimeFrameUnit.Minute),
-            window_sizes=10,
-            client=mock_client,
-        )
-
-        observations = obs_class.get_observations()
-
-        assert isinstance(observations, dict)
-        assert len(observations) == 1
-
-        key = obs_class.get_keys()[0]
-        assert key in observations
-        assert isinstance(observations[key], np.ndarray)
-        assert observations[key].shape[0] == 10  # window_size
-        assert observations[key].shape[1] == 4  # default 4 features
-
-    def test_get_observations_multiple_timeframes(self):
-        """Test getting observations for multiple timeframes."""
-        mock_client = MockCryptoHistoricalDataClient(num_bars=100)
-        obs_class = AlpacaObservationClass(
-            symbol="BTC/USD",
-            timeframes=[
-                TimeFrame(1, TimeFrameUnit.Minute),
-                TimeFrame(5, TimeFrameUnit.Minute),
-            ],
-            window_sizes=[10, 20],
-            client=mock_client,
-        )
-
-        observations = obs_class.get_observations()
-
-        assert len(observations) == 2
-        keys = obs_class.get_keys()
+            timeframes=[TimeFrame(1, TimeFrameUnit.Minute), TimeFrame(5, TimeFrameUnit.Minute)],
+            window_sizes=[10, 20])
+        observations = obs.get_observations()
+        keys = obs.get_keys()
         assert observations[keys[0]].shape == (10, 4)
         assert observations[keys[1]].shape == (20, 4)
 
     def test_get_observations_with_base_ohlc(self):
-        """Test getting observations with base OHLC data."""
-        mock_client = MockCryptoHistoricalDataClient(num_bars=100)
-        obs_class = AlpacaObservationClass(
-            symbol="BTC/USD",
-            timeframes=TimeFrame(1, TimeFrameUnit.Minute),
-            window_sizes=10,
-            client=mock_client,
-        )
-
-        observations = obs_class.get_observations(return_base_ohlc=True)
-
+        """base_features + base_timestamps present (Alpaca also exposes base_timestamps)."""
+        obs = self.create_observer(
+            symbol="BTC/USD", timeframes=TimeFrame(1, TimeFrameUnit.Minute), window_sizes=10)
+        observations = obs.get_observations(return_base_ohlc=True)
         assert "base_features" in observations
         assert "base_timestamps" in observations
-        assert observations["base_features"].shape[1] == 4  # OHLC
+        assert observations["base_features"].shape[1] == 4
 
-    def test_observations_are_float32(self):
-        """Test that observations are float32."""
-        mock_client = MockCryptoHistoricalDataClient()
-        obs_class = AlpacaObservationClass(
-            symbol="BTC/USD",
-            timeframes=TimeFrame(1, TimeFrameUnit.Minute),
-            window_sizes=10,
-            client=mock_client,
-        )
-
-        observations = obs_class.get_observations()
-        key = obs_class.get_keys()[0]
-
-        assert observations[key].dtype == np.float32
-
-    def test_observations_no_nan_values(self):
-        """Test that observations don't contain NaN values."""
-        mock_client = MockCryptoHistoricalDataClient()
-        obs_class = AlpacaObservationClass(
-            symbol="BTC/USD",
-            timeframes=TimeFrame(1, TimeFrameUnit.Minute),
-            window_sizes=10,
-            client=mock_client,
-        )
-
-        observations = obs_class.get_observations()
-        key = obs_class.get_keys()[0]
-
-        assert not np.isnan(observations[key]).any()
-
-
-class TestAlpacaObservationClassGetFeatures:
-    """Tests for get_features method."""
-
-    def test_get_features_default_preprocessing(self):
-        """Test get_features with default preprocessing."""
-        mock_client = MockCryptoHistoricalDataClient()
-        obs_class = AlpacaObservationClass(
-            symbol="BTC/USD",
-            timeframes=TimeFrame(1, TimeFrameUnit.Minute),
-            window_sizes=10,
-            client=mock_client,
-        )
-
-        features = obs_class.get_features()
-
-        assert "observation_features" in features
-        assert "original_features" in features
-        assert len(features["observation_features"]) == 4  # close, open, high, low
-        assert "feature_close" in features["observation_features"]
-        assert "feature_open" in features["observation_features"]
-        assert "feature_high" in features["observation_features"]
-        assert "feature_low" in features["observation_features"]
-
-
-class TestAlpacaObservationClassCustomPreprocessing:
-    """Tests for custom preprocessing functions."""
-
-    def test_custom_preprocessing(self):
-        """Test with custom preprocessing function."""
-        mock_client = MockCryptoHistoricalDataClient()
-
-        def custom_preprocessing(df):
-            df = df.reset_index()
-            df.dropna(inplace=True)
-            df["feature_volatility"] = df["high"] - df["low"]
-            df["feature_volume_ma"] = df["volume"].rolling(window=3).mean()
-            df.dropna(inplace=True)
-            return df
-
-        obs_class = AlpacaObservationClass(
-            symbol="BTC/USD",
-            timeframes=TimeFrame(1, TimeFrameUnit.Minute),
-            window_sizes=10,
-            feature_preprocessing_fn=custom_preprocessing,
-            client=mock_client,
-        )
-
-        observations = obs_class.get_observations()
-        key = obs_class.get_keys()[0]
-
-        # Custom preprocessing has 2 features
-        assert observations[key].shape[1] == 2
+    def test_get_features_default_names(self):
+        """Default preprocessing yields the four named OHLC features."""
+        obs = self.create_observer(
+            symbol="BTC/USD", timeframes=TimeFrame(1, TimeFrameUnit.Minute), window_sizes=10)
+        features = obs.get_features()
+        for feat in ["feature_close", "feature_open", "feature_high", "feature_low"]:
+            assert feat in features["observation_features"]
 
     def test_preprocessing_preserves_window_size(self):
-        """Test that preprocessing respects window size."""
-        mock_client = MockCryptoHistoricalDataClient(num_bars=100)
-
+        """A custom preprocessing fn still yields the requested window size."""
         def simple_preprocessing(df):
             df = df.reset_index()
             df.dropna(inplace=True)
@@ -269,161 +84,47 @@ class TestAlpacaObservationClassCustomPreprocessing:
             df.dropna(inplace=True)
             return df
 
-        obs_class = AlpacaObservationClass(
-            symbol="BTC/USD",
-            timeframes=TimeFrame(1, TimeFrameUnit.Minute),
-            window_sizes=15,
-            feature_preprocessing_fn=simple_preprocessing,
-            client=mock_client,
-        )
-
-        observations = obs_class.get_observations()
-        key = obs_class.get_keys()[0]
-
-        assert observations[key].shape[0] == 15
-
-
-class TestAlpacaObservationClassDefaultPreprocessing:
-    """Tests for default preprocessing behavior."""
-
-    def test_default_preprocessing_features(self):
-        """Test that default preprocessing creates expected features."""
-        mock_client = MockCryptoHistoricalDataClient()
-        obs_class = AlpacaObservationClass(
-            symbol="BTC/USD",
-            timeframes=TimeFrame(1, TimeFrameUnit.Minute),
-            window_sizes=10,
-            client=mock_client,
-        )
-
-        features = obs_class.get_features()
-        obs_features = features["observation_features"]
-
-        expected_features = ["feature_close", "feature_open", "feature_high", "feature_low"]
-        for feat in expected_features:
-            assert feat in obs_features
+        obs = self.create_observer(
+            symbol="BTC/USD", timeframes=TimeFrame(1, TimeFrameUnit.Minute),
+            window_sizes=15, feature_preprocessing_fn=simple_preprocessing)
+        key = obs.get_keys()[0]
+        assert obs.get_observations()[key].shape[0] == 15
 
     def test_feature_close_is_pct_change(self):
-        """Test that feature_close is percentage change."""
-        mock_client = MockCryptoHistoricalDataClient()
-        obs_class = AlpacaObservationClass(
-            symbol="BTC/USD",
-            timeframes=TimeFrame(1, TimeFrameUnit.Minute),
-            window_sizes=10,
-            client=mock_client,
-        )
-
-        observations = obs_class.get_observations()
-        key = obs_class.get_keys()[0]
-
-        # feature_close should be percentage changes (small values around 0)
-        feature_close = observations[key][:, 0]  # First column
-        assert np.abs(feature_close).max() < 0.1  # Should be small percentages
-
-
-class TestAlpacaObservationClassEdgeCases:
-    """Tests for edge cases and boundary conditions."""
-
-    def test_window_size_one(self):
-        """Test with window size of 1."""
-        mock_client = MockCryptoHistoricalDataClient(num_bars=100)
-        obs_class = AlpacaObservationClass(
-            symbol="BTC/USD",
-            timeframes=TimeFrame(1, TimeFrameUnit.Minute),
-            window_sizes=1,
-            client=mock_client,
-        )
-
-        observations = obs_class.get_observations()
-        key = obs_class.get_keys()[0]
-
-        assert observations[key].shape[0] == 1
-
-    def test_large_window_size(self):
-        """Test with large window size."""
-        mock_client = MockCryptoHistoricalDataClient(num_bars=500)
-        obs_class = AlpacaObservationClass(
-            symbol="BTC/USD",
-            timeframes=TimeFrame(1, TimeFrameUnit.Minute),
-            window_sizes=100,
-            client=mock_client,
-        )
-
-        observations = obs_class.get_observations()
-        key = obs_class.get_keys()[0]
-
-        assert observations[key].shape[0] == 100
+        """feature_close is a percentage change (small values around 0)."""
+        obs = self.create_observer(
+            symbol="BTC/USD", timeframes=TimeFrame(1, TimeFrameUnit.Minute), window_sizes=10)
+        key = obs.get_keys()[0]
+        feature_close = obs.get_observations()[key][:, 0]
+        assert np.abs(feature_close).max() < 0.1
 
     def test_different_timeframe_units(self):
-        """Test with different timeframe units."""
-        mock_client = MockCryptoHistoricalDataClient(num_bars=100)
-
-        # Test hourly
-        obs_class = AlpacaObservationClass(
-            symbol="BTC/USD",
-            timeframes=TimeFrame(1, TimeFrameUnit.Hour),
-            window_sizes=10,
-            client=mock_client,
-        )
-
-        keys = obs_class.get_keys()
-        assert "1Hour_10" in keys
+        """Hourly timeframe produces the expected key."""
+        obs = self.create_observer(
+            symbol="BTC/USD", timeframes=TimeFrame(1, TimeFrameUnit.Hour), window_sizes=10)
+        assert "1Hour_10" in obs.get_keys()
 
     def test_multiple_calls_consistency(self):
-        """Test that multiple calls return consistent structure."""
-        mock_client = MockCryptoHistoricalDataClient()
-        obs_class = AlpacaObservationClass(
-            symbol="BTC/USD",
-            timeframes=TimeFrame(1, TimeFrameUnit.Minute),
-            window_sizes=10,
-            client=mock_client,
-        )
-
-        obs1 = obs_class.get_observations()
-        obs2 = obs_class.get_observations()
-
-        key = obs_class.get_keys()[0]
-        assert obs1[key].shape == obs2[key].shape
-
-
-class TestAlpacaObservationClassDataIntegrity:
-    """Tests for data integrity and correctness."""
+        """Repeated calls return the same-shaped output (structural consistency)."""
+        obs = self.create_observer(
+            symbol="BTC/USD", timeframes=TimeFrame(1, TimeFrameUnit.Minute), window_sizes=10)
+        key = obs.get_keys()[0]
+        obs1 = obs.get_observations()[key]
+        obs2 = obs.get_observations()[key]
+        assert obs1.shape == obs2.shape == (10, 4)
 
     def test_ohlc_relationship(self):
-        """Test that OHLC relationships are maintained."""
-        mock_client = MockCryptoHistoricalDataClient()
-        obs_class = AlpacaObservationClass(
-            symbol="BTC/USD",
-            timeframes=TimeFrame(1, TimeFrameUnit.Minute),
-            window_sizes=10,
-            client=mock_client,
-        )
-
-        observations = obs_class.get_observations(return_base_ohlc=True)
-        base = observations["base_features"]
-
-        # base_features columns: open, high, low, close
-        opens = base[:, 0]
-        highs = base[:, 1]
-        lows = base[:, 2]
-        closes = base[:, 3]
-
-        # High should be >= low
+        """OHLC high >= low holds in the base features."""
+        obs = self.create_observer(
+            symbol="BTC/USD", timeframes=TimeFrame(1, TimeFrameUnit.Minute), window_sizes=10)
+        base = obs.get_observations(return_base_ohlc=True)["base_features"]
+        highs, lows = base[:, 1], base[:, 2]
         assert np.all(highs >= lows)
 
     def test_timestamps_are_ordered(self):
-        """Test that timestamps are in chronological order."""
-        mock_client = MockCryptoHistoricalDataClient()
-        obs_class = AlpacaObservationClass(
-            symbol="BTC/USD",
-            timeframes=TimeFrame(1, TimeFrameUnit.Minute),
-            window_sizes=10,
-            client=mock_client,
-        )
-
-        observations = obs_class.get_observations(return_base_ohlc=True)
-        timestamps = observations["base_timestamps"]
-
-        # Convert to comparable format if needed
+        """base_timestamps are chronological."""
+        obs = self.create_observer(
+            symbol="BTC/USD", timeframes=TimeFrame(1, TimeFrameUnit.Minute), window_sizes=10)
+        timestamps = obs.get_observations(return_base_ohlc=True)["base_timestamps"]
         for i in range(len(timestamps) - 1):
             assert timestamps[i] < timestamps[i + 1]

--- a/tests/envs/base_exchange_tests.py
+++ b/tests/envs/base_exchange_tests.py
@@ -84,7 +84,7 @@ class BaseObservationClassTests(ABC):
             window_sizes=[10, 20, 30],
         )
 
-        timeframes = getattr(observer, 'timeframes', getattr(observer, 'time_frames'))
+        timeframes = getattr(observer, 'timeframes', getattr(observer, 'time_frames', None))
         assert len(timeframes) == 3
         assert len(observer.window_sizes) == 3
 

--- a/tests/envs/base_exchange_tests.py
+++ b/tests/envs/base_exchange_tests.py
@@ -65,10 +65,10 @@ class BaseObservationClassTests(ABC):
             window_sizes=20,
         )
 
-        assert len(observer.timeframes) == 1 or len(observer.time_frames) == 1
-        timeframes = getattr(observer, 'timeframes', getattr(observer, 'time_frames'))
+        timeframes = getattr(observer, 'timeframes', getattr(observer, 'time_frames', None))
         window_sizes = observer.window_sizes
 
+        assert len(timeframes) == 1
         assert timeframes[0].value == 15
         assert window_sizes[0] == 20
 

--- a/tests/envs/binance/test_obs_class.py
+++ b/tests/envs/binance/test_obs_class.py
@@ -1,73 +1,71 @@
-"""Tests for BinanceObservationClass."""
+"""Tests for BinanceObservationClass.
+
+Common observation-class behavior is inherited from BaseObservationClassTests.
+Only Binance-specific tests (symbol normalization, exchange-specific kline columns,
+default feature names) and stricter assertions live here.
+"""
 
 import pytest
 import numpy as np
 from unittest.mock import MagicMock
 from torchtrade.envs.utils.timeframe import TimeFrame, TimeFrameUnit
+from tests.envs.base_exchange_tests import BaseObservationClassTests
 
 
-class TestBinanceObservationClass:
-    """Tests for BinanceObservationClass."""
+def _make_binance_client():
+    """Mock Binance client returning `limit` 12-column klines (chronological)."""
+    client = MagicMock()
+
+    def mock_get_klines(symbol, interval, limit=500):
+        base_time = 1700000000000
+        return [
+            [base_time + i * 60000, "50000.0", "50100.0", "49900.0", "50050.0", "100.0",
+             base_time + i * 60000 + 59999, "5000000.0", "100", "50.0", "2500000.0", "0"]
+            for i in range(limit)
+        ]
+
+    client.get_klines = MagicMock(side_effect=mock_get_klines)
+    return client
+
+
+class TestBinanceObservationClass(BaseObservationClassTests):
+    """Binance observation class — common tests inherited from the base."""
+
+    def create_observer(self, symbol, timeframes, window_sizes, **kwargs):
+        from torchtrade.envs.live.binance.observation import BinanceObservationClass
+        client = kwargs.pop("client", None) or _make_binance_client()
+        return BinanceObservationClass(
+            symbol=symbol, time_frames=timeframes, window_sizes=window_sizes,
+            client=client, **kwargs,
+        )
+
+    def get_expected_symbol_format(self, symbol):
+        return symbol.replace("/", "")
 
     @pytest.fixture
     def mock_client(self):
-        """Create a mock Binance client."""
-        client = MagicMock()
-
-        # Mock klines data (12 columns)
-        def mock_get_klines(symbol, interval, limit=500):
-            klines = []
-            base_time = 1700000000000  # Base timestamp in ms
-            for i in range(limit):
-                klines.append([
-                    base_time + i * 60000,  # open_time
-                    "50000.0",  # open
-                    "50100.0",  # high
-                    "49900.0",  # low
-                    "50050.0",  # close
-                    "100.0",    # volume
-                    base_time + i * 60000 + 59999,  # close_time
-                    "5000000.0",  # quote_volume
-                    "100",      # trades (string, matching real Binance API)
-                    "50.0",     # taker_buy_base
-                    "2500000.0",  # taker_buy_quote
-                    "0",        # ignore
-                ])
-            return klines
-
-        client.get_klines = MagicMock(side_effect=mock_get_klines)
-        return client
+        return _make_binance_client()
 
     @pytest.fixture
     def observer_single(self, mock_client):
-        """Create observer with single timeframe."""
         from torchtrade.envs.live.binance.observation import BinanceObservationClass
-
         return BinanceObservationClass(
-            symbol="BTCUSDT",
-            time_frames=TimeFrame(15, TimeFrameUnit.Minute),
-            window_sizes=10,
-            client=mock_client,
-        )
+            symbol="BTCUSDT", time_frames=TimeFrame(15, TimeFrameUnit.Minute),
+            window_sizes=10, client=mock_client)
 
     @pytest.fixture
     def observer_multi(self, mock_client):
-        """Create observer with multiple timeframes."""
         from torchtrade.envs.live.binance.observation import BinanceObservationClass
-
         return BinanceObservationClass(
             symbol="BTCUSDT",
-            time_frames=[
-                TimeFrame(1, TimeFrameUnit.Minute),
-                TimeFrame(5, TimeFrameUnit.Minute),
-                TimeFrame(1, TimeFrameUnit.Hour),
-            ],
-            window_sizes=[10, 20, 15],
-            client=mock_client,
-        )
+            time_frames=[TimeFrame(1, TimeFrameUnit.Minute), TimeFrame(5, TimeFrameUnit.Minute),
+                         TimeFrame(1, TimeFrameUnit.Hour)],
+            window_sizes=[10, 20, 15], client=mock_client)
+
+    # --- Binance-specific / stricter tests ---
 
     def test_single_interval_initialization(self, observer_single):
-        """Test initialization with single timeframe."""
+        """Symbol + timeframe unit preserved (base checks neither)."""
         assert observer_single.symbol == "BTCUSDT"
         assert len(observer_single.time_frames) == 1
         assert observer_single.time_frames[0].value == 15
@@ -75,102 +73,40 @@ class TestBinanceObservationClass:
         assert observer_single.window_sizes == [10]
 
     def test_multi_interval_initialization(self, observer_multi):
-        """Test initialization with multiple timeframes."""
         assert observer_multi.symbol == "BTCUSDT"
         assert len(observer_multi.time_frames) == 3
-        assert observer_multi.time_frames[0].value == 1
-        assert observer_multi.time_frames[1].value == 5
-        assert observer_multi.time_frames[2].value == 1
         assert observer_multi.window_sizes == [10, 20, 15]
 
     def test_symbol_normalization(self, mock_client):
-        """Test that symbol with slash is normalized."""
+        """Slash is stripped from the symbol."""
         from torchtrade.envs.live.binance.observation import BinanceObservationClass
-
         observer = BinanceObservationClass(
-            symbol="BTC/USDT",
-            time_frames=TimeFrame(1, TimeFrameUnit.Minute),
-            window_sizes=10,
-            client=mock_client,
-        )
+            symbol="BTC/USDT", time_frames=TimeFrame(1, TimeFrameUnit.Minute),
+            window_sizes=10, client=mock_client)
         assert observer.symbol == "BTCUSDT"
 
-    def test_mismatched_lengths_raises_error(self, mock_client):
-        """Test that mismatched time_frames and window_sizes raises error."""
-        from torchtrade.envs.live.binance.observation import BinanceObservationClass
-
-        with pytest.raises(ValueError, match="same length"):
-            BinanceObservationClass(
-                symbol="BTCUSDT",
-                time_frames=[
-                    TimeFrame(1, TimeFrameUnit.Minute),
-                    TimeFrame(5, TimeFrameUnit.Minute),
-                ],
-                window_sizes=[10],  # Mismatched length
-                client=mock_client,
-            )
-
-    def test_get_keys_single(self, observer_single):
-        """Test get_keys with single timeframe."""
-        keys = observer_single.get_keys()
-        assert keys == ["15Minute_10"]
-
     def test_get_keys_multi(self, observer_multi):
-        """Test get_keys with multiple timeframes."""
-        keys = observer_multi.get_keys()
-        assert keys == ["1Minute_10", "5Minute_20", "1Hour_15"]
+        assert observer_multi.get_keys() == ["1Minute_10", "5Minute_20", "1Hour_15"]
 
-    def test_get_observations_single(self, observer_single):
-        """Test get_observations with single interval."""
-        observations = observer_single.get_observations()
+    def test_get_observations_single_dtype(self, observer_single):
+        """Single-timeframe observation is exactly (10, 4) float32 (stricter than base)."""
+        obs = observer_single.get_observations()
+        assert obs["15Minute_10"].shape == (10, 4)
+        assert obs["15Minute_10"].dtype == np.float32
 
-        assert "15Minute_10" in observations
-        assert observations["15Minute_10"].shape == (10, 4)  # window_size x num_features
-        assert observations["15Minute_10"].dtype == np.float32
-
-    def test_get_observations_multi(self, observer_multi):
-        """Test get_observations with multiple intervals."""
-        observations = observer_multi.get_observations()
-
-        assert "1Minute_10" in observations
-        assert "5Minute_20" in observations
-        assert "1Hour_15" in observations
-
-        assert observations["1Minute_10"].shape == (10, 4)
-        assert observations["5Minute_20"].shape == (20, 4)
-        assert observations["1Hour_15"].shape == (15, 4)
+    def test_get_observations_multi_exact_shapes(self, observer_multi):
+        obs = observer_multi.get_observations()
+        assert obs["1Minute_10"].shape == (10, 4)
+        assert obs["5Minute_20"].shape == (20, 4)
+        assert obs["1Hour_15"].shape == (15, 4)
 
     def test_get_observations_with_base_ohlc(self, observer_single):
-        """Test get_observations with base OHLC data."""
-        observations = observer_single.get_observations(return_base_ohlc=True)
-
-        assert "15Minute_10" in observations
-        assert "base_features" in observations
-        assert "base_timestamps" in observations
-
-        assert observations["base_features"].shape == (10, 4)
-
-    def test_custom_preprocessing(self, mock_client):
-        """Test custom preprocessing function."""
-        from torchtrade.envs.live.binance.observation import BinanceObservationClass
-
-        def custom_preprocessing(df):
-            df = df.copy()
-            df["feature_custom1"] = df["close"].pct_change().fillna(0)
-            df["feature_custom2"] = df["volume"].pct_change().fillna(0)
-            df.dropna(inplace=True)
-            return df
-
-        observer = BinanceObservationClass(
-            symbol="BTCUSDT",
-            time_frames=TimeFrame(1, TimeFrameUnit.Minute),
-            window_sizes=10,
-            client=mock_client,
-            feature_preprocessing_fn=custom_preprocessing,
-        )
-
-        observations = observer.get_observations()
-        assert observations["1Minute_10"].shape == (10, 2)  # 2 custom features
+        """base_features + base_timestamps present with exact shape (adds base_timestamps)."""
+        obs = observer_single.get_observations(return_base_ohlc=True)
+        assert "15Minute_10" in obs
+        assert "base_features" in obs
+        assert "base_timestamps" in obs
+        assert obs["base_features"].shape == (10, 4)
 
     def test_custom_preprocessing_with_kline_extra_fields(self, mock_client):
         """Custom preprocessing can derive features from Binance-specific kline fields."""
@@ -186,36 +122,18 @@ class TestBinanceObservationClass:
             return df
 
         observer = BinanceObservationClass(
-            symbol="BTCUSDT",
-            time_frames=TimeFrame(1, TimeFrameUnit.Minute),
-            window_sizes=10,
-            client=mock_client,
-            feature_preprocessing_fn=kline_preprocessing,
-        )
+            symbol="BTCUSDT", time_frames=TimeFrame(1, TimeFrameUnit.Minute),
+            window_sizes=10, client=mock_client, feature_preprocessing_fn=kline_preprocessing)
 
-        # get_features() uses dummy data — verifies dummy DataFrame has extra columns
         features = observer.get_features()
         for f in ["feature_taker_ratio", "feature_quote_vol", "feature_avg_trade_size"]:
             assert f in features["observation_features"]
-
-        # get_observations() uses mock kline data — verifies type casting is correct
-        observations = observer.get_observations()
-        assert observations["1Minute_10"].shape == (10, 4)
-
-    def test_get_features(self, observer_single):
-        """Test get_features returns feature information."""
-        features = observer_single.get_features()
-
-        assert "observation_features" in features
-        assert "original_features" in features
-        assert len(features["observation_features"]) > 0
+        assert observer.get_observations()["1Minute_10"].shape == (10, 4)
 
     def test_default_preprocessing_output(self, observer_single):
-        """Test that default preprocessing produces expected features."""
+        """Default preprocessing produces the expected named features."""
         features = observer_single.get_features()
-
-        expected_features = ["feature_close", "feature_open", "feature_high", "feature_low"]
-        for feat in expected_features:
+        for feat in ["feature_close", "feature_open", "feature_high", "feature_low"]:
             assert feat in features["observation_features"]
 
 
@@ -226,16 +144,10 @@ class TestBinanceObservationClassIntegration:
     def test_live_data_fetch(self):
         """Test fetching live data from Binance."""
         from torchtrade.envs.live.binance.observation import BinanceObservationClass
-
         observer = BinanceObservationClass(
             symbol="BTCUSDT",
-            time_frames=[
-                TimeFrame(1, TimeFrameUnit.Minute),
-                TimeFrame(5, TimeFrameUnit.Minute),
-            ],
-            window_sizes=[10, 10],
-        )
-
+            time_frames=[TimeFrame(1, TimeFrameUnit.Minute), TimeFrame(5, TimeFrameUnit.Minute)],
+            window_sizes=[10, 10])
         observations = observer.get_observations()
         assert "1Minute_10" in observations
         assert "5Minute_10" in observations

--- a/tests/envs/bitget/test_obs_class.py
+++ b/tests/envs/bitget/test_obs_class.py
@@ -1,49 +1,66 @@
-"""Tests for BitgetObservationClass with CCXT."""
+"""Tests for BitgetObservationClass with CCXT.
+
+Common observation-class behavior is inherited from BaseObservationClassTests.
+Only Bitget-specific tests (symbol normalization, product type, CCXT call/empty
+handling) and stricter assertions live here.
+"""
 
 import pytest
 import numpy as np
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 from torchtrade.envs.utils.timeframe import TimeFrame, TimeFrameUnit
+from torchtrade.envs.live.bitget.observation import BitgetObservationClass
+from tests.envs.base_exchange_tests import BaseObservationClassTests
 
 
-class TestBitgetObservationClass:
-    """Tests for BitgetObservationClass using CCXT."""
+def _make_bitget_client():
+    """Mock CCXT bitget client returning `limit` 6-column OHLCV candles."""
+    client = MagicMock()
+
+    def mock_fetch_ohlcv(symbol, timeframe, limit=200):
+        base_time = 1700000000000
+        return [
+            [base_time + i * 60000, 50000.0, 50100.0, 49900.0, 50050.0, 100.0]
+            for i in range(limit)
+        ]
+
+    client.fetch_ohlcv = MagicMock(side_effect=mock_fetch_ohlcv)
+    client.load_markets = MagicMock(return_value={})
+    return client
+
+
+class TestBitgetObservationClass(BaseObservationClassTests):
+    """Bitget observation class — common tests inherited from the base."""
+
+    def create_observer(self, symbol, timeframes, window_sizes, **kwargs):
+        # Injecting client= skips BitgetObservationClass's ccxt.bitget() creation.
+        client = kwargs.pop("client", None) or _make_bitget_client()
+        return BitgetObservationClass(
+            symbol=symbol, time_frames=timeframes, window_sizes=window_sizes,
+            client=client, **kwargs,
+        )
+
+    def get_expected_symbol_format(self, symbol):
+        from torchtrade.envs.live.bitget.utils import normalize_symbol
+        return normalize_symbol(symbol)
 
     @pytest.fixture
     def observer_single(self, mock_ccxt_client):
-        """Create observer with single timeframe."""
-        from torchtrade.envs.live.bitget.observation import BitgetObservationClass
-
-        with patch('torchtrade.envs.live.bitget.observation.ccxt.bitget', return_value=mock_ccxt_client):
-            observer = BitgetObservationClass(
-                symbol="BTC/USDT:USDT",
-                time_frames=TimeFrame(15, TimeFrameUnit.Minute),
-                window_sizes=10,
-            )
-            observer.client = mock_ccxt_client
-            return observer
+        return BitgetObservationClass(
+            symbol="BTC/USDT:USDT", time_frames=TimeFrame(15, TimeFrameUnit.Minute),
+            window_sizes=10, client=mock_ccxt_client)
 
     @pytest.fixture
     def observer_multi(self, mock_ccxt_client):
-        """Create observer with multiple timeframes."""
-        from torchtrade.envs.live.bitget.observation import BitgetObservationClass
+        return BitgetObservationClass(
+            symbol="BTC/USDT:USDT",
+            time_frames=[TimeFrame(1, TimeFrameUnit.Minute), TimeFrame(5, TimeFrameUnit.Minute),
+                         TimeFrame(1, TimeFrameUnit.Hour)],
+            window_sizes=[10, 20, 15], client=mock_ccxt_client)
 
-        with patch('torchtrade.envs.live.bitget.observation.ccxt.bitget', return_value=mock_ccxt_client):
-            observer = BitgetObservationClass(
-                symbol="BTC/USDT:USDT",
-                time_frames=[
-                    TimeFrame(1, TimeFrameUnit.Minute),
-                    TimeFrame(5, TimeFrameUnit.Minute),
-                    TimeFrame(1, TimeFrameUnit.Hour),
-                ],
-                window_sizes=[10, 20, 15],
-            )
-            observer.client = mock_ccxt_client
-            return observer
+    # --- Bitget-specific / stricter tests ---
 
     def test_single_interval_initialization(self, observer_single):
-        """Test initialization with single timeframe."""
-        # Symbol gets normalized
         assert "USDT" in observer_single.symbol
         assert len(observer_single.time_frames) == 1
         assert observer_single.time_frames[0].value == 15
@@ -51,198 +68,88 @@ class TestBitgetObservationClass:
         assert observer_single.window_sizes == [10]
 
     def test_multi_interval_initialization(self, observer_multi):
-        """Test initialization with multiple timeframes."""
         assert "USDT" in observer_multi.symbol
         assert len(observer_multi.time_frames) == 3
-        assert observer_multi.time_frames[0].value == 1
-        assert observer_multi.time_frames[1].value == 5
-        assert observer_multi.time_frames[2].value == 1
         assert observer_multi.window_sizes == [10, 20, 15]
 
     def test_symbol_normalization(self, mock_ccxt_client):
-        """Test that various symbol formats are handled."""
-        from torchtrade.envs.live.bitget.observation import BitgetObservationClass
-
-        with patch('torchtrade.envs.live.bitget.observation.ccxt.bitget', return_value=mock_ccxt_client):
-            observer = BitgetObservationClass(
-                symbol="BTCUSDT:USDT",
-                time_frames=TimeFrame(1, TimeFrameUnit.Minute),
-                window_sizes=10,
-            )
-            observer.client = mock_ccxt_client
-            # Symbol gets normalized to CCXT format
-            assert "USDT" in observer.symbol
+        """Various symbol formats normalize to CCXT format."""
+        observer = BitgetObservationClass(
+            symbol="BTCUSDT:USDT", time_frames=TimeFrame(1, TimeFrameUnit.Minute),
+            window_sizes=10, client=mock_ccxt_client)
+        assert "USDT" in observer.symbol
 
     def test_invalid_interval_raises_error(self, mock_ccxt_client):
-        """Test that invalid timeframe raises ValueError."""
-        from torchtrade.envs.live.bitget.observation import BitgetObservationClass
-
         with pytest.raises(ValueError, match="Unsupported timeframe"):
-            with patch('torchtrade.envs.live.bitget.observation.ccxt.bitget', return_value=mock_ccxt_client):
-                BitgetObservationClass(
-                    symbol="BTC/USDT:USDT",
-                    time_frames=TimeFrame(2, TimeFrameUnit.Minute),  # 2 minutes not supported
-                    window_sizes=10,
-                )
-
-    def test_mismatched_lengths_raises_error(self, mock_ccxt_client):
-        """Test that mismatched time_frames and window_sizes raises error."""
-        from torchtrade.envs.live.bitget.observation import BitgetObservationClass
-
-        with pytest.raises(ValueError, match="same length"):
-            with patch('torchtrade.envs.live.bitget.observation.ccxt.bitget', return_value=mock_ccxt_client):
-                BitgetObservationClass(
-                    symbol="BTC/USDT:USDT",
-                    time_frames=[
-                        TimeFrame(1, TimeFrameUnit.Minute),
-                        TimeFrame(5, TimeFrameUnit.Minute),
-                    ],
-                    window_sizes=[10],  # Mismatched length
-                )
+            BitgetObservationClass(
+                symbol="BTC/USDT:USDT", time_frames=TimeFrame(2, TimeFrameUnit.Minute),
+                window_sizes=10, client=mock_ccxt_client)
 
     def test_product_type_demo(self, mock_ccxt_client):
-        """Test that demo=True sets product type correctly."""
-        from torchtrade.envs.live.bitget.observation import BitgetObservationClass
-
-        with patch('torchtrade.envs.live.bitget.observation.ccxt.bitget', return_value=mock_ccxt_client):
-            observer = BitgetObservationClass(
-                symbol="BTC/USDT:USDT",
-                time_frames=TimeFrame(1, TimeFrameUnit.Minute),
-                window_sizes=10,
-                product_type="USDT-FUTURES",
-                demo=True,
-            )
-            observer.client = mock_ccxt_client
-            assert observer.product_type == "USDT-FUTURES"
-
-    def test_get_keys_single(self, observer_single):
-        """Test get_keys with single timeframe."""
-        keys = observer_single.get_keys()
-        assert keys == ["15Minute_10"]
+        """demo=True sets the product type."""
+        observer = BitgetObservationClass(
+            symbol="BTC/USDT:USDT", time_frames=TimeFrame(1, TimeFrameUnit.Minute),
+            window_sizes=10, product_type="USDT-FUTURES", demo=True, client=mock_ccxt_client)
+        assert observer.product_type == "USDT-FUTURES"
 
     def test_get_keys_multi(self, observer_multi):
-        """Test get_keys with multiple timeframes."""
-        keys = observer_multi.get_keys()
-        assert keys == ["1Minute_10", "5Minute_20", "1Hour_15"]
+        assert observer_multi.get_keys() == ["1Minute_10", "5Minute_20", "1Hour_15"]
 
-    def test_get_observations_single(self, observer_single):
-        """Test get_observations with single timeframe."""
-        observations = observer_single.get_observations()
+    def test_get_observations_exact_shapes(self, observer_single, observer_multi):
+        """Bitget observations have exact (window, 4) shapes (stricter than base)."""
+        assert observer_single.get_observations()["15Minute_10"].shape == (10, 4)
+        obs = observer_multi.get_observations()
+        assert obs["1Minute_10"].shape == (10, 4)
+        assert obs["5Minute_20"].shape == (20, 4)
+        assert obs["1Hour_15"].shape == (15, 4)
 
-        assert "15Minute_10" in observations
-        assert observations["15Minute_10"].shape == (10, 4)  # window_size x num_features
-
-    def test_get_observations_multi(self, observer_multi):
-        """Test get_observations with multiple timeframes."""
-        observations = observer_multi.get_observations()
-
-        assert "1Minute_10" in observations
-        assert "5Minute_20" in observations
-        assert "1Hour_15" in observations
-
-        assert observations["1Minute_10"].shape == (10, 4)
-        assert observations["5Minute_20"].shape == (20, 4)
-        assert observations["1Hour_15"].shape == (15, 4)
-
-    def test_get_observations_with_base_ohlc(self, observer_single):
-        """Test get_observations with return_base_ohlc=True."""
-        observations = observer_single.get_observations(return_base_ohlc=True)
-
-        assert "15Minute_10" in observations
-        assert "base_features" in observations
-        # Base features should have all history
-        assert observations["base_features"].shape[1] == 4  # OHLC
-
-    def test_custom_preprocessing(self, mock_ccxt_client):
-        """Test custom preprocessing function."""
-        from torchtrade.envs.live.bitget.observation import BitgetObservationClass
-
+    def test_custom_preprocessing_five_features(self, mock_ccxt_client):
+        """Custom preprocessing adding OHLC-derived + custom feature -> 5 cols."""
         def custom_preprocess(df):
-            """Add a custom feature (matching naming convention: feature_X)."""
             df = df.copy()
             df.dropna(inplace=True)
             df.drop_duplicates(inplace=True)
-
-            # Create default features
             df["feature_close"] = df["close"].pct_change().fillna(0)
             df["feature_open"] = df["open"] / df["close"]
             df["feature_high"] = df["high"] / df["close"]
             df["feature_low"] = df["low"] / df["close"]
-
-            # Add custom feature
             df["feature_custom"] = df["close"] * 2
-
             df.dropna(inplace=True)
             return df
 
-        with patch('torchtrade.envs.live.bitget.observation.ccxt.bitget', return_value=mock_ccxt_client):
-            observer = BitgetObservationClass(
-                symbol="BTC/USDT:USDT",
-                time_frames=TimeFrame(1, TimeFrameUnit.Minute),
-                window_sizes=10,
-                feature_preprocessing_fn=custom_preprocess,
-            )
-            observer.client = mock_ccxt_client
+        observer = BitgetObservationClass(
+            symbol="BTC/USDT:USDT", time_frames=TimeFrame(1, TimeFrameUnit.Minute),
+            window_sizes=10, feature_preprocessing_fn=custom_preprocess, client=mock_ccxt_client)
+        assert observer.get_observations()["1Minute_10"].shape[1] == 5
 
-            observations = observer.get_observations()
-            # Should have 5 features (OHLC + custom)
-            assert observations["1Minute_10"].shape[1] == 5
-
-    def test_get_features(self, observer_single):
-        """Test get_features returns feature names."""
+    def test_get_features_names(self, observer_single):
+        """get_features returns the 4 named OHLC features."""
         features = observer_single.get_features()
-
-        # get_features() now returns a dict with 'observation_features' and 'original_features'
-        assert isinstance(features, dict)
-        assert "observation_features" in features
-        assert "original_features" in features
-
-        # Check that observation features contain the expected OHLC features
         obs_features = features["observation_features"]
         assert len(obs_features) == 4
         assert all("feature" in f for f in obs_features)
-        assert any("open" in f for f in obs_features)
-        assert any("high" in f for f in obs_features)
-        assert any("low" in f for f in obs_features)
-        assert any("close" in f for f in obs_features)
+        for name in ("open", "high", "low", "close"):
+            assert any(name in f for f in obs_features)
 
     def test_default_preprocessing_output(self, observer_single):
-        """Test that default preprocessing outputs correct features."""
-        observations = observer_single.get_observations()
-        data = observations["15Minute_10"]
-
-        # Check that data is valid
-        assert not np.isnan(data).any(), "Data contains NaN values"
+        """Default preprocessing produces valid no-NaN (10, 4) data."""
+        data = observer_single.get_observations()["15Minute_10"]
+        assert not np.isnan(data).any()
         assert data.shape == (10, 4)
 
     def test_api_call_parameters(self, observer_single, mock_ccxt_client):
-        """Test that CCXT fetch_ohlcv is called with correct parameters."""
+        """CCXT fetch_ohlcv is called."""
         observer_single.get_observations()
-
-        # Check that fetch_ohlcv was called
         mock_ccxt_client.fetch_ohlcv.assert_called()
 
-        # Get the call arguments
-        call_args = mock_ccxt_client.fetch_ohlcv.call_args
-        assert call_args is not None
-
     def test_empty_candles_raises_error(self, mock_ccxt_client):
-        """Test that empty candles raises RuntimeError."""
-        from torchtrade.envs.live.bitget.observation import BitgetObservationClass
-
-        # Mock fetch_ohlcv to return empty list
+        """Empty candle data raises RuntimeError."""
         mock_ccxt_client.fetch_ohlcv = MagicMock(return_value=[])
-
-        with patch('torchtrade.envs.live.bitget.observation.ccxt.bitget', return_value=mock_ccxt_client):
-            observer = BitgetObservationClass(
-                symbol="BTC/USDT:USDT",
-                time_frames=TimeFrame(1, TimeFrameUnit.Minute),
-                window_sizes=10,
-            )
-            observer.client = mock_ccxt_client
-
-            with pytest.raises(RuntimeError, match="No candle data"):
-                observer.get_observations()
+        observer = BitgetObservationClass(
+            symbol="BTC/USDT:USDT", time_frames=TimeFrame(1, TimeFrameUnit.Minute),
+            window_sizes=10, client=mock_ccxt_client)
+        with pytest.raises(RuntimeError, match="No candle data"):
+            observer.get_observations()
 
 
 class TestBitgetObservationClassIntegration:
@@ -251,20 +158,11 @@ class TestBitgetObservationClassIntegration:
     @pytest.mark.skip(reason="Requires live Bitget API connection")
     def test_live_data_fetch(self):
         """Test fetching real data from Bitget."""
-        from torchtrade.envs.live.bitget.observation import BitgetObservationClass
-
         observer = BitgetObservationClass(
             symbol="BTC/USDT:USDT",
-            time_frames=[
-                TimeFrame(1, TimeFrameUnit.Minute),
-                TimeFrame(5, TimeFrameUnit.Minute),
-            ],
-            window_sizes=[10, 20],
-            demo=True,
-        )
-
+            time_frames=[TimeFrame(1, TimeFrameUnit.Minute), TimeFrame(5, TimeFrameUnit.Minute)],
+            window_sizes=[10, 20], demo=True)
         observations = observer.get_observations()
-
         assert "1Minute_10" in observations
         assert "5Minute_20" in observations
         assert observations["1Minute_10"].shape == (10, 4)

--- a/tests/envs/bybit/test_obs_class.py
+++ b/tests/envs/bybit/test_obs_class.py
@@ -1,57 +1,57 @@
-"""Tests for BybitObservationClass with pybit."""
+"""Tests for BybitObservationClass with pybit.
+
+Common observation-class behavior is inherited from BaseObservationClassTests.
+Only Bybit-specific tests (symbol normalization, pybit envelope validation,
+chronological parsing, utils) and stricter exact-shape assertions live here.
+"""
 
 import pytest
 import numpy as np
 from unittest.mock import MagicMock
 from torchtrade.envs.utils.timeframe import TimeFrame, TimeFrameUnit
+from tests.envs.base_exchange_tests import BaseObservationClassTests
 
 
-class TestBybitObservationClass:
-    """Tests for BybitObservationClass using pybit."""
+def _make_pybit_client():
+    """Mock pybit HTTP client returning `limit` reverse-chronological klines."""
+    client = MagicMock()
 
-    @pytest.fixture
-    def observer_single(self, mock_pybit_client):
-        """Create observer with single timeframe."""
+    def mock_get_kline(category, symbol, interval, limit=200):
+        base_time = 1700000000000
+        candles = [
+            [str(base_time + i * 60000), "50000.0", "50100.0", "49900.0",
+             "50050.0", "100.0", "5005000.0"]
+            for i in range(limit - 1, -1, -1)  # reverse order
+        ]
+        return {"retCode": 0, "result": {"list": candles}}
+
+    client.get_kline = MagicMock(side_effect=mock_get_kline)
+    return client
+
+
+class TestBybitObservationClass(BaseObservationClassTests):
+    """Bybit observation class — common tests inherited from the base."""
+
+    def create_observer(self, symbol, timeframes, window_sizes, **kwargs):
         from torchtrade.envs.live.bybit.observation import BybitObservationClass
-
-        observer = BybitObservationClass(
-            symbol="BTCUSDT",
-            time_frames=TimeFrame(15, TimeFrameUnit.Minute),
-            window_sizes=10,
-            client=mock_pybit_client,
+        client = kwargs.pop("client", None) or _make_pybit_client()
+        return BybitObservationClass(
+            symbol=symbol, time_frames=timeframes, window_sizes=window_sizes,
+            client=client, **kwargs,
         )
-        return observer
 
-    @pytest.fixture
-    def observer_multi(self, mock_pybit_client):
-        """Create observer with multiple timeframes."""
-        from torchtrade.envs.live.bybit.observation import BybitObservationClass
+    def get_expected_symbol_format(self, symbol):
+        from torchtrade.envs.live.bybit.utils import normalize_symbol
+        return normalize_symbol(symbol)
 
-        observer = BybitObservationClass(
-            symbol="BTCUSDT",
-            time_frames=[
-                TimeFrame(1, TimeFrameUnit.Minute),
-                TimeFrame(5, TimeFrameUnit.Minute),
-                TimeFrame(1, TimeFrameUnit.Hour),
-            ],
-            window_sizes=[10, 20, 15],
-            client=mock_pybit_client,
-        )
-        return observer
+    # --- Bybit-specific / stricter tests ---
 
-    def test_single_interval_initialization(self, observer_single):
-        """Test initialization with single timeframe."""
-        assert observer_single.symbol == "BTCUSDT"
-        assert len(observer_single.time_frames) == 1
-        assert observer_single.time_frames[0].value == 15
-        assert observer_single.time_frames[0].unit == TimeFrameUnit.Minute
-        assert observer_single.window_sizes == [10]
-
-    def test_multi_interval_initialization(self, observer_multi):
-        """Test initialization with multiple timeframes."""
-        assert observer_multi.symbol == "BTCUSDT"
-        assert len(observer_multi.time_frames) == 3
-        assert observer_multi.window_sizes == [10, 20, 15]
+    def test_symbol_and_unit_on_init(self):
+        """Bybit normalizes symbol and preserves the timeframe unit (base checks neither)."""
+        observer = self.create_observer(
+            symbol="BTC/USDT", timeframes=TimeFrame(15, TimeFrameUnit.Minute), window_sizes=10)
+        assert observer.symbol == "BTCUSDT"
+        assert observer.time_frames[0].unit == TimeFrameUnit.Minute
 
     @pytest.mark.parametrize("symbol,expected", [
         ("BTCUSDT", "BTCUSDT"),
@@ -59,80 +59,34 @@ class TestBybitObservationClass:
         ("BTC/USDT:USDT", "BTCUSDT"),
         (" btcusdt ", "BTCUSDT"),
     ])
-    def test_symbol_normalization(self, mock_pybit_client, symbol, expected):
-        """Test that various symbol formats are normalized to Bybit format."""
-        from torchtrade.envs.live.bybit.observation import BybitObservationClass
-
-        observer = BybitObservationClass(
-            symbol=symbol,
-            time_frames=TimeFrame(1, TimeFrameUnit.Minute),
-            window_sizes=10,
-            client=mock_pybit_client,
-        )
+    def test_symbol_normalization(self, symbol, expected):
+        """Various symbol formats normalize to Bybit format."""
+        observer = self.create_observer(
+            symbol=symbol, timeframes=TimeFrame(1, TimeFrameUnit.Minute), window_sizes=10)
         assert observer.symbol == expected
 
-    def test_invalid_interval_raises_error(self, mock_pybit_client):
-        """Test that invalid timeframe raises ValueError."""
+    def test_invalid_interval_raises_error(self):
+        """Unsupported timeframe raises ValueError."""
         from torchtrade.envs.live.bybit.observation import BybitObservationClass
-
         with pytest.raises(ValueError, match="Unsupported timeframe"):
             BybitObservationClass(
-                symbol="BTCUSDT",
-                time_frames=TimeFrame(2, TimeFrameUnit.Minute),  # 2 minutes not supported
-                window_sizes=10,
-                client=mock_pybit_client,
-            )
+                symbol="BTCUSDT", time_frames=TimeFrame(2, TimeFrameUnit.Minute),
+                window_sizes=10, client=_make_pybit_client())
 
-    def test_mismatched_lengths_raises_error(self, mock_pybit_client):
-        """Test that mismatched time_frames and window_sizes raises error."""
-        from torchtrade.envs.live.bybit.observation import BybitObservationClass
+    def test_get_observations_exact_shapes(self):
+        """Bybit observations have exact (window, 4) shapes (stricter than base >=4)."""
+        observer = self.create_observer(
+            symbol="BTCUSDT",
+            timeframes=[TimeFrame(1, TimeFrameUnit.Minute), TimeFrame(5, TimeFrameUnit.Minute),
+                        TimeFrame(1, TimeFrameUnit.Hour)],
+            window_sizes=[10, 20, 15])
+        obs = observer.get_observations()
+        assert obs["1Minute_10"].shape == (10, 4)
+        assert obs["5Minute_20"].shape == (20, 4)
+        assert obs["1Hour_15"].shape == (15, 4)
 
-        with pytest.raises(ValueError, match="same length"):
-            BybitObservationClass(
-                symbol="BTCUSDT",
-                time_frames=[
-                    TimeFrame(1, TimeFrameUnit.Minute),
-                    TimeFrame(5, TimeFrameUnit.Minute),
-                ],
-                window_sizes=[10],  # Mismatched length
-                client=mock_pybit_client,
-            )
-
-    def test_get_keys_single(self, observer_single):
-        """Test get_keys with single timeframe."""
-        keys = observer_single.get_keys()
-        assert keys == ["15Minute_10"]
-
-    def test_get_keys_multi(self, observer_multi):
-        """Test get_keys with multiple timeframes."""
-        keys = observer_multi.get_keys()
-        assert keys == ["1Minute_10", "5Minute_20", "1Hour_15"]
-
-    def test_get_observations_single(self, observer_single):
-        """Test get_observations with single timeframe returns correct shape."""
-        observations = observer_single.get_observations()
-
-        assert "15Minute_10" in observations
-        assert observations["15Minute_10"].shape == (10, 4)  # window_size x num_features
-
-    def test_get_observations_multi(self, observer_multi):
-        """Test get_observations with multiple timeframes returns correct shapes."""
-        observations = observer_multi.get_observations()
-
-        assert observations["1Minute_10"].shape == (10, 4)
-        assert observations["5Minute_20"].shape == (20, 4)
-        assert observations["1Hour_15"].shape == (15, 4)
-
-    def test_get_observations_with_base_ohlc(self, observer_single):
-        """Test get_observations with return_base_ohlc=True."""
-        observations = observer_single.get_observations(return_base_ohlc=True)
-
-        assert "15Minute_10" in observations
-        assert "base_features" in observations
-        assert observations["base_features"].shape[1] == 4  # OHLC
-
-    def test_custom_preprocessing(self, mock_pybit_client):
-        """Test custom preprocessing function."""
+    def test_custom_preprocessing_five_features(self):
+        """Custom preprocessing adding OHLC-derived + custom feature -> 5 cols."""
         from torchtrade.envs.live.bybit.observation import BybitObservationClass
 
         def custom_preprocess(df):
@@ -148,87 +102,55 @@ class TestBybitObservationClass:
             return df
 
         observer = BybitObservationClass(
-            symbol="BTCUSDT",
-            time_frames=TimeFrame(1, TimeFrameUnit.Minute),
-            window_sizes=10,
-            feature_preprocessing_fn=custom_preprocess,
-            client=mock_pybit_client,
-        )
+            symbol="BTCUSDT", time_frames=TimeFrame(1, TimeFrameUnit.Minute),
+            window_sizes=10, feature_preprocessing_fn=custom_preprocess,
+            client=_make_pybit_client())
+        assert observer.get_observations()["1Minute_10"].shape[1] == 5
 
-        observations = observer.get_observations()
-        assert observations["1Minute_10"].shape[1] == 5  # 4 default + 1 custom
-
-    def test_api_call_parameters(self, observer_single, mock_pybit_client):
-        """Test that pybit get_kline is called with correct parameters."""
-        observer_single.get_observations()
-
-        mock_pybit_client.get_kline.assert_called()
-        call_kwargs = mock_pybit_client.get_kline.call_args[1]
+    def test_api_call_parameters(self):
+        """pybit get_kline is called with category=linear and the symbol."""
+        client = _make_pybit_client()
+        observer = self.create_observer(
+            symbol="BTCUSDT", timeframes=TimeFrame(15, TimeFrameUnit.Minute),
+            window_sizes=10, client=client)
+        observer.get_observations()
+        client.get_kline.assert_called()
+        call_kwargs = client.get_kline.call_args[1]
         assert call_kwargs["category"] == "linear"
         assert call_kwargs["symbol"] == "BTCUSDT"
 
-    def test_empty_candles_raises_error(self, mock_pybit_client):
-        """Test that empty candles raises RuntimeError."""
+    def test_empty_candles_raises_error(self):
+        """Empty candle data raises RuntimeError."""
         from torchtrade.envs.live.bybit.observation import BybitObservationClass
-
-        mock_pybit_client.get_kline = MagicMock(return_value={
-            "retCode": 0,
-            "result": {"list": []},
-        })
-
+        client = _make_pybit_client()
+        client.get_kline = MagicMock(return_value={"retCode": 0, "result": {"list": []}})
         observer = BybitObservationClass(
-            symbol="BTCUSDT",
-            time_frames=TimeFrame(1, TimeFrameUnit.Minute),
-            window_sizes=10,
-            client=mock_pybit_client,
-        )
-
+            symbol="BTCUSDT", time_frames=TimeFrame(1, TimeFrameUnit.Minute),
+            window_sizes=10, client=client)
         with pytest.raises(RuntimeError, match="No candle data"):
             observer.get_observations()
 
-    def test_default_preprocessing_output(self, observer_single):
-        """Test that default preprocessing outputs valid data."""
-        observations = observer_single.get_observations()
-        data = observations["15Minute_10"]
-
-        assert not np.isnan(data).any(), "Data contains NaN values"
-        assert data.shape == (10, 4)
-
-    def test_fetch_klines_validates_retcode(self, mock_pybit_client):
+    def test_fetch_klines_validates_retcode(self):
         """_fetch_klines must raise RuntimeError on non-zero retCode."""
         from torchtrade.envs.live.bybit.observation import BybitObservationClass
-
-        mock_pybit_client.get_kline = MagicMock(return_value={
-            "retCode": 10001,
-            "retMsg": "Invalid parameter",
-            "result": {"list": []},
-        })
-
+        client = _make_pybit_client()
+        client.get_kline = MagicMock(return_value={
+            "retCode": 10001, "retMsg": "Invalid parameter", "result": {"list": []}})
         observer = BybitObservationClass(
-            symbol="BTCUSDT",
-            time_frames=TimeFrame(1, TimeFrameUnit.Minute),
-            window_sizes=10,
-            client=mock_pybit_client,
-        )
-
+            symbol="BTCUSDT", time_frames=TimeFrame(1, TimeFrameUnit.Minute),
+            window_sizes=10, client=client)
         with pytest.raises(RuntimeError, match="retCode=10001"):
             observer._fetch_klines("BTCUSDT", "1", 200)
 
-    def test_parse_klines_sorts_chronologically(self, mock_pybit_client):
+    def test_parse_klines_sorts_chronologically(self):
         """Reverse-ordered klines from Bybit must be sorted oldest-first."""
         from torchtrade.envs.live.bybit.observation import BybitObservationClass
-
         observer = BybitObservationClass(
-            symbol="BTCUSDT",
-            time_frames=TimeFrame(1, TimeFrameUnit.Minute),
-            window_sizes=5,
-            client=mock_pybit_client,
-        )
-
-        # Feed reverse-chronological data (newest first, like Bybit returns)
+            symbol="BTCUSDT", time_frames=TimeFrame(1, TimeFrameUnit.Minute),
+            window_sizes=5, client=_make_pybit_client())
         raw_klines = [
             [str(1700000000000 + i * 60000), "50000", "50100", "49900", "50050", "100", "5000000"]
-            for i in [4, 3, 2, 1, 0]  # Reverse: 4min, 3min, 2min, 1min, 0min
+            for i in [4, 3, 2, 1, 0]
         ]
         df = observer._parse_klines(raw_klines)
         timestamps = df["timestamp"].tolist()

--- a/tests/envs/okx/test_obs_class.py
+++ b/tests/envs/okx/test_obs_class.py
@@ -1,91 +1,97 @@
-"""Tests for OKXObservationClass."""
+"""Tests for OKXObservationClass.
+
+Common observation-class behavior (init, keys, shapes, float32, no-NaN, features,
+window sizes) is inherited from BaseObservationClassTests. Only OKX-specific tests
+(symbol normalization, REST envelope validation, chronological parsing, utils) live
+here.
+"""
 
 import pytest
 import numpy as np
 from unittest.mock import MagicMock
 from torchtrade.envs.utils.timeframe import TimeFrame, TimeFrameUnit
+from tests.envs.base_exchange_tests import BaseObservationClassTests
 
 
-class TestOKXObservationClass:
-    """Tests for OKXObservationClass."""
+def _make_okx_market_client():
+    """Build a mock OKX MarketData client (mirrors the conftest fixture).
 
-    @pytest.fixture
-    def observer_single(self, mock_okx_market_client):
-        """Create observer with single timeframe."""
+    Generates exactly ``limit`` candles in reverse-chronological order (as OKX
+    returns them), so window sizes up to the base tests' 100 are satisfied.
+    """
+    client = MagicMock()
+
+    def mock_get_candlesticks(instId, bar, limit="200"):
+        n = int(limit)
+        base_time = 1700000000000
+        candles = [
+            [str(base_time + i * 60000), "50000.0", "50100.0", "49900.0",
+             "50050.0", "100.0", "5005000.0", "5005000.0", "1"]
+            for i in range(n - 1, -1, -1)  # reverse order
+        ]
+        return {"code": "0", "msg": "", "data": candles}
+
+    client.get_candlesticks = MagicMock(side_effect=mock_get_candlesticks)
+    return client
+
+
+class TestOKXObservationClass(BaseObservationClassTests):
+    """OKX observation class — common tests inherited from the base."""
+
+    def create_observer(self, symbol, timeframes, window_sizes, **kwargs):
         from torchtrade.envs.live.okx.observation import OKXObservationClass
-
+        client = kwargs.pop("client", None) or _make_okx_market_client()
         return OKXObservationClass(
-            symbol="BTC-USDT-SWAP",
-            time_frames=TimeFrame(15, TimeFrameUnit.Minute),
-            window_sizes=10,
-            client=mock_okx_market_client,
+            symbol=symbol,
+            time_frames=timeframes,
+            window_sizes=window_sizes,
+            client=client,
+            **kwargs,
         )
 
-    @pytest.fixture
-    def observer_multi(self, mock_okx_market_client):
-        """Create observer with multiple timeframes."""
+    def get_expected_symbol_format(self, symbol):
+        from torchtrade.envs.live.okx.utils import normalize_symbol
+        return normalize_symbol(symbol)
+
+    # --- OKX-specific tests (no base equivalent) ---
+
+    def test_invalid_interval_raises_error(self):
+        """Unsupported timeframe raises ValueError."""
         from torchtrade.envs.live.okx.observation import OKXObservationClass
-
-        return OKXObservationClass(
-            symbol="BTC-USDT-SWAP",
-            time_frames=[
-                TimeFrame(1, TimeFrameUnit.Minute),
-                TimeFrame(5, TimeFrameUnit.Minute),
-                TimeFrame(1, TimeFrameUnit.Hour),
-            ],
-            window_sizes=[10, 20, 15],
-            client=mock_okx_market_client,
-        )
-
-    def test_invalid_interval_raises_error(self, mock_okx_market_client):
-        """Test that invalid timeframe raises ValueError."""
-        from torchtrade.envs.live.okx.observation import OKXObservationClass
-
         with pytest.raises(ValueError, match="Unsupported timeframe"):
             OKXObservationClass(
                 symbol="BTC-USDT-SWAP",
                 time_frames=TimeFrame(2, TimeFrameUnit.Minute),
                 window_sizes=10,
-                client=mock_okx_market_client,
+                client=_make_okx_market_client(),
             )
 
-    def test_mismatched_lengths_raises_error(self, mock_okx_market_client):
-        """Test that mismatched time_frames and window_sizes raises error."""
-        from torchtrade.envs.live.okx.observation import OKXObservationClass
-
-        with pytest.raises(ValueError, match="same length"):
-            OKXObservationClass(
-                symbol="BTC-USDT-SWAP",
-                time_frames=[
-                    TimeFrame(1, TimeFrameUnit.Minute),
-                    TimeFrame(5, TimeFrameUnit.Minute),
-                ],
-                window_sizes=[10],
-                client=mock_okx_market_client,
-            )
-
-    def test_get_observations_single(self, observer_single):
-        """Test get_observations with single timeframe returns correct shape."""
-        observations = observer_single.get_observations()
-        assert "15Minute_10" in observations
+    def test_get_observations_single_exact_shape(self):
+        """OKX single-timeframe observation is exactly (10, 4) (stricter than base >=4)."""
+        observer = self.create_observer(
+            symbol="BTC-USDT-SWAP",
+            timeframes=TimeFrame(15, TimeFrameUnit.Minute),
+            window_sizes=10,
+        )
+        observations = observer.get_observations()
         assert observations["15Minute_10"].shape == (10, 4)
 
-    def test_get_observations_multi(self, observer_multi):
-        """Test get_observations with multiple timeframes returns correct shapes."""
-        observations = observer_multi.get_observations()
+    def test_get_observations_multi_exact_shapes(self):
+        """OKX multi-timeframe observations have exact per-timeframe shapes."""
+        observer = self.create_observer(
+            symbol="BTC-USDT-SWAP",
+            timeframes=[TimeFrame(1, TimeFrameUnit.Minute),
+                        TimeFrame(5, TimeFrameUnit.Minute),
+                        TimeFrame(1, TimeFrameUnit.Hour)],
+            window_sizes=[10, 20, 15],
+        )
+        observations = observer.get_observations()
         assert observations["1Minute_10"].shape == (10, 4)
         assert observations["5Minute_20"].shape == (20, 4)
         assert observations["1Hour_15"].shape == (15, 4)
 
-    def test_get_observations_with_base_ohlc(self, observer_single):
-        """Test get_observations with return_base_ohlc=True."""
-        observations = observer_single.get_observations(return_base_ohlc=True)
-        assert "15Minute_10" in observations
-        assert "base_features" in observations
-        assert observations["base_features"].shape[1] == 4
-
-    def test_custom_preprocessing(self, mock_okx_market_client):
-        """Test custom preprocessing function changes feature count."""
+    def test_custom_preprocessing_five_features(self):
+        """Custom preprocessing that adds OHLC-derived + a custom feature -> 5 cols."""
         from torchtrade.envs.live.okx.observation import OKXObservationClass
 
         def custom_preprocess(df):
@@ -105,59 +111,48 @@ class TestOKXObservationClass:
             time_frames=TimeFrame(1, TimeFrameUnit.Minute),
             window_sizes=10,
             feature_preprocessing_fn=custom_preprocess,
-            client=mock_okx_market_client,
+            client=_make_okx_market_client(),
         )
-
         observations = observer.get_observations()
         assert observations["1Minute_10"].shape[1] == 5  # 4 default + 1 custom
 
-    def test_empty_candles_raises_error(self, mock_okx_market_client):
-        """Test that empty candles raises RuntimeError."""
+    def test_empty_candles_raises_error(self):
+        """Empty candle data raises RuntimeError."""
         from torchtrade.envs.live.okx.observation import OKXObservationClass
-
-        mock_okx_market_client.get_candlesticks = MagicMock(return_value={
-            "code": "0", "msg": "", "data": [],
-        })
-
+        client = _make_okx_market_client()
+        client.get_candlesticks = MagicMock(return_value={"code": "0", "msg": "", "data": []})
         observer = OKXObservationClass(
             symbol="BTC-USDT-SWAP",
             time_frames=TimeFrame(1, TimeFrameUnit.Minute),
             window_sizes=10,
-            client=mock_okx_market_client,
+            client=client,
         )
-
         with pytest.raises(RuntimeError, match="No candle data"):
             observer.get_observations()
 
-    def test_fetch_klines_validates_code(self, mock_okx_market_client):
+    def test_fetch_klines_validates_code(self):
         """_fetch_klines must raise RuntimeError on non-zero code."""
         from torchtrade.envs.live.okx.observation import OKXObservationClass
-
-        mock_okx_market_client.get_candlesticks = MagicMock(return_value={
-            "code": "51001", "msg": "Invalid parameter", "data": [],
-        })
-
+        client = _make_okx_market_client()
+        client.get_candlesticks = MagicMock(return_value={"code": "51001", "msg": "Invalid parameter", "data": []})
         observer = OKXObservationClass(
             symbol="BTC-USDT-SWAP",
             time_frames=TimeFrame(1, TimeFrameUnit.Minute),
             window_sizes=10,
-            client=mock_okx_market_client,
+            client=client,
         )
-
         with pytest.raises(RuntimeError, match="code=51001"):
             observer._fetch_klines("BTC-USDT-SWAP", "1m", 200)
 
-    def test_parse_klines_sorts_chronologically(self, mock_okx_market_client):
+    def test_parse_klines_sorts_chronologically(self):
         """Reverse-ordered klines from OKX must be sorted oldest-first."""
         from torchtrade.envs.live.okx.observation import OKXObservationClass
-
         observer = OKXObservationClass(
             symbol="BTC-USDT-SWAP",
             time_frames=TimeFrame(1, TimeFrameUnit.Minute),
             window_sizes=5,
-            client=mock_okx_market_client,
+            client=_make_okx_market_client(),
         )
-
         raw_klines = [
             [str(1700000000000 + i * 60000), "50000", "50100", "49900", "50050", "100", "5000000", "5000000", "1"]
             for i in [4, 3, 2, 1, 0]


### PR DESCRIPTION
First slice of a cross-exchange test-consolidation series. All 5 exchanges' `test_obs_class.py` now subclass the previously-**unused** `BaseObservationClassTests` (3 of the base's 4 classes had zero subclasses). Reviewed by `pr-test-analyzer` (coverage preservation) + `code-simplifier`.

## What changed
- Each exchange implements `create_observer` + `get_expected_symbol_format` and inherits the 14 common tests (init/keys/shapes/float32/no-NaN/features/window/custom-preprocessing).
- **Fixed a latent base-class bug**: it hard-accessed `observer.timeframes`, which `AttributeError`'d on the four exchanges exposing `time_frames` (eager `getattr` default) — this is *why* the base was never adopted.
- Kept every exchange-specific test (symbol normalization — the base's `get_expected_symbol_format` is dead/never-called so it gives zero symbol coverage; REST-envelope validation; chronological sorting; exchange-specific kline fields; `TestBybitUtils`/`TestOKXUtils`) and stricter exact-shape/dtype assertions.

## Coverage: preserved and net-increased
`pr-test-analyzer` verified no per-exchange coverage was dropped. **OKX/binance/bybit/bitget gained** float32/no-NaN/window-size tests they previously lacked; alpaca is pure dedup. Net **−553 lines**, and the full suite went **1808 → 1847** (+39 tests).

## Review fixes applied
- Removed bitget's unnecessary `ccxt.bitget` patch dance — the observer accepts `client=` directly like the other four (verified).
- Fixed an alpaca `shape == shape` tautology + a dead `pytest` import.

Remaining slices (order-executor, futures-env, SLTP) are follow-on PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)