### PR TITLE
fix(polymarket): refuse live trading instead of silently mis-trading it

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,8 @@ See **[Online Environments Documentation](https://torchtrade.github.io/torchtrad
 
 ## Trading Platforms
 
-Start live trading with these supported platforms:
+Live trading is supported on the platforms below. **Polymarket is the exception: it is
+paper-only** — see its entry.
 
 ### 🪙 Cryptocurrency Trading
 
@@ -182,7 +183,7 @@ Start live trading with these supported platforms:
 **[Polymarket](https://polymarket.com/)** - Decentralized prediction market on Polygon
 - **Supported by:** `PolymarketBetEnv`
 - **Features:** Rolling one-shot bets on short-cadence binary markets (BTC/ETH/SOL up-or-down at 5m / 15m / 1h / 4h / daily cadences), Gamma API market scanner
-- **⚠️ Paper trading only:** `dry_run=False` raises. `py-clob-client` is archived/non-functional (Polymarket moved to CLOB V2), and the env holds bets to resolution while Polymarket only releases collateral on an on-chain redeem no client exposes — so a live bot would drain to zero *while winning*. Reviving live needs the V2 port **and** a redemption workflow.
+- **⚠️ Paper trading only — not live:** `dry_run=False` raises. `py-clob-client` is archived/non-functional (Polymarket moved to CLOB V2), and the env holds bets to resolution while Polymarket only releases collateral on an on-chain redeem no client exposes — so a live bot would drain to zero *while winning*. Reviving live needs the V2 port **and** a redemption workflow.
 - **Get Started:** [Browse markets at Polymarket](https://polymarket.com/)
 
 ### 📈 Stock & Crypto API

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ TorchTrade provides modular environments for both live trading with major exchan
 - 🎯 **Multi-Timeframe Observations** - Train on 1m, 5m, 15m, 1h bars simultaneously
 - 🤖 **Multiple RL Algorithms** - PPO, DQN, IQL, GRPO, DSAC, CTRL implementations
 - 📊 **Feature Engineering** - Add technical indicators and custom features
-- 🔴 **Live Trading** - Direct Alpaca, Binance, Bitget, Bybit, OKX, and Polymarket integrations
+- 🔴 **Live Trading** - Direct Alpaca, Binance, Bitget, Bybit, and OKX integrations (Polymarket is paper-only)
 - 🧠 **LLM Integration** - Use GPT-4o-mini or local LLMs as trading agents
 - 🔧 **LLM Tool Use** - Let LLM agents call tools mid-reasoning (e.g. live Google News for sentiment) before choosing an action
 - 🎓 **LLM GRPO Fine-tuning** - Train/finetune a local LLM actor on your data with GRPO ([guide](docs/guides/llm-grpo-training.md))
@@ -181,7 +181,8 @@ Start live trading with these supported platforms:
 
 **[Polymarket](https://polymarket.com/)** - Decentralized prediction market on Polygon
 - **Supported by:** `PolymarketBetEnv`
-- **Features:** Rolling one-shot bets on short-cadence binary markets (BTC/ETH/SOL up-or-down at 5m / 15m / 1h / 4h / daily cadences), Gamma API market scanner, dry-run paper trading without `py-clob-client` installed
+- **Features:** Rolling one-shot bets on short-cadence binary markets (BTC/ETH/SOL up-or-down at 5m / 15m / 1h / 4h / daily cadences), Gamma API market scanner
+- **⚠️ Paper trading only:** `dry_run=False` raises. `py-clob-client` is archived/non-functional (Polymarket moved to CLOB V2), and the env holds bets to resolution while Polymarket only releases collateral on an on-chain redeem no client exposes — so a live bot would drain to zero *while winning*. Reviving live needs the V2 port **and** a redemption workflow.
 - **Get Started:** [Browse markets at Polymarket](https://polymarket.com/)
 
 ### 📈 Stock & Crypto API

--- a/docs/environments/online.md
+++ b/docs/environments/online.md
@@ -385,8 +385,8 @@ env = OKXFuturesSLTPTorchTradingEnv(
 !!! note "Authentication"
     Polymarket uses a **Polygon private key**, not an API key/secret pair. The key is used to derive CLOB API credentials at runtime.
 
-!!! warning "USDC Required"
-    The wallet must hold USDC.e on Polygon to place real orders. Use `dry_run=True` to validate the pipeline without spending capital, `dry_run` works without `py-clob-client` installed.
+!!! danger "Paper trading only, live is refused"
+    `dry_run=False` raises `NotImplementedError`. Two blockers: (1) `py-clob-client` was **archived** in May 2026 ("no longer functional") — Polymarket's CLOB V2 uses new contracts and replaced USDC.e collateral with pUSD, so no order can reach production; (2) this env buys and holds every bet through resolution, and Polymarket does **not** release collateral on resolution — winning shares must be **redeemed** on-chain via their Relayer, which no client exposes. Without the redeem, a bot's spendable balance drains to zero *while it is winning*. That is also why the balance cannot simply be read from the wallet. Reviving live needs the CLOB V2 port **and** a redemption workflow.
 
 ### PolymarketBetEnv
 
@@ -402,19 +402,18 @@ config = PolymarketBetEnvConfig(
     bet_fraction=0.01,                    # stake 1 % of cash per bet
     max_steps=10,                         # 10 bets per episode
     initial_cash=1_000.0,                 # for dry-run accounting
-    dry_run=True,                         # paper trading (recommended!)
+    dry_run=True,                         # the only supported mode (the default)
 )
 
 env = PolymarketBetEnv(
     config=config,
-    private_key=os.getenv("POLYGON_PRIVATE_KEY", ""),
 )
 # observation_spec: {"market_state": (4,)}  → [yes_price, spread, vol_24h, liquidity]
 # action_spec:      Categorical(2)            → 0 = Down, 1 = Up
 ```
 
 Each `step()`:
-1. Submits the bet on the current market (skipped in `dry_run`).
+1. Books the bet on the current market (paper only — no order is submitted).
 2. Sleeps until the market's `endDate` plus a small grace period.
 3. Polls Polymarket's **CLOB** at `clob.polymarket.com/midpoint?token_id=…` for each outcome token; the market is resolved once the YES midpoint is `≥ 0.99` and the NO midpoint is `≤ 0.01` (Up won), or vice versa (Down won). The CLOB is used here rather than Gamma's `outcomePrices` because Gamma evicts short-cadence markets within minutes of `endDate` and its prices field is a stale snapshot, not a live mid.
 4. Computes realized payoff, a win pays `stake × (1 − fill) / fill`; a loss returns `−stake`.
@@ -767,8 +766,7 @@ OKX_API_KEY=your_okx_api_key
 OKX_API_SECRET=your_okx_api_secret
 OKX_PASSPHRASE=your_okx_passphrase
 
-# Polymarket (Polygon wallet, fund with USDC.e)
-POLYGON_PRIVATE_KEY=your_polygon_wallet_private_key
+# Polymarket: paper-only, no live orders -- no funded wallet or key is needed.
 ```
 
 !!! warning "Always Start with Paper/Testnet Trading"
@@ -783,9 +781,9 @@ POLYGON_PRIVATE_KEY=your_polygon_wallet_private_key
 | **Asset Types** | Stocks, Crypto | Crypto | Crypto | Crypto | Crypto | Prediction markets |
 | **Futures** | - | Yes | Yes | Yes | Yes | - |
 | **Max Leverage** | 1x | 125x | 125x | 100x | 125x | 1x |
-| **Paper Trading** | Yes | Yes (Testnet) | Yes (Testnet) | Yes (Testnet) | Yes (Demo) | Yes (dry_run) |
+| **Paper Trading** | Yes | Yes (Testnet) | Yes (Testnet) | Yes (Testnet) | Yes (Demo) | Yes (dry_run — the ONLY mode) |
 | **Commission** | Free | 0.02%/0.04% | 0.02%/0.06% | 0.02%/0.055% | 0.02%/0.05% | Variable (CLOB) |
-| **SDK** | Alpaca SDK | CCXT | CCXT | pybit (native) | python-okx (native) | py-clob-client |
+| **SDK** | Alpaca SDK | CCXT | CCXT | pybit (native) | python-okx (native) | py-clob-client (archived; live unsupported) |
 
 ---
 

--- a/docs/environments/online.md
+++ b/docs/environments/online.md
@@ -382,20 +382,13 @@ env = OKXFuturesSLTPTorchTradingEnv(
 !!! info "Starter environment, more to come"
     `PolymarketBetEnv` is intentionally a **starter env** matching the most common Polymarket use case for TorchTrade (rolling binary up/down bets). Polymarket also has multi-strike daily price markets, sports, politics, and longer-horizon markets that benefit from a different env shape. Additional Polymarket envs will be added based on user requests and as new market types appear, open an issue describing the pattern you need.
 
-!!! note "Authentication"
-    Polymarket uses a **Polygon private key**, not an API key/secret pair. The key is used to derive CLOB API credentials at runtime.
-
 !!! danger "Paper trading only, live is refused"
-    `dry_run=False` raises `NotImplementedError`. Two blockers: (1) `py-clob-client` was **archived** in May 2026 ("no longer functional") — Polymarket's CLOB V2 uses new contracts and replaced USDC.e collateral with pUSD, so no order can reach production; (2) this env buys and holds every bet through resolution, and Polymarket does **not** release collateral on resolution — winning shares must be **redeemed** on-chain via their Relayer, which no client exposes. Without the redeem, a bot's spendable balance drains to zero *while it is winning*. That is also why the balance cannot simply be read from the wallet. Reviving live needs the CLOB V2 port **and** a redemption workflow.
+    `dry_run=False` raises `NotImplementedError`. Two blockers: (1) `py-clob-client` was **archived** in May 2026 ("no longer functional") — Polymarket's CLOB V2 uses new contracts and replaced USDC.e collateral with pUSD, so no order can reach production; (2) this env buys and holds every bet through resolution, and Polymarket does **not** release collateral on resolution — winning shares must be **redeemed** on-chain, which no Polymarket client exposes. Without the redeem, a bot's spendable balance drains to zero *while it is winning*. That is also why the balance cannot simply be read from the wallet. Reviving live needs the CLOB V2 port **and** a redemption workflow.
 
 ### PolymarketBetEnv
 
 ```python
 from torchtrade.envs.live.polymarket import PolymarketBetEnv, PolymarketBetEnvConfig
-import os
-from dotenv import load_dotenv
-
-load_dotenv()
 
 config = PolymarketBetEnvConfig(
     market_slug_prefix="btc-updown-5m-",  # discover via scan_markets.py

--- a/docs/environments/online.md
+++ b/docs/environments/online.md
@@ -377,7 +377,7 @@ env = OKXFuturesSLTPTorchTradingEnv(
 
 ## Polymarket Environment
 
-[Polymarket](https://polymarket.com/) is a decentralized prediction market on Polygon. TorchTrade currently exposes a single env, `PolymarketBetEnv`, tailored for short-cadence binary markets, Polymarket runs continuous **5-minute, 15-minute, 1-hour, and 4-hour** crypto "up/down" markets (BTC, ETH, SOL) plus daily markets. Each step is an independent bet: place direction, wait for resolution, collect realized payoff, advance to the next market in the series. There is no carried position, so the observation deliberately omits any `account_state`.
+[Polymarket](https://polymarket.com/) is a decentralized prediction market on Polygon. TorchTrade currently exposes a single env, `PolymarketBetEnv`, tailored for short-cadence binary markets, Polymarket runs continuous **5-minute, 15-minute, 1-hour, and 4-hour** crypto "up/down" markets (BTC, ETH, SOL) plus daily markets. Each step is an independent bet: place direction, wait for resolution, collect the modelled payoff, advance to the next market in the series. There is no carried position, so the observation deliberately omits any `account_state`.
 
 !!! info "Starter environment, more to come"
     `PolymarketBetEnv` is intentionally a **starter env** matching the most common Polymarket use case for TorchTrade (rolling binary up/down bets). Polymarket also has multi-strike daily price markets, sports, politics, and longer-horizon markets that benefit from a different env shape. Additional Polymarket envs will be added based on user requests and as new market types appear, open an issue describing the pattern you need.
@@ -416,7 +416,7 @@ Each `step()`:
 1. Books the bet on the current market (paper only — no order is submitted).
 2. Sleeps until the market's `endDate` plus a small grace period.
 3. Polls Polymarket's **CLOB** at `clob.polymarket.com/midpoint?token_id=…` for each outcome token; the market is resolved once the YES midpoint is `≥ 0.99` and the NO midpoint is `≤ 0.01` (Up won), or vice versa (Down won). The CLOB is used here rather than Gamma's `outcomePrices` because Gamma evicts short-cadence markets within minutes of `endDate` and its prices field is a stale snapshot, not a live mid.
-4. Computes realized payoff, a win pays `stake × (1 − fill) / fill`; a loss returns `−stake`.
+4. Computes the modelled payoff, a win pays `stake × (1 − fill) / fill`; a loss returns `−stake`.
 5. Picks the next active market matching `market_slug_prefix` and returns its `market_state`.
 
 ### Discovering markets and slug prefixes

--- a/examples/broker/polymarket/README.md
+++ b/examples/broker/polymarket/README.md
@@ -197,9 +197,7 @@ discrete index; an RL policy gets logits over two classes.
 
 ## Running for real
 
-**You can't, and you shouldn't try.** `dry_run=False` raises `NotImplementedError`. The
-previous instructions here (set `POLYGON_PRIVATE_KEY`, `pip install py-clob-client`, flip
-`dry_run`) were all wrong, and following them would have lost money quietly. Two blockers:
+**Live trading is not supported.** `dry_run=False` raises `NotImplementedError`. Two blockers:
 
 1. **The client is dead.** `py-clob-client` was archived in May 2026 — *"no longer functional
    and should not be used for new or existing integrations."* Polymarket's CLOB V2 uses new
@@ -208,9 +206,8 @@ previous instructions here (set `POLYGON_PRIVATE_KEY`, `pip install py-clob-clie
 2. **There is no redemption.** This env buys and holds every bet through resolution, and
    Polymarket does **not** release collateral when a market resolves — a winning share is
    worth $1 but stays an ERC-1155 token until an explicit on-chain `redeemPositions` call,
-   which no Polymarket client exposes (it has to go through their Relayer, because the
-   proxy wallet owns the position, not your EOA). A bot that never redeems watches its
-   spendable balance **drain to zero while it is winning.**
+   which no Polymarket client exposes. A bot that never redeems watches its spendable
+   balance **drain to zero while it is winning.**
 
 Blocker 2 is why this can't be fixed by "just reading the real wallet": while winnings sit
 unredeemed, the collateral balance isn't the account's worth, so a wallet-backed balance

--- a/examples/broker/polymarket/README.md
+++ b/examples/broker/polymarket/README.md
@@ -194,14 +194,26 @@ discrete index; an RL policy gets logits over two classes.
 
 ## Running for real
 
-To trade real funds:
+**You can't, and you shouldn't try.** `dry_run=False` raises `NotImplementedError`. The
+previous instructions here (set `POLYGON_PRIVATE_KEY`, `pip install py-clob-client`, flip
+`dry_run`) were all wrong, and following them would have lost money quietly. Two blockers:
 
-1. Set `POLYGON_PRIVATE_KEY` in `.env`, the wallet must hold USDC.e on Polygon.
-2. `pip install py-clob-client`.
-3. Set `dry_run=False` in `PolymarketBetEnvConfig`.
+1. **The client is dead.** `py-clob-client` was archived in May 2026 — *"no longer functional
+   and should not be used for new or existing integrations."* Polymarket's CLOB V2 uses new
+   contracts and replaced USDC.e collateral with pUSD. No order this env submits can reach
+   production.
+2. **There is no redemption.** This env buys and holds every bet through resolution, and
+   Polymarket does **not** release collateral when a market resolves — a winning share is
+   worth $1 but stays an ERC-1155 token until an explicit on-chain `redeemPositions` call,
+   which no Polymarket client exposes (it has to go through their Relayer, because the
+   proxy wallet owns the position, not your EOA). A bot that never redeems watches its
+   spendable balance **drain to zero while it is winning.**
 
-Always start with `dry_run=True` and verify the bet timing, payoff
-computation, and accounting before flipping the switch.
+Blocker 2 is why this can't be fixed by "just reading the real wallet": while winnings sit
+unredeemed, the collateral balance isn't the account's worth, so a wallet-backed balance
+would make a *winning* agent declare itself bankrupt.
+
+Reviving live trading needs the CLOB V2 port **and** a redemption workflow.
 
 ## See Also
 

--- a/examples/broker/polymarket/README.md
+++ b/examples/broker/polymarket/README.md
@@ -107,22 +107,13 @@ config = PolymarketBetEnvConfig(
 env = PolymarketBetEnv(config)
 ```
 
-> **Paper trading only.** `dry_run=False` raises `NotImplementedError`. Two reasons, either
-> fatal on its own:
-> 1. `py-clob-client`, which the order executor is built on, was **archived** in May 2026
->    ("no longer functional"). Polymarket's CLOB V2 uses new contracts and replaced USDC.e
->    collateral with pUSD, so no order this env submits can reach production.
-> 2. This env **buys and holds every bet through resolution**, and Polymarket does *not*
->    release collateral on resolution — a winning share stays an ERC-1155 token until it is
->    explicitly **redeemed** on-chain, which no Polymarket client exposes. A live bot that
->    never redeems would watch its balance drain to zero *while winning*.
->
-> Reviving live trading needs the CLOB V2 port **and** a redemption workflow.
+> **Paper trading only.** `dry_run=False` raises `NotImplementedError` — the archived CLOB
+> client and the missing redemption workflow are spelled out under
+> [Running for real](#running-for-real).
 >
 > The market data and the resolution are real. The **payoff is modelled**, not real: it fills
 > at the quoted outcome price with no spread crossing and no fees, so it is optimistic
 > versus the fill-or-kill order a live bot would actually pay.
-
 
 Swapping to ETH 15-minute is a one-line change:
 

--- a/examples/broker/polymarket/README.md
+++ b/examples/broker/polymarket/README.md
@@ -9,8 +9,9 @@ bet: did the asset go up or down over the bar? The env rolls through the
 series, bet → wait for resolution → collect payoff → next market, without
 holding any position across steps.
 
-All examples default to `dry_run=True`, so you can run them without a funded
-Polygon wallet or `py-clob-client` installed.
+**Paper trading only.** `dry_run=False` raises `NotImplementedError` — see
+[Running for real](#running-for-real). No funded Polygon wallet, private key, or
+`py-clob-client` install is needed (or useful).
 
 ## End-to-end walkthrough
 
@@ -116,9 +117,11 @@ env = PolymarketBetEnv(config)
 >    explicitly **redeemed** on-chain, which no Polymarket client exposes. A live bot that
 >    never redeems would watch its balance drain to zero *while winning*.
 >
-> Reviving live trading needs the CLOB V2 port **and** a redemption workflow. Everything
-> else about the env is real: real market data, real resolution, real payoffs — booked
-> against a simulated balance.
+> Reviving live trading needs the CLOB V2 port **and** a redemption workflow.
+>
+> The market data and the resolution are real. The **payoff is modelled**, not real: it fills
+> at the quoted outcome price with no spread crossing and no fees, so it is optimistic
+> versus the fill-or-kill order a live bot would actually pay.
 
 
 Swapping to ETH 15-minute is a one-line change:
@@ -147,11 +150,11 @@ Cumulative P&L is captured directly in the per-step rewards.
 Each `step()` does five things:
 
 ```
-1. Submit the bet on the current market (skipped in dry_run)
+1. Book the bet on the current market (paper only — no order is submitted)
 2. Sleep until the market's endDate + grace
 3. Poll the CLOB midpoint for each outcome token; resolved when YES mid >= 0.99
    and NO mid <= 0.01 (Up won) or vice versa (Down won)
-4. Compute realized payoff:  win → stake * (1 - fill) / fill, loss → -stake
+4. Compute the modelled payoff:  win → stake * (1 - fill) / fill, loss → -stake
 5. Pick the next active market matching market_slug_prefix and return its market_state
 ```
 

--- a/examples/broker/polymarket/README.md
+++ b/examples/broker/polymarket/README.md
@@ -100,11 +100,26 @@ config = PolymarketBetEnvConfig(
     market_slug_prefix="btc-updown-5m-",   # the only required field
     bet_fraction=0.01,                     # stake 1 % of cash per bet
     max_steps=10,                          # 10 bets per episode
-    initial_cash=1_000.0,                  # for dry-run accounting
-    dry_run=True,                          # skip real CLOB orders
+    initial_cash=1_000.0,                  # simulated paper balance
+    dry_run=True,                          # the only supported mode (the default)
 )
-env = PolymarketBetEnv(config, private_key="")  # private_key only needed when dry_run=False
+env = PolymarketBetEnv(config)
 ```
+
+> **Paper trading only.** `dry_run=False` raises `NotImplementedError`. Two reasons, either
+> fatal on its own:
+> 1. `py-clob-client`, which the order executor is built on, was **archived** in May 2026
+>    ("no longer functional"). Polymarket's CLOB V2 uses new contracts and replaced USDC.e
+>    collateral with pUSD, so no order this env submits can reach production.
+> 2. This env **buys and holds every bet through resolution**, and Polymarket does *not*
+>    release collateral on resolution — a winning share stays an ERC-1155 token until it is
+>    explicitly **redeemed** on-chain, which no Polymarket client exposes. A live bot that
+>    never redeems would watch its balance drain to zero *while winning*.
+>
+> Reviving live trading needs the CLOB V2 port **and** a redemption workflow. Everything
+> else about the env is real: real market data, real resolution, real payoffs — booked
+> against a simulated balance.
+
 
 Swapping to ETH 15-minute is a one-line change:
 

--- a/examples/broker/polymarket/run_dry_run.py
+++ b/examples/broker/polymarket/run_dry_run.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 
 import argparse
 import logging
-import os
 
 import torch
 
@@ -47,7 +46,8 @@ def main():
         initial_cash=args.initial_cash,
         dry_run=True,
     )
-    env = PolymarketBetEnv(config, private_key=os.getenv("POLYGON_PRIVATE_KEY", ""))
+    # No private key: paper-only, nothing is signed or submitted.
+    env = PolymarketBetEnv(config)
 
     td = env.reset()
     print(f"slug_prefix:        {config.market_slug_prefix}")

--- a/examples/broker/polymarket/run_dry_run.py
+++ b/examples/broker/polymarket/run_dry_run.py
@@ -1,9 +1,12 @@
 """Dry-run a few rolling Polymarket bets on a short-cadence series.
 
 Picks the next active market matching ``market_slug_prefix`` (e.g.
-``btc-updown-5m-``), bets a random direction, *waits for resolution*, collects
-the realized payoff, and rolls to the next market. ``dry_run=True`` skips real
-CLOB orders so no funded wallet is required.
+``btc-updown-5m-``), bets a random direction, *waits for resolution*, books the
+modelled payoff, and rolls to the next market.
+
+Paper only -- the env never submits an order, and ``dry_run=False`` raises. No funded
+wallet or private key is needed (or useful). The market data and the resolution are real;
+the payoff is modelled at the quoted price, without spread crossing or fees.
 
 Run with:
     python examples/broker/polymarket/run_dry_run.py

--- a/tests/envs/polymarket/test_env.py
+++ b/tests/envs/polymarket/test_env.py
@@ -130,7 +130,7 @@ class TestSpecs:
             PolymarketBetEnv(PolymarketBetEnvConfig())
 
     def test_default_trader_constructed_when_not_injected(self):
-        """Lazy import path: ``PolymarketOrderExecutor`` is built when no trader is passed."""
+        """``PolymarketOrderExecutor`` is built when no trader is injected."""
         config = PolymarketBetEnvConfig(
             market_slug_prefix="btc-updown-5m-", dry_run=True
         )
@@ -145,7 +145,7 @@ class TestSpecs:
         # dry_run=True, so passing config.dry_run, passing True, and omitting the kwarg (the
         # executor's own default) are indistinguishable here -- a dead assertion dressed as a
         # second lock. The executor's safe default is pinned for real in
-        # test_order_executor.py::test_executor_defaults_to_paper; that is the actual guard.
+        # test_order_executor.py (TestPaperExecution); that is the actual guard.
 
 
 # --- Pure helpers ----------------------------------------------------------- #
@@ -172,8 +172,8 @@ class TestConstructorCompat:
         the call site instead.
         """
         cfg = PolymarketBetEnvConfig(market_slug_prefix="btc-updown-5m-")
-        with pytest.raises(TypeError):
-            PolymarketBetEnv(cfg, "0xdeadbeef")   # noqa: the point is that this must raise
+        with pytest.raises(TypeError, match="positional"):
+            PolymarketBetEnv(cfg, "0xdeadbeef")
 
 
 class TestClose:
@@ -504,12 +504,21 @@ class TestFetchResolvedOutcome:
             ("0.0", "1.0", 0),       # Down snapped fully
             ("0.99", "0.01", 1),     # EXACTLY at threshold (Up): >= must not become >
             ("0.01", "0.99", 0),     # EXACTLY at threshold (Down): <= must not become <
+            # PARTIALLY snapped: the winning side is still moving while the losing side has
+            # already collapsed. The two midpoints are two INDEPENDENT HTTP reads and need not
+            # sum to 1 mid-settlement, so this state is real -- it is the state the poll loop
+            # exists to wait through. Nothing pinned the 0.99 CONSTANT (only the >= operator),
+            # so degrading it to 0.90 -- or even 0.10 -- passed the entire suite while making
+            # _fetch_resolved_outcome declare a WINNER on an unresolved market, which _step
+            # then books a payoff for. These two rows are what kill that.
+            ("0.90", "0.005", None),  # Up only partly snapped, Down already collapsed
+            ("0.005", "0.90", None),  # Down only partly snapped, Up already collapsed
             ("0.989", "0.011", None),  # below the 0.99 threshold
             ("0.99", "0.05", None),    # Up at threshold but Down still too high
             ("0.5", "0.5", None),      # mid-market
         ],
-        ids=["up", "down", "tight-up", "tight-down", "below-up",
-             "asymmetric-pending", "midmarket"],
+        ids=["up", "down", "at-threshold-up", "at-threshold-down", "below-up",
+             "asymmetric-pending", "midmarket", "partial-up", "partial-down"],
     )
     def test_outcome_parsing(self, yes_mid, no_mid, expected):
         env, _, _ = _make_env(mock_fetch=False)
@@ -691,18 +700,31 @@ class TestConfigValidation:
         assert "redeem" in str(exc.value)     # blocker 2: the one a port cannot skip
 
     def test_config_is_frozen_so_the_guard_cannot_be_mutated_away(self):
-        """__post_init__ runs ONCE. On a mutable dataclass this is the bypass:
+        """__post_init__ runs ONCE. On a mutable dataclass this was the bypass:
 
             config = PolymarketBetEnvConfig(...)   # dry_run=True, passes
             config.dry_run = False                 # guard never re-runs
-            env = PolymarketBetEnv(config)         # wires a LIVE trader
+            env = PolymarketBetEnv(config)         # ...used to wire a LIVE trader
 
-        frozen=True does not make the bypass impossible (object.__setattr__ still works);
-        it makes it deliberate rather than an ordinary attribute assignment.
+        frozen=True does not make it impossible (object.__setattr__ still works); it makes it
+        deliberate rather than an ordinary attribute assignment. It is no longer the last line
+        of defence either: the executor now refuses dry_run=False itself, so even a forced
+        mutation raises there -- pinned by test_forced_mutation_is_still_caught_downstream.
         """
         config = PolymarketBetEnvConfig(market_slug_prefix="btc-updown-5m-")
         with pytest.raises(dataclasses.FrozenInstanceError):
             config.dry_run = False
+
+    def test_forced_mutation_is_still_caught_downstream(self):
+        """Defence in depth: even object.__setattr__ (which defeats frozen=True) cannot get a
+        live trader wired, because the executor refuses dry_run=False on its own account.
+
+        Two independent guards must both regress before a live client can be built.
+        """
+        config = PolymarketBetEnvConfig(market_slug_prefix="btc-updown-5m-")
+        object.__setattr__(config, "dry_run", False)
+        with pytest.raises(NotImplementedError, match="archived"):
+            PolymarketBetEnv(config, scanner=MagicMock())
 
     def test_zero_is_legal_for_both_fractions(self):
         """0.0 is DOCUMENTED as supported for both (a no-bet agent; bankruptcy disabled).

--- a/tests/envs/polymarket/test_env.py
+++ b/tests/envs/polymarket/test_env.py
@@ -125,67 +125,6 @@ class TestSpecs:
         env, _, _ = _make_env()
         assert env.action_spec.n == 2
 
-    def test_live_mode_is_refused(self):
-        """dry_run=False must RAISE, not silently paper-trade.
-
-        The env can never execute live: py-clob-client is archived/non-functional, and the
-        env holds every bet to resolution while Polymarket only releases collateral on an
-        explicit on-chain redeem that no client exposes -- so a live bot's balance drains to
-        zero while it is winning. Refusing the config is the whole point of this guard; a
-        regression that quietly downgraded live to paper (or dropped the check) would let a
-        user believe real money was at work.
-        """
-        # Match the SUBSTANCE, not a contentless phrase. Pinning only "not supported" let the
-        # whole message be replaced with "pip install py-clob-client, then set dry_run=False"
-        # -- the exact dead-end advice this PR exists to delete -- with the suite still green.
-        # Both reasons must survive: the dead client AND the redemption blocker.
-        with pytest.raises(NotImplementedError) as exc:
-            PolymarketBetEnvConfig(market_slug_prefix="btc-updown-5m-", dry_run=False)
-        assert "archived" in str(exc.value)   # blocker 1: the client is dead
-        assert "redeem" in str(exc.value)     # blocker 2: the one a port cannot skip
-
-    def test_config_is_frozen_so_the_guard_cannot_be_mutated_away(self):
-        """__post_init__ runs ONCE. On a mutable dataclass this is the bypass:
-
-            config = PolymarketBetEnvConfig(...)   # dry_run=True, passes
-            config.dry_run = False                 # guard never re-runs
-            env = PolymarketBetEnv(config)         # wires a LIVE trader
-
-        frozen=True is what turns the check from a speed bump into a boundary.
-        """
-        config = PolymarketBetEnvConfig(market_slug_prefix="btc-updown-5m-")
-        with pytest.raises(dataclasses.FrozenInstanceError):
-            config.dry_run = False
-
-    def test_paper_env_never_touches_the_trader_during_a_step(self):
-        """The paper env must not call the trader AT ALL during a step -- not just `.buy`.
-
-        Asserting `buy.assert_not_called()` pinned only that one attribute name; a _step that
-        called `trader.submit_market_order(...)` would have passed. mock_calls == [] pins the
-        whole surface, which is the actual contract: nothing is submitted, ever.
-        """
-        env, _, trader = _make_env()
-        env.reset()
-        env._step(TensorDict({"action": torch.tensor(1)}, batch_size=()))
-        assert trader.mock_calls == []
-
-    @pytest.mark.parametrize("bad", [-0.1, 1.5], ids=["negative", "over-100%"])
-    def test_bet_fraction_validated_at_the_boundary(self, bad):
-        """bet_fraction > 1 stakes more than the account holds -> cash goes negative -> a LOSS
-        pays out (inverted P&L). Refuse the config rather than guard downstream."""
-        with pytest.raises(ValueError, match="bet_fraction"):
-            PolymarketBetEnvConfig(market_slug_prefix="btc-updown-5m-", bet_fraction=bad)
-
-    def test_default_config_is_paper(self):
-        """The DEFAULT must be the safe mode.
-
-        Not a tautology against the line above: this pins that a user who never mentions
-        dry_run gets a constructible paper env. The default used to be dry_run=False, which
-        (once the guard exists) means the default config would not even build.
-        """
-        config = PolymarketBetEnvConfig(market_slug_prefix="btc-updown-5m-")
-        assert config.dry_run is True
-
     def test_missing_slug_prefix_raises(self):
         with pytest.raises(ValueError, match="market_slug_prefix"):
             PolymarketBetEnv(PolymarketBetEnvConfig())
@@ -278,6 +217,18 @@ class TestReset:
 # --- Step ------------------------------------------------------------------- #
 
 class TestStep:
+    def test_paper_env_never_touches_the_trader_during_a_step(self):
+        """The paper env must not call the trader AT ALL during a step -- not just `.buy`.
+
+        Asserting `buy.assert_not_called()` pinned only that one attribute name; a _step that
+        called `trader.submit_market_order(...)` would have passed. mock_calls == [] pins the
+        whole surface, which is the actual contract: nothing is submitted, ever.
+        """
+        env, _, trader = _make_env()
+        env.reset()
+        env._step(TensorDict({"action": torch.tensor(1)}, batch_size=()))
+        assert trader.mock_calls == []
+
     @pytest.mark.parametrize(
         "action,outcome,fill_price,expected_payoff",
         [
@@ -566,12 +517,16 @@ class TestPollForResolution:
         assert env._fetch_resolved_outcome.call_count == 1
 
     def test_retries_until_resolved(self):
-        env = self._real_poll_env()
+        env = self._real_poll_env(resolution_poll_interval_seconds=15.0)
         # First two calls: still mid-market. Third: Up wins.
         env._fetch_resolved_outcome = MagicMock(side_effect=[None, None, 1])
-        with patch("torchtrade.envs.live.polymarket.env.time.sleep"):
+        with patch("torchtrade.envs.live.polymarket.env.time.sleep") as mock_sleep:
             assert env._poll_for_resolution("0xcond") == 1
         assert env._fetch_resolved_outcome.call_count == 3
+        # Pin the poll interval BY VALUE, not just "it slept". Nothing pinned this, so
+        # hardcoding time.sleep(1.0) passed the whole suite -- turning a 15s poll into a 1s
+        # one, i.e. ~600 CLOB requests per resolution instead of ~40.
+        assert mock_sleep.call_args_list == [call(15.0), call(15.0)]
 
     def test_returns_none_when_max_wait_exhausted(self):
         env = self._real_poll_env(
@@ -623,14 +578,62 @@ class TestWaitForResolution:
             assert slept_for == pytest.approx(150, abs=2)
 
 
-class TestCloseLifecycle:
-    def test_close_calls_trader_cancel_all(self):
-        env, _, trader = _make_env()
-        env.close()
-        trader.cancel_all.assert_called_once()
-
 class TestConfigValidation:
     """The config is the boundary. A nonsense value must be refused there, not absorbed."""
+
+    def test_live_mode_is_refused(self):
+        """dry_run=False must RAISE, not silently paper-trade.
+
+        The env can never execute live: py-clob-client is archived/non-functional, and the
+        env holds every bet to resolution while Polymarket only releases collateral on an
+        explicit on-chain redeem that no client exposes -- so a live bot's balance drains to
+        zero while it is winning. Refusing the config is the whole point of this guard; a
+        regression that quietly downgraded live to paper (or dropped the check) would let a
+        user believe real money was at work.
+        """
+        # Match the SUBSTANCE, not a contentless phrase. Pinning only "not supported" let the
+        # whole message be replaced with "pip install py-clob-client, then set dry_run=False"
+        # -- the exact dead-end advice this PR exists to delete -- with the suite still green.
+        # Both reasons must survive: the dead client AND the redemption blocker.
+        with pytest.raises(NotImplementedError) as exc:
+            PolymarketBetEnvConfig(market_slug_prefix="btc-updown-5m-", dry_run=False)
+        assert "archived" in str(exc.value)   # blocker 1: the client is dead
+        assert "redeem" in str(exc.value)     # blocker 2: the one a port cannot skip
+
+    def test_config_is_frozen_so_the_guard_cannot_be_mutated_away(self):
+        """__post_init__ runs ONCE. On a mutable dataclass this is the bypass:
+
+            config = PolymarketBetEnvConfig(...)   # dry_run=True, passes
+            config.dry_run = False                 # guard never re-runs
+            env = PolymarketBetEnv(config)         # wires a LIVE trader
+
+        frozen=True does not make the bypass impossible (object.__setattr__ still works);
+        it makes it deliberate rather than an ordinary attribute assignment.
+        """
+        config = PolymarketBetEnvConfig(market_slug_prefix="btc-updown-5m-")
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            config.dry_run = False
+
+    @pytest.mark.parametrize("bad", [-0.1, 1.5], ids=["negative", "over-100%"])
+    def test_bet_fraction_validated_at_the_boundary(self, bad):
+        """bet_fraction > 1 stakes more than the account holds, driving cash negative.
+
+        Today only _compute_payoff's `stake <= 0` guard (plus same-step bankruptcy) stands
+        between that and inverted P&L -- a loss paying out. Refuse the config at the boundary
+        rather than depend on a downstream guard to absorb it.
+        """
+        with pytest.raises(ValueError, match="bet_fraction"):
+            PolymarketBetEnvConfig(market_slug_prefix="btc-updown-5m-", bet_fraction=bad)
+
+    def test_default_config_is_paper(self):
+        """The DEFAULT must be the safe mode.
+
+        Not a tautology against the line above: this pins that a user who never mentions
+        dry_run gets a constructible paper env. The default used to be dry_run=False, which
+        (once the guard exists) means the default config would not even build.
+        """
+        config = PolymarketBetEnvConfig(market_slug_prefix="btc-updown-5m-")
+        assert config.dry_run is True
 
     @pytest.mark.parametrize("initial_cash", [-100.0, 0.0], ids=["negative", "zero"])
     def test_nonsense_starting_cash_is_refused(self, initial_cash):

--- a/tests/envs/polymarket/test_env.py
+++ b/tests/envs/polymarket/test_env.py
@@ -1,5 +1,6 @@
 """Tests for PolymarketBetEnv."""
 
+import dataclasses
 import itertools
 from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, call, patch
@@ -117,8 +118,34 @@ class TestSpecs:
         regression that quietly downgraded live to paper (or dropped the check) would let a
         user believe real money was at work.
         """
-        with pytest.raises(NotImplementedError, match="not supported"):
+        # Match the SUBSTANCE, not a contentless phrase. Pinning only "not supported" let the
+        # whole message be replaced with "pip install py-clob-client, then set dry_run=False"
+        # -- the exact dead-end advice this PR exists to delete -- with the suite still green.
+        # Both reasons must survive: the dead client AND the redemption blocker.
+        with pytest.raises(NotImplementedError, match="archived"):
             PolymarketBetEnvConfig(market_slug_prefix="btc-updown-5m-", dry_run=False)
+        with pytest.raises(NotImplementedError, match="redeem"):
+            PolymarketBetEnvConfig(market_slug_prefix="btc-updown-5m-", dry_run=False)
+
+    def test_config_is_frozen_so_the_guard_cannot_be_mutated_away(self):
+        """__post_init__ runs ONCE. On a mutable dataclass this is the bypass:
+
+            config = PolymarketBetEnvConfig(...)   # dry_run=True, passes
+            config.dry_run = False                 # guard never re-runs
+            env = PolymarketBetEnv(config)         # wires a LIVE trader
+
+        frozen=True is what turns the check from a speed bump into a boundary.
+        """
+        config = PolymarketBetEnvConfig(market_slug_prefix="btc-updown-5m-")
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            config.dry_run = False
+
+    @pytest.mark.parametrize("bad", [-0.1, 1.5], ids=["negative", "over-100%"])
+    def test_bet_fraction_validated_at_the_boundary(self, bad):
+        """bet_fraction > 1 stakes more than the account holds -> cash goes negative -> a LOSS
+        pays out (inverted P&L). Refuse the config rather than guard downstream."""
+        with pytest.raises(ValueError, match="bet_fraction"):
+            PolymarketBetEnvConfig(market_slug_prefix="btc-updown-5m-", bet_fraction=bad)
 
     def test_default_config_is_paper(self):
         """The DEFAULT must be the safe mode.
@@ -146,6 +173,11 @@ class TestSpecs:
             PolymarketOrderExecutor,
         )
         assert isinstance(env.trader, PolymarketOrderExecutor)
+        # THE load-bearing assertion. Without it, dropping `dry_run=config.dry_run` from the
+        # executor call leaves a PAPER-configured env holding a LIVE trader that builds a real
+        # authenticated CLOB client from the private key -- and the suite stays green (it only
+        # failed here by accident, because py-clob-client happens not to be installed).
+        assert env.trader._dry_run is True
 
 
 # --- Pure helpers ----------------------------------------------------------- #
@@ -238,8 +270,16 @@ class TestStep:
         env._step(TensorDict({"action": torch.tensor(1)}, batch_size=()))  # Up wins
         after_win = env.cash
         env._step(TensorDict({"action": torch.tensor(1)}, batch_size=()))  # Up loses
-        assert after_win > before
-        assert env.cash < after_win
+
+        # EXACT values, not just direction: stake COMPOUNDS off current cash, and a fixed stake
+        # (initial_cash * frac) satisfies "up then down" just as well, so directional asserts
+        # cannot tell the two apart. This is the rule that decides how much is at risk per bet.
+        # bet_fraction=0.1, fill=0.4 -> win pays stake*(1-f)/f = 1.5x stake.
+        #   stake1 = 1000 * 0.1 = 100      -> +150  -> 1150
+        #   stake2 = 1150 * 0.1 = 115      -> -115  -> 1035   (a fixed stake would give 1050)
+        assert before == pytest.approx(1000.0)
+        assert after_win == pytest.approx(1150.0)
+        assert env.cash == pytest.approx(1035.0)
 
     def test_max_steps_truncation(self):
         env, _, _ = _make_env(

--- a/tests/envs/polymarket/test_env.py
+++ b/tests/envs/polymarket/test_env.py
@@ -217,6 +217,48 @@ class TestReset:
 # --- Step ------------------------------------------------------------------- #
 
 class TestStep:
+    def test_step_returns_the_NEXT_market_state_not_the_resolved_one(self):
+        """_step's observation must come from the market the agent will BET ON next.
+
+        The reset path was pinned; this one was not, and `_market_state(next_market)` ->
+        `_market_state(market)` (the stale, already-resolved market) passed the whole suite.
+        Live that is severe: the policy conditions on the OLD market's quotes while the next
+        bet's fill_price is read from the NEW one -- the agent bets at prices it never saw.
+        The two markets here differ in every slot so no swap or staleness can hide.
+        (CLAUDE.md invariant #3, one method over from where it was just fixed.)
+        """
+        resolved = _make_market(yes_price=0.42, spread=0.02, volume_24h=1500.0, liquidity=12000.0)
+        upcoming = _make_market(yes_price=0.77, spread=0.05, volume_24h=999.0, liquidity=4321.0)
+        env, _, _ = _make_env(outcomes=[1], markets=[resolved, upcoming])
+        env.reset()
+        td = env._step(TensorDict({"action": torch.tensor(1)}, batch_size=()))
+        assert torch.equal(
+            td["market_state"],
+            torch.tensor([0.77, 0.05, 999.0, 4321.0], dtype=torch.float32),
+        )
+
+    def test_step_waits_for_endDate_before_polling(self):
+        """The wait must happen BEFORE the poll, and be handed the right market.
+
+        Nothing observed this: _make_env stubs _wait_for_resolution with a bare lambda, so
+        deleting the call, or polling first, both passed. Live, polling a market that has not
+        ended means the midpoint never snaps to 0.99/0.01, the resolution budget burns out, and
+        EVERY bet books reward=0 -- silent in tests, poison in the training data.
+        Also pins that _poll_for_resolution gets the MARKET, not market.condition_id (which
+        would AttributeError on the first live step).
+        """
+        market = _make_market()
+        env, _, _ = _make_env(outcomes=[1], markets=[market, _make_market()], mock_fetch=False)
+        env.reset()
+        rec = MagicMock()
+        env._wait_for_resolution = rec.wait
+        env._poll_for_resolution = lambda *a, **k: (rec.poll(*a, **k), 1)[1]
+        env._step(TensorDict({"action": torch.tensor(1)}, batch_size=()))
+
+        assert [c[0] for c in rec.mock_calls] == ["wait", "poll"]   # order, not just presence
+        rec.wait.assert_called_once_with(market.end_date)
+        rec.poll.assert_called_once_with(market)
+
     def test_paper_env_never_touches_the_trader_during_a_step(self):
         """The paper env must not call the trader AT ALL during a step -- not just `.buy`.
 
@@ -434,8 +476,8 @@ class TestFetchResolvedOutcome:
         [
             ("1.0", "0.0", 1),       # Up snapped fully
             ("0.0", "1.0", 0),       # Down snapped fully
-            ("0.995", "0.005", 1),   # boundary: just at threshold (Up)
-            ("0.005", "0.995", 0),   # boundary: just at threshold (Down)
+            ("0.99", "0.01", 1),     # EXACTLY at threshold (Up): >= must not become >
+            ("0.01", "0.99", 0),     # EXACTLY at threshold (Down): <= must not become <
             ("0.989", "0.011", None),  # below the 0.99 threshold
             ("0.99", "0.05", None),    # Up at threshold but Down still too high
             ("0.5", "0.5", None),      # mid-market
@@ -517,7 +559,10 @@ class TestPollForResolution:
         assert env._fetch_resolved_outcome.call_count == 1
 
     def test_retries_until_resolved(self):
-        env = self._real_poll_env(resolution_poll_interval_seconds=15.0)
+        # 7.0, NOT the 15.0 default: pinning the default cannot distinguish a config read
+        # from a hardcoded constant. (The sibling backoff test at test_retry_sleep_... does
+        # this correctly; I missed it here and pinned 15.0, which killed nothing.)
+        env = self._real_poll_env(resolution_poll_interval_seconds=7.0)
         # First two calls: still mid-market. Third: Up wins.
         env._fetch_resolved_outcome = MagicMock(side_effect=[None, None, 1])
         with patch("torchtrade.envs.live.polymarket.env.time.sleep") as mock_sleep:
@@ -526,7 +571,7 @@ class TestPollForResolution:
         # Pin the poll interval BY VALUE, not just "it slept". Nothing pinned this, so
         # hardcoding time.sleep(1.0) passed the whole suite -- turning a 15s poll into a 1s
         # one, i.e. ~600 CLOB requests per resolution instead of ~40.
-        assert mock_sleep.call_args_list == [call(15.0), call(15.0)]
+        assert mock_sleep.call_args_list == [call(7.0), call(7.0)]
 
     def test_returns_none_when_max_wait_exhausted(self):
         env = self._real_poll_env(
@@ -613,6 +658,19 @@ class TestConfigValidation:
         config = PolymarketBetEnvConfig(market_slug_prefix="btc-updown-5m-")
         with pytest.raises(dataclasses.FrozenInstanceError):
             config.dry_run = False
+
+    @pytest.mark.parametrize("bad", [-1.0, 1.5], ids=["negative-disables-the-stop", "over-100%"])
+    def test_bankrupt_threshold_validated_at_the_boundary(self, bad):
+        """The same silent-default trap as initial_cash, one field over.
+
+        > 1: threshold * initial exceeds the starting cash, so the account is bankrupt on step
+        1, before a single bet resolves.
+        < 0: `current < threshold * initial` is unsatisfiable for any non-negative cash, which
+        SILENTLY DISABLES the safety stop -- the exact failure this repo keeps getting bitten
+        by, and the reason _is_bankrupt's old `initial > 0` guard was removed rather than kept.
+        """
+        with pytest.raises(ValueError, match="bankrupt_threshold"):
+            PolymarketBetEnvConfig(market_slug_prefix="btc-updown-5m-", bankrupt_threshold=bad)
 
     @pytest.mark.parametrize("bad", [-0.1, 1.5], ids=["negative", "over-100%"])
     def test_bet_fraction_validated_at_the_boundary(self, bad):

--- a/tests/envs/polymarket/test_env.py
+++ b/tests/envs/polymarket/test_env.py
@@ -659,12 +659,16 @@ class TestConfigValidation:
         with pytest.raises(dataclasses.FrozenInstanceError):
             config.dry_run = False
 
-    @pytest.mark.parametrize("bad", [-1.0, 1.5], ids=["negative-disables-the-stop", "over-100%"])
+    @pytest.mark.parametrize(
+        "bad", [-1.0, 1.0, 1.5],
+        ids=["negative-disables-the-stop", "exactly-1.0", "over-100%"],
+    )
     def test_bankrupt_threshold_validated_at_the_boundary(self, bad):
         """The same silent-default trap as initial_cash, one field over.
 
-        > 1: threshold * initial exceeds the starting cash, so step 1 terminates unless the
-        opening bet alone lifts cash back above the line.
+        >= 1: the account starts at or below its own bankruptcy line. The domain is half-open
+        [0, 1) to match SequentialTradingEnvConfig, which already settled this field's domain
+        -- a live env inventing a different one is exactly the drift we keep paying for.
         < 0: `current < threshold * initial` is unsatisfiable for any non-negative cash, which
         SILENTLY DISABLES the safety stop -- the exact failure this repo keeps getting bitten
         by, and the reason _is_bankrupt's old `initial > 0` guard was removed rather than kept.

--- a/tests/envs/polymarket/test_env.py
+++ b/tests/envs/polymarket/test_env.py
@@ -150,6 +150,32 @@ class TestSpecs:
 
 # --- Pure helpers ----------------------------------------------------------- #
 
+class TestConstructorCompat:
+    """The private_key removal must not break callers SILENTLY."""
+
+    def test_private_key_is_refused_with_an_explanation_not_a_bare_TypeError(self):
+        """Old callers passed private_key=... (the repo's own example did). Rather than let
+        Python emit a bare "unexpected keyword argument", say what happened and why.
+
+        It is REFUSED, not ignored: silently swallowing a real private key would tell the
+        caller their key is configured when the env can never sign anything.
+        """
+        cfg = PolymarketBetEnvConfig(market_slug_prefix="btc-updown-5m-")
+        with pytest.raises(TypeError, match="paper-only"):
+            PolymarketBetEnv(cfg, private_key="0xdeadbeef", scanner=MagicMock())
+
+    def test_positional_misuse_is_loud_not_silent(self):
+        """private_key used to be the SECOND POSITIONAL parameter. Removing it would have
+        silently rebound `PolymarketBetEnv(config, "0xkey")` to `scanner`, which then blows up
+        much later with an AttributeError on a str -- a silent break, which is precisely the
+        bug class this whole env is being fixed for. Keyword-only args make it a TypeError at
+        the call site instead.
+        """
+        cfg = PolymarketBetEnvConfig(market_slug_prefix="btc-updown-5m-")
+        with pytest.raises(TypeError):
+            PolymarketBetEnv(cfg, "0xdeadbeef")   # noqa: the point is that this must raise
+
+
 class TestClose:
     def test_close_works_through_a_transform(self):
         """Regression: `def close(self)` did not accept EnvBase's keyword-only

--- a/tests/envs/polymarket/test_env.py
+++ b/tests/envs/polymarket/test_env.py
@@ -141,11 +141,11 @@ class TestSpecs:
             PolymarketOrderExecutor,
         )
         assert isinstance(env.trader, PolymarketOrderExecutor)
-        # Pins that the env actually wires the executor to PAPER rather than trusting the
-        # executor's default. Belt-and-braces: the executor now defaults to dry_run=True too,
-        # so BOTH must regress before a live client can be built -- this assertion is what
-        # makes that take two mistakes instead of one.
-        assert env.trader._dry_run is True
+        # NOT asserting env.trader._dry_run: it cannot fail. The config admits only
+        # dry_run=True, so passing config.dry_run, passing True, and omitting the kwarg (the
+        # executor's own default) are indistinguishable here -- a dead assertion dressed as a
+        # second lock. The executor's safe default is pinned for real in
+        # test_order_executor.py::test_executor_defaults_to_paper; that is the actual guard.
 
 
 # --- Pure helpers ----------------------------------------------------------- #
@@ -554,7 +554,7 @@ class TestPollForResolution:
         env = self._real_poll_env()
         env._fetch_resolved_outcome = MagicMock(return_value=1)
         with patch("torchtrade.envs.live.polymarket.env.time.sleep") as mock_sleep:
-            assert env._poll_for_resolution("0xcond") == 1
+            assert env._poll_for_resolution(_make_market()) == 1
         mock_sleep.assert_not_called()
         assert env._fetch_resolved_outcome.call_count == 1
 
@@ -566,7 +566,7 @@ class TestPollForResolution:
         # First two calls: still mid-market. Third: Up wins.
         env._fetch_resolved_outcome = MagicMock(side_effect=[None, None, 1])
         with patch("torchtrade.envs.live.polymarket.env.time.sleep") as mock_sleep:
-            assert env._poll_for_resolution("0xcond") == 1
+            assert env._poll_for_resolution(_make_market()) == 1
         assert env._fetch_resolved_outcome.call_count == 3
         # Pin the poll interval BY VALUE, not just "it slept". Nothing pinned this, so
         # hardcoding a constant passed the whole suite -- turning a 15s poll into a 1s one,
@@ -574,14 +574,32 @@ class TestPollForResolution:
         assert mock_sleep.call_args_list == [call(7.0), call(7.0)]
 
     def test_returns_none_when_max_wait_exhausted(self):
+        """The deadline must come from resolution_max_wait_seconds, and be OBSERVABLE.
+
+        A fake clock advancing exactly one poll-interval per tick makes the poll count a
+        deterministic function of the config: 50s budget / 10s interval = 5 polls. Asserting
+        the COUNT is what turns "the deadline was hardcoded to 600.0" from a 600-second HANG
+        (which no assertion catches -- only a CI timeout) into an ordinary test failure.
+        """
         env = self._real_poll_env(
-            resolution_max_wait_seconds=0.1,
-            resolution_poll_interval_seconds=0.01,
+            resolution_max_wait_seconds=50.0,
+            resolution_poll_interval_seconds=10.0,
         )
         env._fetch_resolved_outcome = MagicMock(return_value=None)
-        with patch("torchtrade.envs.live.polymarket.env.time.sleep"):
-            assert env._poll_for_resolution("0xcond") is None
-        assert env._fetch_resolved_outcome.call_count >= 1
+
+        # Clock advances ONLY when the loop sleeps -- a faithful simulation of elapsed time,
+        # and robust to how many times the loop happens to read the clock per iteration
+        # (it reads it twice today; a per-read counter would break on any refactor).
+        now = [0.0]
+        with patch("torchtrade.envs.live.polymarket.env.time.sleep",
+                   side_effect=lambda sec: now.__setitem__(0, now[0] + sec)), \
+             patch("torchtrade.envs.live.polymarket.env.time.monotonic",
+                   side_effect=lambda: now[0]):
+            assert env._poll_for_resolution(_make_market()) is None
+
+        # 50s budget / 10s interval => 5 sleeps, so 6 polls before the deadline bites.
+        # A hardcoded 600.0 budget would poll 61 times -- a wrong NUMBER, not a 600s hang.
+        assert env._fetch_resolved_outcome.call_count == 6
 
 
 class TestWaitForResolution:
@@ -607,7 +625,7 @@ class TestWaitForResolution:
             assert mock_sleep.called == expect_sleep
 
     def test_sleeps_when_future_endDate(self):
-        env, _, _ = _make_env()
+        env, _, _ = _make_env(config_overrides={"resolution_grace_seconds": 45.0})
         env._wait_for_resolution = (
             PolymarketBetEnv._wait_for_resolution.__get__(env, PolymarketBetEnv)
         )
@@ -618,9 +636,10 @@ class TestWaitForResolution:
             env._wait_for_resolution(future)
             mock_sleep.assert_called_once()
             slept_for = mock_sleep.call_args.args[0]
-            # By VALUE, not "> 100": a 120s horizon plus the configured 30s grace. The loose
-            # bound let `target = end_dt` (grace dropped entirely) pass, since 120 > 100.
-            assert slept_for == pytest.approx(150, abs=2)
+            # 45s grace, NOT the 30.0 default: pinning a knob at its default cannot tell a
+            # config read from a hardcoded constant. (Same trap as the poll interval; I shipped
+            # this bug class twice before catching it here.) 120s horizon + 45s grace = 165.
+            assert slept_for == pytest.approx(165, abs=2)
 
 
 class TestConfigValidation:
@@ -658,6 +677,17 @@ class TestConfigValidation:
         config = PolymarketBetEnvConfig(market_slug_prefix="btc-updown-5m-")
         with pytest.raises(dataclasses.FrozenInstanceError):
             config.dry_run = False
+
+    def test_zero_is_legal_for_both_fractions(self):
+        """0.0 is DOCUMENTED as supported for both (a no-bet agent; bankruptcy disabled).
+
+        The lower bounds were never constructed, so `0 <= x` -> `0 < x` silently forbade a
+        config the docstrings promise. Pin that both zeros still build.
+        """
+        cfg = PolymarketBetEnvConfig(
+            market_slug_prefix="btc-updown-5m-", bet_fraction=0.0, bankrupt_threshold=0.0
+        )
+        assert cfg.bet_fraction == 0.0 and cfg.bankrupt_threshold == 0.0
 
     @pytest.mark.parametrize(
         "bad", [-1.0, 1.0, 1.5],

--- a/tests/envs/polymarket/test_env.py
+++ b/tests/envs/polymarket/test_env.py
@@ -76,7 +76,6 @@ def _make_env(
         scanner.next_active_market.side_effect = list(markets)
 
     trader = MagicMock()
-    trader.buy.return_value = {"success": True}
 
     env = PolymarketBetEnv(config, scanner=scanner, trader=trader)
     env._wait_for_resolution = lambda *a, **k: None
@@ -98,6 +97,24 @@ class TestSpecs:
     def test_check_env_specs_passes(self):
         env, _, _ = _make_env()
         check_env_specs(env)
+
+    def test_market_state_is_exactly_yes_spread_volume_liquidity(self):
+        """The policy's ENTIRE input. Pin the ORDER and the SOURCE FIELD of all four slots.
+
+        Four mutually distinct values, so no swap can hide: spread<->liquidity,
+        volume<->liquidity, and yes_price->no_price each survived the whole suite before this
+        test existed. A permutation is invisible to check_env_specs -- Bounded(0, inf) accepts
+        any order -- and feeding the policy `no_price` inverts the market it thinks it sees.
+        (CLAUDE.md invariant #3: an observation mutation once passed 1977 tests.)
+        """
+        market = _make_market(yes_price=0.42, no_price=0.58, spread=0.02,
+                              volume_24h=1500.0, liquidity=12000.0)
+        env, _, _ = _make_env(markets=[market])
+        td = env.reset()
+        assert torch.equal(
+            td["market_state"],
+            torch.tensor([0.42, 0.02, 1500.0, 12000.0], dtype=torch.float32),
+        )
 
     def test_observation_has_only_market_state(self):
         env, _, _ = _make_env()
@@ -122,10 +139,10 @@ class TestSpecs:
         # whole message be replaced with "pip install py-clob-client, then set dry_run=False"
         # -- the exact dead-end advice this PR exists to delete -- with the suite still green.
         # Both reasons must survive: the dead client AND the redemption blocker.
-        with pytest.raises(NotImplementedError, match="archived"):
+        with pytest.raises(NotImplementedError) as exc:
             PolymarketBetEnvConfig(market_slug_prefix="btc-updown-5m-", dry_run=False)
-        with pytest.raises(NotImplementedError, match="redeem"):
-            PolymarketBetEnvConfig(market_slug_prefix="btc-updown-5m-", dry_run=False)
+        assert "archived" in str(exc.value)   # blocker 1: the client is dead
+        assert "redeem" in str(exc.value)     # blocker 2: the one a port cannot skip
 
     def test_config_is_frozen_so_the_guard_cannot_be_mutated_away(self):
         """__post_init__ runs ONCE. On a mutable dataclass this is the bypass:
@@ -139,6 +156,18 @@ class TestSpecs:
         config = PolymarketBetEnvConfig(market_slug_prefix="btc-updown-5m-")
         with pytest.raises(dataclasses.FrozenInstanceError):
             config.dry_run = False
+
+    def test_paper_env_never_touches_the_trader_during_a_step(self):
+        """The paper env must not call the trader AT ALL during a step -- not just `.buy`.
+
+        Asserting `buy.assert_not_called()` pinned only that one attribute name; a _step that
+        called `trader.submit_market_order(...)` would have passed. mock_calls == [] pins the
+        whole surface, which is the actual contract: nothing is submitted, ever.
+        """
+        env, _, trader = _make_env()
+        env.reset()
+        env._step(TensorDict({"action": torch.tensor(1)}, batch_size=()))
+        assert trader.mock_calls == []
 
     @pytest.mark.parametrize("bad", [-0.1, 1.5], ids=["negative", "over-100%"])
     def test_bet_fraction_validated_at_the_boundary(self, bad):
@@ -173,14 +202,31 @@ class TestSpecs:
             PolymarketOrderExecutor,
         )
         assert isinstance(env.trader, PolymarketOrderExecutor)
-        # THE load-bearing assertion. Without it, dropping `dry_run=config.dry_run` from the
-        # executor call leaves a PAPER-configured env holding a LIVE trader that builds a real
-        # authenticated CLOB client from the private key -- and the suite stays green (it only
-        # failed here by accident, because py-clob-client happens not to be installed).
+        # Pins that the env actually wires the executor to PAPER rather than trusting the
+        # executor's default. Belt-and-braces: the executor now defaults to dry_run=True too,
+        # so BOTH must regress before a live client can be built -- this assertion is what
+        # makes that take two mistakes instead of one.
         assert env.trader._dry_run is True
 
 
 # --- Pure helpers ----------------------------------------------------------- #
+
+class TestClose:
+    def test_close_works_through_a_transform(self):
+        """Regression: `def close(self)` did not accept EnvBase's keyword-only
+        `raise_if_closed`, which TransformedEnv forwards -- so closing a wrapped env raised
+        TypeError. RewardSum is the wrapper this env's own spec comment points users at."""
+        from torchrl.envs import TransformedEnv
+        from torchrl.envs.transforms import RewardSum
+
+        env, _, trader = _make_env()
+        TransformedEnv(env, RewardSum()).close()   # must not raise
+        trader.cancel_all.assert_called_once()
+        # NOT asserting is_closed: EnvBase.close() only sets is_closed=True, and this env's
+        # is_closed is ALREADY True from construction -- so the assertion would pass whether or
+        # not close() delegates upward. A dead assertion is worse than no assertion. The
+        # super() call in close() is correct delegation, but it is currently unobservable.
+
 
 class TestComputePayoff:
     @pytest.mark.parametrize(
@@ -191,8 +237,12 @@ class TestComputePayoff:
             (1, 0.4, 0, -100.0),
             (0, 0.4, 1, -100.0),
             (1, 0.5, 1, 100.0),
+            # A market quoting 0.0 must not ZeroDivisionError mid-episode. The chosen silent
+            # default -- a WIN at fill 0 books 0.0, not an infinite payout -- is pinned here
+            # because deleting the guard otherwise passes the whole suite.
+            (1, 0.0, 1, 0.0),
         ],
-        ids=["up-wins", "down-wins", "up-loses", "down-loses", "even-money"],
+        ids=["up-wins", "down-wins", "up-loses", "down-loses", "even-money", "zero-fill-price"],
     )
     def test_payoff(self, action, fill, outcome, expected):
         assert PolymarketBetEnv._compute_payoff(action, fill, outcome, 100.0) == pytest.approx(expected)
@@ -249,12 +299,6 @@ class TestStep:
         env.reset()
         td = env._step(TensorDict({"action": torch.tensor(action)}, batch_size=()))
         assert td["reward"].item() == pytest.approx(expected_payoff)
-
-    def test_dry_run_skips_trader_buy(self):
-        env, _, trader = _make_env(config_overrides={"dry_run": True})
-        env.reset()
-        env._step(TensorDict({"action": torch.tensor(1)}, batch_size=()))
-        trader.buy.assert_not_called()
 
     def test_cash_updates_after_win_and_loss(self):
         env, _, _ = _make_env(
@@ -574,7 +618,9 @@ class TestWaitForResolution:
             env._wait_for_resolution(future)
             mock_sleep.assert_called_once()
             slept_for = mock_sleep.call_args.args[0]
-            assert slept_for > 100  # 120s + 30s grace ≈ 150s
+            # By VALUE, not "> 100": a 120s horizon plus the configured 30s grace. The loose
+            # bound let `target = end_dt` (grace dropped entirely) pass, since 120 > 100.
+            assert slept_for == pytest.approx(150, abs=2)
 
 
 class TestCloseLifecycle:

--- a/tests/envs/polymarket/test_env.py
+++ b/tests/envs/polymarket/test_env.py
@@ -569,8 +569,8 @@ class TestPollForResolution:
             assert env._poll_for_resolution("0xcond") == 1
         assert env._fetch_resolved_outcome.call_count == 3
         # Pin the poll interval BY VALUE, not just "it slept". Nothing pinned this, so
-        # hardcoding time.sleep(1.0) passed the whole suite -- turning a 15s poll into a 1s
-        # one, i.e. ~600 CLOB requests per resolution instead of ~40.
+        # hardcoding a constant passed the whole suite -- turning a 15s poll into a 1s one,
+        # i.e. ~600 polls per resolution instead of ~40 (and each poll is 2 CLOB requests).
         assert mock_sleep.call_args_list == [call(7.0), call(7.0)]
 
     def test_returns_none_when_max_wait_exhausted(self):
@@ -663,8 +663,8 @@ class TestConfigValidation:
     def test_bankrupt_threshold_validated_at_the_boundary(self, bad):
         """The same silent-default trap as initial_cash, one field over.
 
-        > 1: threshold * initial exceeds the starting cash, so the account is bankrupt on step
-        1, before a single bet resolves.
+        > 1: threshold * initial exceeds the starting cash, so step 1 terminates unless the
+        opening bet alone lifts cash back above the line.
         < 0: `current < threshold * initial` is unsatisfiable for any non-negative cash, which
         SILENTLY DISABLES the safety stop -- the exact failure this repo keeps getting bitten
         by, and the reason _is_bankrupt's old `initial > 0` guard was removed rather than kept.
@@ -674,11 +674,12 @@ class TestConfigValidation:
 
     @pytest.mark.parametrize("bad", [-0.1, 1.5], ids=["negative", "over-100%"])
     def test_bet_fraction_validated_at_the_boundary(self, bad):
-        """bet_fraction > 1 stakes more than the account holds, driving cash negative.
+        """bet_fraction > 1 stakes more than the account holds, driving cash negative -- which
+        flips the sign of a loss, so a losing bet would PAY OUT.
 
-        Today only _compute_payoff's `stake <= 0` guard (plus same-step bankruptcy) stands
-        between that and inverted P&L -- a loss paying out. Refuse the config at the boundary
-        rather than depend on a downstream guard to absorb it.
+        Refusing it here is what guarantees cash >= 0, and that guarantee is in turn why
+        _compute_payoff carries no `stake <= 0` guard (it was deleted as unreachable). The
+        boundary check REPLACES the downstream guard; it does not merely back it up.
         """
         with pytest.raises(ValueError, match="bet_fraction"):
             PolymarketBetEnvConfig(market_slug_prefix="btc-updown-5m-", bet_fraction=bad)

--- a/tests/envs/polymarket/test_env.py
+++ b/tests/envs/polymarket/test_env.py
@@ -107,6 +107,29 @@ class TestSpecs:
         env, _, _ = _make_env()
         assert env.action_spec.n == 2
 
+    def test_live_mode_is_refused(self):
+        """dry_run=False must RAISE, not silently paper-trade.
+
+        The env can never execute live: py-clob-client is archived/non-functional, and the
+        env holds every bet to resolution while Polymarket only releases collateral on an
+        explicit on-chain redeem that no client exposes -- so a live bot's balance drains to
+        zero while it is winning. Refusing the config is the whole point of this guard; a
+        regression that quietly downgraded live to paper (or dropped the check) would let a
+        user believe real money was at work.
+        """
+        with pytest.raises(NotImplementedError, match="not supported"):
+            PolymarketBetEnvConfig(market_slug_prefix="btc-updown-5m-", dry_run=False)
+
+    def test_default_config_is_paper(self):
+        """The DEFAULT must be the safe mode.
+
+        Not a tautology against the line above: this pins that a user who never mentions
+        dry_run gets a constructible paper env. The default used to be dry_run=False, which
+        (once the guard exists) means the default config would not even build.
+        """
+        config = PolymarketBetEnvConfig(market_slug_prefix="btc-updown-5m-")
+        assert config.dry_run is True
+
     def test_missing_slug_prefix_raises(self):
         with pytest.raises(ValueError, match="market_slug_prefix"):
             PolymarketBetEnv(PolymarketBetEnvConfig())
@@ -200,75 +223,6 @@ class TestStep:
         env.reset()
         env._step(TensorDict({"action": torch.tensor(1)}, batch_size=()))
         trader.buy.assert_not_called()
-
-    @pytest.mark.parametrize(
-        "action,expected_token_id",
-        [(1, "tok_yes"), (0, "tok_no")],
-        ids=["bet-up-targets-yes-token", "bet-down-targets-no-token"],
-    )
-    def test_live_mode_calls_trader_buy_with_correct_token(self, action, expected_token_id):
-        """A YES↔NO token swap on either action would silently pass without
-        parametrizing both directions — so this test exercises both."""
-        env, _, trader = _make_env(config_overrides={"dry_run": False})
-        env.reset()
-        env._step(TensorDict({"action": torch.tensor(action)}, batch_size=()))
-        trader.buy.assert_called_once()
-        kwargs = trader.buy.call_args.kwargs
-        assert kwargs["token_id"] == expected_token_id
-        assert kwargs["amount_usdc"] > 0
-
-    def test_zero_stake_in_live_mode_does_not_call_trader(self):
-        """bet_fraction=0 → stake=0 → no order even in live mode."""
-        env, _, trader = _make_env(
-            config_overrides={"dry_run": False, "bet_fraction": 0.0}
-        )
-        env.reset()
-        env._step(TensorDict({"action": torch.tensor(1)}, batch_size=()))
-        trader.buy.assert_not_called()
-
-    @pytest.mark.parametrize(
-        "underlying_outcome",
-        [1, 0],
-        ids=["would-have-won", "would-have-lost"],
-    )
-    def test_failed_order_in_live_mode_books_zero_payoff(self, underlying_outcome):
-        """Critical safety: a rejected/failed order must NOT produce phantom P&L.
-
-        Pins the FULL post-failure contract, not just reward, so a future
-        refactor that ``return``-s early on failure (skipping the next-market
-        fetch, step counter, or done flags) breaks the test instead of silently
-        breaking episode progression. Parametrized over both possible underlying
-        outcomes, a regression that booked ``-stake`` on failure (instead of 0)
-        would only show up in the would-have-lost case otherwise.
-        """
-        market = _make_market(yes_price=0.4, no_price=0.6)
-        env, scanner, trader = _make_env(
-            outcomes=[underlying_outcome],
-            markets=[market, _make_market(slug="btc-updown-5m-next")],
-            config_overrides={"dry_run": False},
-        )
-        trader.buy.return_value = {"success": False, "error": "insufficient USDC"}
-        env.reset()
-        cash_before = env.cash
-        scanner_calls_before = scanner.next_active_market.call_count
-        td = env._step(TensorDict({"action": torch.tensor(1)}, batch_size=()))
-
-        # We tried to place the order
-        trader.buy.assert_called_once()
-
-        # No phantom P&L
-        assert td["reward"].item() == 0.0
-        assert env.cash == pytest.approx(cash_before)
-
-        # Episode progression continues normally, these assertions catch a
-        # naive `if failure: return early_td` shortcut.
-        assert env._step_count == 1
-        assert not td["terminated"].item()
-        assert not td["truncated"].item()
-        assert scanner.next_active_market.call_count > scanner_calls_before
-        # Next market's state is non-zero (real market_state, not the terminal
-        # zero-tensor used for "no next market" cases).
-        assert not torch.equal(td["market_state"], torch.zeros(4))
 
     def test_cash_updates_after_win_and_loss(self):
         env, _, _ = _make_env(

--- a/tests/envs/polymarket/test_order_executor.py
+++ b/tests/envs/polymarket/test_order_executor.py
@@ -1,9 +1,12 @@
 """Tests for the paper-only Polymarket order executor.
 
-The V1 live path (ClobClient construction, MarketOrderArgs/OrderType.FOK order posting) and
-the ~10 tests that pinned its call shape were deleted together: ``dry_run=False`` is now
-REFUSED by the constructor, so none of it was reachable. What remains is the contract that
-actually matters -- this class cannot submit an order, and cannot be talked into trying.
+The V1 live path and the ~10 tests that pinned its call shape were deleted together:
+``dry_run=False`` is now refused by the constructor, so none of it was reachable.
+
+What is left is deliberately small. The class is a stub, and a stub's constants
+(``cancel_all() is True``, the dry-run marker dict) cannot be usefully asserted -- a test that
+re-states a `return True` is a tautology, not coverage. Only the REFUSALS can fail, so only
+the refusals are tested here.
 """
 
 import pytest
@@ -14,57 +17,64 @@ from torchtrade.envs.live.polymarket.order_executor import PolymarketOrderExecut
 class TestLiveIsRefused:
     """Makes the paper-only contract true for the PUBLIC API, not just for the env.
 
-    PolymarketOrderExecutor is exported from ``torchtrade.envs.live``. With the config
-    boundary on PolymarketBetEnv as the only gate, a caller using the exported class directly
-    could still build a live CLOB client from a real private key and post an order -- against
-    an archived V1 API, with no redemption workflow. The env believing itself paper-only did
-    nothing to stop that.
+    PolymarketOrderExecutor is exported from ``torchtrade.envs.live``. With the config boundary
+    on PolymarketBetEnv as the only gate, a caller using the exported class directly could
+    still build a live CLOB client from a real key and post an order -- against an archived V1
+    API, with no redemption workflow -- while the env believed itself paper-only.
     """
 
     def test_live_mode_raises(self):
         with pytest.raises(NotImplementedError) as exc:
-            PolymarketOrderExecutor(private_key="0xtest", dry_run=False)
-        # Pin the SUBSTANCE, not a contentless phrase: both blockers must survive, or the
-        # message could be reduced to "not supported yet" and still pass.
+            PolymarketOrderExecutor(dry_run=False)
+        # Pin the SUBSTANCE. Matching a contentless phrase would let the message be reduced to
+        # "not supported yet" -- or back to "pip install py-clob-client" -- and still pass.
         assert "archived" in str(exc.value)
         assert "redeem" in str(exc.value)
 
-    def test_live_mode_raises_even_with_a_funded_looking_config(self):
-        """A full live config -- key, chain, proxy signature type, funder -- must not sneak
-        past. The refusal is on dry_run, not on whether the caller looks prepared."""
-        with pytest.raises(NotImplementedError):
-            PolymarketOrderExecutor(
-                private_key="0xdeadbeef",
-                chain_id=137,
-                signature_type=2,
-                funder="0xproxy",
-                dry_run=False,
-            )
+    def test_a_real_private_key_is_refused_not_swallowed(self):
+        """The executor must not pocket a key it can never use.
+
+        It previously accepted private_key/chain_id/signature_type/funder and ignored all four
+        -- so a caller handing the EXPORTED class a funded key was told nothing, while the env
+        refused the very same argument. "Refused, not ignored" is self-refuting if the class
+        the env wraps does the ignoring.
+        """
+        with pytest.raises(TypeError, match="paper-only"):
+            PolymarketOrderExecutor(private_key="0xREAL_SECRET")
+
+    def test_empty_string_key_is_refused_too(self):
+        """`if private_key:` would wave this through -- and the old example passed exactly
+        os.getenv("POLYGON_PRIVATE_KEY", ""), i.e. "" whenever the var was unset."""
+        with pytest.raises(TypeError, match="paper-only"):
+            PolymarketOrderExecutor(private_key="")
+
+    def test_the_dead_live_params_are_gone(self):
+        """chain_id/signature_type/funder fed the deleted CLOB client. They must not linger as
+        accepted-and-ignored params -- that is the same silent-swallow bug as the key."""
+        with pytest.raises(TypeError):
+            PolymarketOrderExecutor(signature_type=2, funder="0xproxy")
 
 
 class TestPaperExecution:
-    def test_defaults_to_paper(self):
-        """The DEFAULT must be the safe mode. It used to default to dry_run=False, so any
-        caller who forgot the kwarg -- including the env -- got a live client."""
-        assert PolymarketOrderExecutor(private_key="x")._dry_run is True
+    def test_default_construction_is_paper(self):
+        """The DEFAULT must be the safe mode: it used to default to dry_run=False, so a caller
+        who omitted the kwarg got a live client. Flipping it back makes this RAISE.
 
-    def test_no_clob_client_is_ever_constructed(self):
-        """Constructing a ClobClient would derive API creds -- a network roundtrip against the
-        wallet. That shipped as a real bug once; it is now structurally impossible."""
-        assert PolymarketOrderExecutor(private_key="0xtest").client is None
-
-    def test_buy_submits_nothing(self):
-        assert PolymarketOrderExecutor().buy(token_id="tok", amount_usdc=10.0) == {
-            "success": True,
-            "dry_run": True,
-        }
-
-    def test_cancel_all_is_a_noop(self):
-        assert PolymarketOrderExecutor().cancel_all() is True
+        The construction not raising IS the assertion. Asserting on buy()'s literal return, or
+        on ._dry_run, would be asserting a constant against itself -- the class has no live
+        state left to observe.
+        """
+        PolymarketOrderExecutor()
 
     def test_does_not_depend_on_py_clob_client_at_all(self):
         """Paper trading must not need the archived package. The module no longer imports it,
-        so this is structural now rather than a runtime dry_run branch."""
+        so this is structural now rather than a runtime dry_run branch -- and this test is what
+        stops the import shim being quietly resurrected."""
+        import inspect
+
         import torchtrade.envs.live.polymarket.order_executor as oe
 
-        assert not hasattr(oe, "ClobClient")
+        # Assert against the module SOURCE, not one symbol name: pinning only `ClobClient`
+        # would miss MarketOrderArgs / OrderType / BUY / a bare `import py_clob_client`.
+        src = inspect.getsource(oe)
+        assert "py_clob_client" not in src.replace("py-clob-client", "")

--- a/tests/envs/polymarket/test_order_executor.py
+++ b/tests/envs/polymarket/test_order_executor.py
@@ -1,4 +1,9 @@
-"""Tests for the slim Polymarket order executor (buy + cancel_all)."""
+"""Tests for the slim Polymarket order executor (buy + cancel_all).
+
+NOTE: the live path exercised below is DORMANT -- PolymarketBetEnv is paper-only and calls
+nothing here but cancel_all() (a no-op in dry-run). These tests pin the V1 call shape for
+the CLOB V2 port; they do not cover any shipped code path. See LIVE_UNSUPPORTED in env.py.
+"""
 
 from unittest.mock import MagicMock, patch
 

--- a/tests/envs/polymarket/test_order_executor.py
+++ b/tests/envs/polymarket/test_order_executor.py
@@ -1,181 +1,70 @@
-"""Tests for the slim Polymarket order executor (buy + cancel_all).
+"""Tests for the paper-only Polymarket order executor.
 
-NOTE: the live path exercised below is DORMANT -- PolymarketBetEnv is paper-only and calls
-nothing here but cancel_all() (a no-op in dry-run). These tests pin the V1 call shape for
-the CLOB V2 port; they do not cover any shipped code path. See LIVE_UNSUPPORTED in env.py.
+The V1 live path (ClobClient construction, MarketOrderArgs/OrderType.FOK order posting) and
+the ~10 tests that pinned its call shape were deleted together: ``dry_run=False`` is now
+REFUSED by the constructor, so none of it was reachable. What remains is the contract that
+actually matters -- this class cannot submit an order, and cannot be talked into trying.
 """
-
-from unittest.mock import MagicMock, patch
 
 import pytest
 
 from torchtrade.envs.live.polymarket.order_executor import PolymarketOrderExecutor
 
 
-def _make_order_args(token_id, amount, side):
-    obj = MagicMock()
-    obj.token_id = token_id
-    obj.amount = amount
-    obj.side = side
-    return obj
+class TestLiveIsRefused:
+    """Makes the paper-only contract true for the PUBLIC API, not just for the env.
 
-
-@pytest.fixture
-def patched_module():
-    """Patch the optional py-clob-client imports for the whole test."""
-    mock_order_type = MagicMock()
-    mock_order_type.FOK = "FOK"
-    patches = [
-        patch(
-            "torchtrade.envs.live.polymarket.order_executor.ClobClient",
-            new=MagicMock(),
-        ),
-        patch(
-            "torchtrade.envs.live.polymarket.order_executor.MarketOrderArgs",
-            side_effect=_make_order_args,
-        ),
-        patch(
-            "torchtrade.envs.live.polymarket.order_executor.OrderType",
-            new=mock_order_type,
-        ),
-    ]
-    for p in patches:
-        p.start()
-    yield
-    for p in patches:
-        p.stop()
-
-
-@pytest.fixture
-def executor(patched_module):
-    # dry_run=False is now explicit: the executor DEFAULTS to paper, so the live path has
-    # to be asked for by name.
-    exe = PolymarketOrderExecutor(private_key="0xtest", chain_id=137, dry_run=False)
-    exe.client = MagicMock()
-    exe.client.post_order.return_value = {"success": True, "orderID": "ord-1"}
-    return exe
-
-
-class TestBuy:
-    def test_returns_success_dict(self, executor):
-        result = executor.buy(token_id="tok_yes_1", amount_usdc=100.0)
-        assert result["success"] is True
-
-    def test_returns_failure_dict_on_post_order_exception(self, executor):
-        executor.client.post_order = MagicMock(side_effect=Exception("api down"))
-        result = executor.buy(token_id="tok", amount_usdc=1.0)
-        assert result == {"success": False, "error": "api down"}
-
-    def test_pins_buy_side_and_fok_order_type(self, executor):
-        """A BUY↔SELL or FOK↔GTC swap must fail this test, not silently pass."""
-        from torchtrade.envs.live.polymarket import order_executor as oe
-
-        executor.buy(token_id="tok_yes", amount_usdc=42.0)
-        # MarketOrderArgs called with side=BUY (the constant from the package)
-        args_call = oe.MarketOrderArgs.call_args
-        assert args_call.kwargs["side"] == oe.BUY
-        assert args_call.kwargs["token_id"] == "tok_yes"
-        assert args_call.kwargs["amount"] == 42.0
-        # post_order called with OrderType.FOK (fill-or-kill)
-        post_call = executor.client.post_order.call_args
-        assert post_call.args[1] == oe.OrderType.FOK
-
-
-class TestCancelAll:
-    def test_returns_true_on_success(self, executor):
-        assert executor.cancel_all() is True
-
-    def test_returns_false_on_api_failure(self, executor):
-        executor.client.cancel_all = MagicMock(side_effect=Exception("503"))
-        assert executor.cancel_all() is False
-
-
-class TestDryRunWithoutClient:
-    """``dry_run=True`` works without py-clob-client installed."""
-
-    def test_constructs_with_no_clob_dependency(self, monkeypatch):
-        monkeypatch.setattr(
-            "torchtrade.envs.live.polymarket.order_executor.ClobClient", None
-        )
-        exe = PolymarketOrderExecutor(private_key="0x", dry_run=True)
-        assert exe.client is None
-
-    def test_methods_return_safe_defaults_without_client(self, monkeypatch):
-        monkeypatch.setattr(
-            "torchtrade.envs.live.polymarket.order_executor.ClobClient", None
-        )
-        exe = PolymarketOrderExecutor(private_key="0x", dry_run=True)
-        assert exe.buy("tok", 1.0)["success"] is True
-        assert exe.cancel_all() is True
-
-    def test_live_mode_error_does_not_advise_installing_the_dead_package(self, monkeypatch):
-        """The old message said "pip install py-clob-client" -- advice that now sends people
-        to an archived, non-functional package. Pin the honest message instead."""
-        monkeypatch.setattr(
-            "torchtrade.envs.live.polymarket.order_executor.ClobClient", None
-        )
-        with pytest.raises(ImportError, match="archived and no longer functional"):
-            PolymarketOrderExecutor(private_key="0x", dry_run=False)
-
-
-class TestSafeDefault:
-    def test_executor_defaults_to_paper(self):
-        """The default must be the SAFE mode. It used to default to dry_run=False, so any
-        caller that forgot the kwarg -- including the env -- got a live client. Nothing pinned
-        this, so flipping the default back was an invisible regression."""
-        assert PolymarketOrderExecutor(private_key="x")._dry_run is True
-
-
-class TestDryRunSkipsRealOrder:
-    def test_buy_in_dry_run_returns_dry_run_marker(self, patched_module):
-        exe = PolymarketOrderExecutor(private_key="0x", dry_run=True)
-        exe.client = MagicMock()  # would error if hit
-        result = exe.buy(token_id="tok", amount_usdc=10.0)
-        assert result == {"success": True, "dry_run": True}
-        exe.client.create_market_order.assert_not_called()
-        exe.client.post_order.assert_not_called()
-
-
-class TestDryRunSkipsClientConstructionEvenWhenAvailable:
-    """dry_run=True must not touch the network even when py-clob-client IS installed.
-
-    The previous behavior constructed a real ``ClobClient`` and called
-    ``set_api_creds(create_or_derive_api_creds())`` (a network roundtrip + valid
-    private key requirement) whenever the package was available, regardless of
-    ``dry_run``. Paper trading should be fully offline.
+    PolymarketOrderExecutor is exported from ``torchtrade.envs.live``. With the config
+    boundary on PolymarketBetEnv as the only gate, a caller using the exported class directly
+    could still build a live CLOB client from a real private key and post an order -- against
+    an archived V1 API, with no redemption workflow. The env believing itself paper-only did
+    nothing to stop that.
     """
 
-    def test_dry_run_does_not_construct_clob_client(self):
-        mock_clob_class = MagicMock()
-        with patch(
-            "torchtrade.envs.live.polymarket.order_executor.ClobClient",
-            new=mock_clob_class,
-        ):
-            exe = PolymarketOrderExecutor(private_key="0xtest", dry_run=True)
-        assert exe.client is None
-        mock_clob_class.assert_not_called()
+    def test_live_mode_raises(self):
+        with pytest.raises(NotImplementedError) as exc:
+            PolymarketOrderExecutor(private_key="0xtest", dry_run=False)
+        # Pin the SUBSTANCE, not a contentless phrase: both blockers must survive, or the
+        # message could be reduced to "not supported yet" and still pass.
+        assert "archived" in str(exc.value)
+        assert "redeem" in str(exc.value)
 
-    def test_dry_run_does_not_derive_api_creds(self):
-        """Critical: the API-creds derivation hits the wallet RPC."""
-        mock_clob_instance = MagicMock()
-        mock_clob_class = MagicMock(return_value=mock_clob_instance)
-        with patch(
-            "torchtrade.envs.live.polymarket.order_executor.ClobClient",
-            new=mock_clob_class,
-        ):
-            PolymarketOrderExecutor(private_key="0xtest", dry_run=True)
-        mock_clob_instance.create_or_derive_api_creds.assert_not_called()
-        mock_clob_instance.set_api_creds.assert_not_called()
+    def test_live_mode_raises_even_with_a_funded_looking_config(self):
+        """A full live config -- key, chain, proxy signature type, funder -- must not sneak
+        past. The refusal is on dry_run, not on whether the caller looks prepared."""
+        with pytest.raises(NotImplementedError):
+            PolymarketOrderExecutor(
+                private_key="0xdeadbeef",
+                chain_id=137,
+                signature_type=2,
+                funder="0xproxy",
+                dry_run=False,
+            )
 
-    def test_dry_run_buy_returns_marker_when_package_available(self):
-        """End-to-end dry-run contract: even with py-clob-client installed,
-        ``buy()`` must return the dry-run marker without touching the network."""
-        mock_clob_class = MagicMock()
-        with patch(
-            "torchtrade.envs.live.polymarket.order_executor.ClobClient",
-            new=mock_clob_class,
-        ):
-            exe = PolymarketOrderExecutor(private_key="0xtest", dry_run=True)
-        result = exe.buy(token_id="tok", amount_usdc=10.0)
-        assert result == {"success": True, "dry_run": True}
-        mock_clob_class.assert_not_called()
+
+class TestPaperExecution:
+    def test_defaults_to_paper(self):
+        """The DEFAULT must be the safe mode. It used to default to dry_run=False, so any
+        caller who forgot the kwarg -- including the env -- got a live client."""
+        assert PolymarketOrderExecutor(private_key="x")._dry_run is True
+
+    def test_no_clob_client_is_ever_constructed(self):
+        """Constructing a ClobClient would derive API creds -- a network roundtrip against the
+        wallet. That shipped as a real bug once; it is now structurally impossible."""
+        assert PolymarketOrderExecutor(private_key="0xtest").client is None
+
+    def test_buy_submits_nothing(self):
+        assert PolymarketOrderExecutor().buy(token_id="tok", amount_usdc=10.0) == {
+            "success": True,
+            "dry_run": True,
+        }
+
+    def test_cancel_all_is_a_noop(self):
+        assert PolymarketOrderExecutor().cancel_all() is True
+
+    def test_does_not_depend_on_py_clob_client_at_all(self):
+        """Paper trading must not need the archived package. The module no longer imports it,
+        so this is structural now rather than a runtime dry_run branch."""
+        import torchtrade.envs.live.polymarket.order_executor as oe
+
+        assert not hasattr(oe, "ClobClient")

--- a/tests/envs/polymarket/test_order_executor.py
+++ b/tests/envs/polymarket/test_order_executor.py
@@ -101,11 +101,13 @@ class TestDryRunWithoutClient:
         assert exe.buy("tok", 1.0)["success"] is True
         assert exe.cancel_all() is True
 
-    def test_live_mode_still_requires_clob(self, monkeypatch):
+    def test_live_mode_error_does_not_advise_installing_the_dead_package(self, monkeypatch):
+        """The old message said "pip install py-clob-client" -- advice that now sends people
+        to an archived, non-functional package. Pin the honest message instead."""
         monkeypatch.setattr(
             "torchtrade.envs.live.polymarket.order_executor.ClobClient", None
         )
-        with pytest.raises(ImportError, match="py-clob-client is required"):
+        with pytest.raises(ImportError, match="archived and no longer functional"):
             PolymarketOrderExecutor(private_key="0x", dry_run=False)
 
 

--- a/tests/envs/polymarket/test_order_executor.py
+++ b/tests/envs/polymarket/test_order_executor.py
@@ -113,6 +113,14 @@ class TestDryRunWithoutClient:
             PolymarketOrderExecutor(private_key="0x", dry_run=False)
 
 
+class TestSafeDefault:
+    def test_executor_defaults_to_paper(self):
+        """The default must be the SAFE mode. It used to default to dry_run=False, so any
+        caller that forgot the kwarg -- including the env -- got a live client. Nothing pinned
+        this, so flipping the default back was an invisible regression."""
+        assert PolymarketOrderExecutor(private_key="x")._dry_run is True
+
+
 class TestDryRunSkipsRealOrder:
     def test_buy_in_dry_run_returns_dry_run_marker(self, patched_module):
         exe = PolymarketOrderExecutor(private_key="0x", dry_run=True)

--- a/tests/envs/polymarket/test_order_executor.py
+++ b/tests/envs/polymarket/test_order_executor.py
@@ -43,7 +43,9 @@ def patched_module():
 
 @pytest.fixture
 def executor(patched_module):
-    exe = PolymarketOrderExecutor(private_key="0xtest", chain_id=137)
+    # dry_run=False is now explicit: the executor DEFAULTS to paper, so the live path has
+    # to be asked for by name.
+    exe = PolymarketOrderExecutor(private_key="0xtest", chain_id=137, dry_run=False)
     exe.client = MagicMock()
     exe.client.post_order.return_value = {"success": True, "orderID": "ord-1"}
     return exe

--- a/torchtrade/envs/live/polymarket/__init__.py
+++ b/torchtrade/envs/live/polymarket/__init__.py
@@ -1,4 +1,5 @@
-"""Polymarket prediction market live trading environment."""
+"""Polymarket prediction market environment (PAPER ONLY -- live trading is refused;
+see LIVE_UNSUPPORTED in env.py)."""
 
 from torchtrade.envs.live.polymarket.env import (
     PolymarketBetEnv,

--- a/torchtrade/envs/live/polymarket/env.py
+++ b/torchtrade/envs/live/polymarket/env.py
@@ -41,6 +41,7 @@ from torchtrade.envs.live.polymarket.market_scanner import (
     MarketScannerConfig,
     PolymarketMarket,
 )
+from torchtrade.envs.live.polymarket.order_executor import PolymarketOrderExecutor
 
 from torchtrade.envs.utils.termination import is_bankrupt
 
@@ -232,12 +233,10 @@ class PolymarketBetEnv(EnvBase):
         if trader is not None:
             self.trader = trader
         else:
-            from torchtrade.envs.live.polymarket.order_executor import (
-                PolymarketOrderExecutor,
-            )
-            # No private key: paper-only, so nothing is ever signed or submitted. The port
-            # re-adds one here. dry_run is passed explicitly (not left to the executor's
-            # default) so the two cannot silently disagree -- a test pins it.
+            # dry_run passed explicitly rather than left to the executor's default, so the two
+            # cannot silently disagree. The executor refuses dry_run=False on its own account,
+            # which is what makes a forced config mutation (object.__setattr__ defeats
+            # frozen=True) still fail to wire a live trader.
             self.trader = PolymarketOrderExecutor(dry_run=config.dry_run)
 
         # Specs, Binary for bool flags (per TorchRL spec semantics) and

--- a/torchtrade/envs/live/polymarket/env.py
+++ b/torchtrade/envs/live/polymarket/env.py
@@ -51,18 +51,13 @@ logger = logging.getLogger(__name__)
 # Gamma's outcomePrices.
 CLOB_API_BASE = "https://clob.polymarket.com"
 
-# For whoever does the CLOB V2 port -- the part LIVE_UNSUPPORTED does not say.
-#
-# The redemption blocker is the deep one, and porting to the V2 SDK does NOT fix it. This env
-# never sells: it buys and holds every position through resolution. Polymarket resolution does
-# not move collateral, so a winning share is worth $1 but stays an ERC-1155 token until an
-# explicit redeemPositions call -- which must go through their Relayer, because the proxy/Safe
-# wallet owns the position, not the EOA.
-#
-# The corollary is the whole reason this env is refused rather than repaired: you CANNOT fix
-# the simulated `cash` by reading the real wallet. While winnings sit unredeemed the collateral
-# balance is not the account's worth, so wiring it in would make a WINNING agent watch its
-# balance drain and declare itself bankrupt -- strictly worse than the simulation it replaced.
+# Two implementation details for the CLOB V2 port, on top of what LIVE_UNSUPPORTED tells users:
+#   - The redeem must go through Polymarket's Relayer: the proxy/Safe wallet owns the ERC-1155
+#     position, not the EOA, so redeemPositions sent from the EOA redeems nothing.
+#   - Corollary, and the reason this env is refused rather than repaired: you CANNOT fix the
+#     simulated `cash` by reading the real wallet. While winnings sit unredeemed the collateral
+#     balance is not the account's worth, so a wallet-backed balance would make a WINNING agent
+#     drain to zero and declare itself bankrupt -- worse than the simulation it replaced.
 LIVE_UNSUPPORTED = (
     "Live Polymarket trading is not supported. `dry_run=False` is refused rather than "
     "silently mis-trading:\n"
@@ -119,6 +114,15 @@ class PolymarketBetEnvConfig:
     # 10 min is a safe ceiling.
     resolution_max_wait_seconds: float = 600.0
 
+    # When the scanner returns no upcoming market, retry at the env level after
+    # this sleep. The scanner's internal retry budget (~48s) covers brief blips;
+    # this layer covers minutes-long Gamma outages where the underlying series
+    # is still running. For continuous short-cadence series (e.g. 5-min crypto),
+    # "no next market" is almost always "API unreachable" rather than "series
+    # ended", so a few sleep+retry rounds before terminating saves the run.
+    next_market_max_attempts: int = 3
+    next_market_retry_sleep_seconds: float = 30.0
+
     def __post_init__(self):
         # Validated at the boundary, not guarded inside the rule. _is_bankrupt() used to carry
         # an `initial > 0` guard, which silently turned a nonsense config into "never bankrupt"
@@ -136,20 +140,12 @@ class PolymarketBetEnvConfig:
         # frozen=True above is load-bearing, not style: __post_init__ runs ONCE, at
         # construction, so on a mutable dataclass `config.dry_run = False` afterwards sails
         # straight past this check and the guard becomes a speed bump rather than a boundary.
-        # (Safe for TorchRL: pickle/deepcopy restore via __dict__ without re-running
-        # __post_init__, so ParallelEnv workers and env.clone() cannot spuriously raise, while
-        # dataclasses.replace() DOES re-validate.)
+        # (Safe for TorchRL: pickle/deepcopy restore via __dict__ WITHOUT re-running
+        # __post_init__, so ParallelEnv/SerialEnv workers -- which re-pickle the env factory,
+        # verified under both fork and spawn -- cannot spuriously raise on an already-valid
+        # config. dataclasses.replace() DOES re-validate, which is what we want.)
         if not self.dry_run:
             raise NotImplementedError(LIVE_UNSUPPORTED)
-
-    # When the scanner returns no upcoming market, retry at the env level after
-    # this sleep. The scanner's internal retry budget (~48s) covers brief blips;
-    # this layer covers minutes-long Gamma outages where the underlying series
-    # is still running. For continuous short-cadence series (e.g. 5-min crypto),
-    # "no next market" is almost always "API unreachable" rather than "series
-    # ended", so a few sleep+retry rounds before terminating saves the run.
-    next_market_max_attempts: int = 3
-    next_market_retry_sleep_seconds: float = 30.0
 
 
 class PolymarketBetEnv(EnvBase):
@@ -163,7 +159,7 @@ class PolymarketBetEnv(EnvBase):
     3. No order is submitted (paper-only; see ``LIVE_UNSUPPORTED``).
     4. The env sleeps until the market's endDate plus a small grace period.
     5. The resolved outcome is polled from the Polymarket CLOB
-       (``/midpoint`` per outcome token); the realized payoff is computed
+       (``/midpoint`` per outcome token); the modelled payoff is computed
        and returned as the step's reward.
     6. The scanner picks the next active market matching ``market_slug_prefix``
        and its market_state becomes the next observation.
@@ -187,7 +183,6 @@ class PolymarketBetEnv(EnvBase):
     def __init__(
         self,
         config: PolymarketBetEnvConfig,
-        private_key: str = "",
         scanner: Optional[MarketScanner] = None,
         trader=None,
         device: Optional[torch.device] = None,
@@ -209,9 +204,10 @@ class PolymarketBetEnv(EnvBase):
             from torchtrade.envs.live.polymarket.order_executor import (
                 PolymarketOrderExecutor,
             )
-            self.trader = PolymarketOrderExecutor(
-                private_key=private_key, dry_run=config.dry_run
-            )
+            # No private key: paper-only, so nothing is ever signed or submitted. The port
+            # re-adds one here. dry_run is passed explicitly (not left to the executor's
+            # default) so the two cannot silently disagree -- a test pins it.
+            self.trader = PolymarketOrderExecutor(dry_run=config.dry_run)
 
         # Specs, Binary for bool flags (per TorchRL spec semantics) and
         # reward inside a Composite so RewardSum-style transforms work.
@@ -275,13 +271,8 @@ class PolymarketBetEnv(EnvBase):
         fill_price = market.yes_price if action_idx == 1 else market.no_price
         stake = self.cash * self.config.bet_fraction
 
-        # No order is submitted -- this env is paper-only (LIVE_UNSUPPORTED). The CLOB V2 port
-        # re-enters HERE: submit before _wait_for_resolution, redeem the winnings after it.
-        # The order-submission branch that used to sit here, and the four tests that pinned its
-        # safety contract (a failed order must book zero, not phantom, P&L), were removed
-        # together -- recover both with `git show 1a83d54^ -- torchtrade/ tests/`. They are not
-        # a head start: the V1 call shape (buy() -> {"success": bool}) does not survive the
-        # port, and reading the real wallet is NOT sufficient without the redeem.
+        # Paper-only: no order is submitted (LIVE_UNSUPPORTED). The CLOB V2 port re-enters
+        # here -- submit before _wait_for_resolution, redeem the winnings after it.
         self._wait_for_resolution(market.end_date)
         outcome = self._poll_for_resolution(market)
 
@@ -450,7 +441,11 @@ class PolymarketBetEnv(EnvBase):
     def _compute_payoff(
         action: int, fill_price: float, outcome: int, stake: float
     ) -> float:
-        """Realized USDC payoff. Win pays ``stake * (1 - fill) / fill``; loss returns ``-stake``."""
+        """MODELLED USDC payoff. Win pays ``stake * (1 - fill) / fill``; loss returns ``-stake``.
+
+        Not the realized payoff: ``fill`` is the quoted outcome price, so this assumes a fill at
+        the quote with no spread crossing and no fees. Optimistic vs. a real FOK market order.
+        """
         if stake <= 0:
             return 0.0
         if action == outcome:
@@ -472,5 +467,9 @@ class PolymarketBetEnv(EnvBase):
             enabled=self.config.done_on_bankruptcy,
         )
 
-    def close(self):
+    def close(self, *, raise_if_closed: bool = True):
+        # Signature must match EnvBase.close(*, raise_if_closed=True): TransformedEnv forwards
+        # that kwarg, so a bare `def close(self)` made TransformedEnv(env, RewardSum()).close()
+        # raise TypeError -- on the very composition this env's spec comment advertises.
         self.trader.cancel_all()
+        super().close(raise_if_closed=raise_if_closed)

--- a/torchtrade/envs/live/polymarket/env.py
+++ b/torchtrade/envs/live/polymarket/env.py
@@ -51,13 +51,13 @@ logger = logging.getLogger(__name__)
 # Gamma's outcomePrices.
 CLOB_API_BASE = "https://clob.polymarket.com"
 
-# Two implementation details for the CLOB V2 port, on top of what LIVE_UNSUPPORTED tells users:
-#   - The redeem must go through Polymarket's Relayer: the proxy/Safe wallet owns the ERC-1155
-#     position, not the EOA, so redeemPositions sent from the EOA redeems nothing.
-#   - Corollary, and the reason this env is refused rather than repaired: you CANNOT fix the
-#     simulated `cash` by reading the real wallet. While winnings sit unredeemed the collateral
-#     balance is not the account's worth, so a wallet-backed balance would make a WINNING agent
-#     drain to zero and declare itself bankrupt -- worse than the simulation it replaced.
+# For the CLOB V2 port, the one thing LIVE_UNSUPPORTED does not spell out: you cannot repair the
+# simulated `cash` by reading the real wallet. While winnings sit unredeemed the collateral
+# balance is not the account's worth, so a wallet-backed balance would make a WINNING agent drain
+# to zero and declare itself bankrupt -- worse than the simulation it replaces. Redemption comes
+# first; the balance read is meaningless without it.
+# (Which contract/route the redeem takes depends on the signature type -- an EOA (sig 0, the
+# default here) holds its own positions, a proxy/Safe (sig 1/2) does not. Work it out then.)
 LIVE_UNSUPPORTED = (
     "Live Polymarket trading is not supported. `dry_run=False` is refused rather than "
     "silently mis-trading:\n"
@@ -68,7 +68,9 @@ LIVE_UNSUPPORTED = (
     "which no Polymarket client exposes. Without that, a winning account's balance drains "
     "to zero.\n"
     "Use dry_run=True (paper trading against live market data). Reviving live mode needs "
-    "the CLOB V2 port plus a redemption workflow."
+    "the CLOB V2 port plus a redemption workflow.\n"
+    "Sources: https://github.com/Polymarket/py-clob-client (archive notice) and "
+    "https://docs.polymarket.com/trading/ctf/redeem (redemption is manual)."
 )
 
 
@@ -139,11 +141,8 @@ class PolymarketBetEnvConfig:
 
         # frozen=True above is load-bearing, not style: __post_init__ runs ONCE, at
         # construction, so on a mutable dataclass `config.dry_run = False` afterwards sails
-        # straight past this check and the guard becomes a speed bump rather than a boundary.
-        # (Safe for TorchRL: pickle/deepcopy restore via __dict__ WITHOUT re-running
-        # __post_init__, so ParallelEnv/SerialEnv workers -- which re-pickle the env factory,
-        # verified under both fork and spawn -- cannot spuriously raise on an already-valid
-        # config. dataclasses.replace() DOES re-validate, which is what we want.)
+        # straight past this check. Frozen does not make the bypass impossible
+        # (object.__setattr__ still works) -- it makes it deliberate rather than accidental.
         if not self.dry_run:
             raise NotImplementedError(LIVE_UNSUPPORTED)
 
@@ -468,8 +467,6 @@ class PolymarketBetEnv(EnvBase):
         )
 
     def close(self, *, raise_if_closed: bool = True):
-        # Signature must match EnvBase.close(*, raise_if_closed=True): TransformedEnv forwards
-        # that kwarg, so a bare `def close(self)` made TransformedEnv(env, RewardSum()).close()
-        # raise TypeError -- on the very composition this env's spec comment advertises.
+        # TransformedEnv forwards raise_if_closed; a bare `def close(self)` raised TypeError.
         self.trader.cancel_all()
         super().close(raise_if_closed=raise_if_closed)

--- a/torchtrade/envs/live/polymarket/env.py
+++ b/torchtrade/envs/live/polymarket/env.py
@@ -2,7 +2,7 @@
 
 Pattern B (contextual-bandit shape): each step is an independent bet on a
 fresh, short-cadence binary market, bet on direction, wait for resolution,
-collect the realized payoff, then move to the next market in the series.
+collect the modelled payoff, then move to the next market in the series.
 
 PAPER TRADING ONLY. The env runs against live Polymarket market data but never submits an
 order: ``dry_run=False`` is refused at the config boundary. See ``LIVE_UNSUPPORTED`` below
@@ -51,26 +51,18 @@ logger = logging.getLogger(__name__)
 # Gamma's outcomePrices.
 CLOB_API_BASE = "https://clob.polymarket.com"
 
-# Live trading is refused at the config boundary. Two independent blockers, either one
-# fatal on its own:
+# For whoever does the CLOB V2 port -- the part LIVE_UNSUPPORTED does not say.
 #
-# 1. py-clob-client, which order_executor.py is written against, was archived on
-#    2026-05-25: "The client is no longer functional and should not be used for new or
-#    existing integrations." Polymarket's CLOB V2 (2026-04) moved to new Exchange
-#    contracts and replaced USDC.e collateral with pUSD. No order this env submits can
-#    reach production.
+# The redemption blocker is the deep one, and porting to the V2 SDK does NOT fix it. This env
+# never sells: it buys and holds every position through resolution. Polymarket resolution does
+# not move collateral, so a winning share is worth $1 but stays an ERC-1155 token until an
+# explicit redeemPositions call -- which must go through their Relayer, because the proxy/Safe
+# wallet owns the position, not the EOA.
 #
-# 2. Worse, and not fixed by porting to the V2 SDK: this env NEVER SELLS. It buys and
-#    holds every position through resolution (_step -> _wait_for_resolution). Polymarket
-#    resolution does not move collateral -- a winning share is worth $1 but stays an
-#    ERC-1155 token until it is explicitly REDEEMED, and no Polymarket client (V1, V2, or
-#    the unified py-sdk) exposes redeem; it needs a hand-built redeemPositions call through
-#    their Relayer. So a live bot that never redeems watches its queryable collateral drain
-#    monotonically to zero WHILE IT IS WINNING.
-#
-# (2) is why this env cannot simply "read the real wallet" to fix its simulated cash: the
-# real wallet balance is not the account's worth, and wiring it in would make a winning
-# agent declare itself bankrupt. Live support needs the V2 port AND a redemption workflow.
+# The corollary is the whole reason this env is refused rather than repaired: you CANNOT fix
+# the simulated `cash` by reading the real wallet. While winnings sit unredeemed the collateral
+# balance is not the account's worth, so wiring it in would make a WINNING agent watch its
+# balance drain and declare itself bankrupt -- strictly worse than the simulation it replaced.
 LIVE_UNSUPPORTED = (
     "Live Polymarket trading is not supported. `dry_run=False` is refused rather than "
     "silently mis-trading:\n"
@@ -85,7 +77,7 @@ LIVE_UNSUPPORTED = (
 )
 
 
-@dataclass
+@dataclass(frozen=True)
 class PolymarketBetEnvConfig:
     """Configuration for :class:`PolymarketBetEnv`.
 
@@ -131,11 +123,22 @@ class PolymarketBetEnvConfig:
         # Validated at the boundary, not guarded inside the rule. _is_bankrupt() used to carry
         # an `initial > 0` guard, which silently turned a nonsense config into "never bankrupt"
         # instead of saying so -- the silent-default pattern this repo keeps getting bitten by.
-        # Refuse the config instead. (Only initial_cash: bet_fraction=0 is a supported config
-        # here, with a test that relies on it.)
+        # Refuse the config instead.
         if self.initial_cash <= 0:
             raise ValueError(f"initial_cash must be > 0, got {self.initial_cash}")
 
+        # bet_fraction > 1 stakes more than the account holds, drives cash negative, and then
+        # only the `stake <= 0` guard inside _compute_payoff stands between that and INVERTED
+        # P&L (a loss paying out). Same boundary rule; 0 is allowed (a no-bet agent).
+        if not 0.0 <= self.bet_fraction <= 1.0:
+            raise ValueError(f"bet_fraction must be in [0, 1], got {self.bet_fraction}")
+
+        # frozen=True above is load-bearing, not style: __post_init__ runs ONCE, at
+        # construction, so on a mutable dataclass `config.dry_run = False` afterwards sails
+        # straight past this check and the guard becomes a speed bump rather than a boundary.
+        # (Safe for TorchRL: pickle/deepcopy restore via __dict__ without re-running
+        # __post_init__, so ParallelEnv workers and env.clone() cannot spuriously raise, while
+        # dataclasses.replace() DOES re-validate.)
         if not self.dry_run:
             raise NotImplementedError(LIVE_UNSUPPORTED)
 
@@ -157,7 +160,7 @@ class PolymarketBetEnv(EnvBase):
     1. The current market_state is observed
        (``[yes_price, spread, volume_24h, liquidity]``).
     2. The agent picks a side (0 = Down, 1 = Up).
-    3. The trader submits a market order (skipped in ``dry_run``).
+    3. No order is submitted (paper-only; see ``LIVE_UNSUPPORTED``).
     4. The env sleeps until the market's endDate plus a small grace period.
     5. The resolved outcome is polled from the Polymarket CLOB
        (``/midpoint`` per outcome token); the realized payoff is computed
@@ -166,8 +169,10 @@ class PolymarketBetEnv(EnvBase):
        and its market_state becomes the next observation.
 
     Paper trading only (``dry_run=True``, enforced by the config): step 3 never submits an
-    order. Every other step is real -- real market data in, real resolution polled from the
-    CLOB, real payoff booked against a simulated balance. See ``LIVE_UNSUPPORTED``.
+    order. The market data and the resolution are real, polled live from Gamma and the CLOB.
+    The PAYOFF IS MODELLED, not real: ``_compute_payoff`` fills at the quoted outcome price
+    with no spread crossing and no fees, so it is optimistic relative to the fill-or-kill
+    market order a live bot would actually pay. See ``LIVE_UNSUPPORTED``.
 
     Episode ends when the scanner finds no next market across
     ``next_market_max_attempts`` env-level retries (terminated), the simulated
@@ -269,27 +274,14 @@ class PolymarketBetEnv(EnvBase):
 
         fill_price = market.yes_price if action_idx == 1 else market.no_price
         stake = self.cash * self.config.bet_fraction
-        token_id = market.yes_token_id if action_idx == 1 else market.no_token_id
 
-        # UNREACHABLE today: the config refuses dry_run=False (see LIVE_UNSUPPORTED), so this
-        # branch never runs. Kept, not deleted, as the call site the CLOB V2 port revives by
-        # lifting that one guard -- and kept UNTESTED for the same reason: the contract this
-        # env makes right now is "live is refused" (tested), not "live buys like so".
-        # If you are here to do the port: reading the real wallet is NOT enough. You must also
-        # redeem resolved winnings, or `cash` decays to zero on a winning account.
-        if stake > 0 and not self.config.dry_run:
-            result = self.trader.buy(token_id=token_id, amount_usdc=stake)
-            if not result.get("success"):
-                # Order failed (FOK rejection, insufficient USDC, network glitch).
-                # Do NOT book a payoff against an order we never filled, set the
-                # effective stake to zero so _compute_payoff returns 0.0.
-                logger.warning(
-                    "Order failed for %s: %s, recording as no-bet",
-                    market.slug,
-                    result.get("error", "unknown"),
-                )
-                stake = 0.0
-
+        # No order is submitted -- this env is paper-only (LIVE_UNSUPPORTED). The CLOB V2 port
+        # re-enters HERE: submit before _wait_for_resolution, redeem the winnings after it.
+        # The order-submission branch that used to sit here, and the four tests that pinned its
+        # safety contract (a failed order must book zero, not phantom, P&L), were removed
+        # together -- recover both with `git show 1a83d54^ -- torchtrade/ tests/`. They are not
+        # a head start: the V1 call shape (buy() -> {"success": bool}) does not survive the
+        # port, and reading the real wallet is NOT sufficient without the redeem.
         self._wait_for_resolution(market.end_date)
         outcome = self._poll_for_resolution(market)
 

--- a/torchtrade/envs/live/polymarket/env.py
+++ b/torchtrade/envs/live/polymarket/env.py
@@ -133,11 +133,20 @@ class PolymarketBetEnvConfig:
         if self.initial_cash <= 0:
             raise ValueError(f"initial_cash must be > 0, got {self.initial_cash}")
 
-        # bet_fraction > 1 stakes more than the account holds, drives cash negative, and then
-        # only the `stake <= 0` guard inside _compute_payoff stands between that and INVERTED
-        # P&L (a loss paying out). Same boundary rule; 0 is allowed (a no-bet agent).
+        # bet_fraction > 1 would stake more than the account holds and drive cash negative,
+        # which flips the sign of a loss (a losing bet paying out). Refusing it here is what
+        # GUARANTEES cash >= 0 -- which is in turn why _compute_payoff needs no `stake <= 0`
+        # guard. 0 is allowed (a no-bet agent).
         if not 0.0 <= self.bet_fraction <= 1.0:
             raise ValueError(f"bet_fraction must be in [0, 1], got {self.bet_fraction}")
+
+        # Unvalidated, this is the same silent-default trap as initial_cash, one field over:
+        # > 1 makes the account bankrupt on step 1, before a single bet resolves; < 0 makes
+        # `current < threshold * initial` unsatisfiable and SILENTLY DISABLES the safety stop.
+        if not 0.0 <= self.bankrupt_threshold <= 1.0:
+            raise ValueError(
+                f"bankrupt_threshold must be in [0, 1], got {self.bankrupt_threshold}"
+            )
 
         # frozen=True above is load-bearing, not style: __post_init__ runs ONCE, at
         # construction, so on a mutable dataclass `config.dry_run = False` afterwards sails
@@ -445,8 +454,6 @@ class PolymarketBetEnv(EnvBase):
         Not the realized payoff: ``fill`` is the quoted outcome price, so this assumes a fill at
         the quote with no spread crossing and no fees. Optimistic vs. a real FOK market order.
         """
-        if stake <= 0:
-            return 0.0
         if action == outcome:
             if fill_price <= 0:
                 return 0.0

--- a/torchtrade/envs/live/polymarket/env.py
+++ b/torchtrade/envs/live/polymarket/env.py
@@ -64,7 +64,8 @@ LIVE_UNSUPPORTED = (
     "  - py-clob-client is archived and non-functional (Polymarket shipped CLOB V2, with "
     "pUSD collateral replacing USDC.e); no order can reach production.\n"
     "  - This env holds every bet through resolution, and Polymarket does not auto-credit "
-    "collateral on resolution. Winning shares must be redeemed on-chain via the Relayer, "
+    "collateral on resolution. Winning shares must be redeemed on-chain via an explicit "
+    "redeemPositions call, "
     "which no Polymarket client exposes. Without that, a winning account's balance drains "
     "to zero.\n"
     "Use dry_run=True (paper trading against live market data). Reviving live mode needs "
@@ -141,7 +142,8 @@ class PolymarketBetEnvConfig:
             raise ValueError(f"bet_fraction must be in [0, 1], got {self.bet_fraction}")
 
         # Unvalidated, this is the same silent-default trap as initial_cash, one field over:
-        # > 1 makes the account bankrupt on step 1, before a single bet resolves; < 0 makes
+        # > 1 puts the account under the bankruptcy line at reset, so step 1 terminates unless
+        # the opening bet alone lifts cash above threshold*initial_cash; < 0 makes
         # `current < threshold * initial` unsatisfiable and SILENTLY DISABLES the safety stop.
         if not 0.0 <= self.bankrupt_threshold <= 1.0:
             raise ValueError(

--- a/torchtrade/envs/live/polymarket/env.py
+++ b/torchtrade/envs/live/polymarket/env.py
@@ -145,9 +145,13 @@ class PolymarketBetEnvConfig:
         # > 1 puts the account under the bankruptcy line at reset, so step 1 terminates unless
         # the opening bet alone lifts cash above threshold*initial_cash; < 0 makes
         # `current < threshold * initial` unsatisfiable and SILENTLY DISABLES the safety stop.
-        if not 0.0 <= self.bankrupt_threshold <= 1.0:
+        # [0, 1), half-open, matching SequentialTradingEnvConfig and
+        # VectorizedSequentialTradingEnvConfig -- this codebase already settled this exact
+        # field's domain ("bankrupt_threshold >= 1 is nonsensical"), and a live env inventing a
+        # different one is the drift the "apply to ALL environments" rule exists to stop.
+        if not 0.0 <= self.bankrupt_threshold < 1.0:
             raise ValueError(
-                f"bankrupt_threshold must be in [0, 1], got {self.bankrupt_threshold}"
+                f"bankrupt_threshold must be in [0, 1), got {self.bankrupt_threshold}"
             )
 
         # frozen=True above is load-bearing, not style: __post_init__ runs ONCE, at

--- a/torchtrade/envs/live/polymarket/env.py
+++ b/torchtrade/envs/live/polymarket/env.py
@@ -197,10 +197,27 @@ class PolymarketBetEnv(EnvBase):
     def __init__(
         self,
         config: PolymarketBetEnvConfig,
+        *,
         scanner: Optional[MarketScanner] = None,
         trader=None,
         device: Optional[torch.device] = None,
+        private_key: Optional[str] = None,
     ):
+        # private_key used to be the SECOND POSITIONAL parameter. Dropping it silently rebound
+        # `PolymarketBetEnv(config, "0xkey")` to `scanner`, which then fails much later with a
+        # confusing AttributeError on a str -- a silent break, the exact class of bug this env
+        # is being fixed for. Hence: everything after `config` is keyword-only (so the
+        # positional form is a loud TypeError), and private_key is still ACCEPTED so it can be
+        # rejected with an explanation rather than a bare "unexpected keyword argument".
+        # It is refused, not ignored: silently swallowing a real private key would tell the
+        # caller their key is configured when the env can never sign anything.
+        if private_key is not None:
+            raise TypeError(
+                "PolymarketBetEnv no longer takes private_key: the env is paper-only "
+                "(dry_run=False is refused), so nothing is ever signed or submitted and a key "
+                "would do nothing. Remove the argument. See LIVE_UNSUPPORTED in this module."
+            )
+
         super().__init__(device=device or torch.device("cpu"), batch_size=())
 
         if not config.market_slug_prefix:

--- a/torchtrade/envs/live/polymarket/env.py
+++ b/torchtrade/envs/live/polymarket/env.py
@@ -4,10 +4,15 @@ Pattern B (contextual-bandit shape): each step is an independent bet on a
 fresh, short-cadence binary market, bet on direction, wait for resolution,
 collect the realized payoff, then move to the next market in the series.
 
+PAPER TRADING ONLY. The env runs against live Polymarket market data but never submits an
+order: ``dry_run=False`` is refused at the config boundary. See ``LIVE_UNSUPPORTED`` below
+for the two reasons (archived CLOB client; no redemption workflow, without which a winning
+account's on-chain balance drains to zero).
+
 Concrete example (5-minute Bitcoin up/down):
 
-    config = PolymarketBetEnvConfig(market_slug_prefix="btc-updown-5m-")
-    env = PolymarketBetEnv(config, dry_run=True)
+    config = PolymarketBetEnvConfig(market_slug_prefix="btc-updown-5m-")  # dry_run=True
+    env = PolymarketBetEnv(config)
 
     td = env.reset()
     while True:
@@ -46,6 +51,39 @@ logger = logging.getLogger(__name__)
 # Gamma's outcomePrices.
 CLOB_API_BASE = "https://clob.polymarket.com"
 
+# Live trading is refused at the config boundary. Two independent blockers, either one
+# fatal on its own:
+#
+# 1. py-clob-client, which order_executor.py is written against, was archived on
+#    2026-05-25: "The client is no longer functional and should not be used for new or
+#    existing integrations." Polymarket's CLOB V2 (2026-04) moved to new Exchange
+#    contracts and replaced USDC.e collateral with pUSD. No order this env submits can
+#    reach production.
+#
+# 2. Worse, and not fixed by porting to the V2 SDK: this env NEVER SELLS. It buys and
+#    holds every position through resolution (_step -> _wait_for_resolution). Polymarket
+#    resolution does not move collateral -- a winning share is worth $1 but stays an
+#    ERC-1155 token until it is explicitly REDEEMED, and no Polymarket client (V1, V2, or
+#    the unified py-sdk) exposes redeem; it needs a hand-built redeemPositions call through
+#    their Relayer. So a live bot that never redeems watches its queryable collateral drain
+#    monotonically to zero WHILE IT IS WINNING.
+#
+# (2) is why this env cannot simply "read the real wallet" to fix its simulated cash: the
+# real wallet balance is not the account's worth, and wiring it in would make a winning
+# agent declare itself bankrupt. Live support needs the V2 port AND a redemption workflow.
+LIVE_UNSUPPORTED = (
+    "Live Polymarket trading is not supported. `dry_run=False` is refused rather than "
+    "silently mis-trading:\n"
+    "  - py-clob-client is archived and non-functional (Polymarket shipped CLOB V2, with "
+    "pUSD collateral replacing USDC.e); no order can reach production.\n"
+    "  - This env holds every bet through resolution, and Polymarket does not auto-credit "
+    "collateral on resolution. Winning shares must be redeemed on-chain via the Relayer, "
+    "which no Polymarket client exposes. Without that, a winning account's balance drains "
+    "to zero.\n"
+    "Use dry_run=True (paper trading against live market data). Reviving live mode needs "
+    "the CLOB V2 port plus a redemption workflow."
+)
+
 
 @dataclass
 class PolymarketBetEnvConfig:
@@ -57,16 +95,16 @@ class PolymarketBetEnvConfig:
             up/down markets).
         bet_fraction: Fraction of current cash to stake per bet (default 1%).
         max_steps: Maximum bets per episode.
-        initial_cash: Starting USDC balance. NOTE this is simulated bookkeeping in BOTH
-            dry_run and live mode -- nothing here reads the real USDC wallet, and _reset()
-            restores this constant every episode. So in live mode `cash` (and therefore the
-            bankruptcy check) can drift from the real balance. Tracked as a follow-up; it is
-            a bigger fix than this file.
+        initial_cash: Starting paper balance. This is SIMULATED bookkeeping, by design,
+            and that is correct: the env is paper-only (see ``dry_run``), so there is no
+            real wallet for it to disagree with. ``_reset()`` restores it each episode.
+            It is NOT a claim about any real USDC/pUSD balance.
         done_on_bankruptcy: If True, terminate the episode when cash drops below
             ``bankrupt_threshold * initial_cash``.
         bankrupt_threshold: Bankruptcy cutoff as a fraction of initial cash.
-        dry_run: If True, skip CLOB order submission but still wait for
-            resolution and compute the would-have-been payoff.
+        dry_run: Must be True. Paper-trades against live Polymarket market data: no order
+            is submitted, but the env still waits for real resolution and books the
+            would-have-been payoff. ``dry_run=False`` raises -- see LIVE_UNSUPPORTED.
         resolution_grace_seconds: Extra wait after the market's endDate before
             polling for the resolved outcome (Polymarket settles on-chain).
     """
@@ -77,7 +115,7 @@ class PolymarketBetEnvConfig:
     initial_cash: float = 1_000.0
     done_on_bankruptcy: bool = True
     bankrupt_threshold: float = 0.1
-    dry_run: bool = False
+    dry_run: bool = True
     # Initial wait after a market's endDate before the FIRST resolution poll.
     resolution_grace_seconds: float = 30.0
     # If the first poll finds the market still pre-settlement on the CLOB
@@ -97,6 +135,9 @@ class PolymarketBetEnvConfig:
         # here, with a test that relies on it.)
         if self.initial_cash <= 0:
             raise ValueError(f"initial_cash must be > 0, got {self.initial_cash}")
+
+        if not self.dry_run:
+            raise NotImplementedError(LIVE_UNSUPPORTED)
 
     # When the scanner returns no upcoming market, retry at the env level after
     # this sleep. The scanner's internal retry budget (~48s) covers brief blips;
@@ -124,12 +165,14 @@ class PolymarketBetEnv(EnvBase):
     6. The scanner picks the next active market matching ``market_slug_prefix``
        and its market_state becomes the next observation.
 
+    Paper trading only (``dry_run=True``, enforced by the config): step 3 never submits an
+    order. Every other step is real -- real market data in, real resolution polled from the
+    CLOB, real payoff booked against a simulated balance. See ``LIVE_UNSUPPORTED``.
+
     Episode ends when the scanner finds no next market across
     ``next_market_max_attempts`` env-level retries (terminated), the simulated
-    cash balance drops below the bankruptcy threshold (terminated) -- see
-    ``initial_cash`` on the config, it is NOT the real wallet -- or ``max_steps``
-    is hit
-    (truncated). The observation deliberately omits any ``account_state``, by
+    cash balance drops below the bankruptcy threshold (terminated), or ``max_steps``
+    is hit (truncated). The observation deliberately omits any ``account_state``, by
     the time the next decision is made, the previous bet has already resolved
     and there is no carried position to encode.
     """
@@ -228,6 +271,12 @@ class PolymarketBetEnv(EnvBase):
         stake = self.cash * self.config.bet_fraction
         token_id = market.yes_token_id if action_idx == 1 else market.no_token_id
 
+        # UNREACHABLE today: the config refuses dry_run=False (see LIVE_UNSUPPORTED), so this
+        # branch never runs. Kept, not deleted, as the call site the CLOB V2 port revives by
+        # lifting that one guard -- and kept UNTESTED for the same reason: the contract this
+        # env makes right now is "live is refused" (tested), not "live buys like so".
+        # If you are here to do the port: reading the real wallet is NOT enough. You must also
+        # redeem resolved winnings, or `cash` decays to zero on a winning account.
         if stake > 0 and not self.config.dry_run:
             result = self.trader.buy(token_id=token_id, amount_usdc=stake)
             if not result.get("success"):

--- a/torchtrade/envs/live/polymarket/order_executor.py
+++ b/torchtrade/envs/live/polymarket/order_executor.py
@@ -7,6 +7,16 @@ Minimal surface, only the operations :class:`PolymarketBetEnv` needs:
 
 ``dry_run=True`` skips the CLOB client entirely, so paper-trading the env
 works without ``py-clob-client`` installed.
+
+.. warning::
+   The live path here CANNOT reach production, and :class:`PolymarketBetEnv` refuses
+   ``dry_run=False`` for that reason (see ``LIVE_UNSUPPORTED`` in ``env.py``). The
+   ``py-clob-client`` package this module is written against was archived on 2026-05-25
+   ("no longer functional"); Polymarket's CLOB V2 uses new contracts and pUSD collateral.
+   Reviving live trading means porting this module to the V2 SDK **and** adding on-chain
+   redemption of resolved winnings -- which no Polymarket client exposes, and without
+   which a winning account's collateral drains to zero. This module is kept as the
+   starting point for that port, not because it works.
 """
 
 from __future__ import annotations
@@ -50,10 +60,14 @@ class PolymarketOrderExecutor:
             self.client = None
             return
         if ClobClient is None:
+            # Deliberately NOT "pip install py-clob-client" -- that package is archived and
+            # non-functional against CLOB V2, so the old advice sent people to a dead end.
             raise ImportError(
-                "py-clob-client is required for live Polymarket trading. "
-                "Install with: pip install py-clob-client. "
-                "(Pass dry_run=True to skip the CLOB client.)"
+                "Live Polymarket trading is unsupported: py-clob-client is archived and no "
+                "longer functional (Polymarket shipped CLOB V2 with pUSD collateral), and "
+                "this module has no on-chain redemption of resolved winnings -- without it a "
+                "winning account's collateral drains to zero. Pass dry_run=True to paper "
+                "trade. PolymarketBetEnv refuses dry_run=False for the same reasons."
             )
 
         self.client = ClobClient(

--- a/torchtrade/envs/live/polymarket/order_executor.py
+++ b/torchtrade/envs/live/polymarket/order_executor.py
@@ -11,14 +11,8 @@ The module is kept as the starting point for the CLOB V2 port, not because it wo
 works without ``py-clob-client`` installed.
 
 .. warning::
-   The live path here CANNOT reach production, and :class:`PolymarketBetEnv` refuses
-   ``dry_run=False`` for that reason (see ``LIVE_UNSUPPORTED`` in ``env.py``). The
-   ``py-clob-client`` package this module is written against was archived on 2026-05-25
-   ("no longer functional"); Polymarket's CLOB V2 uses new contracts and pUSD collateral.
-   Reviving live trading means porting this module to the V2 SDK **and** adding on-chain
-   redemption of resolved winnings -- which no Polymarket client exposes, and without
-   which a winning account's collateral drains to zero. This module is kept as the
-   starting point for that port, not because it works.
+   The live path here cannot reach production. See ``LIVE_UNSUPPORTED`` in ``env.py`` for why
+   and for sources -- do not restate it here.
 """
 
 from __future__ import annotations

--- a/torchtrade/envs/live/polymarket/order_executor.py
+++ b/torchtrade/envs/live/polymarket/order_executor.py
@@ -1,11 +1,13 @@
 """Order executor for Polymarket CLOB trading via py-clob-client.
 
-Minimal surface, only the operations :class:`PolymarketBetEnv` needs:
+DORMANT. :class:`PolymarketBetEnv` is paper-only and calls nothing here but
+:meth:`cancel_all` (a no-op in dry-run) -- :meth:`buy` is called by no shipped code path.
+The module is kept as the starting point for the CLOB V2 port, not because it works.
 
-- :meth:`buy`, submits a fill-or-kill market order for a single side.
+- :meth:`buy`, submits a fill-or-kill market order for a single side. Unused.
 - :meth:`cancel_all`, called from :meth:`PolymarketBetEnv.close`.
 
-``dry_run=True`` skips the CLOB client entirely, so paper-trading the env
+``dry_run=True`` (the default) skips the CLOB client entirely, so paper-trading the env
 works without ``py-clob-client`` installed.
 
 .. warning::
@@ -40,13 +42,13 @@ except ImportError:
 class PolymarketOrderExecutor:
     """Buys YES/NO outcome shares on Polymarket via py-clob-client.
 
-    Constructed automatically by :class:`PolymarketBetEnv`; you typically don't
-    instantiate this directly.
+    Constructed automatically by :class:`PolymarketBetEnv`, which only ever builds it in
+    dry-run and never calls :meth:`buy` -- see the module docstring.
     """
 
     def __init__(
         self,
-        private_key: str,
+        private_key: str = "",
         chain_id: int = 137,
         signature_type: int = 0,
         funder: Optional[str] = None,

--- a/torchtrade/envs/live/polymarket/order_executor.py
+++ b/torchtrade/envs/live/polymarket/order_executor.py
@@ -50,7 +50,7 @@ class PolymarketOrderExecutor:
         chain_id: int = 137,
         signature_type: int = 0,
         funder: Optional[str] = None,
-        dry_run: bool = False,
+        dry_run: bool = True,
     ):
         self._dry_run = dry_run
         # Dry-run is fully offline: never construct the live CLOB client, never
@@ -60,14 +60,16 @@ class PolymarketOrderExecutor:
             self.client = None
             return
         if ClobClient is None:
-            # Deliberately NOT "pip install py-clob-client" -- that package is archived and
-            # non-functional against CLOB V2, so the old advice sent people to a dead end.
+            # An honest import diagnostic, NOT a refusal: this fires only when the package is
+            # ABSENT. The refusal that actually stops live trading is at the env boundary
+            # (PolymarketBetEnvConfig -> LIVE_UNSUPPORTED); do not restate it here. It
+            # deliberately does not say "pip install py-clob-client" -- that package is
+            # archived and non-functional, so the old advice sent people to a dead end.
             raise ImportError(
-                "Live Polymarket trading is unsupported: py-clob-client is archived and no "
-                "longer functional (Polymarket shipped CLOB V2 with pUSD collateral), and "
-                "this module has no on-chain redemption of resolved winnings -- without it a "
-                "winning account's collateral drains to zero. Pass dry_run=True to paper "
-                "trade. PolymarketBetEnv refuses dry_run=False for the same reasons."
+                "py-clob-client is not installed, and installing it will not help: it is "
+                "archived and no longer functional against Polymarket's CLOB V2. Live "
+                "Polymarket trading is unsupported -- see LIVE_UNSUPPORTED in "
+                "torchtrade/envs/live/polymarket/env.py. Pass dry_run=True to paper trade."
             )
 
         self.client = ClobClient(

--- a/torchtrade/envs/live/polymarket/order_executor.py
+++ b/torchtrade/envs/live/polymarket/order_executor.py
@@ -1,18 +1,19 @@
-"""Order executor for Polymarket CLOB trading via py-clob-client.
+"""Paper-trading order executor for Polymarket.
 
-DORMANT. :class:`PolymarketBetEnv` is paper-only and calls nothing here but
-:meth:`cancel_all` (a no-op in dry-run) -- :meth:`buy` is called by no shipped code path.
-The module is kept as the starting point for the CLOB V2 port, not because it works.
+PAPER ONLY. ``dry_run=False`` is REFUSED here, not just at the env's config boundary: this
+class is publicly exported (``torchtrade.envs.live``), so a caller reaching for the exported
+API could otherwise construct a live CLOB client and post a real order while
+:class:`PolymarketBetEnv` believed itself paper-only. The guard has to sit on the class that
+can actually move money, not only on the env that happens to build it.
 
-- :meth:`buy`, submits a fill-or-kill market order for a single side. Unused.
-- :meth:`cancel_all`, called from :meth:`PolymarketBetEnv.close`.
+See ``LIVE_UNSUPPORTED`` in ``env.py`` for why live is unsupported, and for sources -- do not
+restate it here.
 
-``dry_run=True`` (the default) skips the CLOB client entirely, so paper-trading the env
-works without ``py-clob-client`` installed.
-
-.. warning::
-   The live path here cannot reach production. See ``LIVE_UNSUPPORTED`` in ``env.py`` for why
-   and for sources -- do not restate it here.
+The V1 py-clob-client machinery this module used to carry (``ClobClient`` construction,
+``MarketOrderArgs``/``OrderType.FOK`` order posting) was deleted rather than left behind the
+guard: it is unreachable once live is refused, and it would not have survived the CLOB V2 port
+anyway (different package, different types, pUSD collateral, plus a redemption workflow that
+does not exist yet). Recover it from git history if the port ever wants a reference.
 """
 
 from __future__ import annotations
@@ -22,22 +23,19 @@ from typing import Optional
 
 logger = logging.getLogger(__name__)
 
-try:
-    from py_clob_client.client import ClobClient
-    from py_clob_client.clob_types import MarketOrderArgs, OrderType
-    from py_clob_client.order_builder.constants import BUY
-except ImportError:
-    ClobClient = None
-    MarketOrderArgs = None
-    OrderType = None
-    BUY = "BUY"
+LIVE_EXECUTOR_UNSUPPORTED = (
+    "PolymarketOrderExecutor is paper-only: dry_run=False is refused. py-clob-client is "
+    "archived and no longer functional against Polymarket's CLOB V2, and resolved winnings "
+    "are never redeemed -- without a redeem, a winning account's collateral drains to zero. "
+    "See LIVE_UNSUPPORTED in torchtrade/envs/live/polymarket/env.py."
+)
 
 
 class PolymarketOrderExecutor:
-    """Buys YES/NO outcome shares on Polymarket via py-clob-client.
+    """Simulates Polymarket order submission. Never touches the network.
 
-    Constructed automatically by :class:`PolymarketBetEnv`, which only ever builds it in
-    dry-run and never calls :meth:`buy` -- see the module docstring.
+    Built automatically by :class:`PolymarketBetEnv` (which is paper-only and calls nothing
+    here but :meth:`cancel_all`). This is where the CLOB V2 port begins.
     """
 
     def __init__(
@@ -48,58 +46,18 @@ class PolymarketOrderExecutor:
         funder: Optional[str] = None,
         dry_run: bool = True,
     ):
-        self._dry_run = dry_run
-        # Dry-run is fully offline: never construct the live CLOB client, never
-        # derive API creds. This keeps paper-trading independent of py-clob-client
-        # availability AND of having a valid funded private key.
-        if dry_run:
-            self.client = None
-            return
-        if ClobClient is None:
-            # An honest import diagnostic, NOT a refusal: this fires only when the package is
-            # ABSENT. The refusal that actually stops live trading is at the env boundary
-            # (PolymarketBetEnvConfig -> LIVE_UNSUPPORTED); do not restate it here. It
-            # deliberately does not say "pip install py-clob-client" -- that package is
-            # archived and non-functional, so the old advice sent people to a dead end.
-            raise ImportError(
-                "py-clob-client is not installed, and installing it will not help: it is "
-                "archived and no longer functional against Polymarket's CLOB V2. Live "
-                "Polymarket trading is unsupported -- see LIVE_UNSUPPORTED in "
-                "torchtrade/envs/live/polymarket/env.py. Pass dry_run=True to paper trade."
-            )
-
-        self.client = ClobClient(
-            host="https://clob.polymarket.com",
-            key=private_key,
-            chain_id=chain_id,
-            signature_type=signature_type,
-            funder=funder,
-        )
-        self.client.set_api_creds(self.client.create_or_derive_api_creds())
+        if not dry_run:
+            raise NotImplementedError(LIVE_EXECUTOR_UNSUPPORTED)
+        self._dry_run = True
+        # Fully offline: no client, no API-cred derivation (which would hit the wallet RPC),
+        # no dependency on py-clob-client being installed, no need for a funded key.
+        self.client = None
 
     def buy(self, token_id: str, amount_usdc: float) -> dict:
-        """Buy ``amount_usdc`` worth of shares for ``token_id`` (FOK market order)."""
-        if self._dry_run:
-            logger.info("DRY RUN: BUY %.4f of %s", amount_usdc, token_id)
-            return {"success": True, "dry_run": True}
-        try:
-            order_args = MarketOrderArgs(
-                token_id=token_id, amount=amount_usdc, side=BUY
-            )
-            signed_order = self.client.create_market_order(order_args)
-            result = self.client.post_order(signed_order, OrderType.FOK)
-            return {"success": True, "order": result}
-        except Exception as e:
-            logger.error("BUY failed for token %s: %s", token_id, e)
-            return {"success": False, "error": str(e)}
+        """Simulate buying ``amount_usdc`` of ``token_id``. Submits nothing."""
+        logger.info("DRY RUN: BUY %.4f of %s", amount_usdc, token_id)
+        return {"success": True, "dry_run": True}
 
     def cancel_all(self) -> bool:
-        """Cancel all open orders. No-op in dry-run; returns False on API failure."""
-        if self._dry_run:
-            return True
-        try:
-            self.client.cancel_all()
-            return True
-        except Exception:
-            logger.exception("Cancel all failed")
-            return False
+        """No-op: there are no live orders to cancel."""
+        return True

--- a/torchtrade/envs/live/polymarket/order_executor.py
+++ b/torchtrade/envs/live/polymarket/order_executor.py
@@ -1,19 +1,23 @@
 """Paper-trading order executor for Polymarket.
 
-PAPER ONLY. ``dry_run=False`` is REFUSED here, not just at the env's config boundary: this
-class is publicly exported (``torchtrade.envs.live``), so a caller reaching for the exported
-API could otherwise construct a live CLOB client and post a real order while
-:class:`PolymarketBetEnv` believed itself paper-only. The guard has to sit on the class that
-can actually move money, not only on the env that happens to build it.
+PAPER ONLY, and it refuses to pretend otherwise:
 
-See ``LIVE_UNSUPPORTED`` in ``env.py`` for why live is unsupported, and for sources -- do not
-restate it here.
+- ``dry_run=False`` raises. The refusal lives HERE, not only on the env's config, because this
+  class is publicly exported (``torchtrade.envs.live``) -- a caller reaching for the exported
+  API could otherwise construct a live CLOB client and post a real order while
+  :class:`PolymarketBetEnv` believed itself paper-only. The guard belongs on the class that
+  can move money, not only on the env that happens to build it.
+- ``private_key`` raises too. Accepting and ignoring a real key would tell the caller their
+  key is configured when nothing here can ever sign anything. Refused, not swallowed.
+
+The refusal message summarizes both blockers (archived client, no redeem); the sources for
+them live in ``LIVE_UNSUPPORTED`` in ``env.py``.
 
 The V1 py-clob-client machinery this module used to carry (``ClobClient`` construction,
-``MarketOrderArgs``/``OrderType.FOK`` order posting) was deleted rather than left behind the
-guard: it is unreachable once live is refused, and it would not have survived the CLOB V2 port
-anyway (different package, different types, pUSD collateral, plus a redemption workflow that
-does not exist yet). Recover it from git history if the port ever wants a reference.
+``MarketOrderArgs``/``OrderType.FOK`` order posting) was deleted rather than parked behind the
+guard: unreachable once live is refused, and it would not have survived the CLOB V2 port
+anyway (different package, different types, pUSD collateral, plus a redeem that does not exist
+yet). Recover it from git history if the port wants a reference.
 """
 
 from __future__ import annotations
@@ -32,26 +36,27 @@ LIVE_EXECUTOR_UNSUPPORTED = (
 
 
 class PolymarketOrderExecutor:
-    """Simulates Polymarket order submission. Never touches the network.
+    """Simulates Polymarket order submission. Never touches the network, never signs.
 
-    Built automatically by :class:`PolymarketBetEnv` (which is paper-only and calls nothing
-    here but :meth:`cancel_all`). This is where the CLOB V2 port begins.
+    Built automatically by :class:`PolymarketBetEnv`, which calls only :meth:`cancel_all`.
+    This is where the CLOB V2 port begins.
     """
 
-    def __init__(
-        self,
-        private_key: str = "",
-        chain_id: int = 137,
-        signature_type: int = 0,
-        funder: Optional[str] = None,
-        dry_run: bool = True,
-    ):
+    def __init__(self, *, private_key: Optional[str] = None, dry_run: bool = True):
+        # Keyword-only, and the live-config params (chain_id / signature_type / funder) are
+        # gone: they fed the deleted CLOB client and no caller in the tree ever passed them.
+        # Any leftover call site now gets a loud TypeError naming the argument.
         if not dry_run:
             raise NotImplementedError(LIVE_EXECUTOR_UNSUPPORTED)
-        self._dry_run = True
-        # Fully offline: no client, no API-cred derivation (which would hit the wallet RPC),
-        # no dependency on py-clob-client being installed, no need for a funded key.
-        self.client = None
+
+        # `is not None`, NOT truthiness: the old example passed
+        # os.getenv("POLYGON_PRIVATE_KEY", ""), and `if private_key:` would wave that through.
+        if private_key is not None:
+            raise TypeError(
+                "PolymarketOrderExecutor no longer takes private_key: it is paper-only and "
+                "can never sign or submit anything, so a key would do nothing. Accepting it "
+                "silently would tell you it was configured. Remove the argument."
+            )
 
     def buy(self, token_id: str, amount_usdc: float) -> dict:
         """Simulate buying ``amount_usdc`` of ``token_id``. Submits nothing."""
@@ -59,5 +64,5 @@ class PolymarketOrderExecutor:
         return {"success": True, "dry_run": True}
 
     def cancel_all(self) -> bool:
-        """No-op: there are no live orders to cancel."""
+        """No-op: a paper env has no live orders to cancel."""
         return True


### PR DESCRIPTION
## The bug, and why the obvious fix would have been worse

Follow-up #45: `PolymarketBetEnv.cash` was simulated bookkeeping in **both** `dry_run` and live mode — nothing ever read the real wallet, and `_reset()` restored a constant every episode. So the bankruptcy check on a live-money env was checking a fiction.

The obvious fix — read the real USDC balance — is **actively dangerous here**, and that took real research to establish:

**This env never sells.** It buys and holds every bet through resolution. Polymarket resolution does **not** release collateral: a winning share is worth $1 but stays an ERC-1155 token until an explicit on-chain `redeemPositions` call, which **no Polymarket client exposes** (V1, V2, or the unified py-sdk). A live bot that never redeems watches its spendable collateral **drain monotonically to zero while it is winning.**

So a wallet-backed `cash` would make a *winning* agent declare itself bankrupt and halt. Strictly worse than the bug it replaced.

**And the live path is dead anyway.** `py-clob-client`, which `order_executor.py` is built on, was archived in May 2026 — *"no longer functional and should not be used for new or existing integrations."* Polymarket shipped CLOB V2 with new contracts and pUSD replacing USDC.e. It was never even a declared dependency, just an optional `try/except` import — so the live path was almost certainly never exercised. Meanwhile `dry_run` **defaulted to `False`**: the default config was live mode.

## What this does

Refuses live at the config boundary rather than pretending. `dry_run=False` raises with both reasons and the sources; `dry_run` now defaults to `True`. In paper mode the simulated cash isn't a bug — it's the correct semantics of a paper env. The lie was only ever that live mode *pretended* to be real.

Reviving live needs the CLOB V2 port **and** a redemption workflow. Tracked separately.

## Bugs found and fixed along the way

- **`close()` broke `TransformedEnv`** (pre-existing). `def close(self)` didn't accept `EnvBase.close`'s keyword-only `raise_if_closed`, which `TransformedEnv` forwards — so `TransformedEnv(env, RewardSum()).close()` raised `TypeError`, on the composition the env's own spec comment advertises.
- **The policy's entire observation vector was unpinned** (pre-existing). Swapping `spread`↔`liquidity`, or emitting `no_price` instead of `yes_price` (feeding the policy the *inverted* market), passed the whole suite. `check_env_specs` can't catch a permutation — `Bounded(0, inf)` accepts any order. Same class as CLAUDE.md invariant #3.
- **`_step`'s observation was unpinned too** — returning the stale, already-resolved market passed everything. Live, the policy conditions on the old market's quotes while the bet's `fill_price` comes from the new one: *the agent bets at prices it never saw.*
- **The wait→poll order was observed by nothing** — deleting `_wait_for_resolution`, or polling first, both passed. Live that polls a market that hasn't ended, burns the budget, and books **reward=0 on every bet**.
- **`bankrupt_threshold` was unvalidated** — `< 0` silently disables the safety stop. Its domain also disagreed with `SequentialTradingEnvConfig`'s already-settled `[0, 1)`.
- Four config knobs (grace, poll interval, max wait, and both lower bounds) were pinned only at their **defaults**, so a hardcoded constant passed. `max_wait` didn't even fail — it *hung*.
- **Dead code**: `_compute_payoff`'s `stake <= 0` guard became unreachable once the boundary validation landed (proven: 200k simulated episodes, min cash `0.0`, zero negative-cash episodes). Deleted rather than tested — validate at the boundary, don't guard in the rule.

## Docs

The README section literally titled **"Running for real"** still told users to `pip install py-clob-client` and set `dry_run=False`; the official docs still documented a funded USDC.e wallet; the root README listed Polymarket under *"Start live trading."* All corrected. The payoff is now honestly described as **modelled** (it fills at the quoted mid, with no spread crossing and no fees) rather than "realized".

## Verification

- **2016 passing**, 25 skipped.
- **15/15 mutations killed**, each verified to actually apply — including all four config knobs, both observation paths, the compounding rule, the resolution threshold, and the lifecycle.
- Reviewed over **4 rounds × 4 agents** (test-justification, code-simplifier, pr-test-analyzer, torchrl-engineer). Rounds 2, 3 and 4 each found real bugs *in my own fixes* — including several dead assertions and a false claim that had migrated into the one string this PR designated canonical.
- TorchRL verified by execution, not inspection: `check_env_specs`, rollout, `TransformedEnv+RewardSum`, `SerialEnv`, and `ParallelEnv` under both fork and spawn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)