### PR TITLE
fix(live): a liquidation could freeze the trade guard for the rest of the episode

### DIFF
--- a/tests/envs/alpaca/test_torch_env.py
+++ b/tests/envs/alpaca/test_torch_env.py
@@ -186,8 +186,8 @@ class TestAlpacaTorchTradingEnvReset:
         """A dust residual on reset is flat -- internally AND in what the agent sees.
 
         A close can leave a float residue (1e-12). Read as an open position it puts a phantom
-        direction in account_state with zero exposure -- an observation the policy never saw
-        in training -- and freezes the trade guard.
+        direction in account_state at zero exposure -- a combination the policy never saw in
+        training.
 
         Behavioural on purpose: the structural guard that every _reset uses the shared rule
         can be dodged by moving the derivation into a helper. This cannot.

--- a/tests/envs/alpaca/test_torch_env.py
+++ b/tests/envs/alpaca/test_torch_env.py
@@ -185,20 +185,27 @@ class TestAlpacaTorchTradingEnvReset:
     def test_reset_reads_dust_as_flat(self, env):
         """A dust residual on reset is flat -- internally AND in what the agent sees.
 
-        A close can leave a float residue (1e-12). Read as an open position it puts a phantom
-        direction in account_state at zero exposure -- a combination the policy never saw in
-        training.
+        A close can leave a float residue (1e-12) behind, with a STALE entry price and market
+        value still attached. Read as an open position, those stale fields become the agent's
+        exposure and unrealized PnL for a position that does not exist.
 
-        Behavioural on purpose: the structural guard that every _reset uses the shared rule
-        can be dodged by moving the derivation into a helper. This cannot.
+        The stale values are the whole point: an earlier version of this test zeroed them, so
+        every element it checked was already 0 whatever the code did, and the fix it was
+        guarding could be deleted with the suite still green.
         """
         env.trader.position_qty = 1e-12
-        env.trader.position_value = 0.0
+        env.trader.position_value = 41.82        # stale market value left on the residual
+        env.trader.avg_entry_price = 45000.0     # stale entry -> a fake +22% unrealized PnL
 
         td = env.reset()
 
         assert env.position.current_position == 0
-        assert td["account_state"][1].item() == 0.0   # the direction the AGENT sees
+
+        exposure, direction, unrealized_pnl, holding_time, _lev, _dist = td["account_state"].tolist()
+        assert exposure == 0.0        # no position -> no exposure, whatever value is attached
+        assert direction == 0.0
+        assert unrealized_pnl == 0.0  # a position that does not exist cannot be up 22%
+        assert holding_time == 0.0
 
 
 class TestAlpacaTorchTradingEnvStep:

--- a/tests/envs/alpaca/test_torch_env.py
+++ b/tests/envs/alpaca/test_torch_env.py
@@ -182,6 +182,24 @@ class TestAlpacaTorchTradingEnvReset:
         env.reset()
         assert env.position.hold_counter == 0
 
+    def test_reset_reads_dust_as_flat(self, env):
+        """A dust residual on reset is flat -- internally AND in what the agent sees.
+
+        A close can leave a float residue (1e-12). Read as an open position it puts a phantom
+        direction in account_state with zero exposure -- an observation the policy never saw
+        in training -- and freezes the trade guard.
+
+        Behavioural on purpose: the structural guard that every _reset uses the shared rule
+        can be dodged by moving the derivation into a helper. This cannot.
+        """
+        env.trader.position_qty = 1e-12
+        env.trader.position_value = 0.0
+
+        td = env.reset()
+
+        assert env.position.current_position == 0
+        assert td["account_state"][1].item() == 0.0   # the direction the AGENT sees
+
 
 class TestAlpacaTorchTradingEnvStep:
     """Tests for environment step."""

--- a/tests/envs/alpaca/test_torch_env.py
+++ b/tests/envs/alpaca/test_torch_env.py
@@ -387,6 +387,30 @@ class TestAlpacaTorchTradingEnvStep:
         td = env._step(buy)                            # a BRAND NEW position
         assert td["account_state"][3].item() == 1.0, "a new position reported as older than 1 bar"
 
+    def test_open_position_looks_open(self, env):
+        """An OPEN position must look open in the vector the policy consumes.
+
+        Every other account_state assertion on this branch checks that a FLAT account reads
+        flat -- because that was the bug. The inverse was unpinned: corrupting exposure,
+        direction or unrealized PnL while genuinely open shipped with the whole suite green.
+        That is the same class of bug, pointing the other way.
+
+        Values measured off the mock, not computed.
+        """
+        env.reset()
+        env._step(TensorDict({"action": torch.tensor(2)}, batch_size=()))   # buy at 100000
+        assert env.trader.position_qty > 0
+
+        env.trader.current_price = 110000.0        # +10% -- entry stays at 100000
+        td = env._step(TensorDict({"action": torch.tensor(2)}, batch_size=()))
+
+        exposure, direction, pnl, _ht, leverage, dist = td["account_state"].tolist()
+        assert direction == 1.0
+        assert exposure > 0.0                      # a held position has exposure
+        assert pnl == pytest.approx(0.1)           # (110000 - 100000) / 100000
+        assert leverage == 1.0                     # spot
+        assert dist == 1.0                         # spot: no liquidation
+
 
 class TestAlpacaTorchTradingEnvReward:
     """Tests for reward calculation."""

--- a/tests/envs/alpaca/test_torch_env.py
+++ b/tests/envs/alpaca/test_torch_env.py
@@ -275,9 +275,13 @@ class TestAlpacaTorchTradingEnvStep:
         assert env.trader.position_qty > 0        # opened
 
         # Still holding it: re-commanding the same level is redundant, guard must suppress.
+        # assert_not_called() alone is NOT enough here -- alpaca's _execute_fractional_action
+        # independently bails when the delta is under its $1 min_trade_value, so it would hold
+        # even with the guard broken. Assert the guard's actual input: the level survived.
         env.trader.trade = MagicMock(wraps=env.trader.trade)
         env._step(buy)
         env.trader.trade.assert_not_called()
+        assert env.position.current_action_level == 1.0
 
         # The position is closed out from under us -- on spot that means a manual close in
         # the Alpaca UI. The proceeds return to cash, exactly as the mock's own sell path

--- a/tests/envs/alpaca/test_torch_env.py
+++ b/tests/envs/alpaca/test_torch_env.py
@@ -4,6 +4,8 @@ Unit tests for AlpacaTorchTradingEnv (TorchRL-style environment).
 Tests environment initialization, reset, step, and trading mechanics using mock clients.
 """
 
+from unittest.mock import MagicMock
+
 import pytest
 import torch
 from tensordict import TensorDict
@@ -254,6 +256,44 @@ class TestAlpacaTorchTradingEnvStep:
         env._step(td_sell)
 
         assert env.position.current_position == 0
+
+    def test_reenters_after_external_position_close(self, env):
+        """A position closed on the exchange must not leave the guard refusing to re-enter.
+
+        Regression: current_position/current_action_level are written only by the env's OWN
+        trades, so a liquidation (or a manual close in the exchange UI) left them stale. The
+        duplicate-action guard then silently no-op'd an agent that re-requested the level it
+        used to hold -- and kept refusing for the REST of the episode.
+
+        Both halves matter. The guard must still suppress a redundant trade while the position
+        is genuinely held, or a fix that simply resynced on every step would pass this too.
+        """
+        buy = TensorDict({"action": torch.tensor(2)}, batch_size=())
+
+        env.reset()
+        env._step(buy)
+        assert env.trader.position_qty > 0        # opened
+
+        # Still holding it: re-commanding the same level is redundant, guard must suppress.
+        env.trader.trade = MagicMock(wraps=env.trader.trade)
+        env._step(buy)
+        env.trader.trade.assert_not_called()
+
+        # The position is closed out from under us -- on spot that means a manual close in
+        # the Alpaca UI. The proceeds return to cash, exactly as the mock's own sell path
+        # does; without that the env would rightly refuse to size a trade against a zero
+        # portfolio, and this test would pass for the wrong reason.
+        env.trader.cash += env.trader.position_qty * env.trader.current_price
+        env.trader.position_qty = 0.0
+        env.trader.position_value = 0.0
+        env.trader.avg_entry_price = 0.0
+
+        env._step(buy)                            # agent still wants to be long
+
+        assert env.trader.position_qty > 0, (
+            "env did not re-enter after an external close -- the duplicate-action guard is "
+            "still trusting the stale pre-close action level"
+        )
 
     def test_step_hold_action(self, env):
         """Test hold action (action=0 -> 0.0, close/neutral)."""

--- a/tests/envs/alpaca/test_torch_env.py
+++ b/tests/envs/alpaca/test_torch_env.py
@@ -390,6 +390,35 @@ class TestAlpacaTorchTradingEnvStep:
         assert leverage == 1.0                     # spot
         assert dist == 1.0                         # spot: no liquidation
 
+    def test_reentry_after_external_close_starts_a_fresh_holding_time(self, env):
+        """A re-entry made in the SAME step as an external close must not inherit its age.
+
+        The sync detects the close and lets the guard re-enter -- but if it does not discard
+        hold_counter, the trade that re-enters in that same _step increments the DEAD
+        position's counter, and the policy is handed a brand-new position as N+1 bars old.
+
+        The other re-entry tests only assert that trade() was called, so they cannot see this.
+        """
+        buy = TensorDict({"action": torch.tensor(2)}, batch_size=())
+
+        env.reset()
+        for _ in range(5):
+            env._step(buy)
+        assert env.position.hold_counter == 5
+
+        # liquidated between steps; proceeds return to cash
+        env.trader.cash += env.trader.position_qty * env.trader.current_price
+        env.trader.position_qty = 0.0
+        env.trader.position_value = 0.0
+        env.trader.avg_entry_price = 0.0
+
+        td = env._step(buy)                     # same-step re-entry at the same level
+
+        assert env.trader.position_qty > 0      # it really did re-enter
+        assert td["account_state"][3].item() == 1.0, (
+            "a position opened after a liquidation inherited the dead position's age"
+        )
+
 
 class TestAlpacaTorchTradingEnvReward:
     """Tests for reward calculation."""

--- a/tests/envs/alpaca/test_torch_env.py
+++ b/tests/envs/alpaca/test_torch_env.py
@@ -177,10 +177,26 @@ class TestAlpacaTorchTradingEnvReset:
 
         assert td[env.account_state_key].dtype == torch.float32
 
-    def test_reset_resets_position_counter(self, env):
-        """Test that reset resets position hold counter."""
+    def test_reset_clears_the_holding_time_of_the_previous_episode(self, env):
+        """Reset must zero hold_counter, or episode 2 inherits episode 1's age.
+
+        Asserting it on a FRESH env proves nothing -- PositionState already defaults it to 0,
+        so the assertion passes whether or not _reset zeroes anything. It has to be aged
+        first. Without this, an agent opens the next episode seeing a position it has "held"
+        for bars it never traded.
+        """
+        env._wait_for_next_timestamp = lambda: None
         env.reset()
+
+        buy = TensorDict({"action": torch.tensor(2)}, batch_size=())
+        for _ in range(5):
+            env._step(buy)
+        assert env.position.hold_counter > 0        # genuinely aged
+
+        td = env.reset()                            # position still open on the exchange
+
         assert env.position.hold_counter == 0
+        assert td["account_state"][3].item() == 0.0
 
     def test_reset_reads_dust_as_flat(self, env):
         """A dust residual on reset is flat -- internally AND in what the agent sees.

--- a/tests/envs/alpaca/test_torch_env.py
+++ b/tests/envs/alpaca/test_torch_env.py
@@ -180,10 +180,8 @@ class TestAlpacaTorchTradingEnvReset:
     def test_reset_clears_the_holding_time_of_the_previous_episode(self, env):
         """Reset must zero hold_counter, or episode 2 inherits episode 1's age.
 
-        Asserting it on a FRESH env proves nothing -- PositionState already defaults it to 0,
-        so the assertion passes whether or not _reset zeroes anything. It has to be aged
-        first. Without this, an agent opens the next episode seeing a position it has "held"
-        for bars it never traded.
+        Asserting it on a fresh env proves nothing (PositionState defaults it to 0), so the
+        counter is aged first. Also pins that an OPEN position looks open.
         """
         env._wait_for_next_timestamp = lambda: None
         env.reset()
@@ -199,15 +197,10 @@ class TestAlpacaTorchTradingEnvReset:
         assert td["account_state"][3].item() == 0.0
 
     def test_reset_reads_dust_as_flat(self, env):
-        """A dust residual on reset is flat -- internally AND in what the agent sees.
+        """A dust residual (1e-12) left behind a close must read as FLAT, not as a position.
 
-        A close can leave a float residue (1e-12) behind, with a STALE entry price and market
-        value still attached. Read as an open position, those stale fields become the agent's
-        exposure and unrealized PnL for a position that does not exist.
-
-        The stale values are the whole point: an earlier version of this test zeroed them, so
-        every element it checked was already 0 whatever the code did, and the fix it was
-        guarding could be deleted with the suite still green.
+        The fixture is hostile in every field on purpose: a zeroed one made every element
+        read 0 whatever the code did.
         """
         env.trader.position_qty = 1e-12
         env.trader.position_value = 41.82        # stale market value left on the residual
@@ -303,13 +296,8 @@ class TestAlpacaTorchTradingEnvStep:
     def test_reenters_after_external_position_close(self, env):
         """A position closed on the exchange must not leave the guard refusing to re-enter.
 
-        Regression: current_position/current_action_level are written only by the env's OWN
-        trades, so a liquidation (or a manual close in the exchange UI) left them stale. The
-        duplicate-action guard then silently no-op'd an agent that re-requested the level it
-        used to hold -- and kept refusing for the REST of the episode.
-
-        Both halves matter. The guard must still suppress a redundant trade while the position
-        is genuinely held, or a fix that simply resynced on every step would pass this too.
+        Both halves matter: the guard must still suppress a genuinely redundant re-command,
+        or a fix that resynced on every step would pass too.
         """
         buy = TensorDict({"action": torch.tensor(2)}, batch_size=())
 
@@ -365,13 +353,8 @@ class TestAlpacaTorchTradingEnvStep:
     def test_closing_a_position_does_not_age_the_next_one(self, env):
         """A closed position's age must not carry into the next one.
 
-        hold 5 bars -> close -> open again. Without the reset on close, the brand-new position
-        is reported to the policy as 6 bars old. The close can be the agent's own flat command
-        OR the external liquidation this branch resyncs -- the counter is the same either way.
-
-        This is the alpaca/binance counterpart of the bitget/bybit/okx dust-between-positions
-        test: those manage hold_counter in _get_observation, these two in _step, so the line
-        that needs pinning lives somewhere else.
+        The alpaca/binance counterpart of dust_between_positions: these two manage
+        hold_counter in _step, not in the observation branch.
         """
         buy = TensorDict({"action": torch.tensor(2)}, batch_size=())    # levels [0.0, 0.5, 1.0]
         flat = TensorDict({"action": torch.tensor(0)}, batch_size=())
@@ -390,12 +373,8 @@ class TestAlpacaTorchTradingEnvStep:
     def test_open_position_looks_open(self, env):
         """An OPEN position must look open in the vector the policy consumes.
 
-        Every other account_state assertion on this branch checks that a FLAT account reads
-        flat -- because that was the bug. The inverse was unpinned: corrupting exposure,
-        direction or unrealized PnL while genuinely open shipped with the whole suite green.
-        That is the same class of bug, pointing the other way.
-
-        Values measured off the mock, not computed.
+        Every other assertion here checks that a FLAT account reads flat -- the inverse was
+        unpinned, and shipped green.
         """
         env.reset()
         env._step(TensorDict({"action": torch.tensor(2)}, batch_size=()))   # buy at 100000

--- a/tests/envs/alpaca/test_torch_env.py
+++ b/tests/envs/alpaca/test_torch_env.py
@@ -221,7 +221,9 @@ class TestAlpacaTorchTradingEnvReset:
         assert exposure == 0.0        # no position -> no exposure, whatever value is attached
         assert direction == 0.0
         assert unrealized_pnl == 0.0  # a position that does not exist cannot be up 122%
-        assert holding_time == 0.0
+        # NOT asserting holding_time here: alpaca manages hold_counter in _step, so at reset it
+        # is 0 in BOTH branches whatever the dust rule does -- the assertion would be dead.
+        # test_closing_a_position_does_not_age_the_next_one covers it where it can actually fail.
 
 
 class TestAlpacaTorchTradingEnvStep:
@@ -359,6 +361,31 @@ class TestAlpacaTorchTradingEnvStep:
         # Account state: [cash, position_size, position_value, entry_price, current_price, unrealized_pnlpc, holding_time]
         account_state = td_out[env.account_state_key]
         assert account_state[1] > 0  # position_size > 0
+
+    def test_closing_a_position_does_not_age_the_next_one(self, env):
+        """A closed position's age must not carry into the next one.
+
+        hold 5 bars -> close -> open again. Without the reset on close, the brand-new position
+        is reported to the policy as 6 bars old. The close can be the agent's own flat command
+        OR the external liquidation this branch resyncs -- the counter is the same either way.
+
+        This is the alpaca/binance counterpart of the bitget/bybit/okx dust-between-positions
+        test: those manage hold_counter in _get_observation, these two in _step, so the line
+        that needs pinning lives somewhere else.
+        """
+        buy = TensorDict({"action": torch.tensor(2)}, batch_size=())    # levels [0.0, 0.5, 1.0]
+        flat = TensorDict({"action": torch.tensor(0)}, batch_size=())
+
+        env.reset()
+        for _ in range(5):
+            env._step(buy)
+        assert env.position.hold_counter == 5          # genuinely aged
+
+        env._step(flat)                                # closed -- the age must go with it
+        assert env.position.hold_counter == 0
+
+        td = env._step(buy)                            # a BRAND NEW position
+        assert td["account_state"][3].item() == 1.0, "a new position reported as older than 1 bar"
 
 
 class TestAlpacaTorchTradingEnvReward:

--- a/tests/envs/alpaca/test_torch_env.py
+++ b/tests/envs/alpaca/test_torch_env.py
@@ -195,7 +195,7 @@ class TestAlpacaTorchTradingEnvReset:
         """
         env.trader.position_qty = 1e-12
         env.trader.position_value = 41.82        # stale market value left on the residual
-        env.trader.avg_entry_price = 45000.0     # stale entry -> a fake +22% unrealized PnL
+        env.trader.avg_entry_price = 45000.0     # stale entry -> a fake +122% unrealized PnL
 
         td = env.reset()
 
@@ -204,7 +204,7 @@ class TestAlpacaTorchTradingEnvReset:
         exposure, direction, unrealized_pnl, holding_time, _lev, _dist = td["account_state"].tolist()
         assert exposure == 0.0        # no position -> no exposure, whatever value is attached
         assert direction == 0.0
-        assert unrealized_pnl == 0.0  # a position that does not exist cannot be up 22%
+        assert unrealized_pnl == 0.0  # a position that does not exist cannot be up 122%
         assert holding_time == 0.0
 
 

--- a/tests/envs/binance/test_torch_env_futures.py
+++ b/tests/envs/binance/test_torch_env_futures.py
@@ -317,7 +317,7 @@ class TestBinanceFuturesTorchTradingEnv:
 
         mock_trader.get_status = MagicMock(return_value={"position_status": PositionStatus(
             qty=0.01, notional_value=500.0, entry_price=50000.0, unrealized_pnl=0.0,
-            unrealized_pnl_pct=0.0, mark_price=50000.0, leverage=5,
+            unrealized_pnl_pct=0.0, mark_price=50000.0, leverage=20,   # NOT the config's 5
             margin_type="isolated", liquidation_price=45000.0,
         )})
 
@@ -344,7 +344,10 @@ class TestBinanceFuturesTorchTradingEnv:
         exposure, direction, _pnl, holding_time, leverage, dist_to_liq = td["account_state"].tolist()
         assert direction == 1.0
         assert exposure == 0.5                       # 500 notional / 1000 balance
-        assert leverage == 5.0
+        # 20, the POSITION's leverage -- not the config's 5. They are deliberately different:
+        # with both set to 5 this assertion could not tell "reports the open position's
+        # leverage" from a regression to "always reports the config's".
+        assert leverage == 20.0
         assert dist_to_liq == pytest.approx(0.1)     # (50000 - 45000) / 50000
         assert holding_time == 0.0
 

--- a/tests/envs/binance/test_torch_env_futures.py
+++ b/tests/envs/binance/test_torch_env_futures.py
@@ -230,6 +230,45 @@ class TestBinanceFuturesTorchTradingEnv:
         env.close()
         mock_trader.cancel_open_orders.assert_called()
 
+    def test_reenters_after_external_position_close(self, env, mock_trader):
+        """A position closed on the exchange must not leave the guard refusing to re-enter.
+
+        Regression: current_position/current_action_level are written only by the env's OWN
+        trades, so a liquidation (or a manual close in the exchange UI) left them stale. The
+        duplicate-action guard then silently no-op'd an agent that re-requested the level it
+        used to hold -- and kept refusing for the REST of the episode.
+
+        Both halves matter. The guard must still suppress a redundant trade while the
+        position is genuinely held, or a fix that just resyncs on every step would pass.
+        """
+        from torchtrade.envs.live.binance.order_executor import PositionStatus
+
+        with patch.object(env, "_wait_for_next_timestamp"):
+            env.reset()
+            long_idx = len(env.action_levels) - 1
+
+            # 1. Agent opens a long.
+            env.step(TensorDict({"action": torch.tensor(long_idx)}, batch_size=()))
+            mock_trader.trade.assert_called()
+
+            # 2. Exchange confirms the position. Re-commanding the SAME level is redundant.
+            mock_trader.get_status = MagicMock(return_value={"position_status": PositionStatus(
+                qty=0.01, notional_value=500.0, entry_price=50000.0, unrealized_pnl=0.0,
+                unrealized_pnl_pct=0.0, mark_price=50000.0, leverage=5,
+                margin_type="isolated", liquidation_price=45000.0,
+            )})
+            mock_trader.trade.reset_mock()
+            env.step(TensorDict({"action": torch.tensor(long_idx)}, batch_size=()))
+            mock_trader.trade.assert_not_called()   # guard still works
+
+            # 3. The exchange liquidates it out from under us.
+            mock_trader.get_status = MagicMock(return_value={"position_status": None})
+            mock_trader.trade.reset_mock()
+            env.step(TensorDict({"action": torch.tensor(long_idx)}, batch_size=()))
+
+            # The agent still wants to be long -> the env must actually re-enter.
+            mock_trader.trade.assert_called()
+
 
 class TestBinanceFuturesTradingEnvConfig:
     """Tests for BinanceFuturesTradingEnvConfig."""

--- a/tests/envs/binance/test_torch_env_futures.py
+++ b/tests/envs/binance/test_torch_env_futures.py
@@ -305,7 +305,6 @@ class TestBinanceFuturesTorchTradingEnv:
         assert leverage == 5.0        # the CONFIG leverage, not the 20 on the residual
         assert dist_to_liq == 1.0     # no position -> no liquidation to be near
 
-
 class TestBinanceFuturesTradingEnvConfig:
     """Tests for BinanceFuturesTradingEnvConfig."""
 

--- a/tests/envs/binance/test_torch_env_futures.py
+++ b/tests/envs/binance/test_torch_env_futures.py
@@ -269,6 +269,26 @@ class TestBinanceFuturesTorchTradingEnv:
             # The agent still wants to be long -> the env must actually re-enter.
             mock_trader.trade.assert_called()
 
+    def test_reset_reads_dust_as_flat(self, env, mock_trader):
+        """A dust residual on reset must not become a phantom position.
+
+        An exchange can leave a float residue (1e-12) behind a full close. Reading it as an
+        open position puts a position in account_state that the agent does not hold -- and
+        _step, which applies the dust rule, would disagree with _reset about the same state.
+        """
+        from torchtrade.envs.live.binance.order_executor import PositionStatus
+
+        mock_trader.get_status = MagicMock(return_value={"position_status": PositionStatus(
+            qty=1e-12, notional_value=0.0, entry_price=50000.0, unrealized_pnl=0.0,
+            unrealized_pnl_pct=0.0, mark_price=50000.0, leverage=5,
+            margin_type="isolated", liquidation_price=0.0,
+        )})
+
+        with patch.object(env, "_wait_for_next_timestamp"):
+            env.reset()
+
+        assert env.position.current_position == 0
+
 
 class TestBinanceFuturesTradingEnvConfig:
     """Tests for BinanceFuturesTradingEnvConfig."""

--- a/tests/envs/binance/test_torch_env_futures.py
+++ b/tests/envs/binance/test_torch_env_futures.py
@@ -335,7 +335,18 @@ class TestBinanceFuturesTorchTradingEnv:
         # _get_observation, so the reset observation does not count a bar. The bug either way
         # is the previous episode's age surviving the reset.
         assert env.position.hold_counter == 0, f"reset carried {aged} bars into the new episode"
-        assert td["account_state"][3].item() == 0.0
+
+        # An OPEN position must look OPEN. Every other account_state assertion on this branch
+        # checks that a FLAT account reads flat -- the inverse was unpinned, and forcing
+        # position_direction to 0 (so the flat branch is always taken) left the whole suite
+        # green while handing the policy a healthy long as flat, unlevered and far from
+        # liquidation. Values measured, not computed.
+        exposure, direction, _pnl, holding_time, leverage, dist_to_liq = td["account_state"].tolist()
+        assert direction == 1.0
+        assert exposure == 0.5                       # 500 notional / 1000 balance
+        assert leverage == 5.0
+        assert dist_to_liq == pytest.approx(0.1)     # (50000 - 45000) / 50000
+        assert holding_time == 0.0
 
     def test_closing_a_position_does_not_age_the_next_one(self, env, mock_trader):
         """A closed position's age must not carry into the next one.

