### PR TITLE
fix(live): closing a pre-existing position was a silent no-op

### DIFF
--- a/tests/envs/binance/test_torch_env_futures.py
+++ b/tests/envs/binance/test_torch_env_futures.py
@@ -201,26 +201,16 @@ class TestBinanceFuturesTorchTradingEnv:
             mock_trader.trade.assert_called()
 
 
-    def test_done_on_bankruptcy(self, env, mock_trader):
-        """Test termination on bankruptcy."""
+    @pytest.mark.parametrize("portfolio_value,expected_done", [
+        (50.0, True),    # below 10% of the 1000 initial -> bankrupt
+        (100.0, False),  # exactly at threshold -> NOT bankrupt (check is a strict <)
+        (500.0, False),  # above threshold -> keep trading
+    ], ids=["below-threshold", "at-threshold", "above-threshold"])
+    def test_bankruptcy_termination(self, env, portfolio_value, expected_done):
+        """Terminates when portfolio falls below bankrupt_threshold * initial_portfolio_value."""
         env.initial_portfolio_value = 1000.0
         env.config.bankrupt_threshold = 0.1
-
-        # Set balance to below threshold
-        mock_trader.get_account_balance = MagicMock(return_value={
-            "total_margin_balance": 50.0,  # Below 10% of 1000
-        })
-
-        done = env._check_termination(50.0)
-        assert done is True
-
-    def test_no_termination_above_threshold(self, env, mock_trader):
-        """Test no termination when above bankruptcy threshold."""
-        env.initial_portfolio_value = 1000.0
-        env.config.bankrupt_threshold = 0.1
-
-        done = env._check_termination(500.0)
-        assert done is False
+        assert env._check_termination(portfolio_value) is expected_done
 
     def test_close_method(self, env, mock_trader):
         """Test environment close method."""

--- a/tests/envs/bitget/test_torch_env_futures.py
+++ b/tests/envs/bitget/test_torch_env_futures.py
@@ -202,6 +202,21 @@ class TestBitgetFuturesTorchTradingEnv:
             assert isinstance(truncated, torch.Tensor)
             assert done.shape == (1,)
 
+    @pytest.mark.parametrize("portfolio_value,expected_done", [
+        (50.0, True),    # below 10% of the 1000 initial -> bankrupt
+        (100.0, False),  # exactly at threshold -> NOT bankrupt (check is a strict <)
+        (500.0, False),  # above threshold -> keep trading
+    ], ids=["below-threshold", "at-threshold", "above-threshold"])
+    def test_bankruptcy_termination(self, env, portfolio_value, expected_done):
+        """Terminates when portfolio falls below bankrupt_threshold * initial_portfolio_value.
+
+        Only the DISABLED path was covered here; this pins the enabled safety behavior
+        (previously tested on binance only).
+        """
+        env.initial_portfolio_value = 1000.0
+        env.config.bankrupt_threshold = 0.1
+        assert env._check_termination(portfolio_value) is expected_done
+
     def test_no_bankruptcy_when_disabled(self, env_config, mock_observer, mock_trader):
         """Test that bankruptcy check can be disabled."""
         from torchtrade.envs.live.bitget.env import BitgetFuturesTorchTradingEnv
@@ -234,10 +249,19 @@ class TestBitgetFuturesTorchTradingEnv:
             assert done.item() is False  # Should not terminate
 
     def test_close_position_action(self, env, mock_trader):
-        """Test that action 1 (hold/close) closes existing position."""
+        """Commanding flat (level 0.0) must close a position the env did NOT open.
+
+        Regression for a silent no-op: _reset synced current_position from the exchange
+        but left current_action_level at its stale 0.0 default, so
+        _execute_trade_if_needed's `desired_action == current_action_level` short-circuit
+        fired and the position was never closed.
+
+        NOTE: this test previously asserted nothing (its body ended in comments) and could
+        never fail, which is why the bug went unnoticed.
+        """
         from torchtrade.envs.live.bitget.order_executor import PositionStatus
 
