### PR TITLE
fix(losses): GroupRelativePGLoss.set_keys() always raised AttributeError

### DIFF
--- a/tests/losses/test_group_relative_pg_loss.py
+++ b/tests/losses/test_group_relative_pg_loss.py
@@ -336,20 +336,6 @@ class TestGroupRelativePGLoss:
         loss = GroupRelativePGLoss(actor_network=actor_network)
         loss.reset()  # Should not raise any errors
 
-    def test_set_keys_does_not_raise(self, actor_network):
-        """LossModule.set_keys() requires _forward_value_estimator_keys; without it, it raised.
-
-        Every external call to the public set_keys() API blew up with
-        AttributeError: 'GroupRelativePGLoss' object has no attribute
-        '_forward_value_estimator_keys'.
-        """
-        loss = GroupRelativePGLoss(actor_network=actor_network)
-
-        loss.set_keys(action="custom_action", sample_log_prob="custom_log_prob")
-
-        assert loss.tensor_keys.action == "custom_action"
-        assert loss.tensor_keys.sample_log_prob == "custom_log_prob"
-
     def test_set_keys_invalidates_the_cached_in_keys(self, actor_network):
         """A renamed key must appear in in_keys, and the old one must be gone.
 

--- a/tests/losses/test_group_relative_pg_loss.py
+++ b/tests/losses/test_group_relative_pg_loss.py
@@ -336,6 +336,46 @@ class TestGroupRelativePGLoss:
         loss = GroupRelativePGLoss(actor_network=actor_network)
         loss.reset()  # Should not raise any errors
 
+    def test_set_keys_does_not_raise(self, actor_network):
+        """LossModule.set_keys() requires _forward_value_estimator_keys; without it, it raised.
+
+        Every external call to the public set_keys() API blew up with
+        AttributeError: 'GroupRelativePGLoss' object has no attribute
+        '_forward_value_estimator_keys'.
+        """
+        loss = GroupRelativePGLoss(actor_network=actor_network)
+
+        loss.set_keys(action="custom_action", sample_log_prob="custom_log_prob")
+
+        assert loss.tensor_keys.action == "custom_action"
+        assert loss.tensor_keys.sample_log_prob == "custom_log_prob"
+
+    def test_set_keys_invalidates_the_cached_in_keys(self, actor_network):
+        """A renamed key must appear in in_keys, and the old one must be gone.
+
+        This is the half that an empty `_forward_value_estimator_keys` would silently break:
+        set_keys() would stop raising, tensor_keys would update, but the CACHED in_keys would
+        still name the old key -- so a training loop doing tensordict.select(*loss.in_keys)
+        would quietly drop the renamed one.
+        """
+        loss = GroupRelativePGLoss(actor_network=actor_network)
+        _ = loss.in_keys                      # populate the cache with the default keys
+
+        loss.set_keys(action="custom_action")
+
+        in_keys = [str(k) for k in loss.in_keys]
+        assert "custom_action" in in_keys
+        assert "action" not in in_keys, "the cached in_keys still name the old key"
+
+    def test_constructor_sets_the_actor_keys(self, actor_network):
+        """__init__ configures the keys from the actor. It used to do so inside a try/except
+        AttributeError that swallowed a real error -- so a genuine regression here would have
+        been silent."""
+        loss = GroupRelativePGLoss(actor_network=actor_network)
+
+        assert loss.tensor_keys.action == actor_network.dist_sample_keys[0]
+        assert loss.tensor_keys.sample_log_prob == actor_network.log_prob_keys[0]
+
 
 class TestGroupRelativePGLossGroupingInvariant:
     """Regression test for the group-relative-advantage invariant.

--- a/tests/losses/test_group_relative_pg_loss.py
+++ b/tests/losses/test_group_relative_pg_loss.py
@@ -367,14 +367,29 @@ class TestGroupRelativePGLoss:
         assert "custom_action" in in_keys
         assert "action" not in in_keys, "the cached in_keys still name the old key"
 