--- a/tests/envs/binance/test_torch_env_futures.py
+++ b/tests/envs/binance/test_torch_env_futures.py
@@ -297,11 +297,12 @@ class TestBinanceFuturesTorchTradingEnv:
         # passed 0.0 for notional / pnl / liquidation_price -- the exact values that make the
         # position branch produce a flat-looking vector whatever the code does, so the bug it
         # was guarding could be deleted with the suite green.
-        exposure, direction, pnl, holding_time, leverage, dist_to_liq = td["account_state"].tolist()
+        exposure, direction, pnl, _holding_time, leverage, dist_to_liq = td["account_state"].tolist()
         assert exposure == 0.0        # 500 notional attached to a position that is not there
         assert direction == 0.0
         assert pnl == 0.0             # a position that does not exist cannot be up 5.26%
-        assert holding_time == 0.0    # nor can it have been held for a bar
+        # NOT asserting holding_time: binance manages hold_counter in _step, so at reset it is 0
+        # in BOTH branches whatever the dust rule does -- the assertion would be dead.
         assert leverage == 5.0        # the CONFIG leverage, not the 20 on the residual
         assert dist_to_liq == 1.0     # no position -> no liquidation to be near
 
@@ -335,6 +336,36 @@ class TestBinanceFuturesTorchTradingEnv:
         # is the previous episode's age surviving the reset.
         assert env.position.hold_counter == 0, f"reset carried {aged} bars into the new episode"
         assert td["account_state"][3].item() == 0.0
+
+    def test_closing_a_position_does_not_age_the_next_one(self, env, mock_trader):
+        """A closed position's age must not carry into the next one.
+
+        hold 5 bars -> close -> open again. Without the reset on close, the brand-new position
+        is reported to the policy as 6 bars old. The close can be the agent's own flat command
+        OR the external liquidation this branch resyncs -- the counter is the same either way.
+
+        This is the alpaca/binance counterpart of the bitget/bybit/okx dust-between-positions
+        test: those manage hold_counter in _get_observation, these two in _step, so the line
+        that needs pinning lives somewhere else.
+        """
+        long = TensorDict({"action": torch.tensor(2)}, batch_size=())   # levels [-1, 0, 1]
+        flat = TensorDict({"action": torch.tensor(1)}, batch_size=())
+
+        with patch.object(env, "_wait_for_next_timestamp"):
+            env.reset()
+            for _ in range(5):
+                env._step(long)
+            assert env.position.hold_counter == 5      # genuinely aged
+
+            env._step(flat)                            # closed -- the age must go with it
+            assert env.position.hold_counter == 0
+
+            env._step(long)                            # a BRAND NEW position
+
+        # Asserting the counter, not account_state[3]: this fixture's trader reports no
+        # position_status, so the observation takes the flat branch and would read 0.0 either
+        # way. The counter is the value the missing reset actually corrupts.
+        assert env.position.hold_counter == 1, "a new position starts older than 1 bar"
 
 
 class TestBinanceFuturesTradingEnvConfig:

--- a/tests/envs/binance/test_torch_env_futures.py
+++ b/tests/envs/binance/test_torch_env_futures.py
@@ -304,6 +304,7 @@ class TestBinanceFuturesTorchTradingEnv:
         assert holding_time == 0.0    # nor can it have been held for a bar
         assert leverage == 5.0        # the CONFIG leverage, not the 20 on the residual
         assert dist_to_liq == 1.0     # no position -> no liquidation to be near
+
     def test_reset_clears_the_holding_time_of_the_previous_episode(self, env, mock_trader):
         """Reset must zero hold_counter, or episode 2 inherits episode 1's age.
 

--- a/tests/envs/binance/test_torch_env_futures.py
+++ b/tests/envs/binance/test_torch_env_futures.py
@@ -270,11 +270,14 @@ class TestBinanceFuturesTorchTradingEnv:
             mock_trader.trade.assert_called()
 
     def test_reset_reads_dust_as_flat(self, env, mock_trader):
-        """A dust residual on reset must not become a phantom position.
+        """A dust residual on reset is flat -- internally AND in what the agent sees.
 
-        An exchange can leave a float residue (1e-12) behind a full close. Reading it as an
-        open position puts a position in account_state that the agent does not hold -- and
-        _step, which applies the dust rule, would disagree with _reset about the same state.
+        An exchange can leave a float residue (1e-12) behind a full close. Read as an open
+        position it puts a phantom direction in account_state with zero exposure -- an
+        observation the policy never saw in training -- and freezes the trade guard.
+
+        Behavioural on purpose: the structural guard that every _reset uses the shared rule
+        can be dodged by moving the derivation into a helper. This cannot.
         """
         from torchtrade.envs.live.binance.order_executor import PositionStatus
 
@@ -285,14 +288,10 @@ class TestBinanceFuturesTorchTradingEnv:
         )})
 
         with patch.object(env, "_wait_for_next_timestamp"):
-            env.reset()
+            td = env.reset()
 
         assert env.position.current_position == 0
-
-
-class TestBinanceFuturesTradingEnvConfig:
-    """Tests for BinanceFuturesTradingEnvConfig."""
-
+        assert td["account_state"][1].item() == 0.0   # the direction the AGENT sees
 
     def test_custom_config(self):
         """Test custom configuration."""

--- a/tests/envs/binance/test_torch_env_futures.py
+++ b/tests/envs/binance/test_torch_env_futures.py
@@ -316,8 +316,8 @@ class TestBinanceFuturesTorchTradingEnv:
         from torchtrade.envs.live.binance.order_executor import PositionStatus
 
         mock_trader.get_status = MagicMock(return_value={"position_status": PositionStatus(
-            qty=0.01, notional_value=500.0, entry_price=50000.0, unrealized_pnl=0.0,
-            unrealized_pnl_pct=0.0, mark_price=50000.0, leverage=20,   # NOT the config's 5
+            qty=0.01, notional_value=500.0, entry_price=47500.0, unrealized_pnl=26.3,
+            unrealized_pnl_pct=0.0526, mark_price=50000.0, leverage=20,  # NOT the config's 5
             margin_type="isolated", liquidation_price=45000.0,
         )})
 
@@ -341,8 +341,9 @@ class TestBinanceFuturesTorchTradingEnv:
         # position_direction to 0 (so the flat branch is always taken) left the whole suite
         # green while handing the policy a healthy long as flat, unlevered and far from
         # liquidation. Values measured, not computed.
-        exposure, direction, _pnl, holding_time, leverage, dist_to_liq = td["account_state"].tolist()
+        exposure, direction, pnl, holding_time, leverage, dist_to_liq = td["account_state"].tolist()
         assert direction == 1.0
+        assert pnl == pytest.approx(0.0526)          # was unpacked and never asserted
         assert exposure == 0.5                       # 500 notional / 1000 balance
         # 20, the POSITION's leverage -- not the config's 5. They are deliberately different:
         # with both set to 5 this assertion could not tell "reports the open position's

--- a/tests/envs/binance/test_torch_env_futures.py
+++ b/tests/envs/binance/test_torch_env_futures.py
@@ -273,8 +273,9 @@ class TestBinanceFuturesTorchTradingEnv:
         """A dust residual on reset is flat -- internally AND in what the agent sees.
 
         An exchange can leave a float residue (1e-12) behind a full close. Read as an open
-        position it puts a phantom direction in account_state with zero exposure -- an
-        observation the policy never saw in training -- and freezes the trade guard.
+        position it poisons the vector the policy consumes: a direction and a holding_time and
+        a distance-to-liquidation for a position that does not exist, at zero exposure. The
+        policy never saw that combination in training.
 
         Behavioural on purpose: the structural guard that every _reset uses the shared rule
         can be dodged by moving the derivation into a helper. This cannot.
@@ -284,14 +285,26 @@ class TestBinanceFuturesTorchTradingEnv:
         mock_trader.get_status = MagicMock(return_value={"position_status": PositionStatus(
             qty=1e-12, notional_value=0.0, entry_price=50000.0, unrealized_pnl=0.0,
             unrealized_pnl_pct=0.0, mark_price=50000.0, leverage=5,
-            margin_type="isolated", liquidation_price=0.0,
+            margin_type="isolated", liquidation_price=48000.0,
         )})
 
         with patch.object(env, "_wait_for_next_timestamp"):
             td = env.reset()
 
         assert env.position.current_position == 0
-        assert td["account_state"][1].item() == 0.0   # the direction the AGENT sees
+
+        # Every element the dust used to poison. liquidation_price is STALE (48000) on
+        # purpose: passing 0.0 short-circuits the distance_to_liquidation branch and makes
+        # element [5] look correct whatever the code does.
+        exposure, direction, _pnl, holding_time, _lev, dist_to_liq = td["account_state"].tolist()
+        assert exposure == 0.0
+        assert direction == 0.0
+        assert holding_time == 0.0     # flat, so it cannot have been "held" for a bar
+        assert dist_to_liq == 1.0      # no position -> no liquidation to be near
+
+
+class TestBinanceFuturesTradingEnvConfig:
+    """Tests for BinanceFuturesTradingEnvConfig."""
 
     def test_custom_config(self):
         """Test custom configuration."""

--- a/tests/envs/binance/test_torch_env_futures.py
+++ b/tests/envs/binance/test_torch_env_futures.py
@@ -283,8 +283,8 @@ class TestBinanceFuturesTorchTradingEnv:
         from torchtrade.envs.live.binance.order_executor import PositionStatus
 
         mock_trader.get_status = MagicMock(return_value={"position_status": PositionStatus(
-            qty=1e-12, notional_value=0.0, entry_price=50000.0, unrealized_pnl=0.0,
-            unrealized_pnl_pct=0.0, mark_price=50000.0, leverage=5,
+            qty=1e-12, notional_value=500.0, entry_price=47500.0, unrealized_pnl=26.3,
+            unrealized_pnl_pct=0.0526, mark_price=50000.0, leverage=20,
             margin_type="isolated", liquidation_price=48000.0,
         )})
 
@@ -293,14 +293,17 @@ class TestBinanceFuturesTorchTradingEnv:
 
         assert env.position.current_position == 0
 
-        # Every element the dust used to poison. liquidation_price is STALE (48000) on
-        # purpose: passing 0.0 short-circuits the distance_to_liquidation branch and makes
-        # element [5] look correct whatever the code does.
-        exposure, direction, _pnl, holding_time, _lev, dist_to_liq = td["account_state"].tolist()
-        assert exposure == 0.0
+        # EVERY field on the residual is hostile on purpose. Earlier versions of this test
+        # passed 0.0 for notional / pnl / liquidation_price -- the exact values that make the
+        # position branch produce a flat-looking vector whatever the code does, so the bug it
+        # was guarding could be deleted with the suite green.
+        exposure, direction, pnl, holding_time, leverage, dist_to_liq = td["account_state"].tolist()
+        assert exposure == 0.0        # 500 notional attached to a position that is not there
         assert direction == 0.0
-        assert holding_time == 0.0     # flat, so it cannot have been "held" for a bar
-        assert dist_to_liq == 1.0      # no position -> no liquidation to be near
+        assert pnl == 0.0             # a position that does not exist cannot be up 5.26%
+        assert holding_time == 0.0    # nor can it have been held for a bar
+        assert leverage == 5.0        # the CONFIG leverage, not the 20 on the residual
+        assert dist_to_liq == 1.0     # no position -> no liquidation to be near
 
 
 class TestBinanceFuturesTradingEnvConfig:

--- a/tests/envs/binance/test_torch_env_futures.py
+++ b/tests/envs/binance/test_torch_env_futures.py
@@ -344,27 +344,69 @@ class TestBinanceFuturesTorchTradingEnv:
     def test_closing_a_position_does_not_age_the_next_one(self, env, mock_trader):
         """A closed position's age must not carry into the next one.
 
-        The alpaca/binance counterpart of dust_between_positions: these two manage
-        hold_counter in _step, not in the observation branch.
+        The exchange must report what the env holds -- the bare fixture says "no position"
+        while the env believes it is long, and the sync (correctly) resets the counter on that
+        disagreement every step, so it could never age.
         """
-        long = TensorDict({"action": torch.tensor(2)}, batch_size=())   # levels [-1, 0, 1]
-        flat = TensorDict({"action": torch.tensor(1)}, batch_size=())
+        from torchtrade.envs.live.binance.order_executor import PositionStatus
+
+        def status(qty):
+            return {"position_status": PositionStatus(
+                qty=qty, notional_value=500.0, entry_price=50000.0, unrealized_pnl=0.0,
+                unrealized_pnl_pct=0.0, mark_price=50000.0, leverage=5,
+                margin_type="isolated", liquidation_price=45000.0,
+            )} if qty else {"position_status": None}
 
         with patch.object(env, "_wait_for_next_timestamp"):
+            long = TensorDict({"action": torch.tensor(2)}, batch_size=())   # levels [-1, 0, 1]
+            flat = TensorDict({"action": torch.tensor(1)}, batch_size=())
+
+            mock_trader.get_status = MagicMock(return_value=status(0.01))
             env.reset()
             for _ in range(5):
                 env._step(long)
-            assert env.position.hold_counter == 5      # genuinely aged
+            assert env.position.hold_counter == 5           # genuinely aged
 
-            env._step(flat)                            # closed -- the age must go with it
-            assert env.position.hold_counter == 0
+            mock_trader.get_status = MagicMock(return_value=status(None))   # closed
+            env._step(flat)
+            assert env.position.hold_counter == 0           # the age goes with it
 
-            env._step(long)                            # a BRAND NEW position
+            mock_trader.get_status = MagicMock(return_value=status(0.01))   # a BRAND NEW one
+            env._step(long)
 
-        # Asserting the counter, not account_state[3]: this fixture's trader reports no
-        # position_status, so the observation takes the flat branch and would read 0.0 either
-        # way. The counter is the value the missing reset actually corrupts.
         assert env.position.hold_counter == 1, "a new position starts older than 1 bar"
+    def test_reentry_after_external_close_starts_a_fresh_holding_time(self, env, mock_trader):
+        """A re-entry made in the SAME step as an external close must not inherit its age.
+
+        The sync detects the close and lets the guard re-enter -- but if it does not discard
+        hold_counter, the policy is handed a brand-new position as N+1 bars old.
+        """
+        from torchtrade.envs.live.binance.order_executor import PositionStatus
+
+        def status(qty):
+            return {"position_status": PositionStatus(
+                qty=qty, notional_value=500.0, entry_price=50000.0, unrealized_pnl=0.0,
+                unrealized_pnl_pct=0.0, mark_price=50000.0, leverage=5,
+                margin_type="isolated", liquidation_price=45000.0,
+            )} if qty else {"position_status": None}
+
+        with patch.object(env, "_wait_for_next_timestamp"):
+            long_idx = len(env.action_levels) - 1
+            long = TensorDict({"action": torch.tensor(long_idx)}, batch_size=())
+
+            mock_trader.get_status = MagicMock(return_value=status(0.01))
+            env.reset()
+            for _ in range(5):
+                env.step(long)
+            aged = env.position.hold_counter
+            assert aged > 1
+
+            mock_trader.get_status = MagicMock(return_value=status(None))   # liquidated
+            td = env.step(long)                                          # same-step re-entry
+
+        assert td["next"]["account_state"][3].item() <= 1.0, (
+            f"a position opened after a liquidation inherited the dead position's age ({aged})"
+        )
 
 
 class TestBinanceFuturesTradingEnvConfig:

--- a/tests/envs/binance/test_torch_env_futures.py
+++ b/tests/envs/binance/test_torch_env_futures.py
@@ -233,13 +233,8 @@ class TestBinanceFuturesTorchTradingEnv:
     def test_reenters_after_external_position_close(self, env, mock_trader):
         """A position closed on the exchange must not leave the guard refusing to re-enter.
 
-        Regression: current_position/current_action_level are written only by the env's OWN
-        trades, so a liquidation (or a manual close in the exchange UI) left them stale. The
-        duplicate-action guard then silently no-op'd an agent that re-requested the level it
-        used to hold -- and kept refusing for the REST of the episode.
-
-        Both halves matter. The guard must still suppress a redundant trade while the
-        position is genuinely held, or a fix that just resyncs on every step would pass.
+        Both halves matter: the guard must still suppress a genuinely redundant re-command,
+        or a fix that resynced on every step would pass too.
         """
         from torchtrade.envs.live.binance.order_executor import PositionStatus
 
@@ -270,15 +265,10 @@ class TestBinanceFuturesTorchTradingEnv:
             mock_trader.trade.assert_called()
 
     def test_reset_reads_dust_as_flat(self, env, mock_trader):
-        """A dust residual on reset is flat -- internally AND in what the agent sees.
+        """A dust residual (1e-12) left behind a close must read as FLAT, not as a position.
 
-        An exchange can leave a float residue (1e-12) behind a full close. Read as an open
-        position it poisons the vector the policy consumes: a direction and a holding_time and
-        a distance-to-liquidation for a position that does not exist, at zero exposure. The
-        policy never saw that combination in training.
-
-        Behavioural on purpose: the structural guard that every _reset uses the shared rule
-        can be dodged by moving the derivation into a helper. This cannot.
+        The fixture is hostile in every field on purpose: a zeroed one made every element
+        read 0 whatever the code did.
         """
         from torchtrade.envs.live.binance.order_executor import PositionStatus
 
@@ -309,9 +299,8 @@ class TestBinanceFuturesTorchTradingEnv:
     def test_reset_clears_the_holding_time_of_the_previous_episode(self, env, mock_trader):
         """Reset must zero hold_counter, or episode 2 inherits episode 1's age.
 
-        Asserting it on a FRESH env proves nothing -- PositionState already defaults it to 0.
-        The counter has to be aged first. Without this, an agent opens the next episode seeing
-        a position it has "held" for bars it never traded.
+        Asserting it on a fresh env proves nothing (PositionState defaults it to 0), so the
+        counter is aged first. Also pins that an OPEN position looks open.
         """
         from torchtrade.envs.live.binance.order_executor import PositionStatus
 
@@ -355,13 +344,8 @@ class TestBinanceFuturesTorchTradingEnv:
     def test_closing_a_position_does_not_age_the_next_one(self, env, mock_trader):
         """A closed position's age must not carry into the next one.
 
-        hold 5 bars -> close -> open again. Without the reset on close, the brand-new position
-        is reported to the policy as 6 bars old. The close can be the agent's own flat command
-        OR the external liquidation this branch resyncs -- the counter is the same either way.
-
-        This is the alpaca/binance counterpart of the bitget/bybit/okx dust-between-positions
-        test: those manage hold_counter in _get_observation, these two in _step, so the line
-        that needs pinning lives somewhere else.
+        The alpaca/binance counterpart of dust_between_positions: these two manage
+        hold_counter in _step, not in the observation branch.
         """
         long = TensorDict({"action": torch.tensor(2)}, batch_size=())   # levels [-1, 0, 1]
         flat = TensorDict({"action": torch.tensor(1)}, batch_size=())

--- a/tests/envs/binance/test_torch_env_futures.py
+++ b/tests/envs/binance/test_torch_env_futures.py
@@ -304,6 +304,37 @@ class TestBinanceFuturesTorchTradingEnv:
         assert holding_time == 0.0    # nor can it have been held for a bar
         assert leverage == 5.0        # the CONFIG leverage, not the 20 on the residual
         assert dist_to_liq == 1.0     # no position -> no liquidation to be near
+    def test_reset_clears_the_holding_time_of_the_previous_episode(self, env, mock_trader):
+        """Reset must zero hold_counter, or episode 2 inherits episode 1's age.
+
+        Asserting it on a FRESH env proves nothing -- PositionState already defaults it to 0.
+        The counter has to be aged first. Without this, an agent opens the next episode seeing
+        a position it has "held" for bars it never traded.
+        """
+        from torchtrade.envs.live.binance.order_executor import PositionStatus
+
+        mock_trader.get_status = MagicMock(return_value={"position_status": PositionStatus(
+            qty=0.01, notional_value=500.0, entry_price=50000.0, unrealized_pnl=0.0,
+            unrealized_pnl_pct=0.0, mark_price=50000.0, leverage=5,
+            margin_type="isolated", liquidation_price=45000.0,
+        )})
+
+        with patch.object(env, "_wait_for_next_timestamp"):
+            env.reset()
+            long_idx = len(env.action_levels) - 1     # index 1 is FLAT here ([-1, 0, 1])
+            for _ in range(5):
+                env.step(TensorDict({"action": torch.tensor(long_idx)}, batch_size=()))
+            assert env.position.hold_counter > 0      # genuinely aged
+
+            aged = env.position.hold_counter
+            td = env.reset()                         # position still open on the exchange
+
+        # 0 here, unlike bitget/bybit/okx: binance increments hold_counter in _step, not in
+        # _get_observation, so the reset observation does not count a bar. The bug either way
+        # is the previous episode's age surviving the reset.
+        assert env.position.hold_counter == 0, f"reset carried {aged} bars into the new episode"
+        assert td["account_state"][3].item() == 0.0
+
 
 class TestBinanceFuturesTradingEnvConfig:
     """Tests for BinanceFuturesTradingEnvConfig."""

--- a/tests/envs/bitget/test_torch_env_futures.py
+++ b/tests/envs/bitget/test_torch_env_futures.py
@@ -365,8 +365,8 @@ class TestBitgetFuturesTorchTradingEnv:
         from torchtrade.envs.live.bitget.order_executor import PositionStatus
 
         mock_trader.get_status = MagicMock(return_value={"position_status": PositionStatus(
-            qty=1e-12, notional_value=0.0, entry_price=50000.0, unrealized_pnl=0.0,
-            unrealized_pnl_pct=0.0, mark_price=50000.0, leverage=5,
+            qty=1e-12, notional_value=500.0, entry_price=47500.0, unrealized_pnl=26.3,
+            unrealized_pnl_pct=0.0526, mark_price=50000.0, leverage=20,
             margin_mode="isolated", liquidation_price=48000.0,
         )})
 
@@ -375,14 +375,17 @@ class TestBitgetFuturesTorchTradingEnv:
 
         assert env.position.current_position == 0
 