-        # Mock existing long position
+        # A long position already open on the exchange (not opened by this env)
         mock_trader.get_status = MagicMock(return_value={
             "position_status": PositionStatus(
                 qty=0.001,
@@ -254,13 +278,19 @@ class TestBitgetFuturesTorchTradingEnv:
 
         with patch.object(env, "_wait_for_next_timestamp"):
             env.reset()
+            # Discard the close_position() the constructor makes (close_position_on_init),
+            # otherwise assert_called() would pass without _step doing anything.
+            mock_trader.close_position.reset_mock()
 
-            # Action index 2 maps to level 0.0, which should close position
+            # Fractional action levels: [0=-1.0, 1=-0.5, 2=0.0, 3=0.5, 4=1.0]
+            # Action index 2 -> level 0.0 -> close the open position.
             action_td = TensorDict({"action": torch.tensor(2)}, batch_size=())
             env._step(action_td)  # Use _step to test internal logic
 
-            # Fractional action levels: [0=-1.0, 1=-0.5, 2=0.0, 3=0.5, 4=1.0]
-            # Action 0.0 means close position, so if qty != 0, it should close
+        mock_trader.close_position.assert_called_once()
+
+        # The open long must actually be closed (this test previously asserted nothing).
+        mock_trader.close_position.assert_called()
 
     def test_long_from_short(self, env, mock_trader):
         """Test going long from short position executes correct trade."""

--- a/tests/envs/bitget/test_torch_env_futures.py
+++ b/tests/envs/bitget/test_torch_env_futures.py
@@ -208,11 +208,7 @@ class TestBitgetFuturesTorchTradingEnv:
         (500.0, False),  # above threshold -> keep trading
     ], ids=["below-threshold", "at-threshold", "above-threshold"])
     def test_bankruptcy_termination(self, env, portfolio_value, expected_done):
-        """Terminates when portfolio falls below bankrupt_threshold * initial_portfolio_value.
-
-        Only the DISABLED path was covered here; this pins the enabled safety behavior
-        (previously tested on binance only).
-        """
+        """Terminates when portfolio falls below bankrupt_threshold * initial_portfolio_value."""
         env.initial_portfolio_value = 1000.0
         env.config.bankrupt_threshold = 0.1
         assert env._check_termination(portfolio_value) is expected_done
@@ -251,13 +247,8 @@ class TestBitgetFuturesTorchTradingEnv:
     def test_close_position_action(self, env, mock_trader):
         """Commanding flat (level 0.0) must close a position the env did NOT open.
 
-        Regression for a silent no-op: _reset synced current_position from the exchange
-        but left current_action_level at its stale 0.0 default, so
-        _execute_trade_if_needed's `desired_action == current_action_level` short-circuit
-        fired and the position was never closed.
-
-        NOTE: this test previously asserted nothing (its body ended in comments) and could
-        never fail, which is why the bug went unnoticed.
+        Regression: a stale current_action_level let the duplicate-action guard
+        short-circuit the close, silently leaving the position open.
         """
         from torchtrade.envs.live.bitget.order_executor import PositionStatus
 
@@ -278,19 +269,16 @@ class TestBitgetFuturesTorchTradingEnv:
 
         with patch.object(env, "_wait_for_next_timestamp"):
             env.reset()
-            # Discard the close_position() the constructor makes (close_position_on_init),
-            # otherwise assert_called() would pass without _step doing anything.
+            # The constructor closes any position (close_position_on_init); drop that call
+            # so assert_called_once() counts only what _step does.
             mock_trader.close_position.reset_mock()
 
             # Fractional action levels: [0=-1.0, 1=-0.5, 2=0.0, 3=0.5, 4=1.0]
             # Action index 2 -> level 0.0 -> close the open position.
             action_td = TensorDict({"action": torch.tensor(2)}, batch_size=())
-            env._step(action_td)  # Use _step to test internal logic
+            env._step(action_td)
 
         mock_trader.close_position.assert_called_once()
-
-        # The open long must actually be closed (this test previously asserted nothing).
-        mock_trader.close_position.assert_called()
 
     def test_long_from_short(self, env, mock_trader):
         """Test going long from short position executes correct trade."""

--- a/tests/envs/bybit/test_torch_env_futures.py
+++ b/tests/envs/bybit/test_torch_env_futures.py
@@ -145,11 +145,7 @@ class TestBybitFuturesTorchTradingEnv:
         (500.0, False),  # above threshold -> keep trading
     ], ids=["below-threshold", "at-threshold", "above-threshold"])
     def test_bankruptcy_termination(self, env, portfolio_value, expected_done):