-    def test_constructor_sets_the_actor_keys(self, actor_network):
-        """__init__ configures the keys from the actor. It used to do so inside a try/except
-        AttributeError that swallowed a real error -- so a genuine regression here would have
-        been silent."""
-        loss = GroupRelativePGLoss(actor_network=actor_network)
+    def test_constructor_takes_the_keys_from_the_actor(self):
+        """__init__ configures the loss's keys from the actor's, not from the defaults.
 
-        assert loss.tensor_keys.action == actor_network.dist_sample_keys[0]
-        assert loss.tensor_keys.sample_log_prob == actor_network.log_prob_keys[0]
+        The actor deliberately uses NON-default key names. Comparing against
+        `actor.dist_sample_keys[0]` would be a tautology -- that is "action", which is also
+        what _AcceptedKeys.action defaults to, so the assertion would hold even if __init__
+        never configured anything (and it did hold: deleting the whole set_keys block from the
+        constructor left every test in this file green).
+        """
+        policy_net = TensorDictModule(
+            nn.Sequential(nn.Linear(self.OBS_DIM, 64), nn.ReLU(), nn.Linear(64, self.ACTION_DIM)),
+            in_keys=["observation"], out_keys=["logits"],
+        )
+        actor = ProbabilisticTensorDictModule(
+            in_keys=["logits"], out_keys=["my_action"],
+            distribution_class=Categorical, return_log_prob=True,
+        )
+        loss = GroupRelativePGLoss(
+            actor_network=ProbabilisticTensorDictSequential(policy_net, actor)
+        )
+
+        assert loss.tensor_keys.action == "my_action"          # not the "action" default
+        assert loss.tensor_keys.sample_log_prob == "my_action_log_prob"
 
 
 class TestGroupRelativePGLossGroupingInvariant:

--- a/tests/losses/test_group_relative_pg_loss.py
+++ b/tests/losses/test_group_relative_pg_loss.py
@@ -347,11 +347,15 @@ class TestGroupRelativePGLoss:
         loss = GroupRelativePGLoss(actor_network=actor_network)
         _ = loss.in_keys                      # populate the cache with the default keys
 
-        loss.set_keys(action="custom_action")
+        loss.set_keys(action="custom_action", sample_log_prob="custom_log_prob")
 
         in_keys = [str(k) for k in loss.in_keys]
         assert "custom_action" in in_keys
         assert "action" not in in_keys, "the cached in_keys still name the old key"