-        # Every element the dust used to poison. liquidation_price is STALE (48000) on
-        # purpose: passing 0.0 short-circuits the distance_to_liquidation branch and makes
-        # element [5] look correct whatever the code does.
-        exposure, direction, _pnl, holding_time, _lev, dist_to_liq = td["account_state"].tolist()
-        assert exposure == 0.0
+        # EVERY field on the residual is hostile on purpose. Earlier versions of this test
+        # passed 0.0 for notional / pnl / liquidation_price -- the exact values that make the
+        # position branch produce a flat-looking vector whatever the code does, so the bug it
+        # was guarding could be deleted with the suite green.
+        exposure, direction, pnl, holding_time, leverage, dist_to_liq = td["account_state"].tolist()
+        assert exposure == 0.0        # 500 notional attached to a position that is not there
         assert direction == 0.0
-        assert holding_time == 0.0     # flat, so it cannot have been "held" for a bar
-        assert dist_to_liq == 1.0      # no position -> no liquidation to be near
+        assert pnl == 0.0             # a position that does not exist cannot be up 5.26%
+        assert holding_time == 0.0    # nor can it have been held for a bar
+        assert leverage == 5.0        # the CONFIG leverage, not the 20 on the residual
+        assert dist_to_liq == 1.0     # no position -> no liquidation to be near
 
 
 class TestBitgetFractionalPositionResizing:

--- a/tests/envs/bitget/test_torch_env_futures.py
+++ b/tests/envs/bitget/test_torch_env_futures.py
@@ -409,6 +409,40 @@ class TestBitgetFuturesTorchTradingEnv:
                 holding_time = td["next"]["account_state"][3].item()
                 assert holding_time == 0.0, f"dust accrued holding_time={holding_time} by bar {bar}"
 
+    def test_dust_between_positions_does_not_age_the_next_one(self, env, mock_trader):
+        """A residual left between two positions must not carry the old age into the new one.
+
+        Real position held N bars -> closed, leaving dust -> a NEW position opens. If the dust
+        bar does not reset the counter, the fresh position is reported as N+2 bars old. This
+        is what the `hold_counter = 0` in the dust branch is for; nothing else pins it.
+        """
+        from torchtrade.envs.live.bitget.order_executor import PositionStatus
+
+        def status(qty):
+            return {"position_status": PositionStatus(
+                qty=qty, notional_value=500.0, entry_price=50000.0, unrealized_pnl=0.0,
+                unrealized_pnl_pct=0.0, mark_price=50000.0, leverage=5,
+                margin_mode="isolated", liquidation_price=45000.0,
+            )}
+
+        with patch.object(env, "_wait_for_next_timestamp"):
+            mock_trader.get_status = MagicMock(return_value=status(0.01))
+            env.reset()
+            for _ in range(5):                       # age a real position
+                env.step(TensorDict({"action": torch.tensor(1)}, batch_size=()))
+
+            mock_trader.get_status = MagicMock(return_value=status(1e-12))   # closed -> dust
+            env.step(TensorDict({"action": torch.tensor(1)}, batch_size=()))
+
+            mock_trader.get_status = MagicMock(return_value=status(0.01))    # a NEW position
+            td = env.step(TensorDict({"action": torch.tensor(1)}, batch_size=()))
+
+        holding_time = td["next"]["account_state"][3].item()
+        assert holding_time == 1.0, (
+            f"a brand-new position is reported as {holding_time} bars old -- the dust bar "
+            f"between the two did not reset the counter"
+        )
+
 
 class TestBitgetFractionalPositionResizing:
     """Tests for fractional position resizing (regression for #155)."""