-        """Terminates when portfolio falls below bankrupt_threshold * initial_portfolio_value.
-
-        Only the DISABLED path was covered here; this pins the enabled safety behavior
-        (previously tested on binance only).
-        """
+        """Terminates when portfolio falls below bankrupt_threshold * initial_portfolio_value."""
         env.initial_portfolio_value = 1000.0
         env.config.bankrupt_threshold = 0.1
         assert env._check_termination(portfolio_value) is expected_done

--- a/tests/envs/bybit/test_torch_env_futures.py
+++ b/tests/envs/bybit/test_torch_env_futures.py
@@ -139,6 +139,21 @@ class TestBybitFuturesTorchTradingEnv:
             assert next_td["next"]["terminated"].shape == (1,)
             assert next_td["next"]["truncated"].shape == (1,)
 
+    @pytest.mark.parametrize("portfolio_value,expected_done", [
+        (50.0, True),    # below 10% of the 1000 initial -> bankrupt
+        (100.0, False),  # exactly at threshold -> NOT bankrupt (check is a strict <)
+        (500.0, False),  # above threshold -> keep trading
+    ], ids=["below-threshold", "at-threshold", "above-threshold"])
+    def test_bankruptcy_termination(self, env, portfolio_value, expected_done):
+        """Terminates when portfolio falls below bankrupt_threshold * initial_portfolio_value.
+
+        Only the DISABLED path was covered here; this pins the enabled safety behavior
+        (previously tested on binance only).
+        """
+        env.initial_portfolio_value = 1000.0
+        env.config.bankrupt_threshold = 0.1
+        assert env._check_termination(portfolio_value) is expected_done
+
     def test_no_bankruptcy_when_disabled(self, env_config, mock_observer, mock_trader):
         """Test that bankruptcy check can be disabled."""
         from torchtrade.envs.live.bybit.env import BybitFuturesTorchTradingEnv

--- a/tests/envs/okx/test_torch_env_futures.py
+++ b/tests/envs/okx/test_torch_env_futures.py
@@ -101,6 +101,21 @@ class TestOKXFuturesTorchTradingEnv:
             assert next_td["next"]["terminated"].shape == (1,)
             assert next_td["next"]["truncated"].shape == (1,)
 
+    @pytest.mark.parametrize("portfolio_value,expected_done", [
+        (50.0, True),    # below 10% of the 1000 initial -> bankrupt
+        (100.0, False),  # exactly at threshold -> NOT bankrupt (check is a strict <)
+        (500.0, False),  # above threshold -> keep trading
+    ], ids=["below-threshold", "at-threshold", "above-threshold"])
+    def test_bankruptcy_termination(self, env, portfolio_value, expected_done):
+        """Terminates when portfolio falls below bankrupt_threshold * initial_portfolio_value.
+
+        Only the DISABLED path was covered here; this pins the enabled safety behavior
+        (previously tested on binance only).
+        """
+        env.initial_portfolio_value = 1000.0
+        env.config.bankrupt_threshold = 0.1
+        assert env._check_termination(portfolio_value) is expected_done
+
     def test_no_bankruptcy_when_disabled(self, env_config, mock_observer, mock_env_trader):
         """Test that bankruptcy check can be disabled."""
         from torchtrade.envs.live.okx.env import OKXFuturesTorchTradingEnv

--- a/tests/envs/okx/test_torch_env_futures.py
+++ b/tests/envs/okx/test_torch_env_futures.py
@@ -107,11 +107,7 @@ class TestOKXFuturesTorchTradingEnv:
         (500.0, False),  # above threshold -> keep trading
     ], ids=["below-threshold", "at-threshold", "above-threshold"])
     def test_bankruptcy_termination(self, env, portfolio_value, expected_done):