+        # sample_log_prob too, not just action: dropping it from _set_in_keys passed every
+        # test in this file, and the log-prob is what GRPO's importance ratio is built on --
+        # the precise failure this test exists to prevent.
+        assert "custom_log_prob" in in_keys
 
     def test_constructor_takes_the_keys_from_the_actor(self):
         """__init__ configures the loss's keys from the actor's, not from the defaults.

--- a/torchtrade/losses/group_relative_pg_loss.py
+++ b/torchtrade/losses/group_relative_pg_loss.py
@@ -139,15 +139,23 @@ class GroupRelativePGLoss(LossModule):
             raise TypeError("entropy_coeff must be a float or a Mapping[str, float]")
 
 
-        try:
-            log_prob_keys = self.actor_network.log_prob_keys
-            action_keys = self.actor_network.dist_sample_keys
-            if len(log_prob_keys) > 1:
-                self.set_keys(sample_log_prob=log_prob_keys, action=action_keys)
-            else:
-                self.set_keys(sample_log_prob=log_prob_keys[0], action=action_keys[0])
-        except AttributeError:
-            pass
+        log_prob_keys = self.actor_network.log_prob_keys
+        action_keys = self.actor_network.dist_sample_keys
+        if len(log_prob_keys) > 1:
+            self.set_keys(sample_log_prob=log_prob_keys, action=action_keys)
+        else:
+            self.set_keys(sample_log_prob=log_prob_keys[0], action=action_keys[0])
+
+    def _forward_value_estimator_keys(self, **kwargs) -> None:
+        """Required by LossModule.set_keys(); without it, set_keys() raises AttributeError.
+
+        GRPO has no value estimator -- the advantage is group-relative, computed from the
+        rewards themselves, not from a critic. So there are no estimator keys to forward. The
+        one thing that DOES have to happen is invalidating the cached in_keys: a renamed key
+        must show up in `loss.in_keys`, or a training loop doing
+        `tensordict.select(*loss.in_keys)` would silently drop it.
+        """
+        self._set_in_keys()
 
     @property
     def functional(self):


### PR DESCRIPTION
## The bug

TorchRL's `LossModule.set_keys()` calls `self._forward_value_estimator_keys(**kwargs)` after setting the keys. `GroupRelativePGLoss` never defined it, so **every external call to the public `set_keys()` API** died with:

```
AttributeError: 'GroupRelativePGLoss' object has no attribute '_forward_value_estimator_keys'
```

and `__init__`'s own `set_keys()` calls sat inside a `try/except AttributeError: pass` that swallowed it.

## The reported bug was wrong — I checked before fixing

This was flagged as *"multi-head key config is a silent no-op."* **It isn't.** `LossModule.set_keys()` does the `setattr` on `tensor_keys` **before** calling the missing method, so the constructor path has always produced correct keys, single- and multi-head alike. Had I trusted the report I'd have fixed a non-bug and written a test that proved nothing.

The real bug is narrower and plainer: **the public `set_keys()` API is simply broken.**

## The fix

GRPO has no value estimator — the advantage is group-relative, computed from the rewards, not a critic — so there are no estimator keys to forward. But **the override cannot be empty**: it must call `self._set_in_keys()` to invalidate the cached `in_keys`. Without that, a renamed key updates `tensor_keys` but never reaches `loss.in_keys`, and a training loop doing `tensordict.select(*loss.in_keys)` **silently drops it**.

The override is identical to what TorchRL's own `torchrl.objectives.llm.GRPOLoss` does (`grpo.py:320-322`) — same situation, no value estimator.

**One deliberate divergence from upstream:** removing the constructor's `try/except` has no upstream counterpart — PPOLoss *keeps* it. Failing loud is correct for GRPO (a non-probabilistic actor should not silently build with default keys), and both production call sites pass probabilistic actors. Flagging it rather than burying it.

## Tests (2)

| test | uniquely kills |
|---|---|
| `test_set_keys_invalidates_the_cached_in_keys` | the naive empty override; `_set_in_keys` dropping `action`; `_set_in_keys` dropping `sample_log_prob`; accumulate-instead-of-rebuild |
| `test_constructor_takes_the_keys_from_the_actor` | the constructor not configuring keys at all |

Two of these exist because the reviewers caught me:

- My first constructor test was a **tautology** — it compared `tensor_keys.action` to `actor.dist_sample_keys[0]`, which is `"action"`, and `_AcceptedKeys.action` *also* defaults to `"action"`. Delete the entire `set_keys` block from `__init__` and all 32 tests still passed. It now uses an actor with `out_keys=["my_action"]`.
- The PR's central claim — *"a renamed key must reach `in_keys`"* — was pinned for `action` and **not at all for `sample_log_prob`**, the key GRPO's importance ratio is built on. Dropping it from `_set_in_keys` passed every test. Now pinned.

## Known gaps (pre-existing, disclosed)

- The multi-head branch (`len(log_prob_keys) > 1`) is reachable and working but **untested** — under a `> 1` → `False` mutant a multi-head actor silently trains on one head and drops the other, with no error.
- `torchtrade/losses/dg_loss.py` has the **identical** bug: same swallowed `try/except`, same missing override. Follow-up, not scope creep.

**Full suite: 1998 passed.**

Reviewed by `torchrl-engineer`, `code-simplifier`, `pr-test-analyzer`, and a `test-justification` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)