--- a/tests/envs/bitget/test_torch_env_futures.py
+++ b/tests/envs/bitget/test_torch_env_futures.py
@@ -355,8 +355,9 @@ class TestBitgetFuturesTorchTradingEnv:
         """A dust residual on reset is flat -- internally AND in what the agent sees.
 
         An exchange can leave a float residue (1e-12) behind a full close. Read as an open
-        position it puts a phantom direction in account_state with zero exposure -- an
-        observation the policy never saw in training -- and freezes the trade guard.
+        position it poisons the vector the policy consumes: a direction and a holding_time and
+        a distance-to-liquidation for a position that does not exist, at zero exposure. The
+        policy never saw that combination in training.
 
         Behavioural on purpose: the structural guard that every _reset uses the shared rule
         can be dodged by moving the derivation into a helper. This cannot.
@@ -366,14 +367,22 @@ class TestBitgetFuturesTorchTradingEnv:
         mock_trader.get_status = MagicMock(return_value={"position_status": PositionStatus(
             qty=1e-12, notional_value=0.0, entry_price=50000.0, unrealized_pnl=0.0,
             unrealized_pnl_pct=0.0, mark_price=50000.0, leverage=5,
-            margin_mode="isolated", liquidation_price=0.0,
+            margin_mode="isolated", liquidation_price=48000.0,
         )})
 
         with patch.object(env, "_wait_for_next_timestamp"):
             td = env.reset()
 
         assert env.position.current_position == 0
-        assert td["account_state"][1].item() == 0.0   # the direction the AGENT sees
+
+        # Every element the dust used to poison. liquidation_price is STALE (48000) on
+        # purpose: passing 0.0 short-circuits the distance_to_liquidation branch and makes
+        # element [5] look correct whatever the code does.
+        exposure, direction, _pnl, holding_time, _lev, dist_to_liq = td["account_state"].tolist()
+        assert exposure == 0.0
+        assert direction == 0.0
+        assert holding_time == 0.0     # flat, so it cannot have been "held" for a bar
+        assert dist_to_liq == 1.0      # no position -> no liquidation to be near
 
 
 class TestBitgetFractionalPositionResizing:

--- a/tests/envs/bitget/test_torch_env_futures.py
+++ b/tests/envs/bitget/test_torch_env_futures.py
@@ -421,6 +421,36 @@ class TestBitgetFuturesTorchTradingEnv:
             f"between the two did not reset the counter"
         )
 
+    def test_reset_clears_the_holding_time_of_the_previous_episode(self, env, mock_trader):
+        """Reset must zero hold_counter, or episode 2 inherits episode 1's age.
+
+        Asserting it on a FRESH env proves nothing -- PositionState already defaults it to 0.
+        The counter has to be aged first. Without this, an agent opens the next episode seeing
+        a position it has "held" for bars it never traded.
+        """
+        from torchtrade.envs.live.bitget.order_executor import PositionStatus
+
+        mock_trader.get_status = MagicMock(return_value={"position_status": PositionStatus(
+            qty=0.01, notional_value=500.0, entry_price=50000.0, unrealized_pnl=0.0,
+            unrealized_pnl_pct=0.0, mark_price=50000.0, leverage=5,
+            margin_mode="isolated", liquidation_price=45000.0,
+        )})
+
+        with patch.object(env, "_wait_for_next_timestamp"):
+            env.reset()
+            for _ in range(5):
+                env.step(TensorDict({"action": torch.tensor(1)}, batch_size=()))
+            assert env.position.hold_counter > 0     # genuinely aged
+
+            aged = env.position.hold_counter
+            td = env.reset()                         # position still open on the exchange
+
+        # 1, not 0: _reset zeroes the counter and then takes an observation, which legitimately
+        # counts the still-open position as bar ONE of the new episode. The bug is it reading
+        # `aged + 1` -- the previous episode's age carried across the reset.
+        assert env.position.hold_counter == 1, f"reset carried {aged} bars into the new episode"
+        assert td["account_state"][3].item() == 1.0
+
 
 class TestBitgetFractionalPositionResizing:
     """Tests for fractional position resizing (regression for #155)."""

--- a/tests/envs/bitget/test_torch_env_futures.py
+++ b/tests/envs/bitget/test_torch_env_futures.py
@@ -311,6 +311,45 @@ class TestBitgetFuturesTorchTradingEnv:
         assert all(isinstance(tf, TimeFrame) for tf in config.time_frames)
         assert config.window_sizes == [10]
 
+    def test_reenters_after_external_position_close(self, env, mock_trader):
+        """A position closed on the exchange must not leave the guard refusing to re-enter.
+
+        Regression: current_position/current_action_level are written only by the env's OWN
+        trades, so a liquidation (or a manual close in the exchange UI) left them stale. The
+        duplicate-action guard then silently no-op'd an agent that re-requested the level it
+        used to hold -- and kept refusing for the REST of the episode.
+
+        Both halves matter. The guard must still suppress a redundant trade while the
+        position is genuinely held, or a fix that just resyncs on every step would pass.
+        """
+        from torchtrade.envs.live.bitget.order_executor import PositionStatus
+
+        with patch.object(env, "_wait_for_next_timestamp"):
+            env.reset()
+            long_idx = len(env.action_levels) - 1
+
+            # 1. Agent opens a long.
+            env.step(TensorDict({"action": torch.tensor(long_idx)}, batch_size=()))
+            mock_trader.trade.assert_called()
+
+            # 2. Exchange confirms the position. Re-commanding the SAME level is redundant.
+            mock_trader.get_status = MagicMock(return_value={"position_status": PositionStatus(
+                qty=0.01, notional_value=500.0, entry_price=50000.0, unrealized_pnl=0.0,
+                unrealized_pnl_pct=0.0, mark_price=50000.0, leverage=5,
+                margin_mode="isolated", liquidation_price=45000.0,
+            )})
+            mock_trader.trade.reset_mock()
+            env.step(TensorDict({"action": torch.tensor(long_idx)}, batch_size=()))
+            mock_trader.trade.assert_not_called()   # guard still works
+
+            # 3. The exchange liquidates it out from under us.
+            mock_trader.get_status = MagicMock(return_value={"position_status": None})
+            mock_trader.trade.reset_mock()
+            env.step(TensorDict({"action": torch.tensor(long_idx)}, batch_size=()))
+
+            # The agent still wants to be long -> the env must actually re-enter.
+            mock_trader.trade.assert_called()
+
 
 class TestBitgetFractionalPositionResizing:
     """Tests for fractional position resizing (regression for #155)."""

--- a/tests/envs/bitget/test_torch_env_futures.py
+++ b/tests/envs/bitget/test_torch_env_futures.py
@@ -350,7 +350,6 @@ class TestBitgetFuturesTorchTradingEnv:
             # The agent still wants to be long -> the env must actually re-enter.
             mock_trader.trade.assert_called()
 
-
     def test_reset_reads_dust_as_flat(self, env, mock_trader):
         """A dust residual on reset is flat -- internally AND in what the agent sees.
 
@@ -438,9 +437,10 @@ class TestBitgetFuturesTorchTradingEnv:
 
         with patch.object(env, "_wait_for_next_timestamp"):
             env.reset()
+            long_idx = len(env.action_levels) - 1     # index 1 is a half SHORT in these fixtures
             for _ in range(5):
-                env.step(TensorDict({"action": torch.tensor(1)}, batch_size=()))
-            assert env.position.hold_counter > 0     # genuinely aged
+                env.step(TensorDict({"action": torch.tensor(long_idx)}, batch_size=()))
+            assert env.position.hold_counter > 0      # genuinely aged
 
             aged = env.position.hold_counter
             td = env.reset()                         # position still open on the exchange

--- a/tests/envs/bitget/test_torch_env_futures.py
+++ b/tests/envs/bitget/test_torch_env_futures.py
@@ -387,6 +387,28 @@ class TestBitgetFuturesTorchTradingEnv:
         assert leverage == 5.0        # the CONFIG leverage, not the 20 on the residual
         assert dist_to_liq == 1.0     # no position -> no liquidation to be near
 
+    def test_persistent_dust_never_accrues_holding_time(self, env, mock_trader):
+        """Dust that lingers must not make holding_time grow bar after bar.
+
+        The reset test pins holding_time at 0 on the first bar, where hold_counter is 0
+        anyway. This pins the thing that actually bit: a residual that STAYS on the book, so
+        the counter would tick every step -- the agent seeing "flat, but held for 17 bars".
+        """
+        from torchtrade.envs.live.bitget.order_executor import PositionStatus
+
+        mock_trader.get_status = MagicMock(return_value={"position_status": PositionStatus(
+            qty=1e-12, notional_value=500.0, entry_price=47500.0, unrealized_pnl=26.3,
+            unrealized_pnl_pct=0.0526, mark_price=50000.0, leverage=20,
+            margin_mode="isolated", liquidation_price=48000.0,
+        )})
+
+        with patch.object(env, "_wait_for_next_timestamp"):
+            env.reset()
+            for bar in range(5):
+                td = env.step(TensorDict({"action": torch.tensor(1)}, batch_size=()))
+                holding_time = td["next"]["account_state"][3].item()
+                assert holding_time == 0.0, f"dust accrued holding_time={holding_time} by bar {bar}"
+
 
 class TestBitgetFractionalPositionResizing:
     """Tests for fractional position resizing (regression for #155)."""

--- a/tests/envs/bitget/test_torch_env_futures.py
+++ b/tests/envs/bitget/test_torch_env_futures.py
@@ -433,8 +433,8 @@ class TestBitgetFuturesTorchTradingEnv:
         from torchtrade.envs.live.bitget.order_executor import PositionStatus
 
         mock_trader.get_status = MagicMock(return_value={"position_status": PositionStatus(
-            qty=0.01, notional_value=500.0, entry_price=50000.0, unrealized_pnl=0.0,
-            unrealized_pnl_pct=0.0, mark_price=50000.0, leverage=5,
+            qty=0.01, notional_value=500.0, entry_price=47500.0, unrealized_pnl=26.3,
+            unrealized_pnl_pct=0.0526, mark_price=50000.0, leverage=20,  # NOT the config's 5
             margin_mode="isolated", liquidation_price=45000.0,
         )})
 
@@ -452,7 +452,19 @@ class TestBitgetFuturesTorchTradingEnv:
         # counts the still-open position as bar ONE of the new episode. The bug is it reading
         # `aged + 1` -- the previous episode's age carried across the reset.
         assert env.position.hold_counter == 1, f"reset carried {aged} bars into the new episode"
-        assert td["account_state"][3].item() == 1.0
+
+        # An OPEN position must look OPEN. Every other account_state assertion on this branch
+        # checks that a FLAT account reads flat; the inverse was unpinned here, so corrupting
+        # any of these while genuinely open shipped with the suite green. The position's
+        # leverage (20) deliberately differs from the config's (5) -- with both at 5 the
+        # assertion could not tell the open branch from the flat one.
+        exposure, direction, pnl, holding_time, leverage, dist_to_liq = td["account_state"].tolist()
+        assert direction == 1.0
+        assert exposure == 0.5                        # 500 notional / 1000 balance
+        assert pnl == pytest.approx(0.0526)
+        assert leverage == 20.0                       # the POSITION's, not the config's 5
+        assert dist_to_liq == pytest.approx(0.1)      # (50000 - 45000) / 50000
+        assert holding_time == 1.0
 
 
 class TestBitgetFractionalPositionResizing:

--- a/tests/envs/bitget/test_torch_env_futures.py
+++ b/tests/envs/bitget/test_torch_env_futures.py
@@ -314,13 +314,8 @@ class TestBitgetFuturesTorchTradingEnv:
     def test_reenters_after_external_position_close(self, env, mock_trader):
         """A position closed on the exchange must not leave the guard refusing to re-enter.
 
-        Regression: current_position/current_action_level are written only by the env's OWN
-        trades, so a liquidation (or a manual close in the exchange UI) left them stale. The
-        duplicate-action guard then silently no-op'd an agent that re-requested the level it
-        used to hold -- and kept refusing for the REST of the episode.
-
-        Both halves matter. The guard must still suppress a redundant trade while the
-        position is genuinely held, or a fix that just resyncs on every step would pass.
+        Both halves matter: the guard must still suppress a genuinely redundant re-command,
+        or a fix that resynced on every step would pass too.
         """
         from torchtrade.envs.live.bitget.order_executor import PositionStatus
 
@@ -351,15 +346,10 @@ class TestBitgetFuturesTorchTradingEnv:
             mock_trader.trade.assert_called()
 
     def test_reset_reads_dust_as_flat(self, env, mock_trader):
-        """A dust residual on reset is flat -- internally AND in what the agent sees.
+        """A dust residual (1e-12) left behind a close must read as FLAT, not as a position.
 
-        An exchange can leave a float residue (1e-12) behind a full close. Read as an open
-        position it poisons the vector the policy consumes: a direction and a holding_time and
-        a distance-to-liquidation for a position that does not exist, at zero exposure. The
-        policy never saw that combination in training.
-
-        Behavioural on purpose: the structural guard that every _reset uses the shared rule
-        can be dodged by moving the derivation into a helper. This cannot.
+        The fixture is hostile in every field on purpose: a zeroed one made every element
+        read 0 whatever the code did.
         """
         from torchtrade.envs.live.bitget.order_executor import PositionStatus
 
@@ -388,10 +378,6 @@ class TestBitgetFuturesTorchTradingEnv:
 
     def test_dust_between_positions_does_not_age_the_next_one(self, env, mock_trader):
         """A residual left between two positions must not carry the old age into the new one.
-
-        Real position held N bars -> closed, leaving dust -> a NEW position opens. If the dust
-        bar does not reset the counter, the fresh position is reported as N+2 bars old. This
-        is what the `hold_counter = 0` in the dust branch is for; nothing else pins it.
         """
         from torchtrade.envs.live.bitget.order_executor import PositionStatus
 
@@ -426,9 +412,8 @@ class TestBitgetFuturesTorchTradingEnv:
     def test_reset_clears_the_holding_time_of_the_previous_episode(self, env, mock_trader):
         """Reset must zero hold_counter, or episode 2 inherits episode 1's age.
 
-        Asserting it on a FRESH env proves nothing -- PositionState already defaults it to 0.
-        The counter has to be aged first. Without this, an agent opens the next episode seeing
-        a position it has "held" for bars it never traded.
+        Asserting it on a fresh env proves nothing (PositionState defaults it to 0), so the
+        counter is aged first. Also pins that an OPEN position looks open.
         """
         from torchtrade.envs.live.bitget.order_executor import PositionStatus
 

--- a/tests/envs/bitget/test_torch_env_futures.py
+++ b/tests/envs/bitget/test_torch_env_futures.py
@@ -451,6 +451,39 @@ class TestBitgetFuturesTorchTradingEnv:
         assert dist_to_liq == pytest.approx(0.1)      # (50000 - 45000) / 50000
         assert holding_time == 1.0
 
+    def test_reentry_after_external_close_starts_a_fresh_holding_time(self, env, mock_trader):
+        """A re-entry made in the SAME step as an external close must not inherit its age.
+
+        The sync detects the close and lets the guard re-enter -- but if it does not discard
+        hold_counter, the policy is handed a brand-new position as N+1 bars old.
+        """
+        from torchtrade.envs.live.bitget.order_executor import PositionStatus
+
+        def status(qty):
+            return {"position_status": PositionStatus(
+                qty=qty, notional_value=500.0, entry_price=50000.0, unrealized_pnl=0.0,
+                unrealized_pnl_pct=0.0, mark_price=50000.0, leverage=5,
+                margin_mode="isolated", liquidation_price=45000.0,
+            )} if qty else {"position_status": None}
+
+        with patch.object(env, "_wait_for_next_timestamp"):
+            long_idx = len(env.action_levels) - 1
+            long = TensorDict({"action": torch.tensor(long_idx)}, batch_size=())
+
+            mock_trader.get_status = MagicMock(return_value=status(0.01))
+            env.reset()
+            for _ in range(5):
+                env.step(long)
+            aged = env.position.hold_counter
+            assert aged > 1
+
+            mock_trader.get_status = MagicMock(return_value=status(None))   # liquidated
+            td = env.step(long)                                          # same-step re-entry
+
+        assert td["next"]["account_state"][3].item() <= 1.0, (
+            f"a position opened after a liquidation inherited the dead position's age ({aged})"
+        )
+
 
 class TestBitgetFractionalPositionResizing:
     """Tests for fractional position resizing (regression for #155)."""

--- a/tests/envs/bitget/test_torch_env_futures.py
+++ b/tests/envs/bitget/test_torch_env_futures.py
@@ -351,6 +351,31 @@ class TestBitgetFuturesTorchTradingEnv:
             mock_trader.trade.assert_called()
 
 
+    def test_reset_reads_dust_as_flat(self, env, mock_trader):
+        """A dust residual on reset is flat -- internally AND in what the agent sees.
+
+        An exchange can leave a float residue (1e-12) behind a full close. Read as an open
+        position it puts a phantom direction in account_state with zero exposure -- an
+        observation the policy never saw in training -- and freezes the trade guard.
+
+        Behavioural on purpose: the structural guard that every _reset uses the shared rule
+        can be dodged by moving the derivation into a helper. This cannot.
+        """
+        from torchtrade.envs.live.bitget.order_executor import PositionStatus
+
+        mock_trader.get_status = MagicMock(return_value={"position_status": PositionStatus(
+            qty=1e-12, notional_value=0.0, entry_price=50000.0, unrealized_pnl=0.0,
+            unrealized_pnl_pct=0.0, mark_price=50000.0, leverage=5,
+            margin_mode="isolated", liquidation_price=0.0,
+        )})
+
+        with patch.object(env, "_wait_for_next_timestamp"):
+            td = env.reset()
+
+        assert env.position.current_position == 0
+        assert td["account_state"][1].item() == 0.0   # the direction the AGENT sees
+
+
 class TestBitgetFractionalPositionResizing:
     """Tests for fractional position resizing (regression for #155)."""
 

--- a/tests/envs/bitget/test_torch_env_futures.py
+++ b/tests/envs/bitget/test_torch_env_futures.py
@@ -405,14 +405,17 @@ class TestBitgetFuturesTorchTradingEnv:
         with patch.object(env, "_wait_for_next_timestamp"):
             mock_trader.get_status = MagicMock(return_value=status(0.01))
             env.reset()
+            long_idx = len(env.action_levels) - 1     # index 1 is a half SHORT in these fixtures
+            long = TensorDict({"action": torch.tensor(long_idx)}, batch_size=())
+
             for _ in range(5):                       # age a real position
-                env.step(TensorDict({"action": torch.tensor(1)}, batch_size=()))
+                env.step(long)
 
             mock_trader.get_status = MagicMock(return_value=status(1e-12))   # closed -> dust
-            env.step(TensorDict({"action": torch.tensor(1)}, batch_size=()))
+            env.step(long)
 
             mock_trader.get_status = MagicMock(return_value=status(0.01))    # a NEW position
-            td = env.step(TensorDict({"action": torch.tensor(1)}, batch_size=()))
+            td = env.step(long)
 
         holding_time = td["next"]["account_state"][3].item()
         assert holding_time == 1.0, (

--- a/tests/envs/bitget/test_torch_env_futures.py
+++ b/tests/envs/bitget/test_torch_env_futures.py
@@ -387,28 +387,6 @@ class TestBitgetFuturesTorchTradingEnv:
         assert leverage == 5.0        # the CONFIG leverage, not the 20 on the residual
         assert dist_to_liq == 1.0     # no position -> no liquidation to be near
 
-    def test_persistent_dust_never_accrues_holding_time(self, env, mock_trader):
-        """Dust that lingers must not make holding_time grow bar after bar.
-
-        The reset test pins holding_time at 0 on the first bar, where hold_counter is 0
-        anyway. This pins the thing that actually bit: a residual that STAYS on the book, so
-        the counter would tick every step -- the agent seeing "flat, but held for 17 bars".
-        """
-        from torchtrade.envs.live.bitget.order_executor import PositionStatus
-
-        mock_trader.get_status = MagicMock(return_value={"position_status": PositionStatus(
-            qty=1e-12, notional_value=500.0, entry_price=47500.0, unrealized_pnl=26.3,
-            unrealized_pnl_pct=0.0526, mark_price=50000.0, leverage=20,
-            margin_mode="isolated", liquidation_price=48000.0,
-        )})
-
-        with patch.object(env, "_wait_for_next_timestamp"):
-            env.reset()
-            for bar in range(5):
-                td = env.step(TensorDict({"action": torch.tensor(1)}, batch_size=()))
-                holding_time = td["next"]["account_state"][3].item()
-                assert holding_time == 0.0, f"dust accrued holding_time={holding_time} by bar {bar}"
-
     def test_dust_between_positions_does_not_age_the_next_one(self, env, mock_trader):
         """A residual left between two positions must not carry the old age into the new one.
 

--- a/tests/envs/bybit/test_torch_env_futures.py
+++ b/tests/envs/bybit/test_torch_env_futures.py
@@ -236,6 +236,40 @@ class TestBybitFuturesTorchTradingEnv:
                 holding_time = td["next"]["account_state"][3].item()
                 assert holding_time == 0.0, f"dust accrued holding_time={holding_time} by bar {bar}"
 
+    def test_dust_between_positions_does_not_age_the_next_one(self, env, mock_trader):
+        """A residual left between two positions must not carry the old age into the new one.
+
+        Real position held N bars -> closed, leaving dust -> a NEW position opens. If the dust
+        bar does not reset the counter, the fresh position is reported as N+2 bars old. This
+        is what the `hold_counter = 0` in the dust branch is for; nothing else pins it.
+        """
+        from torchtrade.envs.live.bybit.order_executor import PositionStatus
+
+        def status(qty):
+            return {"position_status": PositionStatus(
+                qty=qty, notional_value=500.0, entry_price=50000.0, unrealized_pnl=0.0,
+                unrealized_pnl_pct=0.0, mark_price=50000.0, leverage=5,
+                margin_mode="isolated", liquidation_price=45000.0,
+            )}
+
+        with patch.object(env, "_wait_for_next_timestamp"):
+            mock_trader.get_status = MagicMock(return_value=status(0.01))
+            env.reset()
+            for _ in range(5):                       # age a real position
+                env.step(TensorDict({"action": torch.tensor(1)}, batch_size=()))
+
+            mock_trader.get_status = MagicMock(return_value=status(1e-12))   # closed -> dust
+            env.step(TensorDict({"action": torch.tensor(1)}, batch_size=()))
+
+            mock_trader.get_status = MagicMock(return_value=status(0.01))    # a NEW position
+            td = env.step(TensorDict({"action": torch.tensor(1)}, batch_size=()))
+
+        holding_time = td["next"]["account_state"][3].item()
+        assert holding_time == 1.0, (
+            f"a brand-new position is reported as {holding_time} bars old -- the dust bar "
+            f"between the two did not reset the counter"
+        )
+
 
 class TestBybitActionIndexClamping:
     """Tests for action index out-of-range clamping."""

--- a/tests/envs/bybit/test_torch_env_futures.py
+++ b/tests/envs/bybit/test_torch_env_futures.py
@@ -182,8 +182,9 @@ class TestBybitFuturesTorchTradingEnv:
         """A dust residual on reset is flat -- internally AND in what the agent sees.
 
         An exchange can leave a float residue (1e-12) behind a full close. Read as an open
-        position it puts a phantom direction in account_state with zero exposure -- an
-        observation the policy never saw in training -- and freezes the trade guard.
+        position it poisons the vector the policy consumes: a direction and a holding_time and
+        a distance-to-liquidation for a position that does not exist, at zero exposure. The
+        policy never saw that combination in training.
 
         Behavioural on purpose: the structural guard that every _reset uses the shared rule
         can be dodged by moving the derivation into a helper. This cannot.
@@ -193,14 +194,22 @@ class TestBybitFuturesTorchTradingEnv:
         mock_trader.get_status = MagicMock(return_value={"position_status": PositionStatus(
             qty=1e-12, notional_value=0.0, entry_price=50000.0, unrealized_pnl=0.0,
             unrealized_pnl_pct=0.0, mark_price=50000.0, leverage=5,
-            margin_mode="isolated", liquidation_price=0.0,
+            margin_mode="isolated", liquidation_price=48000.0,
         )})
 
         with patch.object(env, "_wait_for_next_timestamp"):
             td = env.reset()
 
         assert env.position.current_position == 0
-        assert td["account_state"][1].item() == 0.0   # the direction the AGENT sees
+
+        # Every element the dust used to poison. liquidation_price is STALE (48000) on
+        # purpose: passing 0.0 short-circuits the distance_to_liquidation branch and makes
+        # element [5] look correct whatever the code does.
+        exposure, direction, _pnl, holding_time, _lev, dist_to_liq = td["account_state"].tolist()
+        assert exposure == 0.0
+        assert direction == 0.0
+        assert holding_time == 0.0     # flat, so it cannot have been "held" for a bar
+        assert dist_to_liq == 1.0      # no position -> no liquidation to be near
 
 
 class TestBybitActionIndexClamping:

--- a/tests/envs/bybit/test_torch_env_futures.py
+++ b/tests/envs/bybit/test_torch_env_futures.py
@@ -192,8 +192,8 @@ class TestBybitFuturesTorchTradingEnv:
         from torchtrade.envs.live.bybit.order_executor import PositionStatus
 
         mock_trader.get_status = MagicMock(return_value={"position_status": PositionStatus(
-            qty=1e-12, notional_value=0.0, entry_price=50000.0, unrealized_pnl=0.0,
-            unrealized_pnl_pct=0.0, mark_price=50000.0, leverage=5,
+            qty=1e-12, notional_value=500.0, entry_price=47500.0, unrealized_pnl=26.3,
+            unrealized_pnl_pct=0.0526, mark_price=50000.0, leverage=20,
             margin_mode="isolated", liquidation_price=48000.0,
         )})
 
@@ -202,14 +202,39 @@ class TestBybitFuturesTorchTradingEnv:
 
         assert env.position.current_position == 0
 
-        # Every element the dust used to poison. liquidation_price is STALE (48000) on
-        # purpose: passing 0.0 short-circuits the distance_to_liquidation branch and makes
-        # element [5] look correct whatever the code does.
-        exposure, direction, _pnl, holding_time, _lev, dist_to_liq = td["account_state"].tolist()
-        assert exposure == 0.0
+        # EVERY field on the residual is hostile on purpose. Earlier versions of this test
+        # passed 0.0 for notional / pnl / liquidation_price -- the exact values that make the
+        # position branch produce a flat-looking vector whatever the code does, so the bug it
+        # was guarding could be deleted with the suite green.
+        exposure, direction, pnl, holding_time, leverage, dist_to_liq = td["account_state"].tolist()
+        assert exposure == 0.0        # 500 notional attached to a position that is not there
         assert direction == 0.0
-        assert holding_time == 0.0     # flat, so it cannot have been "held" for a bar
-        assert dist_to_liq == 1.0      # no position -> no liquidation to be near
+        assert pnl == 0.0             # a position that does not exist cannot be up 5.26%
+        assert holding_time == 0.0    # nor can it have been held for a bar
+        assert leverage == 5.0        # the CONFIG leverage, not the 20 on the residual
+        assert dist_to_liq == 1.0     # no position -> no liquidation to be near
+
+    def test_persistent_dust_never_accrues_holding_time(self, env, mock_trader):
+        """Dust that lingers must not make holding_time grow bar after bar.
+
+        The reset tests pin holding_time at 0 on the first bar, where hold_counter is 0
+        anyway. This pins the thing that actually bit: a residual that stays on the book, so
+        the counter would tick every step -- the agent seeing "flat, but held for 17 bars".
+        """
+        from torchtrade.envs.live.bybit.order_executor import PositionStatus
+
+        mock_trader.get_status = MagicMock(return_value={"position_status": PositionStatus(
+            qty=1e-12, notional_value=500.0, entry_price=47500.0, unrealized_pnl=26.3,
+            unrealized_pnl_pct=0.0526, mark_price=50000.0, leverage=20,
+            margin_mode="isolated", liquidation_price=48000.0,
+        )})
+
+        with patch.object(env, "_wait_for_next_timestamp"):
+            env.reset()
+            for bar in range(5):
+                td = env.step(TensorDict({"action": torch.tensor(1)}, batch_size=()))
+                holding_time = td["next"]["account_state"][3].item()
+                assert holding_time == 0.0, f"dust accrued holding_time={holding_time} by bar {bar}"
 
 
 class TestBybitActionIndexClamping:

--- a/tests/envs/bybit/test_torch_env_futures.py
+++ b/tests/envs/bybit/test_torch_env_futures.py
@@ -177,7 +177,6 @@ class TestBybitFuturesTorchTradingEnv:
         assert isinstance(config.window_sizes, list)
         assert all(isinstance(tf, TimeFrame) for tf in config.time_frames)
 
-
     def test_reset_reads_dust_as_flat(self, env, mock_trader):
         """A dust residual on reset is flat -- internally AND in what the agent sees.
 
@@ -265,9 +264,10 @@ class TestBybitFuturesTorchTradingEnv:
 
         with patch.object(env, "_wait_for_next_timestamp"):
             env.reset()
+            long_idx = len(env.action_levels) - 1     # index 1 is a half SHORT in these fixtures
             for _ in range(5):
-                env.step(TensorDict({"action": torch.tensor(1)}, batch_size=()))
-            assert env.position.hold_counter > 0     # genuinely aged
+                env.step(TensorDict({"action": torch.tensor(long_idx)}, batch_size=()))
+            assert env.position.hold_counter > 0      # genuinely aged
 
             aged = env.position.hold_counter
             td = env.reset()                         # position still open on the exchange

--- a/tests/envs/bybit/test_torch_env_futures.py
+++ b/tests/envs/bybit/test_torch_env_futures.py
@@ -232,14 +232,17 @@ class TestBybitFuturesTorchTradingEnv:
         with patch.object(env, "_wait_for_next_timestamp"):
             mock_trader.get_status = MagicMock(return_value=status(0.01))
             env.reset()
+            long_idx = len(env.action_levels) - 1     # index 1 is a half SHORT in these fixtures
+            long = TensorDict({"action": torch.tensor(long_idx)}, batch_size=())
+
             for _ in range(5):                       # age a real position
-                env.step(TensorDict({"action": torch.tensor(1)}, batch_size=()))
+                env.step(long)
 
             mock_trader.get_status = MagicMock(return_value=status(1e-12))   # closed -> dust
-            env.step(TensorDict({"action": torch.tensor(1)}, batch_size=()))
+            env.step(long)
 
             mock_trader.get_status = MagicMock(return_value=status(0.01))    # a NEW position
-            td = env.step(TensorDict({"action": torch.tensor(1)}, batch_size=()))
+            td = env.step(long)
 
         holding_time = td["next"]["account_state"][3].item()
         assert holding_time == 1.0, (

--- a/tests/envs/bybit/test_torch_env_futures.py
+++ b/tests/envs/bybit/test_torch_env_futures.py
@@ -178,6 +178,31 @@ class TestBybitFuturesTorchTradingEnv:
         assert all(isinstance(tf, TimeFrame) for tf in config.time_frames)
 
 
+    def test_reset_reads_dust_as_flat(self, env, mock_trader):
+        """A dust residual on reset is flat -- internally AND in what the agent sees.
+
+        An exchange can leave a float residue (1e-12) behind a full close. Read as an open
+        position it puts a phantom direction in account_state with zero exposure -- an
+        observation the policy never saw in training -- and freezes the trade guard.
+
+        Behavioural on purpose: the structural guard that every _reset uses the shared rule
+        can be dodged by moving the derivation into a helper. This cannot.
+        """
+        from torchtrade.envs.live.bybit.order_executor import PositionStatus
+
+        mock_trader.get_status = MagicMock(return_value={"position_status": PositionStatus(
+            qty=1e-12, notional_value=0.0, entry_price=50000.0, unrealized_pnl=0.0,
+            unrealized_pnl_pct=0.0, mark_price=50000.0, leverage=5,
+            margin_mode="isolated", liquidation_price=0.0,
+        )})
+
+        with patch.object(env, "_wait_for_next_timestamp"):
+            td = env.reset()
+
+        assert env.position.current_position == 0
+        assert td["account_state"][1].item() == 0.0   # the direction the AGENT sees
+
+
 class TestBybitActionIndexClamping:
     """Tests for action index out-of-range clamping."""
 

--- a/tests/envs/bybit/test_torch_env_futures.py
+++ b/tests/envs/bybit/test_torch_env_futures.py
@@ -283,6 +283,39 @@ class TestBybitFuturesTorchTradingEnv:
         assert dist_to_liq == pytest.approx(0.1)      # (50000 - 45000) / 50000
         assert holding_time == 1.0
 
+    def test_reentry_after_external_close_starts_a_fresh_holding_time(self, env, mock_trader):
+        """A re-entry made in the SAME step as an external close must not inherit its age.
+
+        The sync detects the close and lets the guard re-enter -- but if it does not discard
+        hold_counter, the policy is handed a brand-new position as N+1 bars old.
+        """
+        from torchtrade.envs.live.bybit.order_executor import PositionStatus
+
+        def status(qty):
+            return {"position_status": PositionStatus(
+                qty=qty, notional_value=500.0, entry_price=50000.0, unrealized_pnl=0.0,
+                unrealized_pnl_pct=0.0, mark_price=50000.0, leverage=5,
+                margin_mode="isolated", liquidation_price=45000.0,
+            )} if qty else {"position_status": None}
+
+        with patch.object(env, "_wait_for_next_timestamp"):
+            long_idx = len(env.action_levels) - 1
+            long = TensorDict({"action": torch.tensor(long_idx)}, batch_size=())
+
+            mock_trader.get_status = MagicMock(return_value=status(0.01))
+            env.reset()
+            for _ in range(5):
+                env.step(long)
+            aged = env.position.hold_counter
+            assert aged > 1
+
+            mock_trader.get_status = MagicMock(return_value=status(None))   # liquidated
+            td = env.step(long)                                          # same-step re-entry
+
+        assert td["next"]["account_state"][3].item() <= 1.0, (
+            f"a position opened after a liquidation inherited the dead position's age ({aged})"
+        )
+
 
 class TestBybitActionIndexClamping:
     """Tests for action index out-of-range clamping."""

--- a/tests/envs/bybit/test_torch_env_futures.py
+++ b/tests/envs/bybit/test_torch_env_futures.py
@@ -178,15 +178,10 @@ class TestBybitFuturesTorchTradingEnv:
         assert all(isinstance(tf, TimeFrame) for tf in config.time_frames)
 
     def test_reset_reads_dust_as_flat(self, env, mock_trader):
-        """A dust residual on reset is flat -- internally AND in what the agent sees.
+        """A dust residual (1e-12) left behind a close must read as FLAT, not as a position.
 
-        An exchange can leave a float residue (1e-12) behind a full close. Read as an open
-        position it poisons the vector the policy consumes: a direction and a holding_time and
-        a distance-to-liquidation for a position that does not exist, at zero exposure. The
-        policy never saw that combination in training.
-
-        Behavioural on purpose: the structural guard that every _reset uses the shared rule
-        can be dodged by moving the derivation into a helper. This cannot.
+        The fixture is hostile in every field on purpose: a zeroed one made every element
+        read 0 whatever the code did.
         """
         from torchtrade.envs.live.bybit.order_executor import PositionStatus
 
@@ -215,10 +210,6 @@ class TestBybitFuturesTorchTradingEnv:
 
     def test_dust_between_positions_does_not_age_the_next_one(self, env, mock_trader):
         """A residual left between two positions must not carry the old age into the new one.
-
-        Real position held N bars -> closed, leaving dust -> a NEW position opens. If the dust
-        bar does not reset the counter, the fresh position is reported as N+2 bars old. This
-        is what the `hold_counter = 0` in the dust branch is for; nothing else pins it.
         """
         from torchtrade.envs.live.bybit.order_executor import PositionStatus
 
@@ -253,9 +244,8 @@ class TestBybitFuturesTorchTradingEnv:
     def test_reset_clears_the_holding_time_of_the_previous_episode(self, env, mock_trader):
         """Reset must zero hold_counter, or episode 2 inherits episode 1's age.
 
-        Asserting it on a FRESH env proves nothing -- PositionState already defaults it to 0.
-        The counter has to be aged first. Without this, an agent opens the next episode seeing
-        a position it has "held" for bars it never traded.
+        Asserting it on a fresh env proves nothing (PositionState defaults it to 0), so the
+        counter is aged first. Also pins that an OPEN position looks open.
         """
         from torchtrade.envs.live.bybit.order_executor import PositionStatus
 

--- a/tests/envs/bybit/test_torch_env_futures.py
+++ b/tests/envs/bybit/test_torch_env_futures.py
@@ -214,28 +214,6 @@ class TestBybitFuturesTorchTradingEnv:
         assert leverage == 5.0        # the CONFIG leverage, not the 20 on the residual
         assert dist_to_liq == 1.0     # no position -> no liquidation to be near
 
-    def test_persistent_dust_never_accrues_holding_time(self, env, mock_trader):
-        """Dust that lingers must not make holding_time grow bar after bar.
-
-        The reset tests pin holding_time at 0 on the first bar, where hold_counter is 0
-        anyway. This pins the thing that actually bit: a residual that stays on the book, so
-        the counter would tick every step -- the agent seeing "flat, but held for 17 bars".
-        """
-        from torchtrade.envs.live.bybit.order_executor import PositionStatus
-
-        mock_trader.get_status = MagicMock(return_value={"position_status": PositionStatus(
-            qty=1e-12, notional_value=500.0, entry_price=47500.0, unrealized_pnl=26.3,
-            unrealized_pnl_pct=0.0526, mark_price=50000.0, leverage=20,
-            margin_mode="isolated", liquidation_price=48000.0,
-        )})
-
-        with patch.object(env, "_wait_for_next_timestamp"):
-            env.reset()
-            for bar in range(5):
-                td = env.step(TensorDict({"action": torch.tensor(1)}, batch_size=()))
-                holding_time = td["next"]["account_state"][3].item()
-                assert holding_time == 0.0, f"dust accrued holding_time={holding_time} by bar {bar}"
-
     def test_dust_between_positions_does_not_age_the_next_one(self, env, mock_trader):
         """A residual left between two positions must not carry the old age into the new one.
 

--- a/tests/envs/bybit/test_torch_env_futures.py
+++ b/tests/envs/bybit/test_torch_env_futures.py
@@ -260,8 +260,8 @@ class TestBybitFuturesTorchTradingEnv:
         from torchtrade.envs.live.bybit.order_executor import PositionStatus
 
         mock_trader.get_status = MagicMock(return_value={"position_status": PositionStatus(
-            qty=0.01, notional_value=500.0, entry_price=50000.0, unrealized_pnl=0.0,
-            unrealized_pnl_pct=0.0, mark_price=50000.0, leverage=5,
+            qty=0.01, notional_value=500.0, entry_price=47500.0, unrealized_pnl=26.3,
+            unrealized_pnl_pct=0.0526, mark_price=50000.0, leverage=20,  # NOT the config's 5
             margin_mode="isolated", liquidation_price=45000.0,
         )})
 
@@ -279,7 +279,19 @@ class TestBybitFuturesTorchTradingEnv:
         # counts the still-open position as bar ONE of the new episode. The bug is it reading
         # `aged + 1` -- the previous episode's age carried across the reset.
         assert env.position.hold_counter == 1, f"reset carried {aged} bars into the new episode"
-        assert td["account_state"][3].item() == 1.0
+
+        # An OPEN position must look OPEN. Every other account_state assertion on this branch
+        # checks that a FLAT account reads flat; the inverse was unpinned here, so corrupting
+        # any of these while genuinely open shipped with the suite green. The position's
+        # leverage (20) deliberately differs from the config's (5) -- with both at 5 the
+        # assertion could not tell the open branch from the flat one.
+        exposure, direction, pnl, holding_time, leverage, dist_to_liq = td["account_state"].tolist()
+        assert direction == 1.0
+        assert exposure == 0.5                        # 500 notional / 1000 balance
+        assert pnl == pytest.approx(0.0526)
+        assert leverage == 20.0                       # the POSITION's, not the config's 5
+        assert dist_to_liq == pytest.approx(0.1)      # (50000 - 45000) / 50000
+        assert holding_time == 1.0
 
 
 class TestBybitActionIndexClamping:

--- a/tests/envs/bybit/test_torch_env_futures.py
+++ b/tests/envs/bybit/test_torch_env_futures.py
@@ -248,6 +248,36 @@ class TestBybitFuturesTorchTradingEnv:
             f"between the two did not reset the counter"
         )
 
+    def test_reset_clears_the_holding_time_of_the_previous_episode(self, env, mock_trader):
+        """Reset must zero hold_counter, or episode 2 inherits episode 1's age.
+
+        Asserting it on a FRESH env proves nothing -- PositionState already defaults it to 0.
+        The counter has to be aged first. Without this, an agent opens the next episode seeing
+        a position it has "held" for bars it never traded.
+        """
+        from torchtrade.envs.live.bybit.order_executor import PositionStatus
+
+        mock_trader.get_status = MagicMock(return_value={"position_status": PositionStatus(
+            qty=0.01, notional_value=500.0, entry_price=50000.0, unrealized_pnl=0.0,
+            unrealized_pnl_pct=0.0, mark_price=50000.0, leverage=5,
+            margin_mode="isolated", liquidation_price=45000.0,
+        )})
+
+        with patch.object(env, "_wait_for_next_timestamp"):
+            env.reset()
+            for _ in range(5):
+                env.step(TensorDict({"action": torch.tensor(1)}, batch_size=()))
+            assert env.position.hold_counter > 0     # genuinely aged
+
+            aged = env.position.hold_counter
+            td = env.reset()                         # position still open on the exchange
+
+        # 1, not 0: _reset zeroes the counter and then takes an observation, which legitimately
+        # counts the still-open position as bar ONE of the new episode. The bug is it reading
+        # `aged + 1` -- the previous episode's age carried across the reset.
+        assert env.position.hold_counter == 1, f"reset carried {aged} bars into the new episode"
+        assert td["account_state"][3].item() == 1.0
+
 
 class TestBybitActionIndexClamping:
     """Tests for action index out-of-range clamping."""

--- a/tests/envs/okx/test_torch_env_futures.py
+++ b/tests/envs/okx/test_torch_env_futures.py
@@ -180,14 +180,17 @@ class TestOKXFuturesTorchTradingEnv:
         with patch.object(env, "_wait_for_next_timestamp"):
             mock_env_trader.get_status = MagicMock(return_value=status(0.01))
             env.reset()
+            long_idx = len(env.action_levels) - 1     # index 1 is a half SHORT in these fixtures
+            long = TensorDict({"action": torch.tensor(long_idx)}, batch_size=())
+
             for _ in range(5):                       # age a real position
-                env.step(TensorDict({"action": torch.tensor(1)}, batch_size=()))
+                env.step(long)
 
             mock_env_trader.get_status = MagicMock(return_value=status(1e-12))   # closed -> dust
-            env.step(TensorDict({"action": torch.tensor(1)}, batch_size=()))
+            env.step(long)
 
             mock_env_trader.get_status = MagicMock(return_value=status(0.01))    # a NEW position
-            td = env.step(TensorDict({"action": torch.tensor(1)}, batch_size=()))
+            td = env.step(long)
 
         holding_time = td["next"]["account_state"][3].item()
         assert holding_time == 1.0, (

--- a/tests/envs/okx/test_torch_env_futures.py
+++ b/tests/envs/okx/test_torch_env_futures.py
@@ -126,15 +126,10 @@ class TestOKXFuturesTorchTradingEnv:
             assert next_td["next"]["done"].item() is expected_done
 
     def test_reset_reads_dust_as_flat(self, env, mock_env_trader):
-        """A dust residual on reset is flat -- internally AND in what the agent sees.
+        """A dust residual (1e-12) left behind a close must read as FLAT, not as a position.
 
-        An exchange can leave a float residue (1e-12) behind a full close. Read as an open
-        position it poisons the vector the policy consumes: a direction and a holding_time and
-        a distance-to-liquidation for a position that does not exist, at zero exposure. The
-        policy never saw that combination in training.
-
-        Behavioural on purpose: the structural guard that every _reset uses the shared rule
-        can be dodged by moving the derivation into a helper. This cannot.
+        The fixture is hostile in every field on purpose: a zeroed one made every element
+        read 0 whatever the code did.
         """
         from torchtrade.envs.live.okx.order_executor import PositionStatus
 
@@ -163,10 +158,6 @@ class TestOKXFuturesTorchTradingEnv:
 
     def test_dust_between_positions_does_not_age_the_next_one(self, env, mock_env_trader):
         """A residual left between two positions must not carry the old age into the new one.
-
-        Real position held N bars -> closed, leaving dust -> a NEW position opens. If the dust
-        bar does not reset the counter, the fresh position is reported as N+2 bars old. This
-        is what the `hold_counter = 0` in the dust branch is for; nothing else pins it.
         """
         from torchtrade.envs.live.okx.order_executor import PositionStatus
 
@@ -201,9 +192,8 @@ class TestOKXFuturesTorchTradingEnv:
     def test_reset_clears_the_holding_time_of_the_previous_episode(self, env, mock_env_trader):
         """Reset must zero hold_counter, or episode 2 inherits episode 1's age.
 
-        Asserting it on a FRESH env proves nothing -- PositionState already defaults it to 0.
-        The counter has to be aged first. Without this, an agent opens the next episode seeing
-        a position it has "held" for bars it never traded.
+        Asserting it on a fresh env proves nothing (PositionState defaults it to 0), so the
+        counter is aged first. Also pins that an OPEN position looks open.
         """
         from torchtrade.envs.live.okx.order_executor import PositionStatus
 

--- a/tests/envs/okx/test_torch_env_futures.py
+++ b/tests/envs/okx/test_torch_env_futures.py
@@ -196,6 +196,36 @@ class TestOKXFuturesTorchTradingEnv:
             f"between the two did not reset the counter"
         )
 
+    def test_reset_clears_the_holding_time_of_the_previous_episode(self, env, mock_env_trader):
+        """Reset must zero hold_counter, or episode 2 inherits episode 1's age.
+
+        Asserting it on a FRESH env proves nothing -- PositionState already defaults it to 0.
+        The counter has to be aged first. Without this, an agent opens the next episode seeing
+        a position it has "held" for bars it never traded.
+        """
+        from torchtrade.envs.live.okx.order_executor import PositionStatus
+
+        mock_env_trader.get_status = MagicMock(return_value={"position_status": PositionStatus(
+            qty=0.01, notional_value=500.0, entry_price=50000.0, unrealized_pnl=0.0,
+            unrealized_pnl_pct=0.0, mark_price=50000.0, leverage=5,
+            margin_mode="isolated", liquidation_price=45000.0,
+        )})
+
+        with patch.object(env, "_wait_for_next_timestamp"):
+            env.reset()
+            for _ in range(5):
+                env.step(TensorDict({"action": torch.tensor(1)}, batch_size=()))
+            assert env.position.hold_counter > 0     # genuinely aged
+
+            aged = env.position.hold_counter
+            td = env.reset()                         # position still open on the exchange
+
+        # 1, not 0: _reset zeroes the counter and then takes an observation, which legitimately
+        # counts the still-open position as bar ONE of the new episode. The bug is it reading
+        # `aged + 1` -- the previous episode's age carried across the reset.
+        assert env.position.hold_counter == 1, f"reset carried {aged} bars into the new episode"
+        assert td["account_state"][3].item() == 1.0
+
 
 class TestOKXActionIndexClamping:
     """Tests for action index out-of-range clamping."""

--- a/tests/envs/okx/test_torch_env_futures.py
+++ b/tests/envs/okx/test_torch_env_futures.py
@@ -125,7 +125,6 @@ class TestOKXFuturesTorchTradingEnv:
             next_td = env.step(TensorDict({"action": torch.tensor(2)}, batch_size=()))
             assert next_td["next"]["done"].item() is expected_done
 
-
     def test_reset_reads_dust_as_flat(self, env, mock_env_trader):
         """A dust residual on reset is flat -- internally AND in what the agent sees.
 
@@ -213,9 +212,10 @@ class TestOKXFuturesTorchTradingEnv:
 
         with patch.object(env, "_wait_for_next_timestamp"):
             env.reset()
+            long_idx = len(env.action_levels) - 1     # index 1 is a half SHORT in these fixtures
             for _ in range(5):
-                env.step(TensorDict({"action": torch.tensor(1)}, batch_size=()))
-            assert env.position.hold_counter > 0     # genuinely aged
+                env.step(TensorDict({"action": torch.tensor(long_idx)}, batch_size=()))
+            assert env.position.hold_counter > 0      # genuinely aged
 
             aged = env.position.hold_counter
             td = env.reset()                         # position still open on the exchange

--- a/tests/envs/okx/test_torch_env_futures.py
+++ b/tests/envs/okx/test_torch_env_futures.py
@@ -130,8 +130,9 @@ class TestOKXFuturesTorchTradingEnv:
         """A dust residual on reset is flat -- internally AND in what the agent sees.
 
         An exchange can leave a float residue (1e-12) behind a full close. Read as an open
-        position it puts a phantom direction in account_state with zero exposure -- an
-        observation the policy never saw in training -- and freezes the trade guard.
+        position it poisons the vector the policy consumes: a direction and a holding_time and
+        a distance-to-liquidation for a position that does not exist, at zero exposure. The
+        policy never saw that combination in training.
 
         Behavioural on purpose: the structural guard that every _reset uses the shared rule
         can be dodged by moving the derivation into a helper. This cannot.
@@ -141,14 +142,22 @@ class TestOKXFuturesTorchTradingEnv:
         mock_env_trader.get_status = MagicMock(return_value={"position_status": PositionStatus(
             qty=1e-12, notional_value=0.0, entry_price=50000.0, unrealized_pnl=0.0,
             unrealized_pnl_pct=0.0, mark_price=50000.0, leverage=5,
-            margin_mode="isolated", liquidation_price=0.0,
+            margin_mode="isolated", liquidation_price=48000.0,
         )})
 
         with patch.object(env, "_wait_for_next_timestamp"):
             td = env.reset()
 
         assert env.position.current_position == 0
-        assert td["account_state"][1].item() == 0.0   # the direction the AGENT sees
+
+        # Every element the dust used to poison. liquidation_price is STALE (48000) on
+        # purpose: passing 0.0 short-circuits the distance_to_liquidation branch and makes
+        # element [5] look correct whatever the code does.
+        exposure, direction, _pnl, holding_time, _lev, dist_to_liq = td["account_state"].tolist()
+        assert exposure == 0.0
+        assert direction == 0.0
+        assert holding_time == 0.0     # flat, so it cannot have been "held" for a bar
+        assert dist_to_liq == 1.0      # no position -> no liquidation to be near
 
 
 class TestOKXActionIndexClamping:

--- a/tests/envs/okx/test_torch_env_futures.py
+++ b/tests/envs/okx/test_torch_env_futures.py
@@ -140,8 +140,8 @@ class TestOKXFuturesTorchTradingEnv:
         from torchtrade.envs.live.okx.order_executor import PositionStatus
 
         mock_env_trader.get_status = MagicMock(return_value={"position_status": PositionStatus(
-            qty=1e-12, notional_value=0.0, entry_price=50000.0, unrealized_pnl=0.0,
-            unrealized_pnl_pct=0.0, mark_price=50000.0, leverage=5,
+            qty=1e-12, notional_value=500.0, entry_price=47500.0, unrealized_pnl=26.3,
+            unrealized_pnl_pct=0.0526, mark_price=50000.0, leverage=20,
             margin_mode="isolated", liquidation_price=48000.0,
         )})
 
@@ -150,14 +150,17 @@ class TestOKXFuturesTorchTradingEnv:
 
         assert env.position.current_position == 0
 
-        # Every element the dust used to poison. liquidation_price is STALE (48000) on
-        # purpose: passing 0.0 short-circuits the distance_to_liquidation branch and makes
-        # element [5] look correct whatever the code does.
-        exposure, direction, _pnl, holding_time, _lev, dist_to_liq = td["account_state"].tolist()
-        assert exposure == 0.0
+        # EVERY field on the residual is hostile on purpose. Earlier versions of this test
+        # passed 0.0 for notional / pnl / liquidation_price -- the exact values that make the
+        # position branch produce a flat-looking vector whatever the code does, so the bug it
+        # was guarding could be deleted with the suite green.
+        exposure, direction, pnl, holding_time, leverage, dist_to_liq = td["account_state"].tolist()
+        assert exposure == 0.0        # 500 notional attached to a position that is not there
         assert direction == 0.0
-        assert holding_time == 0.0     # flat, so it cannot have been "held" for a bar
-        assert dist_to_liq == 1.0      # no position -> no liquidation to be near
+        assert pnl == 0.0             # a position that does not exist cannot be up 5.26%
+        assert holding_time == 0.0    # nor can it have been held for a bar
+        assert leverage == 5.0        # the CONFIG leverage, not the 20 on the residual
+        assert dist_to_liq == 1.0     # no position -> no liquidation to be near
 
 
 class TestOKXActionIndexClamping:

--- a/tests/envs/okx/test_torch_env_futures.py
+++ b/tests/envs/okx/test_torch_env_futures.py
@@ -208,8 +208,8 @@ class TestOKXFuturesTorchTradingEnv:
         from torchtrade.envs.live.okx.order_executor import PositionStatus
 
         mock_env_trader.get_status = MagicMock(return_value={"position_status": PositionStatus(
-            qty=0.01, notional_value=500.0, entry_price=50000.0, unrealized_pnl=0.0,
-            unrealized_pnl_pct=0.0, mark_price=50000.0, leverage=5,
+            qty=0.01, notional_value=500.0, entry_price=47500.0, unrealized_pnl=26.3,
+            unrealized_pnl_pct=0.0526, mark_price=50000.0, leverage=20,  # NOT the config's 5
             margin_mode="isolated", liquidation_price=45000.0,
         )})
 
@@ -227,7 +227,19 @@ class TestOKXFuturesTorchTradingEnv:
         # counts the still-open position as bar ONE of the new episode. The bug is it reading
         # `aged + 1` -- the previous episode's age carried across the reset.
         assert env.position.hold_counter == 1, f"reset carried {aged} bars into the new episode"
-        assert td["account_state"][3].item() == 1.0
+
+        # An OPEN position must look OPEN. Every other account_state assertion on this branch
+        # checks that a FLAT account reads flat; the inverse was unpinned here, so corrupting
+        # any of these while genuinely open shipped with the suite green. The position's
+        # leverage (20) deliberately differs from the config's (5) -- with both at 5 the
+        # assertion could not tell the open branch from the flat one.
+        exposure, direction, pnl, holding_time, leverage, dist_to_liq = td["account_state"].tolist()
+        assert direction == 1.0
+        assert exposure == 0.5                        # 500 notional / 1000 balance
+        assert pnl == pytest.approx(0.0526)
+        assert leverage == 20.0                       # the POSITION's, not the config's 5
+        assert dist_to_liq == pytest.approx(0.1)      # (50000 - 45000) / 50000
+        assert holding_time == 1.0
 
 
 class TestOKXActionIndexClamping:

--- a/tests/envs/okx/test_torch_env_futures.py
+++ b/tests/envs/okx/test_torch_env_futures.py
@@ -184,6 +184,40 @@ class TestOKXFuturesTorchTradingEnv:
                 holding_time = td["next"]["account_state"][3].item()
                 assert holding_time == 0.0, f"dust accrued holding_time={holding_time} by bar {bar}"
 
+    def test_dust_between_positions_does_not_age_the_next_one(self, env, mock_env_trader):
+        """A residual left between two positions must not carry the old age into the new one.
+
+        Real position held N bars -> closed, leaving dust -> a NEW position opens. If the dust
+        bar does not reset the counter, the fresh position is reported as N+2 bars old. This
+        is what the `hold_counter = 0` in the dust branch is for; nothing else pins it.
+        """
+        from torchtrade.envs.live.okx.order_executor import PositionStatus
+
+        def status(qty):
+            return {"position_status": PositionStatus(
+                qty=qty, notional_value=500.0, entry_price=50000.0, unrealized_pnl=0.0,
+                unrealized_pnl_pct=0.0, mark_price=50000.0, leverage=5,
+                margin_mode="isolated", liquidation_price=45000.0,
+            )}
+
+        with patch.object(env, "_wait_for_next_timestamp"):
+            mock_env_trader.get_status = MagicMock(return_value=status(0.01))
+            env.reset()
+            for _ in range(5):                       # age a real position
+                env.step(TensorDict({"action": torch.tensor(1)}, batch_size=()))
+
+            mock_env_trader.get_status = MagicMock(return_value=status(1e-12))   # closed -> dust
+            env.step(TensorDict({"action": torch.tensor(1)}, batch_size=()))
+
+            mock_env_trader.get_status = MagicMock(return_value=status(0.01))    # a NEW position
+            td = env.step(TensorDict({"action": torch.tensor(1)}, batch_size=()))
+
+        holding_time = td["next"]["account_state"][3].item()
+        assert holding_time == 1.0, (
+            f"a brand-new position is reported as {holding_time} bars old -- the dust bar "
+            f"between the two did not reset the counter"
+        )
+
 
 class TestOKXActionIndexClamping:
     """Tests for action index out-of-range clamping."""

--- a/tests/envs/okx/test_torch_env_futures.py
+++ b/tests/envs/okx/test_torch_env_futures.py
@@ -162,28 +162,6 @@ class TestOKXFuturesTorchTradingEnv:
         assert leverage == 5.0        # the CONFIG leverage, not the 20 on the residual
         assert dist_to_liq == 1.0     # no position -> no liquidation to be near
 
-    def test_persistent_dust_never_accrues_holding_time(self, env, mock_env_trader):
-        """Dust that lingers must not make holding_time grow bar after bar.
-
-        The reset test pins holding_time at 0 on the first bar, where hold_counter is 0
-        anyway. This pins the thing that actually bit: a residual that STAYS on the book, so
-        the counter would tick every step -- the agent seeing "flat, but held for 17 bars".
-        """
-        from torchtrade.envs.live.okx.order_executor import PositionStatus
-
-        mock_env_trader.get_status = MagicMock(return_value={"position_status": PositionStatus(
-            qty=1e-12, notional_value=500.0, entry_price=47500.0, unrealized_pnl=26.3,
-            unrealized_pnl_pct=0.0526, mark_price=50000.0, leverage=20,
-            margin_mode="isolated", liquidation_price=48000.0,
-        )})
-
-        with patch.object(env, "_wait_for_next_timestamp"):
-            env.reset()
-            for bar in range(5):
-                td = env.step(TensorDict({"action": torch.tensor(1)}, batch_size=()))
-                holding_time = td["next"]["account_state"][3].item()
-                assert holding_time == 0.0, f"dust accrued holding_time={holding_time} by bar {bar}"
-
     def test_dust_between_positions_does_not_age_the_next_one(self, env, mock_env_trader):
         """A residual left between two positions must not carry the old age into the new one.
 

--- a/tests/envs/okx/test_torch_env_futures.py
+++ b/tests/envs/okx/test_torch_env_futures.py
@@ -162,6 +162,28 @@ class TestOKXFuturesTorchTradingEnv:
         assert leverage == 5.0        # the CONFIG leverage, not the 20 on the residual
         assert dist_to_liq == 1.0     # no position -> no liquidation to be near
 
+    def test_persistent_dust_never_accrues_holding_time(self, env, mock_env_trader):
+        """Dust that lingers must not make holding_time grow bar after bar.
+
+        The reset test pins holding_time at 0 on the first bar, where hold_counter is 0
+        anyway. This pins the thing that actually bit: a residual that STAYS on the book, so
+        the counter would tick every step -- the agent seeing "flat, but held for 17 bars".
+        """
+        from torchtrade.envs.live.okx.order_executor import PositionStatus
+
+        mock_env_trader.get_status = MagicMock(return_value={"position_status": PositionStatus(
+            qty=1e-12, notional_value=500.0, entry_price=47500.0, unrealized_pnl=26.3,
+            unrealized_pnl_pct=0.0526, mark_price=50000.0, leverage=20,
+            margin_mode="isolated", liquidation_price=48000.0,
+        )})
+
+        with patch.object(env, "_wait_for_next_timestamp"):
+            env.reset()
+            for bar in range(5):
+                td = env.step(TensorDict({"action": torch.tensor(1)}, batch_size=()))
+                holding_time = td["next"]["account_state"][3].item()
+                assert holding_time == 0.0, f"dust accrued holding_time={holding_time} by bar {bar}"
+
 
 class TestOKXActionIndexClamping:
     """Tests for action index out-of-range clamping."""

--- a/tests/envs/okx/test_torch_env_futures.py
+++ b/tests/envs/okx/test_torch_env_futures.py
@@ -126,6 +126,31 @@ class TestOKXFuturesTorchTradingEnv:
             assert next_td["next"]["done"].item() is expected_done
 
 
+    def test_reset_reads_dust_as_flat(self, env, mock_env_trader):
+        """A dust residual on reset is flat -- internally AND in what the agent sees.
+
+        An exchange can leave a float residue (1e-12) behind a full close. Read as an open
+        position it puts a phantom direction in account_state with zero exposure -- an
+        observation the policy never saw in training -- and freezes the trade guard.
+
+        Behavioural on purpose: the structural guard that every _reset uses the shared rule
+        can be dodged by moving the derivation into a helper. This cannot.
+        """
+        from torchtrade.envs.live.okx.order_executor import PositionStatus
+
+        mock_env_trader.get_status = MagicMock(return_value={"position_status": PositionStatus(
+            qty=1e-12, notional_value=0.0, entry_price=50000.0, unrealized_pnl=0.0,
+            unrealized_pnl_pct=0.0, mark_price=50000.0, leverage=5,
+            margin_mode="isolated", liquidation_price=0.0,
+        )})
+
+        with patch.object(env, "_wait_for_next_timestamp"):
+            td = env.reset()
+
+        assert env.position.current_position == 0
+        assert td["account_state"][1].item() == 0.0   # the direction the AGENT sees
+
+
 class TestOKXActionIndexClamping:
     """Tests for action index out-of-range clamping."""
 

--- a/tests/envs/okx/test_torch_env_futures.py
+++ b/tests/envs/okx/test_torch_env_futures.py
@@ -231,6 +231,39 @@ class TestOKXFuturesTorchTradingEnv:
         assert dist_to_liq == pytest.approx(0.1)      # (50000 - 45000) / 50000
         assert holding_time == 1.0
 
+    def test_reentry_after_external_close_starts_a_fresh_holding_time(self, env, mock_env_trader):
+        """A re-entry made in the SAME step as an external close must not inherit its age.
+
+        The sync detects the close and lets the guard re-enter -- but if it does not discard
+        hold_counter, the policy is handed a brand-new position as N+1 bars old.
+        """
+        from torchtrade.envs.live.okx.order_executor import PositionStatus
+
+        def status(qty):
+            return {"position_status": PositionStatus(
+                qty=qty, notional_value=500.0, entry_price=50000.0, unrealized_pnl=0.0,
+                unrealized_pnl_pct=0.0, mark_price=50000.0, leverage=5,
+                margin_mode="isolated", liquidation_price=45000.0,
+            )} if qty else {"position_status": None}
+
+        with patch.object(env, "_wait_for_next_timestamp"):
+            long_idx = len(env.action_levels) - 1
+            long = TensorDict({"action": torch.tensor(long_idx)}, batch_size=())
+
+            mock_env_trader.get_status = MagicMock(return_value=status(0.01))
+            env.reset()
+            for _ in range(5):
+                env.step(long)
+            aged = env.position.hold_counter
+            assert aged > 1
+
+            mock_env_trader.get_status = MagicMock(return_value=status(None))   # liquidated
+            td = env.step(long)                                          # same-step re-entry
+
+        assert td["next"]["account_state"][3].item() <= 1.0, (
+            f"a position opened after a liquidation inherited the dead position's age ({aged})"
+        )
+
 
 class TestOKXActionIndexClamping:
     """Tests for action index out-of-range clamping."""

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -71,7 +71,7 @@ def test_check_termination(done_on_bankruptcy, portfolio_value, expected):
     (-1, -1.0, SimpleNamespace(qty=0.5), 1, math.nan),  # flipped short -> long
     # A close can leave a float residual instead of an exact zero. Reading that as an open
     # position is what re-froze the guard -- the dust rule is the whole point of the shared
-    # position_direction_from_qty() rule.
+    # position_direction_from_status() rule.
     (1, 1.0, SimpleNamespace(qty=1e-12), 0, 0.0),     # dust after liquidation -> flat
 ], ids=["long-unchanged", "short-unchanged", "flat-unchanged",
         "liquidated", "opened-externally", "flipped-long-to-short", "flipped-short-to-long",

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -176,3 +176,31 @@ def test_position_sync_resolves_to_a_shared_implementation(env_cls):
         f"{env_cls.__name__} does not resolve _sync_position_from_exchange to "
         f"{expected.__name__}'s -- check base-class order and any local override."
     )
+
+
+@pytest.mark.parametrize("env_cls", LIVE_ENVS, ids=lambda c: c.__name__)
+def test_every_reset_uses_the_shared_direction_rule(env_cls):
+    """_reset must derive the position with the SAME dust rule as _step.
+
+    The five resets each hand-rolled an exact-zero check until now: at qty=1e-12 reset
+    reported a phantom position in account_state that the agent does not hold, while _step
+    read it as flat. One rule, or they disagree.
+
+    Applies to whichever class actually DERIVES the position; the SLTP envs' _reset only
+    delegates to super() and then resets brackets, so it is not one of them.
+    """
+    reset = env_cls.__dict__.get("_reset")
+    if reset is None:
+        pytest.skip(f"{env_cls.__name__} inherits _reset")
+
+    source = inspect.getsource(reset).lstrip()
+    if "current_position" not in source:
+        pytest.skip(f"{env_cls.__name__}._reset delegates the position derivation")
+
+    tree = ast.parse(source)
+    called = {n.func.id for n in ast.walk(tree)
+              if isinstance(n, ast.Call) and isinstance(n.func, ast.Name)}
+    assert "position_direction_from_status" in called, (
+        f"{env_cls.__name__}._reset hand-rolls its position direction instead of using the "
+        f"shared rule -- a dust residual would read as a phantom position."
+    )

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -6,12 +6,14 @@ with a guard that asserts exactly that. If an exchange ever re-adds its own over
 guard fails and tells you to test that exchange separately.
 """
 
+import math
 from types import SimpleNamespace
 
 import pytest
 
 import torchtrade.envs  # noqa: F401  -- registers every live env as a subclass
 from torchtrade.envs.core.live import TorchTradeLiveEnv
+from torchtrade.envs.core.state import PositionState
 
 
 def _subclasses(cls):
@@ -50,6 +52,41 @@ def test_check_termination(done_on_bankruptcy, portfolio_value, expected):
     assert TorchTradeLiveEnv._check_termination(env, portfolio_value) is expected
 
 
+@pytest.mark.parametrize("cached_position,cached_level,observed_qty,expect_position,expect_level", [
+    # The env's own trade already wrote both fields: a matching position must NOT be touched,
+    # or the guard could never suppress a genuinely redundant trade.
+    (1, 1.0, 0.5, 1, 1.0),
+    (-1, -1.0, -0.5, -1, -1.0),
+    (0, 0.0, 0.0, 0, 0.0),
+    # Position moved behind the env's back -> the level that produced it is unknowable.
+    (1, 1.0, 0.0, 0, 0.0),          # liquidated / closed externally -> flat, level flat
+    (0, 0.0, 0.5, 1, math.nan),     # opened externally -> NaN, so ANY next command executes
+    (1, 1.0, -0.5, -1, math.nan),   # flipped externally
+], ids=["long-unchanged", "short-unchanged", "flat-unchanged",
+        "liquidated", "opened-externally", "flipped-externally"])
+def test_sync_position_after_step(
+    cached_position, cached_level, observed_qty, expect_position, expect_level
+):
+    """Exchange truth overwrites the cached position, and an external change NaNs the level.
+
+    The level is the input to _execute_trade_if_needed's duplicate-action guard. If a
+    liquidation leaves it stale, the agent re-requesting the level it already holds is
+    silently refused -- for the rest of the episode.
+    """
+    env = SimpleNamespace(position=PositionState())
+    env.position.current_position = cached_position
+    env.position.current_action_level = cached_level
+
+    status = None if observed_qty == 0 else SimpleNamespace(qty=observed_qty)
+    TorchTradeLiveEnv._sync_position_after_step(env, status)
+
+    assert env.position.current_position == expect_position
+    if math.isnan(expect_level):
+        assert math.isnan(env.position.current_action_level)
+    else:
+        assert env.position.current_action_level == expect_level
+
+
 def test_discovery_covers_every_live_exchange():
     """The override guard below is only as good as this discovery.
 
@@ -62,15 +99,17 @@ def test_discovery_covers_every_live_exchange():
     assert exchanges == {"alpaca", "binance", "bitget", "bybit", "okx"}
 
 
+@pytest.mark.parametrize("method", [
+    "_check_termination", "_sync_position_after_step", "_sync_action_level_after_reset",
+])
 @pytest.mark.parametrize("env_cls", LIVE_ENVS, ids=lambda c: c.__name__)
-def test_no_live_env_overrides_check_termination(env_cls):
-    """No live env class overrides the shared bankruptcy check.
+def test_no_live_env_overrides_shared_method(env_cls, method):
+    """No live env class overrides a shared money-moving method.
 
-    This is what makes testing _check_termination once (above) sufficient rather than a
-    coverage loss: a re-forked copy of money-moving termination logic fails here.
+    This is what makes testing each of them once (above) sufficient rather than a coverage
+    loss: a re-forked copy fails here.
     """
-    assert env_cls._check_termination is TorchTradeLiveEnv._check_termination, (
-        f"{env_cls.__name__} overrides _check_termination. Either drop the override, or "
-        f"give that exchange its own termination tests -- the single shared test above no "
-        f"longer covers it."
+    assert getattr(env_cls, method) is getattr(TorchTradeLiveEnv, method), (
+        f"{env_cls.__name__} overrides {method}. Either drop the override, or give that "
+        f"exchange its own tests -- the single shared test above no longer covers it."
     )

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -6,6 +6,7 @@ with a guard that asserts exactly that. If an exchange ever re-adds its own over
 guard fails and tells you to test that exchange separately.
 """
 
+import ast
 import inspect
 import math
 from types import SimpleNamespace
@@ -14,6 +15,7 @@ import pytest
 
 import torchtrade.envs  # noqa: F401  -- registers every live env as a subclass
 from torchtrade.envs.core.live import TorchTradeLiveEnv
+from torchtrade.envs.utils.sltp_mixin import SLTPMixin
 from torchtrade.envs.core.state import PositionState
 
 
@@ -109,6 +111,9 @@ def test_discovery_covers_every_live_exchange():
     """
     exchanges = {cls.__module__.split(".")[-2] for cls in LIVE_ENVS}
     assert exchanges == {"alpaca", "binance", "bitget", "bybit", "okx"}
+    # NON_SLTP_ENVS drives the call-site guard below, and an empty parametrize SKIPS rather
+    # than fails -- a module rename would silently retire that guard.
+    assert len(NON_SLTP_ENVS) == 5
 
 
 @pytest.mark.parametrize("method", [
@@ -128,16 +133,46 @@ def test_no_live_env_overrides_shared_method(env_cls, method):
 
 
 @pytest.mark.parametrize("env_cls", NON_SLTP_ENVS, ids=lambda c: c.__name__)
-def test_non_sltp_step_syncs_position_from_exchange(env_cls):
-    """Every non-SLTP _step reconciles with the exchange before it trades.
+def test_non_sltp_step_syncs_before_it_trades(env_cls):
+    """Every non-SLTP _step reconciles with the exchange BEFORE the duplicate-action guard.
 
     This is the only thing guarding the call in bybit/okx: they have no duplicate-action
     guard, so deleting the call there changes nothing observable and no behavioural test
-    would notice -- yet it is exactly the call whose absence froze the guard in the three
-    envs that DO have one.
+    would notice -- yet it is the call whose absence froze the guard in the three that do.
+
+    Ordering is asserted, not just presence: a sync placed after _execute_trade_if_needed
+    would be useless, and the guard would still read the stale cache. AST, not source text,
+    so a comment mentioning the method cannot satisfy it.
     """
-    source = inspect.getsource(env_cls.__dict__["_step"])
-    assert "_sync_position_from_exchange" in source, (
-        f"{env_cls.__name__}._step does not reconcile the cached position with the exchange "
-        f"before trading -- a liquidation would leave it stale for the rest of the episode."
+    tree = ast.parse(inspect.getsource(env_cls.__dict__["_step"]).lstrip())
+    calls = [n.func.attr for n in ast.walk(tree)
+             if isinstance(n, ast.Call) and isinstance(n.func, ast.Attribute)]
+
+    assert "_sync_position_from_exchange" in calls, (
+        f"{env_cls.__name__}._step never reconciles the cached position with the exchange -- "
+        f"a liquidation would leave it stale for the rest of the episode."
+    )
+    assert calls.index("_sync_position_from_exchange") < calls.index("_execute_trade_if_needed"), (
+        f"{env_cls.__name__}._step syncs AFTER it trades: the duplicate-action guard still "
+        f"reads the stale position."
+    )
+
+
+@pytest.mark.parametrize("env_cls", LIVE_ENVS, ids=lambda c: c.__name__)
+def test_position_sync_resolves_to_a_shared_implementation(env_cls):
+    """Each env gets the position sync its _step actually expects.
+
+    The base and the mixin share this name but NOT their contract: the base returns None and
+    NaNs current_action_level; the mixin returns the `position_closed` bool that every SLTP
+    _step reads. Declaring an SLTP env as (Base, SLTPMixin) instead of (SLTPMixin, Base) would
+    silently hand it the base version -- position_closed becomes None, falsy, and SL/TP
+    brackets are never cleared. Nothing raises. So base-class ORDER is load-bearing; pin it.
+
+    This also restores what the rename cost: without it, an exchange can re-fork its own
+    _sync_position_from_exchange (dropping the dust rule, say) with the whole suite green.
+    """
+    expected = SLTPMixin if issubclass(env_cls, SLTPMixin) else TorchTradeLiveEnv
+    assert env_cls._sync_position_from_exchange is expected._sync_position_from_exchange, (
+        f"{env_cls.__name__} does not resolve _sync_position_from_exchange to "
+        f"{expected.__name__}'s -- check base-class order and any local override."
     )

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -179,8 +179,9 @@ def test_exactly_five_resets_derive_the_position():
     """One position-deriving _reset per exchange, and the guard below sees all five.
 
     That guard skips a _reset that only delegates. Move a derivation into a helper and the
-    class starts skipping too -- the guard would then cover less while staying green. This is
-    how a reviewer smuggled the old exact-zero rule back into okx with the suite passing.
+    class starts skipping too -- the guard would then cover less while staying green. A review
+    demonstrated exactly that: the old exact-zero rule went back into okx behind a helper and
+    the suite stayed green, with only the skip count moving.
     """
     deriving = [
         c for c in LIVE_ENVS

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -6,6 +6,7 @@ with a guard that asserts exactly that. If an exchange ever re-adds its own over
 guard fails and tells you to test that exchange separately.
 """
 
+import inspect
 import math
 from types import SimpleNamespace
 
@@ -26,6 +27,9 @@ def _subclasses(cls):
 # __subclasses__() is a live registry, so do NOT define a TorchTradeLiveEnv subclass in any
 # test module -- it would land in here, import-order dependent.
 LIVE_ENVS = sorted(_subclasses(TorchTradeLiveEnv), key=lambda c: c.__name__)
+
+# The plain envs (env.py). The SLTP ones get their sync from SLTPMixin instead.
+NON_SLTP_ENVS = [c for c in LIVE_ENVS if c.__module__.endswith(".env")]
 
 
 @pytest.mark.parametrize("done_on_bankruptcy,portfolio_value,expected", [
@@ -52,20 +56,29 @@ def test_check_termination(done_on_bankruptcy, portfolio_value, expected):
     assert TorchTradeLiveEnv._check_termination(env, portfolio_value) is expected
 
 
-@pytest.mark.parametrize("cached_position,cached_level,observed_qty,expect_position,expect_level", [
+@pytest.mark.parametrize("cached_position,cached_level,status,expect_position,expect_level", [
     # The env's own trade already wrote both fields: a matching position must NOT be touched,
     # or the guard could never suppress a genuinely redundant trade.
-    (1, 1.0, 0.5, 1, 1.0),
-    (-1, -1.0, -0.5, -1, -1.0),
-    (0, 0.0, 0.0, 0, 0.0),
+    (1, 1.0, SimpleNamespace(qty=0.5), 1, 1.0),
+    (-1, -1.0, SimpleNamespace(qty=-0.5), -1, -1.0),
+    (0, 0.0, None, 0, 0.0),
     # Position moved behind the env's back -> the level that produced it is unknowable.
-    (1, 1.0, 0.0, 0, 0.0),          # liquidated / closed externally -> flat, level flat
-    (0, 0.0, 0.5, 1, math.nan),     # opened externally -> NaN, so ANY next command executes
-    (1, 1.0, -0.5, -1, math.nan),   # flipped externally
+    (1, 1.0, None, 0, 0.0),                          # liquidated -> flat, level flat
+    (0, 0.0, SimpleNamespace(qty=0.5), 1, math.nan),  # opened externally -> ANY next command runs
+    (1, 1.0, SimpleNamespace(qty=-0.5), -1, math.nan),  # flipped long -> short
+    (-1, -1.0, SimpleNamespace(qty=0.5), 1, math.nan),  # flipped short -> long
+    # A close can leave a float residual instead of an exact zero. Reading that as an open
+    # position is what re-froze the guard -- the dust rule is the whole point of the shared
+    # position_direction() helper.
+    (1, 1.0, SimpleNamespace(qty=1e-12), 0, 0.0),     # dust after liquidation -> flat
+    # Exchanges also report a flat position as a zero-qty object rather than None; every
+    # live _reset already has an explicit branch for it.
+    (1, 1.0, SimpleNamespace(qty=0.0), 0, 0.0),
 ], ids=["long-unchanged", "short-unchanged", "flat-unchanged",
-        "liquidated", "opened-externally", "flipped-externally"])
-def test_sync_position_after_step(
-    cached_position, cached_level, observed_qty, expect_position, expect_level
+        "liquidated", "opened-externally", "flipped-long-to-short", "flipped-short-to-long",
+        "dust-after-liquidation", "zero-qty-status-not-none"])
+def test_sync_position_from_exchange(
+    cached_position, cached_level, status, expect_position, expect_level
 ):
     """Exchange truth overwrites the cached position, and an external change NaNs the level.
 
@@ -77,8 +90,7 @@ def test_sync_position_after_step(
     env.position.current_position = cached_position
     env.position.current_action_level = cached_level
 
-    status = None if observed_qty == 0 else SimpleNamespace(qty=observed_qty)
-    TorchTradeLiveEnv._sync_position_after_step(env, status)
+    TorchTradeLiveEnv._sync_position_from_exchange(env, status)
 
     assert env.position.current_position == expect_position
     if math.isnan(expect_level):
@@ -100,7 +112,7 @@ def test_discovery_covers_every_live_exchange():
 
 
 @pytest.mark.parametrize("method", [
-    "_check_termination", "_sync_position_after_step", "_sync_action_level_after_reset",
+    "_check_termination", "_sync_action_level_after_reset",
 ])
 @pytest.mark.parametrize("env_cls", LIVE_ENVS, ids=lambda c: c.__name__)
 def test_no_live_env_overrides_shared_method(env_cls, method):
@@ -112,4 +124,20 @@ def test_no_live_env_overrides_shared_method(env_cls, method):
     assert getattr(env_cls, method) is getattr(TorchTradeLiveEnv, method), (
         f"{env_cls.__name__} overrides {method}. Either drop the override, or give that "
         f"exchange its own tests -- the single shared test above no longer covers it."
+    )
+
+
+@pytest.mark.parametrize("env_cls", NON_SLTP_ENVS, ids=lambda c: c.__name__)
+def test_non_sltp_step_syncs_position_from_exchange(env_cls):
+    """Every non-SLTP _step reconciles with the exchange before it trades.
+
+    This is the only thing guarding the call in bybit/okx: they have no duplicate-action
+    guard, so deleting the call there changes nothing observable and no behavioural test
+    would notice -- yet it is exactly the call whose absence froze the guard in the three
+    envs that DO have one.
+    """
+    source = inspect.getsource(env_cls.__dict__["_step"])
+    assert "_sync_position_from_exchange" in source, (
+        f"{env_cls.__name__}._step does not reconcile the cached position with the exchange "
+        f"before trading -- a liquidation would leave it stale for the rest of the episode."
     )

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -63,7 +63,6 @@ def test_check_termination(done_on_bankruptcy, portfolio_value, expected):
     # or the guard could never suppress a genuinely redundant trade.
     (1, 1.0, SimpleNamespace(qty=0.5), 1, 1.0),
     (-1, -1.0, SimpleNamespace(qty=-0.5), -1, -1.0),
-    (0, 0.0, None, 0, 0.0),
     # Position moved behind the env's back -> the level that produced it is unknowable.
     (1, 1.0, None, 0, 0.0),                          # liquidated -> flat, level flat
     (0, 0.0, SimpleNamespace(qty=0.5), 1, math.nan),  # opened externally -> ANY next command runs
@@ -73,9 +72,11 @@ def test_check_termination(done_on_bankruptcy, portfolio_value, expected):
     # position is what re-froze the guard -- the dust rule is the whole point of the shared
     # position_direction_from_status() rule.
     (1, 1.0, SimpleNamespace(qty=1e-12), 0, 0.0),     # dust after liquidation -> flat
-], ids=["long-unchanged", "short-unchanged", "flat-unchanged",
+    # qty exactly at the epsilon: the docstring says "at or below" is flat. Pin the boundary.
+    (1, 1.0, SimpleNamespace(qty=1e-9), 0, 0.0),
+], ids=["long-unchanged", "short-unchanged",
         "liquidated", "opened-externally", "flipped-long-to-short", "flipped-short-to-long",
-        "dust-after-liquidation"])
+        "dust-after-liquidation", "at-the-dust-epsilon"])
 def test_sync_position_from_exchange(
     cached_position, cached_level, status, expect_position, expect_level
 ):
@@ -220,3 +221,27 @@ def test_every_reset_uses_the_shared_direction_rule(env_cls):
         f"{env_cls.__name__}._reset hand-rolls its position direction instead of using the "
         f"shared rule -- a dust residual would read as a phantom position."
     )
+
+
+@pytest.mark.parametrize("current_position,expected_level", [
+    (0, 0.0),          # flat -> a flat command is genuinely redundant, let the guard suppress it
+    (1, math.nan),     # a position we did NOT open -> the level behind it is unknowable
+    (-1, math.nan),
+], ids=["flat", "pre-existing-long", "pre-existing-short"])
+def test_sync_action_level_after_reset(current_position, expected_level):
+    """A position that predates the episode must not leave the guard able to refuse a close.
+
+    This pins the #243 fix directly. It had exactly ONE guard -- an incidental assertion in
+    bitget's test_close_position_action -- so an unrelated edit to that test would have
+    silently retired the only cover for a money-moving fix.
+    """
+    env = SimpleNamespace(position=PositionState())
+    env.position.current_position = current_position
+    env.position.current_action_level = 0.0          # the stale default the bug relied on
+
+    TorchTradeLiveEnv._sync_action_level_after_reset(env)
+
+    if math.isnan(expected_level):
+        assert math.isnan(env.position.current_action_level)
+    else:
+        assert env.position.current_action_level == expected_level

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -71,14 +71,11 @@ def test_check_termination(done_on_bankruptcy, portfolio_value, expected):
     (-1, -1.0, SimpleNamespace(qty=0.5), 1, math.nan),  # flipped short -> long
     # A close can leave a float residual instead of an exact zero. Reading that as an open
     # position is what re-froze the guard -- the dust rule is the whole point of the shared
-    # position_direction() helper.
+    # position_direction_from_qty() rule.
     (1, 1.0, SimpleNamespace(qty=1e-12), 0, 0.0),     # dust after liquidation -> flat
-    # Exchanges also report a flat position as a zero-qty object rather than None; every
-    # live _reset already has an explicit branch for it.
-    (1, 1.0, SimpleNamespace(qty=0.0), 0, 0.0),
 ], ids=["long-unchanged", "short-unchanged", "flat-unchanged",
         "liquidated", "opened-externally", "flipped-long-to-short", "flipped-short-to-long",
-        "dust-after-liquidation", "zero-qty-status-not-none"])
+        "dust-after-liquidation"])
 def test_sync_position_from_exchange(
     cached_position, cached_level, status, expect_position, expect_level
 ):
@@ -175,6 +172,24 @@ def test_position_sync_resolves_to_a_shared_implementation(env_cls):
     assert env_cls._sync_position_from_exchange is expected._sync_position_from_exchange, (
         f"{env_cls.__name__} does not resolve _sync_position_from_exchange to "
         f"{expected.__name__}'s -- check base-class order and any local override."
+    )
+
+
+def test_exactly_five_resets_derive_the_position():
+    """One position-deriving _reset per exchange, and the guard below sees all five.
+
+    That guard skips a _reset that only delegates. Move a derivation into a helper and the
+    class starts skipping too -- the guard would then cover less while staying green. This is
+    how a reviewer smuggled the old exact-zero rule back into okx with the suite passing.
+    """
+    deriving = [
+        c for c in LIVE_ENVS
+        if (r := c.__dict__.get("_reset")) is not None
+        and "current_position" in inspect.getsource(r)
+    ]
+    assert len(deriving) == 5, (
+        f"expected one position-deriving _reset per exchange, found {len(deriving)}: "
+        f"{[c.__name__ for c in deriving]}"
     )
 
 

--- a/torchtrade/envs/core/live.py
+++ b/torchtrade/envs/core/live.py
@@ -200,6 +200,11 @@ class TorchTradeLiveEnv(TorchTradeBaseEnv):
         genuinely redundant trade. The level behind a position we did not open is unknowable,
         so it becomes NaN, which never compares equal.
 
+        A mismatch also discards hold_counter. The position we were counting is gone (or was
+        never ours), and this is the only code that knows that -- so if the agent re-enters in
+        THIS same step, the new position must start from zero rather than inherit the dead
+        one's age.
+
         Only the direction is reconciled, not the size: a PARTIAL external close leaves the
         direction intact and is still invisible to the guard. Pre-existing, not fixed here.
         """
@@ -207,6 +212,7 @@ class TorchTradeLiveEnv(TorchTradeBaseEnv):
 
         if observed != self.position.current_position:
             self.position.current_action_level = 0.0 if observed == 0 else float("nan")
+            self.position.hold_counter = 0
 
         self.position.current_position = observed
 

--- a/torchtrade/envs/core/live.py
+++ b/torchtrade/envs/core/live.py
@@ -180,6 +180,31 @@ class TorchTradeLiveEnv(TorchTradeBaseEnv):
             0.0 if self.position.current_position == 0 else float("nan")
         )
 
+    def _sync_position_after_step(self, position_status) -> None:
+        """Reconcile the cached position with exchange truth, before the duplicate-action guard.
+
+        current_position/current_action_level are written only after a trade THIS env made, so
+        anything that moves the position behind the env's back -- a liquidation, a manual close
+        in the exchange UI -- leaves them stale for the REST of the episode. The
+        ``desired_action == current_action_level`` guard would then short-circuit a legitimate
+        command: after a liquidation, an agent re-requesting the level it already holds is
+        silently refused, and stays refused until it happens to pick a different level.
+
+        Only a mismatch means the change was not ours; on a match, leave the cached level alone
+        (that is what lets the guard suppress genuinely redundant trades). The level behind a
+        position we did not open is unknowable, so NaN it -- NaN never compares equal, so the
+        next command always executes.
+
+        Reuses the position_status _step already fetched: no extra API call.
+        """
+        qty = 0.0 if position_status is None else float(position_status.qty)
+        observed = 0 if qty == 0 else (1 if qty > 0 else -1)
+
+        if observed != self.position.current_position:
+            self.position.current_action_level = 0.0 if observed == 0 else float("nan")
+
+        self.position.current_position = observed
+
     def _check_termination(self, portfolio_value: float) -> bool:
         """Terminate when the portfolio falls below bankrupt_threshold * its initial value."""
         if not self.config.done_on_bankruptcy:

--- a/torchtrade/envs/core/live.py
+++ b/torchtrade/envs/core/live.py
@@ -8,7 +8,7 @@ from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 from tensordict import TensorDictBase
 
 from torchtrade.envs.core.base import TorchTradeBaseEnv
-from torchtrade.envs.core.state import PositionState
+from torchtrade.envs.core.state import PositionState, position_direction
 
 
 class TorchTradeLiveEnv(TorchTradeBaseEnv):
@@ -175,30 +175,35 @@ class TorchTradeLiveEnv(TorchTradeBaseEnv):
 
         The level that produced such a position is unknowable: NaN never compares equal,
         so the next command always executes.
+
+        NOT subsumed by _sync_position_from_exchange, though it looks like it should be:
+        _reset writes current_position from the exchange FIRST, so by the first _step the
+        cache and the exchange already agree -- and a sync that only acts on a MISMATCH sees
+        none, and leaves the stale level alone. Reset answers "is this position mine?"; step
+        answers "is it still there?". Only reset can know the position predates the episode.
         """
         self.position.current_action_level = (
             0.0 if self.position.current_position == 0 else float("nan")
         )
 
-    def _sync_position_after_step(self, position_status) -> None:
-        """Reconcile the cached position with exchange truth, before the duplicate-action guard.
+    def _sync_position_from_exchange(self, position_status) -> None:
+        """Overwrite the cached position with what the exchange actually holds.
 
-        current_position/current_action_level are written only after a trade THIS env made, so
-        anything that moves the position behind the env's back -- a liquidation, a manual close
-        in the exchange UI -- leaves them stale for the REST of the episode. The
-        ``desired_action == current_action_level`` guard would then short-circuit a legitimate
-        command: after a liquidation, an agent re-requesting the level it already holds is
-        silently refused, and stays refused until it happens to pick a different level.
+        Call at the top of _step(), BEFORE the duplicate-action guard.
 
-        Only a mismatch means the change was not ours; on a match, leave the cached level alone
-        (that is what lets the guard suppress genuinely redundant trades). The level behind a
-        position we did not open is unknowable, so NaN it -- NaN never compares equal, so the
-        next command always executes.
+        current_position/current_action_level are written only by trades THIS env made, so a
+        liquidation or a manual close leaves them stale, and _execute_trade_if_needed's
+        ``desired_action == current_action_level`` guard then refuses the agent's re-entry for
+        the rest of the episode.
 
-        Reuses the position_status _step already fetched: no extra API call.
+        On a match the level is left alone -- that is what still lets the guard suppress a
+        genuinely redundant trade. The level behind a position we did not open is unknowable,
+        so it becomes NaN, which never compares equal.
+
+        Only the direction is reconciled, not the size: a PARTIAL external close leaves the
+        direction intact and is still invisible to the guard. Pre-existing, not fixed here.
         """
-        qty = 0.0 if position_status is None else float(position_status.qty)
-        observed = 0 if qty == 0 else (1 if qty > 0 else -1)
+        observed = position_direction(position_status)
 
         if observed != self.position.current_position:
             self.position.current_action_level = 0.0 if observed == 0 else float("nan")

--- a/torchtrade/envs/core/live.py
+++ b/torchtrade/envs/core/live.py
@@ -8,7 +8,7 @@ from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 from tensordict import TensorDictBase
 
 from torchtrade.envs.core.base import TorchTradeBaseEnv
-from torchtrade.envs.core.state import PositionState, position_direction
+from torchtrade.envs.core.state import PositionState, position_direction_from_status
 
 
 class TorchTradeLiveEnv(TorchTradeBaseEnv):
@@ -203,7 +203,7 @@ class TorchTradeLiveEnv(TorchTradeBaseEnv):
         Only the direction is reconciled, not the size: a PARTIAL external close leaves the
         direction intact and is still invisible to the guard. Pre-existing, not fixed here.
         """
-        observed = position_direction(position_status)
+        observed = position_direction_from_status(position_status)
 
         if observed != self.position.current_position:
             self.position.current_action_level = 0.0 if observed == 0 else float("nan")

--- a/torchtrade/envs/core/state.py
+++ b/torchtrade/envs/core/state.py
@@ -10,23 +10,17 @@ from typing import Dict, List, Union
 POSITION_DUST_EPS = 1e-9
 
 
-def position_direction_from_qty(qty: float) -> int:
-    """The direction a quantity represents: -1 short, 0 flat, +1 long.
+def position_direction_from_status(position_status) -> int:
+    """The direction the exchange holds: -1 short, 0 flat, +1 long. None means flat.
 
     The single rule for the LIVE envs: their position syncs, their resets, and the
     account_state they show the agent all go through here. The offline envs still derive
-    direction their own way -- out of scope here, but they are not covered by this.
+    direction their own way -- out of scope here, and not covered by this.
     """
+    qty = 0.0 if position_status is None else float(position_status.qty)
     if abs(qty) <= POSITION_DUST_EPS:
         return 0
     return 1 if qty > 0 else -1
-
-
-def position_direction_from_status(position_status) -> int:
-    """Same rule, applied to a trader.get_status() position_status (None means flat)."""
-    return position_direction_from_qty(
-        0.0 if position_status is None else float(position_status.qty)
-    )
 
 
 def binarize_action_type(action_type: str) -> int:

--- a/torchtrade/envs/core/state.py
+++ b/torchtrade/envs/core/state.py
@@ -5,16 +5,17 @@ from typing import Dict, List, Union
 
 
 # Quantities at or below this are dust, not a position. Exchanges can leave a float residual
-# (e.g. 1e-12) behind a full close, and misreading that as an open position is what freezes
-# the live envs' duplicate-action guard -- so every position sync must apply the same rule.
+# (e.g. 1e-12) behind a full close; misreading it as an open position freezes the live envs'
+# duplicate-action guard and puts a position the agent does not hold into its observation.
 POSITION_DUST_EPS = 1e-9
 
 
 def position_direction_from_qty(qty: float) -> int:
     """The direction a quantity represents: -1 short, 0 flat, +1 long.
 
-    THE rule: the position syncs, the resets, and the account_state the agent sees all go
-    through here.
+    The single rule for the LIVE envs: their position syncs, their resets, and the
+    account_state they show the agent all go through here. The offline envs still derive
+    direction their own way -- out of scope here, but they are not covered by this.
     """
     if abs(qty) <= POSITION_DUST_EPS:
         return 0

--- a/torchtrade/envs/core/state.py
+++ b/torchtrade/envs/core/state.py
@@ -10,17 +10,22 @@ from typing import Dict, List, Union
 POSITION_DUST_EPS = 1e-9
 
 
-def position_direction_from_status(position_status) -> int:
-    """The direction the exchange actually holds: -1 short, 0 flat, +1 long.
+def position_direction_from_qty(qty: float) -> int:
+    """The direction a quantity represents: -1 short, 0 flat, +1 long.
 
-    The single normalization used by every position sync -- live _reset, live _step, and
-    SLTP alike. It exists because two copies of it drifted apart once: one applied the dust
-    tolerance, the other compared to exactly zero, and the difference froze a live guard.
+    THE rule: the position syncs, the resets, and the account_state the agent sees all go
+    through here.
     """
-    qty = 0.0 if position_status is None else float(position_status.qty)
     if abs(qty) <= POSITION_DUST_EPS:
         return 0
     return 1 if qty > 0 else -1
+
+
+def position_direction_from_status(position_status) -> int:
+    """Same rule, applied to a trader.get_status() position_status (None means flat)."""
+    return position_direction_from_qty(
+        0.0 if position_status is None else float(position_status.qty)
+    )
 
 
 def binarize_action_type(action_type: str) -> int:

--- a/torchtrade/envs/core/state.py
+++ b/torchtrade/envs/core/state.py
@@ -10,19 +10,15 @@ from typing import Dict, List, Union
 POSITION_DUST_EPS = 1e-9
 
 
-def position_direction(position_status, eps: float = POSITION_DUST_EPS) -> int:
+def position_direction_from_status(position_status) -> int:
     """The direction the exchange actually holds: -1 short, 0 flat, +1 long.
 
-    The single normalization used by every position sync, live and SLTP alike. It exists
-    because two copies of it drifted apart once: one applied the dust tolerance, the other
-    compared to exactly zero.
-
-    Args:
-        position_status: Position status from trader.get_status(), or None if flat.
-        eps: Quantities with |qty| <= eps are dust and read as flat.
+    The single normalization used by every position sync -- live _reset, live _step, and
+    SLTP alike. It exists because two copies of it drifted apart once: one applied the dust
+    tolerance, the other compared to exactly zero, and the difference froze a live guard.
     """
     qty = 0.0 if position_status is None else float(position_status.qty)
-    if abs(qty) <= eps:
+    if abs(qty) <= POSITION_DUST_EPS:
         return 0
     return 1 if qty > 0 else -1
 

--- a/torchtrade/envs/core/state.py
+++ b/torchtrade/envs/core/state.py
@@ -4,6 +4,29 @@ from dataclasses import asdict, dataclass, field, fields
 from typing import Dict, List, Union
 
 
+# Quantities at or below this are dust, not a position. Exchanges can leave a float residual
+# (e.g. 1e-12) behind a full close, and misreading that as an open position is what freezes
+# the live envs' duplicate-action guard -- so every position sync must apply the same rule.
+POSITION_DUST_EPS = 1e-9
+
+
+def position_direction(position_status, eps: float = POSITION_DUST_EPS) -> int:
+    """The direction the exchange actually holds: -1 short, 0 flat, +1 long.
+
+    The single normalization used by every position sync, live and SLTP alike. It exists
+    because two copies of it drifted apart once: one applied the dust tolerance, the other
+    compared to exactly zero.
+
+    Args:
+        position_status: Position status from trader.get_status(), or None if flat.
+        eps: Quantities with |qty| <= eps are dust and read as flat.
+    """
+    qty = 0.0 if position_status is None else float(position_status.qty)
+    if abs(qty) <= eps:
+        return 0
+    return 1 if qty > 0 else -1
+
+
 def binarize_action_type(action_type: str) -> int:
     """Convert action type string to binarized action value.
 

--- a/torchtrade/envs/live/alpaca/base.py
+++ b/torchtrade/envs/live/alpaca/base.py
@@ -11,7 +11,7 @@ from torchrl.data import Composite
 from torchtrade.envs.live.alpaca.observation import AlpacaObservationClass
 from torchtrade.envs.live.alpaca.order_executor import AlpacaOrderClass
 from torchtrade.envs.core.live import TorchTradeLiveEnv
-from torchtrade.envs.core.state import HistoryTracker, PositionState
+from torchtrade.envs.core.state import HistoryTracker, position_direction_from_status, PositionState
 
 
 class AlpacaBaseTorchTradingEnv(TorchTradeLiveEnv):
@@ -281,10 +281,7 @@ class AlpacaBaseTorchTradingEnv(TorchTradeLiveEnv):
         position_status = status.get("position_status")
         self.position.hold_counter = 0
 
-        if position_status is None:
-            self.position.current_position = 0.0
-        else:
-            self.position.current_position = 1 if position_status.qty > 0 else 0
+        self.position.current_position = position_direction_from_status(position_status)
 
         self._sync_action_level_after_reset()
 

--- a/torchtrade/envs/live/alpaca/base.py
+++ b/torchtrade/envs/live/alpaca/base.py
@@ -204,7 +204,6 @@ class AlpacaBaseTorchTradingEnv(TorchTradeLiveEnv):
         # close take the position branch and read stale fields off it.
         position_direction = float(position_direction_from_status(position_status))
         if position_direction == 0:
-            position_size = 0.0
             position_value = 0.0
             entry_price = 0.0
             unrealized_pnlpc = 0.0
@@ -216,7 +215,6 @@ class AlpacaBaseTorchTradingEnv(TorchTradeLiveEnv):
             except Exception:
                 current_price = 0.0
         else:
-            position_size = position_status.qty
             position_value = position_status.market_value
             entry_price = position_status.avg_entry_price
             current_price = position_status.current_price

--- a/torchtrade/envs/live/alpaca/base.py
+++ b/torchtrade/envs/live/alpaca/base.py
@@ -14,7 +14,6 @@ from torchtrade.envs.core.live import TorchTradeLiveEnv
 from torchtrade.envs.core.state import (
     HistoryTracker,
     PositionState,
-    position_direction_from_qty,
     position_direction_from_status,
 )
 
@@ -198,10 +197,10 @@ class AlpacaBaseTorchTradingEnv(TorchTradeLiveEnv):
         position_status = status.get("position_status", None)
 
         # Calculate portfolio value
-        # Dust is not a position. Gating on `is None` let a float residual left behind a
-        # close take the position branch, putting a phantom holding_time / leverage /
-        # distance_to_liquidation into the vector the policy consumes.
-        if position_direction_from_status(position_status) == 0:
+        # Dust is not a position: gating on `is None` let a 1e-12 residual left behind a
+        # close take the position branch and read stale fields off it.
+        position_direction = float(position_direction_from_status(position_status))
+        if position_direction == 0:
             position_size = 0.0
             position_value = 0.0
             entry_price = 0.0
@@ -227,7 +226,6 @@ class AlpacaBaseTorchTradingEnv(TorchTradeLiveEnv):
         exposure_pct = position_value / portfolio_value if portfolio_value > 0 else 0.0
 
         # Element 1: position_direction (0 or +1 for spot, no shorts)
-        position_direction = float(position_direction_from_qty(position_size))
 
         # Element 2: unrealized_pnl_pct (inherited from Alpaca)
         # Element 3: holding_time

--- a/torchtrade/envs/live/alpaca/base.py
+++ b/torchtrade/envs/live/alpaca/base.py
@@ -35,7 +35,10 @@ class AlpacaBaseTorchTradingEnv(TorchTradeLiveEnv):
 
     Element definitions:
         - exposure_pct: position_value / portfolio_value (0.0 to 1.0 for spot)
-        - position_direction: sign(position_size) (0 or +1 for spot, no shorts)
+        - position_direction: sign(position_size). Spot cannot short, so this is 0 or +1
+          in practice -- but it is NOT clamped: a negative qty from the broker is
+          reported as -1 rather than laundered into 'flat', so the observation always
+          agrees with the position state the env tracks internally.
         - unrealized_pnl_pct: (current_price - entry_price) / entry_price * direction
         - holding_time: steps since position opened
         - leverage: Always 1.0 for spot (no leverage)
@@ -225,7 +228,6 @@ class AlpacaBaseTorchTradingEnv(TorchTradeLiveEnv):
         # Element 0: exposure_pct (position_value / portfolio_value)
         exposure_pct = position_value / portfolio_value if portfolio_value > 0 else 0.0
 
-        # Element 1: position_direction (0 or +1 for spot, no shorts)
 
         # Element 2: unrealized_pnl_pct (inherited from Alpaca)
         # Element 3: holding_time

--- a/torchtrade/envs/live/alpaca/base.py
+++ b/torchtrade/envs/live/alpaca/base.py
@@ -11,7 +11,12 @@ from torchrl.data import Composite
 from torchtrade.envs.live.alpaca.observation import AlpacaObservationClass
 from torchtrade.envs.live.alpaca.order_executor import AlpacaOrderClass
 from torchtrade.envs.core.live import TorchTradeLiveEnv
-from torchtrade.envs.core.state import HistoryTracker, position_direction_from_status, PositionState
+from torchtrade.envs.core.state import (
+    HistoryTracker,
+    PositionState,
+    position_direction_from_qty,
+    position_direction_from_status,
+)
 
 
 class AlpacaBaseTorchTradingEnv(TorchTradeLiveEnv):
@@ -219,7 +224,8 @@ class AlpacaBaseTorchTradingEnv(TorchTradeLiveEnv):
         exposure_pct = position_value / portfolio_value if portfolio_value > 0 else 0.0
 
         # Element 1: position_direction (0 or +1 for spot, no shorts)
-        position_direction = 1.0 if position_size > 0 else 0.0
+        # Spot is long-only: max() keeps the domain at {0, +1}.
+        position_direction = float(max(0, position_direction_from_qty(position_size)))
 
         # Element 2: unrealized_pnl_pct (inherited from Alpaca)
         # Element 3: holding_time

--- a/torchtrade/envs/live/alpaca/base.py
+++ b/torchtrade/envs/live/alpaca/base.py
@@ -228,7 +228,6 @@ class AlpacaBaseTorchTradingEnv(TorchTradeLiveEnv):
         # Element 0: exposure_pct (position_value / portfolio_value)
         exposure_pct = position_value / portfolio_value if portfolio_value > 0 else 0.0
 
-
         # Element 2: unrealized_pnl_pct (inherited from Alpaca)
         # Element 3: holding_time
         # Element 4: leverage (always 1.0 for spot)

--- a/torchtrade/envs/live/alpaca/base.py
+++ b/torchtrade/envs/live/alpaca/base.py
@@ -198,7 +198,10 @@ class AlpacaBaseTorchTradingEnv(TorchTradeLiveEnv):
         position_status = status.get("position_status", None)
 
         # Calculate portfolio value
-        if position_status is None:
+        # Dust is not a position. Gating on `is None` let a float residual left behind a
+        # close take the position branch, putting a phantom holding_time / leverage /
+        # distance_to_liquidation into the vector the policy consumes.
+        if position_direction_from_status(position_status) == 0:
             position_size = 0.0
             position_value = 0.0
             entry_price = 0.0
@@ -224,8 +227,7 @@ class AlpacaBaseTorchTradingEnv(TorchTradeLiveEnv):
         exposure_pct = position_value / portfolio_value if portfolio_value > 0 else 0.0
 
         # Element 1: position_direction (0 or +1 for spot, no shorts)
-        # Spot is long-only: max() keeps the domain at {0, +1}.
-        position_direction = float(max(0, position_direction_from_qty(position_size)))
+        position_direction = float(position_direction_from_qty(position_size))
 
         # Element 2: unrealized_pnl_pct (inherited from Alpaca)
         # Element 3: holding_time

--- a/torchtrade/envs/live/alpaca/env.py
+++ b/torchtrade/envs/live/alpaca/env.py
@@ -116,6 +116,10 @@ class AlpacaTorchTradingEnv(AlpacaBaseTorchTradingEnv):
         position_status = status.get("position_status", None)
         current_price = self._get_current_price(position_status)
 
+        # Exchange truth wins: a liquidation or manual close between steps must not leave the
+        # duplicate-action guard trusting a position we no longer hold.
+        self._sync_position_after_step(position_status)
+
         # Calculate and execute trade if needed
         trade_info = self._execute_trade_if_needed(desired_action)
 

--- a/torchtrade/envs/live/alpaca/env.py
+++ b/torchtrade/envs/live/alpaca/env.py
@@ -116,9 +116,7 @@ class AlpacaTorchTradingEnv(AlpacaBaseTorchTradingEnv):
         position_status = status.get("position_status", None)
         current_price = self._get_current_price(position_status)
 
-        # Exchange truth wins: a liquidation or manual close between steps must not leave the
-        # duplicate-action guard trusting a position we no longer hold.
-        self._sync_position_after_step(position_status)
+        self._sync_position_from_exchange(position_status)
 
         # Calculate and execute trade if needed
         trade_info = self._execute_trade_if_needed(desired_action)

--- a/torchtrade/envs/live/binance/base.py
+++ b/torchtrade/envs/live/binance/base.py
@@ -236,7 +236,6 @@ class BinanceBaseTorchTradingEnv(TorchTradeLiveEnv):
         # Element 0: exposure_pct (position_value / portfolio_value)
         exposure_pct = position_value / total_balance if total_balance > 0 else 0.0
 
-
         # Element 2: unrealized_pnl_pct (from Binance API)
 
         # Element 3: holding_time

--- a/torchtrade/envs/live/binance/base.py
+++ b/torchtrade/envs/live/binance/base.py
@@ -12,7 +12,12 @@ from torchtrade.envs.utils.timeframe import timeframe_to_seconds
 from torchtrade.envs.live.binance.observation import BinanceObservationClass
 from torchtrade.envs.live.binance.order_executor import BinanceFuturesOrderClass
 from torchtrade.envs.core.live import TorchTradeLiveEnv
-from torchtrade.envs.core.state import HistoryTracker, position_direction_from_status, PositionState
+from torchtrade.envs.core.state import (
+    HistoryTracker,
+    PositionState,
+    position_direction_from_qty,
+    position_direction_from_status,
+)
 
 
 class BinanceBaseTorchTradingEnv(TorchTradeLiveEnv):
@@ -230,11 +235,7 @@ class BinanceBaseTorchTradingEnv(TorchTradeLiveEnv):
         exposure_pct = position_value / total_balance if total_balance > 0 else 0.0
 
         # Element 1: position_direction (-1, 0, +1)
-        position_direction = float(
-            1 if position_size > 0
-            else -1 if position_size < 0
-            else 0
-        )
+        position_direction = float(position_direction_from_qty(position_size))
 
         # Element 2: unrealized_pnl_pct (from Binance API)
 

--- a/torchtrade/envs/live/binance/base.py
+++ b/torchtrade/envs/live/binance/base.py
@@ -211,7 +211,10 @@ class BinanceBaseTorchTradingEnv(TorchTradeLiveEnv):
 
         position_status = status.get("position_status", None)
 
-        if position_status is None:
+        # Dust is not a position. Gating on `is None` let a float residual left behind a
+        # close take the position branch, putting a phantom holding_time / leverage /
+        # distance_to_liquidation into the vector the policy consumes.
+        if position_direction_from_status(position_status) == 0:
             position_size = 0.0
             position_value = 0.0
             entry_price = 0.0

--- a/torchtrade/envs/live/binance/base.py
+++ b/torchtrade/envs/live/binance/base.py
@@ -236,7 +236,6 @@ class BinanceBaseTorchTradingEnv(TorchTradeLiveEnv):
         # Element 0: exposure_pct (position_value / portfolio_value)
         exposure_pct = position_value / total_balance if total_balance > 0 else 0.0
 
-        # Element 1: position_direction (-1, 0, +1)
 
         # Element 2: unrealized_pnl_pct (from Binance API)
 

--- a/torchtrade/envs/live/binance/base.py
+++ b/torchtrade/envs/live/binance/base.py
@@ -12,7 +12,7 @@ from torchtrade.envs.utils.timeframe import timeframe_to_seconds
 from torchtrade.envs.live.binance.observation import BinanceObservationClass
 from torchtrade.envs.live.binance.order_executor import BinanceFuturesOrderClass
 from torchtrade.envs.core.live import TorchTradeLiveEnv
-from torchtrade.envs.core.state import HistoryTracker, PositionState
+from torchtrade.envs.core.state import HistoryTracker, position_direction_from_status, PositionState
 
 
 class BinanceBaseTorchTradingEnv(TorchTradeLiveEnv):
@@ -312,14 +312,7 @@ class BinanceBaseTorchTradingEnv(TorchTradeLiveEnv):
         position_status = status.get("position_status")
         self.position.hold_counter = 0
 
-        if position_status is None:
-            self.position.current_position = 0
-        elif position_status.qty > 0:
-            self.position.current_position = 1  # Long position
-        elif position_status.qty < 0:
-            self.position.current_position = -1  # Short position
-        else:
-            self.position.current_position = 0  # No position
+        self.position.current_position = position_direction_from_status(position_status)
 
         self._sync_action_level_after_reset()
 

--- a/torchtrade/envs/live/binance/base.py
+++ b/torchtrade/envs/live/binance/base.py
@@ -15,7 +15,6 @@ from torchtrade.envs.core.live import TorchTradeLiveEnv
 from torchtrade.envs.core.state import (
     HistoryTracker,
     PositionState,
-    position_direction_from_qty,
     position_direction_from_status,
 )
 
@@ -211,10 +210,10 @@ class BinanceBaseTorchTradingEnv(TorchTradeLiveEnv):
 
         position_status = status.get("position_status", None)
 
-        # Dust is not a position. Gating on `is None` let a float residual left behind a
-        # close take the position branch, putting a phantom holding_time / leverage /
-        # distance_to_liquidation into the vector the policy consumes.
-        if position_direction_from_status(position_status) == 0:
+        # Dust is not a position: gating on `is None` let a 1e-12 residual left behind a
+        # close take the position branch and read stale fields off it.
+        position_direction = float(position_direction_from_status(position_status))
+        if position_direction == 0:
             position_size = 0.0
             position_value = 0.0
             entry_price = 0.0
@@ -238,7 +237,6 @@ class BinanceBaseTorchTradingEnv(TorchTradeLiveEnv):
         exposure_pct = position_value / total_balance if total_balance > 0 else 0.0
 
         # Element 1: position_direction (-1, 0, +1)
-        position_direction = float(position_direction_from_qty(position_size))
 
         # Element 2: unrealized_pnl_pct (from Binance API)
 

--- a/torchtrade/envs/live/binance/env.py
+++ b/torchtrade/envs/live/binance/env.py
@@ -159,6 +159,10 @@ class BinanceFuturesTorchTradingEnv(BinanceBaseTorchTradingEnv):
             current_price = self.trader.get_mark_price()
             position_size = 0.0
 
+        # Exchange truth wins: a liquidation or manual close between steps must not leave the
+        # duplicate-action guard trusting a position we no longer hold.
+        self._sync_position_after_step(position_status)
+
         # Get desired action
         action_idx = tensordict.get("action", 0)
         if isinstance(action_idx, torch.Tensor):

--- a/torchtrade/envs/live/binance/env.py
+++ b/torchtrade/envs/live/binance/env.py
@@ -159,9 +159,7 @@ class BinanceFuturesTorchTradingEnv(BinanceBaseTorchTradingEnv):
             current_price = self.trader.get_mark_price()
             position_size = 0.0
 
-        # Exchange truth wins: a liquidation or manual close between steps must not leave the
-        # duplicate-action guard trusting a position we no longer hold.
-        self._sync_position_after_step(position_status)
+        self._sync_position_from_exchange(position_status)
 
         # Get desired action
         action_idx = tensordict.get("action", 0)

--- a/torchtrade/envs/live/bitget/base.py
+++ b/torchtrade/envs/live/bitget/base.py
@@ -12,7 +12,7 @@ from torchtrade.envs.utils.timeframe import TimeFrame
 from torchtrade.envs.live.bitget.observation import BitgetObservationClass
 from torchtrade.envs.live.bitget.order_executor import BitgetFuturesOrderClass
 from torchtrade.envs.core.live import TorchTradeLiveEnv
-from torchtrade.envs.core.state import HistoryTracker, PositionState
+from torchtrade.envs.core.state import HistoryTracker, position_direction_from_status, PositionState
 
 
 class BitgetBaseTorchTradingEnv(TorchTradeLiveEnv):
@@ -331,14 +331,7 @@ class BitgetBaseTorchTradingEnv(TorchTradeLiveEnv):
         position_status = status.get("position_status")
         self.position.hold_counter = 0
 
-        if position_status is None:
-            self.position.current_position = 0  # No position
-        elif position_status.qty > 0:
-            self.position.current_position = 1  # Long position
-        elif position_status.qty < 0:
-            self.position.current_position = -1  # Short position
-        else:
-            self.position.current_position = 0  # No position
+        self.position.current_position = position_direction_from_status(position_status)
 
         self._sync_action_level_after_reset()
 

--- a/torchtrade/envs/live/bitget/base.py
+++ b/torchtrade/envs/live/bitget/base.py
@@ -255,7 +255,6 @@ class BitgetBaseTorchTradingEnv(TorchTradeLiveEnv):
         # Element 0: exposure_pct (position_value / portfolio_value)
         exposure_pct = position_value / total_balance if total_balance > 0 else 0.0
 
-
         # Element 2: unrealized_pnl_pct (from Bitget API)
 
         # Element 3: holding_time

--- a/torchtrade/envs/live/bitget/base.py
+++ b/torchtrade/envs/live/bitget/base.py
@@ -255,7 +255,6 @@ class BitgetBaseTorchTradingEnv(TorchTradeLiveEnv):
         # Element 0: exposure_pct (position_value / portfolio_value)
         exposure_pct = position_value / total_balance if total_balance > 0 else 0.0
 
-        # Element 1: position_direction (-1, 0, +1)
 
         # Element 2: unrealized_pnl_pct (from Bitget API)
 

--- a/torchtrade/envs/live/bitget/base.py
+++ b/torchtrade/envs/live/bitget/base.py
@@ -15,7 +15,6 @@ from torchtrade.envs.core.live import TorchTradeLiveEnv
 from torchtrade.envs.core.state import (
     HistoryTracker,
     PositionState,
-    position_direction_from_qty,
     position_direction_from_status,
 )
 
@@ -228,10 +227,10 @@ class BitgetBaseTorchTradingEnv(TorchTradeLiveEnv):
 
         position_status = status.get("position_status", None)
 
-        # Dust is not a position. Gating on `is None` let a float residual left behind a
-        # close take the position branch, putting a phantom holding_time / leverage /
-        # distance_to_liquidation into the vector the policy consumes.
-        if position_direction_from_status(position_status) == 0:
+        # Dust is not a position: gating on `is None` let a 1e-12 residual left behind a
+        # close take the position branch and read stale fields off it.
+        position_direction = float(position_direction_from_status(position_status))
+        if position_direction == 0:
             self.position.hold_counter = 0
             position_size = 0.0
             position_value = 0.0
@@ -257,7 +256,6 @@ class BitgetBaseTorchTradingEnv(TorchTradeLiveEnv):
         exposure_pct = position_value / total_balance if total_balance > 0 else 0.0
 
         # Element 1: position_direction (-1, 0, +1)
-        position_direction = float(position_direction_from_qty(position_size))
 
         # Element 2: unrealized_pnl_pct (from Bitget API)
 

--- a/torchtrade/envs/live/bitget/base.py
+++ b/torchtrade/envs/live/bitget/base.py
@@ -12,7 +12,12 @@ from torchtrade.envs.utils.timeframe import TimeFrame
 from torchtrade.envs.live.bitget.observation import BitgetObservationClass
 from torchtrade.envs.live.bitget.order_executor import BitgetFuturesOrderClass
 from torchtrade.envs.core.live import TorchTradeLiveEnv
-from torchtrade.envs.core.state import HistoryTracker, position_direction_from_status, PositionState
+from torchtrade.envs.core.state import (
+    HistoryTracker,
+    PositionState,
+    position_direction_from_qty,
+    position_direction_from_status,
+)
 
 
 class BitgetBaseTorchTradingEnv(TorchTradeLiveEnv):
@@ -249,11 +254,7 @@ class BitgetBaseTorchTradingEnv(TorchTradeLiveEnv):
         exposure_pct = position_value / total_balance if total_balance > 0 else 0.0
 
         # Element 1: position_direction (-1, 0, +1)
-        position_direction = float(
-            1 if position_size > 0
-            else -1 if position_size < 0
-            else 0
-        )
+        position_direction = float(position_direction_from_qty(position_size))
 
         # Element 2: unrealized_pnl_pct (from Bitget API)
 

--- a/torchtrade/envs/live/bitget/base.py
+++ b/torchtrade/envs/live/bitget/base.py
@@ -228,7 +228,10 @@ class BitgetBaseTorchTradingEnv(TorchTradeLiveEnv):
 
         position_status = status.get("position_status", None)
 
-        if position_status is None:
+        # Dust is not a position. Gating on `is None` let a float residual left behind a
+        # close take the position branch, putting a phantom holding_time / leverage /
+        # distance_to_liquidation into the vector the policy consumes.
+        if position_direction_from_status(position_status) == 0:
             self.position.hold_counter = 0
             position_size = 0.0
             position_value = 0.0

--- a/torchtrade/envs/live/bitget/env.py
+++ b/torchtrade/envs/live/bitget/env.py
@@ -159,6 +159,10 @@ class BitgetFuturesTorchTradingEnv(BitgetBaseTorchTradingEnv):
             current_price = self.trader.get_mark_price()
             position_size = 0.0
 
+        # Exchange truth wins: a liquidation or manual close between steps must not leave the
+        # duplicate-action guard trusting a position we no longer hold.
+        self._sync_position_after_step(position_status)
+
         # Get desired action level
         action_idx = tensordict.get("action", 0)
         if isinstance(action_idx, torch.Tensor):

--- a/torchtrade/envs/live/bitget/env.py
+++ b/torchtrade/envs/live/bitget/env.py
@@ -159,9 +159,7 @@ class BitgetFuturesTorchTradingEnv(BitgetBaseTorchTradingEnv):
             current_price = self.trader.get_mark_price()
             position_size = 0.0
 
-        # Exchange truth wins: a liquidation or manual close between steps must not leave the
-        # duplicate-action guard trusting a position we no longer hold.
-        self._sync_position_after_step(position_status)
+        self._sync_position_from_exchange(position_status)
 
         # Get desired action level
         action_idx = tensordict.get("action", 0)

--- a/torchtrade/envs/live/bybit/base.py
+++ b/torchtrade/envs/live/bybit/base.py
@@ -12,7 +12,7 @@ from torchrl.data.tensor_specs import Composite
 from torchtrade.envs.live.bybit.observation import BybitObservationClass
 from torchtrade.envs.live.bybit.order_executor import BybitFuturesOrderClass
 from torchtrade.envs.core.live import TorchTradeLiveEnv
-from torchtrade.envs.core.state import HistoryTracker
+from torchtrade.envs.core.state import HistoryTracker, position_direction_from_status
 
 logger = logging.getLogger(__name__)
 
@@ -265,14 +265,7 @@ class BybitBaseTorchTradingEnv(TorchTradeLiveEnv):
         position_status = status.get("position_status")
         self.position.hold_counter = 0
 
-        if position_status is None:
-            self.position.current_position = 0
-        elif position_status.qty > 0:
-            self.position.current_position = 1
-        elif position_status.qty < 0:
-            self.position.current_position = -1
-        else:
-            self.position.current_position = 0
+        self.position.current_position = position_direction_from_status(position_status)
 
         # No-op today (bybit's _execute_trade_if_needed recomputes qty live and never reads
         # current_action_level), but keeps the field consistent so adding a duplicate-action

--- a/torchtrade/envs/live/bybit/base.py
+++ b/torchtrade/envs/live/bybit/base.py
@@ -187,7 +187,10 @@ class BybitBaseTorchTradingEnv(TorchTradeLiveEnv):
         total_balance = balance.get("total_wallet_balance", 0)
         position_status = status.get("position_status", None)
 
-        if position_status is None:
+        # Dust is not a position. Gating on `is None` let a float residual left behind a
+        # close take the position branch, putting a phantom holding_time / leverage /
+        # distance_to_liquidation into the vector the policy consumes.
+        if position_direction_from_status(position_status) == 0:
             self.position.hold_counter = 0
             position_size = 0.0
             position_value = 0.0

--- a/torchtrade/envs/live/bybit/base.py
+++ b/torchtrade/envs/live/bybit/base.py
@@ -14,7 +14,6 @@ from torchtrade.envs.live.bybit.order_executor import BybitFuturesOrderClass
 from torchtrade.envs.core.live import TorchTradeLiveEnv
 from torchtrade.envs.core.state import (
     HistoryTracker,
-    position_direction_from_qty,
     position_direction_from_status,
 )
 
@@ -187,10 +186,10 @@ class BybitBaseTorchTradingEnv(TorchTradeLiveEnv):
         total_balance = balance.get("total_wallet_balance", 0)
         position_status = status.get("position_status", None)
 
-        # Dust is not a position. Gating on `is None` let a float residual left behind a
-        # close take the position branch, putting a phantom holding_time / leverage /
-        # distance_to_liquidation into the vector the policy consumes.
-        if position_direction_from_status(position_status) == 0:
+        # Dust is not a position: gating on `is None` let a 1e-12 residual left behind a
+        # close take the position branch and read stale fields off it.
+        position_direction = float(position_direction_from_status(position_status))
+        if position_direction == 0:
             self.position.hold_counter = 0
             position_size = 0.0
             position_value = 0.0
@@ -212,7 +211,6 @@ class BybitBaseTorchTradingEnv(TorchTradeLiveEnv):
         # Build 6-element account state
         exposure_pct = position_value / total_balance if total_balance > 0 else 0.0
 
-        position_direction = float(position_direction_from_qty(position_size))
 
         if position_size == 0 or current_price == 0 or liquidation_price <= 0:
             distance_to_liquidation = 1.0

--- a/torchtrade/envs/live/bybit/base.py
+++ b/torchtrade/envs/live/bybit/base.py
@@ -12,7 +12,11 @@ from torchrl.data.tensor_specs import Composite
 from torchtrade.envs.live.bybit.observation import BybitObservationClass
 from torchtrade.envs.live.bybit.order_executor import BybitFuturesOrderClass
 from torchtrade.envs.core.live import TorchTradeLiveEnv
-from torchtrade.envs.core.state import HistoryTracker, position_direction_from_status
+from torchtrade.envs.core.state import (
+    HistoryTracker,
+    position_direction_from_qty,
+    position_direction_from_status,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -205,12 +209,7 @@ class BybitBaseTorchTradingEnv(TorchTradeLiveEnv):
         # Build 6-element account state
         exposure_pct = position_value / total_balance if total_balance > 0 else 0.0
 
-        if position_size > 0:
-            position_direction = 1.0
-        elif position_size < 0:
-            position_direction = -1.0
-        else:
-            position_direction = 0.0
+        position_direction = float(position_direction_from_qty(position_size))
 
         if position_size == 0 or current_price == 0 or liquidation_price <= 0:
             distance_to_liquidation = 1.0

--- a/torchtrade/envs/live/bybit/base.py
+++ b/torchtrade/envs/live/bybit/base.py
@@ -211,7 +211,6 @@ class BybitBaseTorchTradingEnv(TorchTradeLiveEnv):
         # Build 6-element account state
         exposure_pct = position_value / total_balance if total_balance > 0 else 0.0
 
-
         if position_size == 0 or current_price == 0 or liquidation_price <= 0:
             distance_to_liquidation = 1.0
         else:

--- a/torchtrade/envs/live/bybit/env.py
+++ b/torchtrade/envs/live/bybit/env.py
@@ -114,9 +114,10 @@ class BybitFuturesTorchTradingEnv(BybitBaseTorchTradingEnv):
             current_price = self.trader.get_mark_price()
             position_size = 0.0
 
-        # Exchange truth wins: a liquidation or manual close between steps must not leave the
-        # duplicate-action guard trusting a position we no longer hold.
-        self._sync_position_after_step(position_status)
+        # No-op today (this env's _execute_trade_if_needed recomputes qty live and never reads
+        # current_action_level), but keeps the field consistent so adding a duplicate-action
+        # guard here can't reintroduce the silent no-op that bit alpaca/binance/bitget.
+        self._sync_position_from_exchange(position_status)
 
         action_idx = tensordict.get("action", 0)
         if isinstance(action_idx, torch.Tensor):

--- a/torchtrade/envs/live/bybit/env.py
+++ b/torchtrade/envs/live/bybit/env.py
@@ -114,6 +114,10 @@ class BybitFuturesTorchTradingEnv(BybitBaseTorchTradingEnv):
             current_price = self.trader.get_mark_price()
             position_size = 0.0
 
+        # Exchange truth wins: a liquidation or manual close between steps must not leave the
+        # duplicate-action guard trusting a position we no longer hold.
+        self._sync_position_after_step(position_status)
+
         action_idx = tensordict.get("action", 0)
         if isinstance(action_idx, torch.Tensor):
             action_idx = action_idx.item()

--- a/torchtrade/envs/live/okx/base.py
+++ b/torchtrade/envs/live/okx/base.py
@@ -12,7 +12,11 @@ from torchrl.data.tensor_specs import Composite
 from torchtrade.envs.live.okx.observation import OKXObservationClass
 from torchtrade.envs.live.okx.order_executor import OKXFuturesOrderClass
 from torchtrade.envs.core.live import TorchTradeLiveEnv
-from torchtrade.envs.core.state import HistoryTracker, position_direction_from_status
+from torchtrade.envs.core.state import (
+    HistoryTracker,
+    position_direction_from_qty,
+    position_direction_from_status,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -215,12 +219,7 @@ class OKXBaseTorchTradingEnv(TorchTradeLiveEnv):
         # Build 6-element account state
         exposure_pct = position_value / total_balance if total_balance > 0 else 0.0
 
-        if position_size > 0:
-            position_direction = 1.0
-        elif position_size < 0:
-            position_direction = -1.0
-        else:
-            position_direction = 0.0
+        position_direction = float(position_direction_from_qty(position_size))
 
         if position_size == 0 or current_price == 0 or liquidation_price <= 0:
             distance_to_liquidation = 1.0

--- a/torchtrade/envs/live/okx/base.py
+++ b/torchtrade/envs/live/okx/base.py
@@ -221,7 +221,6 @@ class OKXBaseTorchTradingEnv(TorchTradeLiveEnv):
         # Build 6-element account state
         exposure_pct = position_value / total_balance if total_balance > 0 else 0.0
 
-
         if position_size == 0 or current_price == 0 or liquidation_price <= 0:
             distance_to_liquidation = 1.0
         else:

--- a/torchtrade/envs/live/okx/base.py
+++ b/torchtrade/envs/live/okx/base.py
@@ -14,7 +14,6 @@ from torchtrade.envs.live.okx.order_executor import OKXFuturesOrderClass
 from torchtrade.envs.core.live import TorchTradeLiveEnv
 from torchtrade.envs.core.state import (
     HistoryTracker,
-    position_direction_from_qty,
     position_direction_from_status,
 )
 
@@ -197,10 +196,10 @@ class OKXBaseTorchTradingEnv(TorchTradeLiveEnv):
         total_balance = balance.get("total_wallet_balance", 0)
         position_status = status.get("position_status", None)
 
-        # Dust is not a position. Gating on `is None` let a float residual left behind a
-        # close take the position branch, putting a phantom holding_time / leverage /
-        # distance_to_liquidation into the vector the policy consumes.
-        if position_direction_from_status(position_status) == 0:
+        # Dust is not a position: gating on `is None` let a 1e-12 residual left behind a
+        # close take the position branch and read stale fields off it.
+        position_direction = float(position_direction_from_status(position_status))
+        if position_direction == 0:
             self.position.hold_counter = 0
             position_size = 0.0
             position_value = 0.0
@@ -222,7 +221,6 @@ class OKXBaseTorchTradingEnv(TorchTradeLiveEnv):
         # Build 6-element account state
         exposure_pct = position_value / total_balance if total_balance > 0 else 0.0
 
-        position_direction = float(position_direction_from_qty(position_size))
 
         if position_size == 0 or current_price == 0 or liquidation_price <= 0:
             distance_to_liquidation = 1.0

--- a/torchtrade/envs/live/okx/base.py
+++ b/torchtrade/envs/live/okx/base.py
@@ -12,7 +12,7 @@ from torchrl.data.tensor_specs import Composite
 from torchtrade.envs.live.okx.observation import OKXObservationClass
 from torchtrade.envs.live.okx.order_executor import OKXFuturesOrderClass
 from torchtrade.envs.core.live import TorchTradeLiveEnv
-from torchtrade.envs.core.state import HistoryTracker
+from torchtrade.envs.core.state import HistoryTracker, position_direction_from_status
 
 logger = logging.getLogger(__name__)
 
@@ -275,14 +275,7 @@ class OKXBaseTorchTradingEnv(TorchTradeLiveEnv):
         position_status = status.get("position_status")
         self.position.hold_counter = 0
 
-        if position_status is None:
-            self.position.current_position = 0
-        elif position_status.qty > 0:
-            self.position.current_position = 1
-        elif position_status.qty < 0:
-            self.position.current_position = -1
-        else:
-            self.position.current_position = 0
+        self.position.current_position = position_direction_from_status(position_status)
 
         # No-op today (okx's _execute_trade_if_needed recomputes qty live and never reads
         # current_action_level), but keeps the field consistent so adding a duplicate-action

--- a/torchtrade/envs/live/okx/base.py
+++ b/torchtrade/envs/live/okx/base.py
@@ -197,7 +197,10 @@ class OKXBaseTorchTradingEnv(TorchTradeLiveEnv):
         total_balance = balance.get("total_wallet_balance", 0)
         position_status = status.get("position_status", None)
 
-        if position_status is None:
+        # Dust is not a position. Gating on `is None` let a float residual left behind a
+        # close take the position branch, putting a phantom holding_time / leverage /
+        # distance_to_liquidation into the vector the policy consumes.
+        if position_direction_from_status(position_status) == 0:
             self.position.hold_counter = 0
             position_size = 0.0
             position_value = 0.0

--- a/torchtrade/envs/live/okx/env.py
+++ b/torchtrade/envs/live/okx/env.py
@@ -115,9 +115,10 @@ class OKXFuturesTorchTradingEnv(OKXBaseTorchTradingEnv):
             current_price = self.trader.get_mark_price()
             position_size = 0.0
 
-        # Exchange truth wins: a liquidation or manual close between steps must not leave the
-        # duplicate-action guard trusting a position we no longer hold.
-        self._sync_position_after_step(position_status)
+        # No-op today (this env's _execute_trade_if_needed recomputes qty live and never reads
+        # current_action_level), but keeps the field consistent so adding a duplicate-action
+        # guard here can't reintroduce the silent no-op that bit alpaca/binance/bitget.
+        self._sync_position_from_exchange(position_status)
 
         action_idx = tensordict.get("action", 0)
         if isinstance(action_idx, torch.Tensor):

--- a/torchtrade/envs/live/okx/env.py
+++ b/torchtrade/envs/live/okx/env.py
@@ -115,6 +115,10 @@ class OKXFuturesTorchTradingEnv(OKXBaseTorchTradingEnv):
             current_price = self.trader.get_mark_price()
             position_size = 0.0
 
+        # Exchange truth wins: a liquidation or manual close between steps must not leave the
+        # duplicate-action guard trusting a position we no longer hold.
+        self._sync_position_after_step(position_status)
+
         action_idx = tensordict.get("action", 0)
         if isinstance(action_idx, torch.Tensor):
             action_idx = action_idx.item()

--- a/torchtrade/envs/utils/sltp_mixin.py
+++ b/torchtrade/envs/utils/sltp_mixin.py
@@ -39,6 +39,11 @@ class SLTPMixin:
         prev_position = self.position.current_position
         self.position.current_position = position_direction_from_status(position_status)
 
+        # The position we were counting is gone, or was never ours. Its age must not be
+        # inherited by whatever is there now -- including a re-entry made in THIS same step.
+        if self.position.current_position != prev_position:
+            self.position.hold_counter = 0
+
         # Detect position closure (had position, now don't)
         position_closed = (prev_position != 0 and self.position.current_position == 0)
         if position_closed:

--- a/torchtrade/envs/utils/sltp_mixin.py
+++ b/torchtrade/envs/utils/sltp_mixin.py
@@ -2,6 +2,8 @@
 
 import logging
 
+from torchtrade.envs.core.state import position_direction
+
 logger = logging.getLogger(__name__)
 
 
@@ -17,10 +19,6 @@ class SLTPMixin:
         - self.active_stop_loss: float (current SL price)
         - self.active_take_profit: float (current TP price)
     """
-
-    # Quantities below this threshold are treated as dust (no real position).
-    # Prevents float residuals (e.g. 1e-12) from being read as open positions.
-    POSITION_DUST_EPS = 1e-9
 
     def _sync_position_from_exchange(self, position_status) -> bool:
         """Sync internal position state from exchange and detect SL/TP closures.
@@ -39,15 +37,7 @@ class SLTPMixin:
             or external closure), False otherwise.
         """
         prev_position = self.position.current_position
-
-        qty = 0.0 if position_status is None else float(position_status.qty)
-
-        if abs(qty) <= self.POSITION_DUST_EPS:
-            self.position.current_position = 0
-        elif qty > 0:
-            self.position.current_position = 1
-        else:
-            self.position.current_position = -1
+        self.position.current_position = position_direction(position_status)
 
         # Detect position closure (had position, now don't)
         position_closed = (prev_position != 0 and self.position.current_position == 0)

--- a/torchtrade/envs/utils/sltp_mixin.py
+++ b/torchtrade/envs/utils/sltp_mixin.py
@@ -2,7 +2,7 @@
 
 import logging
 
-from torchtrade.envs.core.state import position_direction
+from torchtrade.envs.core.state import position_direction_from_status
 
 logger = logging.getLogger(__name__)
 
@@ -37,7 +37,7 @@ class SLTPMixin:
             or external closure), False otherwise.
         """
         prev_position = self.position.current_position
-        self.position.current_position = position_direction(position_status)
+        self.position.current_position = position_direction_from_status(position_status)
 
         # Detect position closure (had position, now don't)
         position_closed = (prev_position != 0 and self.position.current_position == 0)


### PR DESCRIPTION
## The bug (live money)

`_execute_trade_if_needed` short-circuits when `desired_action == current_action_level`. But **both cached fields are written only by trades the env itself makes** — nothing reconciled them with the exchange mid-episode.

So when a position closes behind the env's back — a **liquidation**, or a manual close in the exchange UI — the cached level stays at its pre-close value. An agent that re-requests the level it used to hold (*the common case for a converged policy repeating its last action*) matches the stale level, the guard calls it redundant, and **the re-entry is silently dropped**. It stays dropped until the policy happens to emit a different level. Live episodes are indefinite real-time loops, so this can persist for hours.

The nastiest part: **it's invisible from the observation.** `_get_observation()` re-reads the exchange every step and is always correct. Only the trade *guard* trusts the stale cache — so the agent can see it's flat while the env quietly refuses to act on it.

Affects **alpaca, binance, bitget** (they have the guard). bybit/okx have no guard and were immune, but get the same call so a future guard can't silently reintroduce it.

## The fix

`TorchTradeLiveEnv._sync_position_from_exchange()`, called at the top of every non-SLTP `_step()` **before** the guard. It reuses the `position_status` `_step` already fetches, so it costs **no extra API call**. On a mismatch (the change wasn't ours) the level is NaN'd — the level behind a position we did not open is unknowable, and NaN never compares equal, so the next command always executes. On a match the level is left alone, which is what still lets the guard suppress genuinely redundant trades.

This is the mid-episode counterpart of #243, which fixed only the reset-time case.

## What the review found (and it was brutal)

Ten rounds of `torchrl-engineer` + `code-simplifier` + `pr-test-analyzer` + `test-justification`. **The first version of this fix did not work**, and the reviewers caught every subsequent problem. Recording it honestly:

| round | finding |
|---|---|
| 1 | **The fix didn't work.** Exact `qty == 0` missed dust residuals — a `qty=1e-12` liquidation still froze the guard. The `SLTPMixin` I copied the shape from already had `POSITION_DUST_EPS`; I took the method but not the hard-won constant. |
| 2 | "One dust rule" was **false** (5 resets still hand-rolled exact-zero). My rename **silently deleted a guard** — a reviewer re-forked binance's sync with the old broken rule and the suite stayed **green**. |
| 3 | I'd fixed the env's *internal state*, **not `account_state`** — the agent still saw a phantom position. Two of my docstrings claimed otherwise. |
| 4 | The agent sees **six** numbers; I'd fixed one. `holding_time` grew on a flat book; the agent saw a position **4% from a liquidation that didn't exist**. My own fixtures hid it (`liquidation_price=0.0` short-circuits that branch). |
| 5 | **The entire Alpaca fix was untested** — delete it, suite green. My test zeroed the fields it was checking. |
| 6–8 | Three surviving mutants, each hiding behind a **dead assertion** of mine (`assert hold_counter == 0` on a *fresh* env passes no matter what the code does). |
| 9–10 | **The inverse hole:** I spent the whole PR proving a *flat* account reads flat, and never checked that an **open** position reads open. A mutation handing the policy its 20×-levered position as *flat, unlevered, and infinitely far from liquidation* passed all 1977 tests. |

Every one of those is now mutation-verified. Corrupting any element of `account_state` — flat **or** open — dies in every exchange that has that element.

## Not fixed (deliberate, tracked separately)

- **`holding_time` doesn't reset on a direct position flip** (short→long as one order). Pre-existing, byte-identical to `main`.
- For alpaca/binance, `hold_counter` logic is **duplicated** in `env_sltp.py` and unpinned there.

## Suite

**1981 passed**, 25 skipped, 1 xfailed.

> ⚠️ Unrelated: `tests/actor/test_frontier_llm_actor.py::test_generate_batch_preserves_order` only passes because an untracked `.env` supplies `OPENAI_API_KEY`. It fails on a clean checkout **of `main` too**. CI on a fresh clone is not green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)