-        """Terminates when portfolio falls below bankrupt_threshold * initial_portfolio_value.
-
-        Only the DISABLED path was covered here; this pins the enabled safety behavior
-        (previously tested on binance only).
-        """
+        """Terminates when portfolio falls below bankrupt_threshold * initial_portfolio_value."""
         env.initial_portfolio_value = 1000.0
         env.config.bankrupt_threshold = 0.1
         assert env._check_termination(portfolio_value) is expected_done

--- a/torchtrade/envs/core/live.py
+++ b/torchtrade/envs/core/live.py
@@ -164,6 +164,23 @@ class TorchTradeLiveEnv(TorchTradeBaseEnv):
         if sleep_seconds > 0:
             time.sleep(sleep_seconds)
 
+    def _sync_action_level_after_reset(self) -> None:
+        """Reconcile current_action_level with the position observed during reset.
+
+        _execute_trade_if_needed short-circuits when
+        ``desired_action == self.position.current_action_level``. But current_action_level
+        is only ever assigned after a trade THIS env made, so a position the env did not
+        open -- pre-existing on the exchange, or carried across a reset with
+        close_position_on_reset=False -- leaves it at the stale 0.0 default. Commanding
+        flat (0.0) would then match and silently no-op: the position is never closed.
+
+        The action level that produced such a position is unknowable, so mark it NaN.
+        NaN never compares equal to anything, so the next command always executes.
+        """
+        self.position.current_action_level = (
+            0.0 if self.position.current_position == 0 else float("nan")
+        )
+
     @abstractmethod
     def _get_portfolio_value(self, *args, **kwargs) -> float:
         """

--- a/torchtrade/envs/core/live.py
+++ b/torchtrade/envs/core/live.py
@@ -167,15 +167,13 @@ class TorchTradeLiveEnv(TorchTradeBaseEnv):
     def _sync_action_level_after_reset(self) -> None:
         """Reconcile current_action_level with the position observed during reset.
 
-        _execute_trade_if_needed short-circuits when
-        ``desired_action == self.position.current_action_level``. But current_action_level
-        is only ever assigned after a trade THIS env made, so a position the env did not
-        open -- pre-existing on the exchange, or carried across a reset with
-        close_position_on_reset=False -- leaves it at the stale 0.0 default. Commanding
-        flat (0.0) would then match and silently no-op: the position is never closed.
+        current_action_level is only assigned after a trade THIS env made, so a position
+        the env did not open (pre-existing on the exchange) leaves it at the stale 0.0
+        default -- and _execute_trade_if_needed's ``desired_action == current_action_level``
+        guard would then short-circuit a flat command and never close it.
 
-        The action level that produced such a position is unknowable, so mark it NaN.
-        NaN never compares equal to anything, so the next command always executes.
+        The level that produced such a position is unknowable: NaN never compares equal,
+        so the next command always executes.
         """
         self.position.current_action_level = (
             0.0 if self.position.current_position == 0 else float("nan")

--- a/torchtrade/envs/live/alpaca/base.py
+++ b/torchtrade/envs/live/alpaca/base.py
@@ -287,6 +287,8 @@ class AlpacaBaseTorchTradingEnv(TorchTradeLiveEnv):
         else:
             self.position.current_position = 1 if position_status.qty > 0 else 0
 
+        self._sync_action_level_after_reset()
+
         # Get initial observation
         return self._get_observation()
 

--- a/torchtrade/envs/live/binance/base.py
+++ b/torchtrade/envs/live/binance/base.py
@@ -322,6 +322,8 @@ class BinanceBaseTorchTradingEnv(TorchTradeLiveEnv):
         else:
             self.position.current_position = 0  # No position
 
+        self._sync_action_level_after_reset()
+
         # Get initial observation
         return self._get_observation()
 

--- a/torchtrade/envs/live/bitget/base.py
+++ b/torchtrade/envs/live/bitget/base.py
@@ -341,6 +341,8 @@ class BitgetBaseTorchTradingEnv(TorchTradeLiveEnv):
         else:
             self.position.current_position = 0  # No position
 
+        self._sync_action_level_after_reset()
+
         # Get initial observation
         return self._get_observation()
 

--- a/torchtrade/envs/live/bybit/base.py
+++ b/torchtrade/envs/live/bybit/base.py
@@ -275,6 +275,11 @@ class BybitBaseTorchTradingEnv(TorchTradeLiveEnv):
         else:
             self.position.current_position = 0
 
+        # No-op today (bybit's _execute_trade_if_needed recomputes qty live and never reads
+        # current_action_level), but keeps the field consistent so adding a duplicate-action
+        # guard here can't reintroduce the silent no-op that bit bitget/binance/alpaca.
+        self._sync_action_level_after_reset()
+
         return self._get_observation()
 
     @abstractmethod

--- a/torchtrade/envs/live/okx/base.py
+++ b/torchtrade/envs/live/okx/base.py
@@ -285,6 +285,11 @@ class OKXBaseTorchTradingEnv(TorchTradeLiveEnv):
         else:
             self.position.current_position = 0
 
+        # No-op today (okx's _execute_trade_if_needed recomputes qty live and never reads
+        # current_action_level), but keeps the field consistent so adding a duplicate-action
+        # guard here can't reintroduce the silent no-op that bit bitget/binance/alpaca.
+        self._sync_action_level_after_reset()
+
         return self._get_observation()
 
     @abstractmethod


### PR DESCRIPTION
## The bug (live, money-moving)
`_execute_trade_if_needed` short-circuits on `desired_action == self.position.current_action_level` (`bitget/env.py:371`, `binance/env.py:519`, `alpaca/env.py:176`). But `current_action_level` is **only ever assigned after a trade the env itself made** — `_reset` syncs `current_position` from the exchange and never touches it.

So for a position the env did **not** open (pre-existing on the exchange, or carried across a reset with `close_position_on_reset=False`), `current_action_level` stays at its stale `0.0` default while `current_position` is `±1`. **Commanding flat (level `0.0`) then matches, short-circuits, and the position is never closed** — the agent asks to go flat, nothing happens, silently, with real exposure left open.

Confirmed empirically: after reset, `current_position=1` / `current_action_level=0.0`, and `_step(flat)` makes **zero** `close_position` calls.

## The fix
`TorchTradeLiveEnv._sync_action_level_after_reset()` reconciles the two on reset. The level that produced a pre-existing position is unknowable, so mark it `NaN` (never compares equal), forcing the next command to execute. Called from the bitget/binance/alpaca resets.

- **bybit/okx were never affected** — they don't short-circuit (they recompute qty live from the exchange each call).
- **All four SLTP variants are immune** — they gate on `current_position` and resync from the exchange every step.
- `current_action_level` is not part of `account_state`, so the NaN **cannot leak into observations/specs**.

Reviewed by `torchrl-engineer`: **GO**, no changes needed.

## How it was found (and why it hid)
`tests/envs/bitget/.../test_close_position_action` **asserted nothing** — its body ended in comments, so it could never fail. It now drives the real path and is **mutation-verified twice**: gutting the trade logic fails it, and reverting this fix fails it.

## Also: missing bankruptcy coverage
Only **binance** tested the *enabled* bankruptcy-termination path on the live futures envs; bitget/bybit/okx tested only the *disabled* path. Adds a parametrized test to each — below / **exactly-at** / above threshold (the at-threshold case pins the strict `<`, which a mutation matrix showed was otherwise unguarded).

Full suite: **1871 passed**.

## Non-blocking follow-ups (flagged by review, not fixed here)
1. bybit/okx still *write* `current_action_level` but never read it — a future-proofing landmine if someone later adds a duplicate-action guard there.
2. Non-SLTP envs never resync `current_position` from the exchange mid-episode (SLTP variants do, every step) — an external liquidation/manual close would desync state for the rest of the episode. Same failure family, broader scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)