### PR TITLE
fix(live): a direct long→short flip reported the dead position's age to the policy

### DIFF
--- a/tests/envs/base_exchange_tests.py
+++ b/tests/envs/base_exchange_tests.py
@@ -1,7 +1,8 @@
-"""Shared observation-class tests.
+"""Shared test bodies for the per-exchange live-env test files.
 
-Each exchange (alpaca, binance, bitget, bybit, okx) subclasses BaseObservationClassTests in
-its own test_obs_class.py and implements create_observer / get_expected_symbol_format.
+- BaseObservationClassTests: subclassed by each exchange's test_obs_class.py.
+- assert_a_direct_flip_does_not_age_the_new_position: called by each exchange's
+  test_torch_env_futures*.py, so the flip contract has one body and five kills.
 """
 
 import pytest
@@ -269,7 +270,6 @@ class BaseObservationClassTests(ABC):
         assert observations[key].shape[0] == 100
 
 
-
 def assert_a_direct_flip_does_not_age_the_new_position(
     env, trader, PositionStatus, long_action, short_action, set_side=None
 ):
@@ -285,11 +285,16 @@ def assert_a_direct_flip_does_not_age_the_new_position(
     import torch
     from tensordict import TensorDict
 
-    # the four PositionStatus dataclasses are field-identical in order (only field 8 is named
-    # margin_type on binance, margin_mode elsewhere), so build them positionally
+    # Built positionally because the four dataclasses differ only in the NAME of field 8
+    # (margin_type on binance, margin_mode elsewhere). The only field this test actually reads
+    # is qty -- everything else is inert filler -- so that is the one thing worth pinning.
+    from dataclasses import fields
+    assert [f.name for f in fields(PositionStatus)][0] == "qty"
+
     def pos(qty):
+        liq = 45000.0 if qty > 0 else 55000.0     # shorts liquidate ABOVE the mark
         return {"position_status": PositionStatus(
-            qty, 500.0, 50000.0, 0.0, 0.0, 50000.0, 5, "isolated", 45000.0)}
+            qty, 500.0, 50000.0, 0.0, 0.0, 50000.0, 5, "isolated", liq)}
 
     with patch.object(env, "_wait_for_next_timestamp"):
         if set_side:
@@ -304,8 +309,18 @@ def assert_a_direct_flip_does_not_age_the_new_position(
 
         if set_side:
             set_side("SELL")
-        first = iter([pos(0.01)])          # sync reads the OLD long; every later read is short
-        trader.get_status = MagicMock(side_effect=lambda: next(first, pos(-0.01)))
+
+        # The exchange reports the OLD long until the trade actually executes -- keyed off the
+        # TRADE, not off how many times _step happens to call get_status(). An earlier
+        # get_status() added to _step (a price prefetch, a retry) would consume a
+        # call-ordering-based mock's single "long", the sync would then see the short, reset
+        # hold_counter ITSELF, and all five tests would go green on buggy code.
+        traded = []
+        inner_trade = trader.trade
+        trader.trade = MagicMock(
+            side_effect=lambda *a, **k: (traded.append(1), inner_trade(*a, **k))[1]
+        )
+        trader.get_status = MagicMock(side_effect=lambda: pos(-0.01) if traded else pos(0.01))
         td = env.step(TensorDict({"action": torch.tensor(short_action)}, batch_size=()))
 
     holding_time = td["next"]["account_state"][3].item()

--- a/tests/envs/base_exchange_tests.py
+++ b/tests/envs/base_exchange_tests.py
@@ -267,3 +267,49 @@ class BaseObservationClassTests(ABC):
         key = observer.get_keys()[0]
 
         assert observations[key].shape[0] == 100
+
+
+
+def assert_a_direct_flip_does_not_age_the_new_position(
+    env, trader, PositionStatus, long_action, short_action, set_side=None
+):
+    """A long flipped straight to a short is ONE step old, not the long's age.
+
+    THE TRAP: the exchange must still report the LONG when _step syncs -- the trade has not
+    executed yet. Reporting the short there makes _sync_position_from_exchange see an EXTERNAL
+    change and reset hold_counter itself (PR #245 / SLTPMixin), masking the bug: the test goes
+    vacuous. Two of these passed on the buggy code before I found that.
+    """
+    from unittest.mock import MagicMock, patch
+
+    import torch
+    from tensordict import TensorDict
+
+    # the four PositionStatus dataclasses are field-identical in order (only field 8 is named
+    # margin_type on binance, margin_mode elsewhere), so build them positionally
+    def pos(qty):
+        return {"position_status": PositionStatus(
+            qty, 500.0, 50000.0, 0.0, 0.0, 50000.0, 5, "isolated", 45000.0)}
+
+    with patch.object(env, "_wait_for_next_timestamp"):
+        if set_side:
+            set_side("BUY")
+        trader.get_status = MagicMock(return_value=pos(0.01))
+        env.reset()
+
+        for _ in range(5):
+            td = env.step(TensorDict({"action": torch.tensor(long_action)}, batch_size=()))
+        aged = td["next"]["account_state"][3].item()
+        assert aged > 1.0, f"the long never aged ({aged}) -- the assertion below would be vacuous"
+
+        if set_side:
+            set_side("SELL")
+        first = iter([pos(0.01)])          # sync reads the OLD long; every later read is short
+        trader.get_status = MagicMock(side_effect=lambda: next(first, pos(-0.01)))
+        td = env.step(TensorDict({"action": torch.tensor(short_action)}, batch_size=()))
+
+    holding_time = td["next"]["account_state"][3].item()
+    assert holding_time == 1.0, (
+        f"a one-step-old short reports {holding_time} bars (the long aged to {aged}): the flip "
+        f"never passed through flat, so the counter was never reset"
+    )

--- a/tests/envs/base_exchange_tests.py
+++ b/tests/envs/base_exchange_tests.py
@@ -5,8 +5,13 @@
   test_torch_env_futures*.py, so the flip contract has one body and five kills.
 """
 
+from dataclasses import fields
+
 import pytest
 import numpy as np
+import torch
+from tensordict import TensorDict
+from unittest.mock import MagicMock, patch
 from abc import ABC, abstractmethod
 from torchtrade.envs.utils.timeframe import TimeFrame, TimeFrameUnit
 
@@ -271,7 +276,7 @@ class BaseObservationClassTests(ABC):
 
 
 def assert_a_direct_flip_does_not_age_the_new_position(
-    env, trader, PositionStatus, long_action, short_action, set_side=None
+    env, trader, PositionStatus, long_action, short_action
 ):
     """A long flipped straight to a short is ONE step old, not the long's age.
 
@@ -280,15 +285,9 @@ def assert_a_direct_flip_does_not_age_the_new_position(
     change and reset hold_counter itself (PR #245 / SLTPMixin), masking the bug: the test goes
     vacuous. Two of these passed on the buggy code before I found that.
     """
-    from unittest.mock import MagicMock, patch
-
-    import torch
-    from tensordict import TensorDict
-
     # Built positionally because the four dataclasses differ only in the NAME of field 8
     # (margin_type on binance, margin_mode elsewhere). The only field this test actually reads
     # is qty -- everything else is inert filler -- so that is the one thing worth pinning.
-    from dataclasses import fields
     assert [f.name for f in fields(PositionStatus)][0] == "qty"
 
     def pos(qty):
@@ -297,8 +296,6 @@ def assert_a_direct_flip_does_not_age_the_new_position(
             qty, 500.0, 50000.0, 0.0, 0.0, 50000.0, 5, "isolated", liq)}
 
     with patch.object(env, "_wait_for_next_timestamp"):
-        if set_side:
-            set_side("BUY")
         trader.get_status = MagicMock(return_value=pos(0.01))
         env.reset()
 
@@ -307,8 +304,6 @@ def assert_a_direct_flip_does_not_age_the_new_position(
         aged = td["next"]["account_state"][3].item()
         assert aged > 1.0, f"the long never aged ({aged}) -- the assertion below would be vacuous"
 
-        if set_side:
-            set_side("SELL")
 
         # The exchange reports the OLD long until the trade actually executes -- keyed off the
         # TRADE, not off how many times _step happens to call get_status(). An earlier

--- a/tests/envs/binance/test_torch_env_futures.py
+++ b/tests/envs/binance/test_torch_env_futures.py
@@ -296,6 +296,49 @@ class TestBinanceFuturesTorchTradingEnv:
         assert leverage == 5.0        # the CONFIG leverage, not the 20 on the residual
         assert dist_to_liq == 1.0     # no position -> no liquidation to be near
 
+    def test_a_direct_flip_does_not_age_the_new_position(self, env, mock_trader):
+        """END TO END on account_state[3], for BINANCE's wiring specifically.
+
+        Binance advances the counter from the env's CACHED direction (after the trade updates
+        it), while bybit/bitget/okx advance it from the direction OBSERVED on the exchange.
+        Two different wirings, so the shared rule being right does not prove binance feeds it
+        the right thing -- only this does.
+
+        The flip is modelled honestly: at _sync_position_from_exchange time the trade has not
+        executed, so the exchange still shows the OLD long. Mocking the short for the whole step
+        would make the sync treat it as an EXTERNAL change and reset the counter itself (PR
+        #245), masking the bug entirely.
+        """
+        from torchtrade.envs.live.binance.order_executor import PositionStatus
+
+        def pos(qty):
+            return {"position_status": PositionStatus(
+                qty=qty, notional_value=500.0, entry_price=50000.0, unrealized_pnl=0.0,
+                unrealized_pnl_pct=0.0, mark_price=50000.0, leverage=5,
+                margin_type="isolated", liquidation_price=45000.0,
+            )}
+
+        with patch.object(env, "_wait_for_next_timestamp"):
+            mock_trader.get_status = MagicMock(return_value=pos(0.01))     # LONG
+            env.reset()
+            long_idx = len(env.action_levels) - 1
+            long = TensorDict({"action": torch.tensor(long_idx)}, batch_size=())
+
+            for _ in range(5):
+                td = env.step(long)
+            aged = td["next"]["account_state"][3].item()
+            assert aged > 1.0, f"the long should have aged, got {aged}"
+
+            # the flip: still long at sync time, short by the time we observe
+            mock_trader.get_status = MagicMock(side_effect=[pos(0.01)] + [pos(-0.01)] * 4)
+            td = env.step(TensorDict({"action": torch.tensor(0)}, batch_size=()))
+
+        holding_time = td["next"]["account_state"][3].item()
+        assert holding_time == 1.0, (
+            f"a one-step-old short is reported as {holding_time} bars old (the long's age was "
+            f"{aged}) -- the flip never passed through flat, so the counter was never reset"
+        )
+
     def test_reset_clears_the_holding_time_of_the_previous_episode(self, env, mock_trader):
         """Reset must zero hold_counter, or episode 2 inherits episode 1's age.
 

--- a/tests/envs/binance/test_torch_env_futures.py
+++ b/tests/envs/binance/test_torch_env_futures.py
@@ -297,47 +297,12 @@ class TestBinanceFuturesTorchTradingEnv:
         assert dist_to_liq == 1.0     # no position -> no liquidation to be near
 
     def test_a_direct_flip_does_not_age_the_new_position(self, env, mock_trader):
-        """END TO END on account_state[3], for BINANCE's wiring specifically.
-
-        Binance advances the counter from the env's CACHED direction (after the trade updates
-        it), while bybit/bitget/okx advance it from the direction OBSERVED on the exchange.
-        Two different wirings, so the shared rule being right does not prove binance feeds it
-        the right thing -- only this does.
-
-        The flip is modelled honestly: at _sync_position_from_exchange time the trade has not
-        executed, so the exchange still shows the OLD long. Mocking the short for the whole step
-        would make the sync treat it as an EXTERNAL change and reset the counter itself (PR
-        #245), masking the bug entirely.
-        """
         from torchtrade.envs.live.binance.order_executor import PositionStatus
-
-        def pos(qty):
-            return {"position_status": PositionStatus(
-                qty=qty, notional_value=500.0, entry_price=50000.0, unrealized_pnl=0.0,
-                unrealized_pnl_pct=0.0, mark_price=50000.0, leverage=5,
-                margin_type="isolated", liquidation_price=45000.0,
-            )}
-
-        with patch.object(env, "_wait_for_next_timestamp"):
-            mock_trader.get_status = MagicMock(return_value=pos(0.01))     # LONG
-            env.reset()
-            long_idx = len(env.action_levels) - 1
-            long = TensorDict({"action": torch.tensor(long_idx)}, batch_size=())
-
-            for _ in range(5):
-                td = env.step(long)
-            aged = td["next"]["account_state"][3].item()
-            assert aged > 1.0, f"the long should have aged, got {aged}"
-
-            # the flip: still long at sync time, short by the time we observe
-            mock_trader.get_status = MagicMock(side_effect=[pos(0.01)] + [pos(-0.01)] * 4)
-            td = env.step(TensorDict({"action": torch.tensor(0)}, batch_size=()))
-
-        holding_time = td["next"]["account_state"][3].item()
-        assert holding_time == 1.0, (
-            f"a one-step-old short is reported as {holding_time} bars old (the long's age was "
-            f"{aged}) -- the flip never passed through flat, so the counter was never reset"
+        from tests.envs.base_exchange_tests import (
+            assert_a_direct_flip_does_not_age_the_new_position as assert_flip,
         )
+        assert_flip(env, mock_trader, PositionStatus,
+                    long_action=len(env.action_levels) - 1, short_action=0)
 
     def test_reset_clears_the_holding_time_of_the_previous_episode(self, env, mock_trader):
         """Reset must zero hold_counter, or episode 2 inherits episode 1's age.

--- a/tests/envs/binance/test_torch_env_futures_sltp.py
+++ b/tests/envs/binance/test_torch_env_futures_sltp.py
@@ -341,7 +341,6 @@ class TestBinanceFuturesSLTPTorchTradingEnv:
         env.close()
         mock_trader.cancel_open_orders.assert_called()
 
-
     def test_a_direct_flip_does_not_age_the_new_position(self, env, mock_trader):
         """env_sltp sets current_position from the trade SIDE, so LONG -> SHORT bracket flips
         without ever passing through flat."""

--- a/tests/envs/binance/test_torch_env_futures_sltp.py
+++ b/tests/envs/binance/test_torch_env_futures_sltp.py
@@ -342,19 +342,13 @@ class TestBinanceFuturesSLTPTorchTradingEnv:
         mock_trader.cancel_open_orders.assert_called()
 
     def test_a_direct_flip_does_not_age_the_new_position(self, env, mock_trader):
-        """env_sltp sets current_position from the trade SIDE, so LONG -> SHORT bracket flips
+        """env_sltp sets current_position from the trade SIDE, so a LONG -> SHORT bracket flips
         without ever passing through flat."""
         from torchtrade.envs.live.binance.order_executor import PositionStatus
         from tests.envs.base_exchange_tests import (
             assert_a_direct_flip_does_not_age_the_new_position as assert_flip,
         )
-
-        def set_side(side):
-            mock_trader.trade = MagicMock(return_value={
-                "side": side, "executed": True, "success": True, "closed_position": False})
-
-        assert_flip(env, mock_trader, PositionStatus, long_action=1, short_action=5,
-                    set_side=set_side)
+        assert_flip(env, mock_trader, PositionStatus, long_action=1, short_action=5)
 
 class TestBinanceFuturesSLTPTradingEnvConfig:
     """Tests for BinanceFuturesSLTPTradingEnvConfig."""

--- a/tests/envs/binance/test_torch_env_futures_sltp.py
+++ b/tests/envs/binance/test_torch_env_futures_sltp.py
@@ -342,6 +342,57 @@ class TestBinanceFuturesSLTPTorchTradingEnv:
         mock_trader.cancel_open_orders.assert_called()
 
 
+    def test_a_direct_flip_does_not_age_the_new_position(self, env, mock_trader):
+        """The SLTP flip path, which the non-SLTP fix left completely uncovered.
+
+        env_sltp.py sets current_position = 1 on BUY and -1 on SELL directly, so a LONG bracket
+        followed by a SHORT bracket is a DIRECT FLIP that never passes through flat -- exactly
+        the bug. Reverting env_sltp.py to the old hand-rolled rule passed the ENTIRE suite
+        before this test existed.
+
+        The flip is modelled honestly: the trade's SIDE is what drives current_position here, so
+        the sync cannot mask it the way it does in the non-SLTP path.
+        """
+        from torchtrade.envs.live.binance.order_executor import PositionStatus
+
+        def pos(qty):
+            return {"position_status": PositionStatus(
+                qty=qty, notional_value=500.0, entry_price=50000.0, unrealized_pnl=0.0,
+                unrealized_pnl_pct=0.0, mark_price=50000.0, leverage=5,
+                margin_type="isolated", liquidation_price=45000.0,
+            )}
+
+        with patch.object(env, "_wait_for_next_timestamp"):
+            mock_trader.trade = MagicMock(return_value={"side": "BUY", "executed": True,
+                                                        "success": True, "closed_position": False})
+            mock_trader.get_status = MagicMock(return_value=pos(0.001))
+            env.reset()
+
+            long_bracket = TensorDict({"action": torch.tensor(1)}, batch_size=())
+            for _ in range(4):
+                td = env.step(long_bracket)
+            aged = td["next"]["account_state"][3].item()
+            assert aged > 1.0, f"the long should have aged, got {aged}"
+
+            # A SHORT bracket while long. env_sltp writes current_position = -1 from the trade
+            # SIDE, so the flip happens in the env, not on the exchange.
+            #
+            # The exchange must still report the LONG at _sync_position_from_exchange time --
+            # the trade has not executed yet. Reporting the short there makes SLTPMixin's sync
+            # see a direction change, reset hold_counter ITSELF, and mask the bug completely.
+            # (I shipped exactly that vacuous test once already on the non-SLTP path.)
+            mock_trader.trade = MagicMock(return_value={"side": "SELL", "executed": True,
+                                                        "success": True, "closed_position": False})
+            mock_trader.get_status = MagicMock(side_effect=[pos(0.001)] + [pos(-0.001)] * 5)
+            td = env.step(TensorDict({"action": torch.tensor(5)}, batch_size=()))
+
+        holding_time = td["next"]["account_state"][3].item()
+        assert holding_time == 1.0, (
+            f"a one-step-old short bracket is reported as {holding_time} bars old (the long's "
+            f"age was {aged}) -- the flip never passed through flat"
+        )
+
+
 class TestBinanceFuturesSLTPTradingEnvConfig:
     """Tests for BinanceFuturesSLTPTradingEnvConfig."""
 

--- a/tests/envs/binance/test_torch_env_futures_sltp.py
+++ b/tests/envs/binance/test_torch_env_futures_sltp.py
@@ -343,55 +343,19 @@ class TestBinanceFuturesSLTPTorchTradingEnv:
 
 
     def test_a_direct_flip_does_not_age_the_new_position(self, env, mock_trader):
-        """The SLTP flip path, which the non-SLTP fix left completely uncovered.
-
-        env_sltp.py sets current_position = 1 on BUY and -1 on SELL directly, so a LONG bracket
-        followed by a SHORT bracket is a DIRECT FLIP that never passes through flat -- exactly
-        the bug. Reverting env_sltp.py to the old hand-rolled rule passed the ENTIRE suite
-        before this test existed.
-
-        The flip is modelled honestly: the trade's SIDE is what drives current_position here, so
-        the sync cannot mask it the way it does in the non-SLTP path.
-        """
+        """env_sltp sets current_position from the trade SIDE, so LONG -> SHORT bracket flips
+        without ever passing through flat."""
         from torchtrade.envs.live.binance.order_executor import PositionStatus
-
-        def pos(qty):
-            return {"position_status": PositionStatus(
-                qty=qty, notional_value=500.0, entry_price=50000.0, unrealized_pnl=0.0,
-                unrealized_pnl_pct=0.0, mark_price=50000.0, leverage=5,
-                margin_type="isolated", liquidation_price=45000.0,
-            )}
-
-        with patch.object(env, "_wait_for_next_timestamp"):
-            mock_trader.trade = MagicMock(return_value={"side": "BUY", "executed": True,
-                                                        "success": True, "closed_position": False})
-            mock_trader.get_status = MagicMock(return_value=pos(0.001))
-            env.reset()
-
-            long_bracket = TensorDict({"action": torch.tensor(1)}, batch_size=())
-            for _ in range(4):
-                td = env.step(long_bracket)
-            aged = td["next"]["account_state"][3].item()
-            assert aged > 1.0, f"the long should have aged, got {aged}"
-
-            # A SHORT bracket while long. env_sltp writes current_position = -1 from the trade
-            # SIDE, so the flip happens in the env, not on the exchange.
-            #
-            # The exchange must still report the LONG at _sync_position_from_exchange time --
-            # the trade has not executed yet. Reporting the short there makes SLTPMixin's sync
-            # see a direction change, reset hold_counter ITSELF, and mask the bug completely.
-            # (I shipped exactly that vacuous test once already on the non-SLTP path.)
-            mock_trader.trade = MagicMock(return_value={"side": "SELL", "executed": True,
-                                                        "success": True, "closed_position": False})
-            mock_trader.get_status = MagicMock(side_effect=[pos(0.001)] + [pos(-0.001)] * 5)
-            td = env.step(TensorDict({"action": torch.tensor(5)}, batch_size=()))
-
-        holding_time = td["next"]["account_state"][3].item()
-        assert holding_time == 1.0, (
-            f"a one-step-old short bracket is reported as {holding_time} bars old (the long's "
-            f"age was {aged}) -- the flip never passed through flat"
+        from tests.envs.base_exchange_tests import (
+            assert_a_direct_flip_does_not_age_the_new_position as assert_flip,
         )
 
+        def set_side(side):
+            mock_trader.trade = MagicMock(return_value={
+                "side": side, "executed": True, "success": True, "closed_position": False})
+
+        assert_flip(env, mock_trader, PositionStatus, long_action=1, short_action=5,
+                    set_side=set_side)
 
 class TestBinanceFuturesSLTPTradingEnvConfig:
     """Tests for BinanceFuturesSLTPTradingEnvConfig."""

--- a/tests/envs/bitget/test_torch_env_futures.py
+++ b/tests/envs/bitget/test_torch_env_futures.py
@@ -377,44 +377,12 @@ class TestBitgetFuturesTorchTradingEnv:
         assert dist_to_liq == 1.0     # no position -> no liquidation to be near
 
     def test_a_direct_flip_does_not_age_the_new_position(self, env, mock_trader):
-        """END TO END on account_state[3]. The unit test proves the RULE; this proves the WIRING.
-
-        Reverting bitget to the old hand-rolled rule passed the ENTIRE suite before this test
-        existed -- the exchange could be fully un-fixed with zero failures.
-
-        The flip is modelled honestly: at _sync_position_from_exchange time the trade has NOT
-        executed, so the exchange still shows the OLD long. Mocking the short for the whole step
-        makes the sync see exchange(short) != cache(long), treat it as an EXTERNAL change and
-        reset the counter itself (PR #245) -- which masks this bug completely.
-        """
         from torchtrade.envs.live.bitget.order_executor import PositionStatus
-
-        def pos(qty):
-            return {"position_status": PositionStatus(
-                qty=qty, notional_value=500.0, entry_price=50000.0, unrealized_pnl=0.0,
-                unrealized_pnl_pct=0.0, mark_price=50000.0, leverage=5,
-                margin_mode="isolated", liquidation_price=45000.0,
-            )}
-
-        with patch.object(env, "_wait_for_next_timestamp"):
-            mock_trader.get_status = MagicMock(return_value=pos(0.01))      # LONG
-            env.reset()
-            long = TensorDict({"action": torch.tensor(len(env.action_levels) - 1)}, batch_size=())
-
-            for _ in range(5):
-                td = env.step(long)
-            aged = td["next"]["account_state"][3].item()
-            assert aged > 1.0, f"the long should have aged, got {aged}"
-
-            # still long at sync time; short by the time we observe. A real flip.
-            mock_trader.get_status = MagicMock(side_effect=[pos(0.01)] + [pos(-0.01)] * 4)
-            td = env.step(TensorDict({"action": torch.tensor(0)}, batch_size=()))
-
-        holding_time = td["next"]["account_state"][3].item()
-        assert holding_time == 1.0, (
-            f"a one-step-old short is reported as {holding_time} bars old (the long's age was "
-            f"{aged}) -- the flip never passed through flat, so the counter was never reset"
+        from tests.envs.base_exchange_tests import (
+            assert_a_direct_flip_does_not_age_the_new_position as assert_flip,
         )
+        assert_flip(env, mock_trader, PositionStatus,
+                    long_action=len(env.action_levels) - 1, short_action=0)
 
     def test_dust_between_positions_does_not_age_the_next_one(self, env, mock_trader):
         """A residual left between two positions must not carry the old age into the new one.

--- a/tests/envs/bitget/test_torch_env_futures.py
+++ b/tests/envs/bitget/test_torch_env_futures.py
@@ -376,6 +376,46 @@ class TestBitgetFuturesTorchTradingEnv:
         assert leverage == 5.0        # the CONFIG leverage, not the 20 on the residual
         assert dist_to_liq == 1.0     # no position -> no liquidation to be near
 
+    def test_a_direct_flip_does_not_age_the_new_position(self, env, mock_trader):
+        """END TO END on account_state[3]. The unit test proves the RULE; this proves the WIRING.
+
+        Reverting bitget to the old hand-rolled rule passed the ENTIRE suite before this test
+        existed -- the exchange could be fully un-fixed with zero failures.
+
+        The flip is modelled honestly: at _sync_position_from_exchange time the trade has NOT
+        executed, so the exchange still shows the OLD long. Mocking the short for the whole step
+        makes the sync see exchange(short) != cache(long), treat it as an EXTERNAL change and
+        reset the counter itself (PR #245) -- which masks this bug completely.
+        """
+        from torchtrade.envs.live.bitget.order_executor import PositionStatus
+
+        def pos(qty):
+            return {"position_status": PositionStatus(
+                qty=qty, notional_value=500.0, entry_price=50000.0, unrealized_pnl=0.0,
+                unrealized_pnl_pct=0.0, mark_price=50000.0, leverage=5,
+                margin_mode="isolated", liquidation_price=45000.0,
+            )}
+
+        with patch.object(env, "_wait_for_next_timestamp"):
+            mock_trader.get_status = MagicMock(return_value=pos(0.01))      # LONG
+            env.reset()
+            long = TensorDict({"action": torch.tensor(len(env.action_levels) - 1)}, batch_size=())
+
+            for _ in range(5):
+                td = env.step(long)
+            aged = td["next"]["account_state"][3].item()
+            assert aged > 1.0, f"the long should have aged, got {aged}"
+
+            # still long at sync time; short by the time we observe. A real flip.
+            mock_trader.get_status = MagicMock(side_effect=[pos(0.01)] + [pos(-0.01)] * 4)
+            td = env.step(TensorDict({"action": torch.tensor(0)}, batch_size=()))
+
+        holding_time = td["next"]["account_state"][3].item()
+        assert holding_time == 1.0, (
+            f"a one-step-old short is reported as {holding_time} bars old (the long's age was "
+            f"{aged}) -- the flip never passed through flat, so the counter was never reset"
+        )
+
     def test_dust_between_positions_does_not_age_the_next_one(self, env, mock_trader):
         """A residual left between two positions must not carry the old age into the new one.
         """

--- a/tests/envs/bybit/test_torch_env_futures.py
+++ b/tests/envs/bybit/test_torch_env_futures.py
@@ -242,59 +242,12 @@ class TestBybitFuturesTorchTradingEnv:
         )
 
     def test_a_direct_flip_does_not_age_the_new_position(self, env, mock_trader):
-        """END TO END, on the value the policy actually receives.
-
-        The unit test for advance_hold_counter proves the RULE; this proves the WIRING -- that
-        the env feeds it the right direction and emits the result as account_state[3]. The rule
-        could be perfect while the env passed it the cached direction instead of the observed
-        one, and the unit test would never notice.
-
-        A long held for 5 bars, then flipped straight to a short with NO flat bar in between.
-        The short is ONE step old. Before the fix the env reported it as 6 bars old, because
-        "reset when flat" never fired -- and holding_time is what a hold-aware policy reasons
-        about.
-        """
         from torchtrade.envs.live.bybit.order_executor import PositionStatus
-
-        def status(qty):
-            return {"position_status": PositionStatus(
-                qty=qty, notional_value=500.0, entry_price=50000.0, unrealized_pnl=0.0,
-                unrealized_pnl_pct=0.0, mark_price=50000.0, leverage=5,
-                margin_mode="isolated", liquidation_price=45000.0,
-            )}
-
-        with patch.object(env, "_wait_for_next_timestamp"):
-            mock_trader.get_status = MagicMock(return_value=status(0.01))     # LONG
-            env.reset()
-            long = TensorDict({"action": torch.tensor(len(env.action_levels) - 1)}, batch_size=())
-
-            for _ in range(5):
-                td = env.step(long)
-            # reset() emits an observation too, so that first bar counts: 1 + 5 = 6.
-            aged = td["next"]["account_state"][3].item()
-            assert aged == 6.0, f"the long should have aged, got {aged}"
-
-            # A REAL flip, modelled honestly: at _sync_position_from_exchange time the trade
-            # has NOT executed yet, so the exchange still shows the OLD long. Only afterwards,
-            # when _get_observation re-reads it, does it show the short.
-            #
-            # This distinction is the whole test. Mocking the short for the ENTIRE step makes
-            # the sync see exchange(short) != cache(long), treat it as an EXTERNAL change, and
-            # reset the counter itself -- PR #245's logic -- which masks this bug completely.
-            mock_trader.get_status = MagicMock(side_effect=[
-                status(0.01),    # sync: still long, the flip has not executed
-                status(-0.01),   # observation: now short
-                status(-0.01),   # (any further reads)
-                status(-0.01),
-            ])
-            short = TensorDict({"action": torch.tensor(0)}, batch_size=())
-            td = env.step(short)
-
-        holding_time = td["next"]["account_state"][3].item()
-        assert holding_time == 1.0, (
-            f"a one-step-old short is reported as {holding_time} bars old (the long's age was "
-            f"{aged}) -- the flip never passed through flat, so the counter was never reset"
+        from tests.envs.base_exchange_tests import (
+            assert_a_direct_flip_does_not_age_the_new_position as assert_flip,
         )
+        assert_flip(env, mock_trader, PositionStatus,
+                    long_action=len(env.action_levels) - 1, short_action=0)
 
     def test_reset_clears_the_holding_time_of_the_previous_episode(self, env, mock_trader):
         """Reset must zero hold_counter, or episode 2 inherits episode 1's age.

--- a/tests/envs/bybit/test_torch_env_futures.py
+++ b/tests/envs/bybit/test_torch_env_futures.py
@@ -241,6 +241,61 @@ class TestBybitFuturesTorchTradingEnv:
             f"between the two did not reset the counter"
         )
 
+    def test_a_direct_flip_does_not_age_the_new_position(self, env, mock_trader):
+        """END TO END, on the value the policy actually receives.
+
+        The unit test for advance_hold_counter proves the RULE; this proves the WIRING -- that
+        the env feeds it the right direction and emits the result as account_state[3]. The rule
+        could be perfect while the env passed it the cached direction instead of the observed
+        one, and the unit test would never notice.
+
+        A long held for 5 bars, then flipped straight to a short with NO flat bar in between.
+        The short is ONE step old. Before the fix the env reported it as 6 bars old, because
+        "reset when flat" never fired -- and holding_time is what a hold-aware policy reasons
+        about.
+        """
+        from torchtrade.envs.live.bybit.order_executor import PositionStatus
+
+        def status(qty):
+            return {"position_status": PositionStatus(
+                qty=qty, notional_value=500.0, entry_price=50000.0, unrealized_pnl=0.0,
+                unrealized_pnl_pct=0.0, mark_price=50000.0, leverage=5,
+                margin_mode="isolated", liquidation_price=45000.0,
+            )}
+
+        with patch.object(env, "_wait_for_next_timestamp"):
+            mock_trader.get_status = MagicMock(return_value=status(0.01))     # LONG
+            env.reset()
+            long = TensorDict({"action": torch.tensor(len(env.action_levels) - 1)}, batch_size=())
+
+            for _ in range(5):
+                td = env.step(long)
+            # reset() emits an observation too, so that first bar counts: 1 + 5 = 6.
+            aged = td["next"]["account_state"][3].item()
+            assert aged == 6.0, f"the long should have aged, got {aged}"
+
+            # A REAL flip, modelled honestly: at _sync_position_from_exchange time the trade
+            # has NOT executed yet, so the exchange still shows the OLD long. Only afterwards,
+            # when _get_observation re-reads it, does it show the short.
+            #
+            # This distinction is the whole test. Mocking the short for the ENTIRE step makes
+            # the sync see exchange(short) != cache(long), treat it as an EXTERNAL change, and
+            # reset the counter itself -- PR #245's logic -- which masks this bug completely.
+            mock_trader.get_status = MagicMock(side_effect=[
+                status(0.01),    # sync: still long, the flip has not executed
+                status(-0.01),   # observation: now short
+                status(-0.01),   # (any further reads)
+                status(-0.01),
+            ])
+            short = TensorDict({"action": torch.tensor(0)}, batch_size=())
+            td = env.step(short)
+
+        holding_time = td["next"]["account_state"][3].item()
+        assert holding_time == 1.0, (
+            f"a one-step-old short is reported as {holding_time} bars old (the long's age was "
+            f"{aged}) -- the flip never passed through flat, so the counter was never reset"
+        )
+
     def test_reset_clears_the_holding_time_of_the_previous_episode(self, env, mock_trader):
         """Reset must zero hold_counter, or episode 2 inherits episode 1's age.
 

--- a/tests/envs/okx/test_torch_env_futures.py
+++ b/tests/envs/okx/test_torch_env_futures.py
@@ -156,6 +156,46 @@ class TestOKXFuturesTorchTradingEnv:
         assert leverage == 5.0        # the CONFIG leverage, not the 20 on the residual
         assert dist_to_liq == 1.0     # no position -> no liquidation to be near
 
+    def test_a_direct_flip_does_not_age_the_new_position(self, env, mock_env_trader):
+        """END TO END on account_state[3]. The unit test proves the RULE; this proves the WIRING.
+
+        Reverting okx to the old hand-rolled rule passed the ENTIRE suite before this test
+        existed -- the exchange could be fully un-fixed with zero failures.
+
+        The flip is modelled honestly: at _sync_position_from_exchange time the trade has NOT
+        executed, so the exchange still shows the OLD long. Mocking the short for the whole step
+        makes the sync see exchange(short) != cache(long), treat it as an EXTERNAL change and
+        reset the counter itself (PR #245) -- which masks this bug completely.
+        """
+        from torchtrade.envs.live.okx.order_executor import PositionStatus
+
+        def pos(qty):
+            return {"position_status": PositionStatus(
+                qty=qty, notional_value=500.0, entry_price=50000.0, unrealized_pnl=0.0,
+                unrealized_pnl_pct=0.0, mark_price=50000.0, leverage=5,
+                margin_mode="isolated", liquidation_price=45000.0,
+            )}
+
+        with patch.object(env, "_wait_for_next_timestamp"):
+            mock_env_trader.get_status = MagicMock(return_value=pos(0.01))      # LONG
+            env.reset()
+            long = TensorDict({"action": torch.tensor(len(env.action_levels) - 1)}, batch_size=())
+
+            for _ in range(5):
+                td = env.step(long)
+            aged = td["next"]["account_state"][3].item()
+            assert aged > 1.0, f"the long should have aged, got {aged}"
+
+            # still long at sync time; short by the time we observe. A real flip.
+            mock_env_trader.get_status = MagicMock(side_effect=[pos(0.01)] + [pos(-0.01)] * 4)
+            td = env.step(TensorDict({"action": torch.tensor(0)}, batch_size=()))
+
+        holding_time = td["next"]["account_state"][3].item()
+        assert holding_time == 1.0, (
+            f"a one-step-old short is reported as {holding_time} bars old (the long's age was "
+            f"{aged}) -- the flip never passed through flat, so the counter was never reset"
+        )
+
     def test_dust_between_positions_does_not_age_the_next_one(self, env, mock_env_trader):
         """A residual left between two positions must not carry the old age into the new one.
         """

--- a/tests/envs/okx/test_torch_env_futures.py
+++ b/tests/envs/okx/test_torch_env_futures.py
@@ -157,44 +157,12 @@ class TestOKXFuturesTorchTradingEnv:
         assert dist_to_liq == 1.0     # no position -> no liquidation to be near
 
     def test_a_direct_flip_does_not_age_the_new_position(self, env, mock_env_trader):
-        """END TO END on account_state[3]. The unit test proves the RULE; this proves the WIRING.
-
-        Reverting okx to the old hand-rolled rule passed the ENTIRE suite before this test
-        existed -- the exchange could be fully un-fixed with zero failures.
-
-        The flip is modelled honestly: at _sync_position_from_exchange time the trade has NOT
-        executed, so the exchange still shows the OLD long. Mocking the short for the whole step
-        makes the sync see exchange(short) != cache(long), treat it as an EXTERNAL change and
-        reset the counter itself (PR #245) -- which masks this bug completely.
-        """
         from torchtrade.envs.live.okx.order_executor import PositionStatus
-
-        def pos(qty):
-            return {"position_status": PositionStatus(
-                qty=qty, notional_value=500.0, entry_price=50000.0, unrealized_pnl=0.0,
-                unrealized_pnl_pct=0.0, mark_price=50000.0, leverage=5,
-                margin_mode="isolated", liquidation_price=45000.0,
-            )}
-
-        with patch.object(env, "_wait_for_next_timestamp"):
-            mock_env_trader.get_status = MagicMock(return_value=pos(0.01))      # LONG
-            env.reset()
-            long = TensorDict({"action": torch.tensor(len(env.action_levels) - 1)}, batch_size=())
-
-            for _ in range(5):
-                td = env.step(long)
-            aged = td["next"]["account_state"][3].item()
-            assert aged > 1.0, f"the long should have aged, got {aged}"
-
-            # still long at sync time; short by the time we observe. A real flip.
-            mock_env_trader.get_status = MagicMock(side_effect=[pos(0.01)] + [pos(-0.01)] * 4)
-            td = env.step(TensorDict({"action": torch.tensor(0)}, batch_size=()))
-
-        holding_time = td["next"]["account_state"][3].item()
-        assert holding_time == 1.0, (
-            f"a one-step-old short is reported as {holding_time} bars old (the long's age was "
-            f"{aged}) -- the flip never passed through flat, so the counter was never reset"
+        from tests.envs.base_exchange_tests import (
+            assert_a_direct_flip_does_not_age_the_new_position as assert_flip,
         )
+        assert_flip(env, mock_env_trader, PositionStatus,
+                    long_action=len(env.action_levels) - 1, short_action=0)
 
     def test_dust_between_positions_does_not_age_the_next_one(self, env, mock_env_trader):
         """A residual left between two positions must not carry the old age into the new one.

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -274,3 +274,38 @@ def test_holding_time_resets_on_a_direct_flip(directions, expected, why):
     assert got == [float(e) for e in expected], why
 
 
+@pytest.mark.parametrize(
+    "path", sorted(pathlib.Path("torchtrade/envs/live").rglob("*.py")), ids=str
+)
+def test_only_the_shared_rule_ages_a_position(path):
+    """Nothing may age a position except advance_hold_counter().
+
+    This bug shipped FIVE times -- once per exchange, in two spellings -- because no guard
+    existed. But the first version of this guard was theatre: a substring search for
+    "hold_counter += 1" over a hand-listed set of paths, so it missed both
+    `hold_counter = hold_counter + 1` AND any exchange added later.
+
+    This one walks the AST and auto-discovers the files, so neither escape works. Plain
+    `hold_counter = 0` resets are still allowed -- they are how a flat position and a new
+    episode are expressed; what is banned is anything DERIVING a new age.
+    """
+    tree = ast.parse(path.read_text())
+
+    offenders = []
+    for node in ast.walk(tree):
+        target, value = None, None
+        if isinstance(node, ast.AugAssign):                  # hold_counter += 1
+            target, value = node.target, node.value
+        elif isinstance(node, ast.Assign) and len(node.targets) == 1:
+            target, value = node.targets[0], node.value      # hold_counter = <anything>
+        if not (isinstance(target, ast.Attribute) and target.attr == "hold_counter"):
+            continue
+        # a literal reset to 0 is the one legal write
+        if isinstance(node, ast.Assign) and isinstance(value, ast.Constant) and value.value == 0:
+            continue
+        offenders.append(f"line {node.lineno}: {ast.unparse(node)}")
+
+    assert not offenders, (
+        f"{path} ages the position itself instead of calling advance_hold_counter():\n  "
+        + "\n  ".join(offenders)
+    )

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -16,7 +16,7 @@ import pytest
 import torchtrade.envs  # noqa: F401  -- registers every live env as a subclass
 from torchtrade.envs.core.live import TorchTradeLiveEnv
 from torchtrade.envs.utils.sltp_mixin import SLTPMixin
-from torchtrade.envs.core.state import PositionState
+from torchtrade.envs.core.state import PositionState, advance_hold_counter
 
 
 def _subclasses(cls):
@@ -245,3 +245,46 @@ def test_sync_action_level_after_reset(current_position, expected_level):
         assert math.isnan(env.position.current_action_level)
     else:
         assert env.position.current_action_level == expected_level
+
+
+# --- holding_time on a direct flip (#44) ------------------------------------- #
+
+@pytest.mark.parametrize("directions,expected,why", [
+    ([1, 1, 1],            [1, 2, 3], "a held position ages"),
+    ([1, 1, -1],           [1, 2, 1], "a DIRECT FLIP is a brand-new position, not a 3-bar-old one"),
+    ([-1, -1, 1],          [1, 2, 1], "and the same the other way round"),
+    ([1, 1, 0, 1],         [1, 2, 0, 1], "flat resets; the re-entry starts over"),
+    ([1, -1, 1, -1],       [1, 1, 1, 1], "every flip is a new position"),
+], ids=["held", "flip-long-to-short", "flip-short-to-long", "via-flat", "repeated-flips"])
+def test_holding_time_resets_on_a_direct_flip(directions, expected, why):
+    """holding_time is account_state[3] -- the policy conditions on it directly.
+
+    Every live env hand-rolled the rule as "increment while a position exists, reset when
+    flat", in two different spellings. A direct long->short flip never passes through flat, so
+    the reset never fired: the counter just kept climbing and a ONE-STEP-OLD short reported
+    itself as (say) 6 bars old. A hold-time-aware policy would read a position it had just
+    opened as one it had been sitting in for six bars.
+
+    Reachable with the DEFAULT config on every futures env -- the default action levels span
+    -1..+1, so +1 -> -1 is an ordinary single action.
+    """
+    position = PositionState()
+    got = [advance_hold_counter(position, d) for d in directions]
+    assert got == [float(e) for e in expected], why
+
+
+@pytest.mark.parametrize("env_cls", NON_SLTP_ENVS, ids=lambda c: c.__name__)
+def test_no_live_env_hand_rolls_the_holding_time_rule(env_cls):
+    """Structural guard: the rule lives in ONE place.
+
+    It was hand-rolled in two idioms across four exchanges, and all of them had the same hole.
+    A re-forked copy that has not drifted YET is still a bug waiting to happen -- this repo has
+    paid for that with three divergent SLTP action maps and four copies of _check_termination.
+    """
+    import inspect
+    src = inspect.getsource(inspect.getmodule(env_cls))
+    # the reset in _reset() is fine; what is banned is re-deriving the AGE of a position
+    assert "hold_counter += 1" not in src, (
+        f"{env_cls.__name__} increments hold_counter itself instead of calling "
+        f"advance_hold_counter() -- which is how the direct-flip hole got in, four times."
+    )

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -7,6 +7,7 @@ guard fails and tells you to test that exchange separately.
 """
 
 import ast
+import pathlib
 import inspect
 import math
 from types import SimpleNamespace
@@ -273,18 +274,29 @@ def test_holding_time_resets_on_a_direct_flip(directions, expected, why):
     assert got == [float(e) for e in expected], why
 
 
-@pytest.mark.parametrize("env_cls", NON_SLTP_ENVS, ids=lambda c: c.__name__)
-def test_no_live_env_hand_rolls_the_holding_time_rule(env_cls):
+@pytest.mark.parametrize("module", [
+    f"torchtrade/envs/live/{ex}/{mod}.py"
+    for ex in ("alpaca", "binance", "bitget", "bybit", "okx")
+    for mod in ("env", "env_sltp", "base")
+])
+def test_no_live_env_hand_rolls_the_holding_time_rule(module):
     """Structural guard: the rule lives in ONE place.
 
-    It was hand-rolled in two idioms across four exchanges, and all of them had the same hole.
+    It was hand-rolled in two idioms across five exchanges, and every copy had the same hole.
     A re-forked copy that has not drifted YET is still a bug waiting to happen -- this repo has
     paid for that with three divergent SLTP action maps and four copies of _check_termination.
+
+    Scans base.py AND env_sltp.py, not just env.py. The first version of this guard scanned
+    only the `.env` modules -- which is where the rule lives for alpaca/binance and NOWHERE
+    ELSE. bitget/bybit/okx keep it in base.py, and the SLTP variants in env_sltp.py, so 5 of
+    the 7 places it lives were unscanned: the guard was green while the files that HAD the bug
+    were never looked at. A guard that green-lights the buggy files is worse than no guard.
     """
-    import inspect
-    src = inspect.getsource(inspect.getmodule(env_cls))
-    # the reset in _reset() is fine; what is banned is re-deriving the AGE of a position
+    path = pathlib.Path(module)
+    assert path.exists(), f"{module} vanished -- this guard must not silently stop scanning"
+
+    src = path.read_text()
     assert "hold_counter += 1" not in src, (
-        f"{env_cls.__name__} increments hold_counter itself instead of calling "
-        f"advance_hold_counter() -- which is how the direct-flip hole got in, four times."
+        f"{module} ages the position itself instead of calling advance_hold_counter(). "
+        f"That is how the direct-flip hole got in -- five times, in two spellings."
     )

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -274,29 +274,3 @@ def test_holding_time_resets_on_a_direct_flip(directions, expected, why):
     assert got == [float(e) for e in expected], why
 
 
-@pytest.mark.parametrize("module", [
-    f"torchtrade/envs/live/{ex}/{mod}.py"
-    for ex in ("alpaca", "binance", "bitget", "bybit", "okx")
-    for mod in ("env", "env_sltp", "base")
-])
-def test_no_live_env_hand_rolls_the_holding_time_rule(module):
-    """Structural guard: the rule lives in ONE place.
-
-    It was hand-rolled in two idioms across five exchanges, and every copy had the same hole.
-    A re-forked copy that has not drifted YET is still a bug waiting to happen -- this repo has
-    paid for that with three divergent SLTP action maps and four copies of _check_termination.
-
-    Scans base.py AND env_sltp.py, not just env.py. The first version of this guard scanned
-    only the `.env` modules -- which is where the rule lives for alpaca/binance and NOWHERE
-    ELSE. bitget/bybit/okx keep it in base.py, and the SLTP variants in env_sltp.py, so 5 of
-    the 7 places it lives were unscanned: the guard was green while the files that HAD the bug
-    were never looked at. A guard that green-lights the buggy files is worse than no guard.
-    """
-    path = pathlib.Path(module)
-    assert path.exists(), f"{module} vanished -- this guard must not silently stop scanning"
-
-    src = path.read_text()
-    assert "hold_counter += 1" not in src, (
-        f"{module} ages the position itself instead of calling advance_hold_counter(). "
-        f"That is how the direct-flip hole got in -- five times, in two spellings."
-    )

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -250,30 +250,6 @@ def test_sync_action_level_after_reset(current_position, expected_level):
 
 # --- holding_time on a direct flip (#44) ------------------------------------- #
 
-@pytest.mark.parametrize("directions,expected,why", [
-    ([1, 1, 1],            [1, 2, 3], "a held position ages"),
-    ([1, 1, -1],           [1, 2, 1], "a DIRECT FLIP is a brand-new position, not a 3-bar-old one"),
-    ([-1, -1, 1],          [1, 2, 1], "and the same the other way round"),
-    ([1, 1, 0, 1],         [1, 2, 0, 1], "flat resets; the re-entry starts over"),
-    ([1, -1, 1, -1],       [1, 1, 1, 1], "every flip is a new position"),
-], ids=["held", "flip-long-to-short", "flip-short-to-long", "via-flat", "repeated-flips"])
-def test_holding_time_resets_on_a_direct_flip(directions, expected, why):
-    """holding_time is account_state[3] -- the policy conditions on it directly.
-
-    Every live env hand-rolled the rule as "increment while a position exists, reset when
-    flat", in two different spellings. A direct long->short flip never passes through flat, so
-    the reset never fired: the counter just kept climbing and a ONE-STEP-OLD short reported
-    itself as (say) 6 bars old. A hold-time-aware policy would read a position it had just
-    opened as one it had been sitting in for six bars.
-
-    Reachable with the DEFAULT config on every futures env -- the default action levels span
-    -1..+1, so +1 -> -1 is an ordinary single action.
-    """
-    position = PositionState()
-    got = [advance_hold_counter(position, d) for d in directions]
-    assert got == [float(e) for e in expected], why
-
-
 @pytest.mark.parametrize(
     "path", sorted(pathlib.Path("torchtrade/envs/live").rglob("*.py")), ids=str
 )

--- a/torchtrade/envs/core/state.py
+++ b/torchtrade/envs/core/state.py
@@ -64,6 +64,8 @@ class PositionState:
         entry_price: Price at which the position was entered
         unrealized_pnlpc: Unrealized profit/loss as percentage of entry price
         hold_counter: Number of steps the position has been held
+        hold_direction: The direction hold_counter is counting, so a direct flip
+            (long -> short, never passing through flat) can be told apart from a hold
     """
     current_position: float = 0.0
     position_size: float = 0.0
@@ -74,7 +76,7 @@ class PositionState:
     # The direction the hold_counter is currently counting. Without it, a DIRECT
     # FLIP (long -> short in one step, never passing through flat) leaves the
     # counter running, and the brand-new position reports the old one's age.
-    hold_direction: int = 0
+    hold_direction: float = 0.0
     current_action_level: float = 0.0
 
     def reset(self):
@@ -167,7 +169,7 @@ class HistoryTracker:
         return len(self.base_prices)
 
 
-def advance_hold_counter(position: PositionState, direction: int) -> float:
+def advance_hold_counter(position: PositionState, direction: float) -> float:
     """Age the CURRENT position by one step, and return it as holding_time.
 
     THE rule for holding_time. Every live env hand-rolled it as "increment while a position
@@ -185,8 +187,11 @@ def advance_hold_counter(position: PositionState, direction: int) -> float:
     read a position it just opened as one it had been sitting in for six bars.
 
     Reachable with the DEFAULT config on every futures env: the default action levels span
-    -1..+1, so +1 -> -1 in one step is an ordinary action. Spot (Alpaca) cannot flip and is
-    unaffected.
+    -1..+1, so +1 -> -1 in one step is an ordinary action, not an exotic path.
+
+    Alpaca is unaffected because it never RECORDS a short direction (its _step only ever
+    writes 0 or +1) -- not because the config forbids one: action_levels is an unvalidated
+    field, so 'the levels are long-only' is a default, not a constraint.
     """
     if direction == 0:
         position.hold_counter = 0

--- a/torchtrade/envs/core/state.py
+++ b/torchtrade/envs/core/state.py
@@ -71,6 +71,10 @@ class PositionState:
     entry_price: float = 0.0
     unrealized_pnlpc: float = 0.0
     hold_counter: int = 0
+    # The direction the hold_counter is currently counting. Without it, a DIRECT
+    # FLIP (long -> short in one step, never passing through flat) leaves the
+    # counter running, and the brand-new position reports the old one's age.
+    hold_direction: int = 0
     current_action_level: float = 0.0
 
     def reset(self):
@@ -161,3 +165,35 @@ class HistoryTracker:
             Number of steps in the history
         """
         return len(self.base_prices)
+
+
+def advance_hold_counter(position: PositionState, direction: int) -> float:
+    """Age the CURRENT position by one step, and return it as holding_time.
+
+    THE rule for holding_time. Every live env hand-rolled it as "increment while a position
+    exists, reset when flat", in two different spellings -- and all of them missed the third
+    case:
+
+        flat -> long    : a new position     -> 1
+        long -> long    : the same position  -> 2, 3, 4, ...
+        long -> SHORT   : a NEW position     -> 1        <-- every env reported the old age
+        short -> flat   : no position        -> 0
+
+    A direct flip never passes through flat, so "reset when flat" never fires: the counter just
+    kept climbing, and a one-step-old short reported itself as (say) 6 bars old. holding_time is
+    account_state[3] -- the policy conditions on it directly, and a hold-time-aware policy would
+    read a position it just opened as one it had been sitting in for six bars.
+
+    Reachable with the DEFAULT config on every futures env: the default action levels span
+    -1..+1, so +1 -> -1 in one step is an ordinary action. Spot (Alpaca) cannot flip and is
+    unaffected.
+    """
+    if direction == 0:
+        position.hold_counter = 0
+    elif direction != position.hold_direction:
+        position.hold_counter = 1      # brand-new position: 1 step old, exactly like a fresh open
+    else:
+        position.hold_counter += 1
+
+    position.hold_direction = direction
+    return float(position.hold_counter)

--- a/torchtrade/envs/core/state.py
+++ b/torchtrade/envs/core/state.py
@@ -73,9 +73,6 @@ class PositionState:
     entry_price: float = 0.0
     unrealized_pnlpc: float = 0.0
     hold_counter: int = 0
-    # The direction the hold_counter is currently counting. Without it, a DIRECT
-    # FLIP (long -> short in one step, never passing through flat) leaves the
-    # counter running, and the brand-new position reports the old one's age.
     hold_direction: float = 0.0
     current_action_level: float = 0.0
 
@@ -170,33 +167,21 @@ class HistoryTracker:
 
 
 def advance_hold_counter(position: PositionState, direction: float) -> float:
-    """Age the CURRENT position by one step, and return it as holding_time.
+    """Age the CURRENT position by one step and return it as holding_time.
 
-    THE rule for holding_time. Every live env hand-rolled it as "increment while a position
-    exists, reset when flat", in two different spellings -- and all of them missed the third
-    case:
+        flat  -> long   a new position     -> 1
+        long  -> long   the same position  -> 2, 3, 4, ...
+        long  -> SHORT  a NEW position     -> 1     <-- a DIRECT flip, no flat bar between
+        short -> flat   no position        -> 0
 
-        flat -> long    : a new position     -> 1
-        long -> long    : the same position  -> 2, 3, 4, ...
-        long -> SHORT   : a NEW position     -> 1        <-- every env reported the old age
-        short -> flat   : no position        -> 0
-
-    A direct flip never passes through flat, so "reset when flat" never fires: the counter just
-    kept climbing, and a one-step-old short reported itself as (say) 6 bars old. holding_time is
-    account_state[3] -- the policy conditions on it directly, and a hold-time-aware policy would
-    read a position it just opened as one it had been sitting in for six bars.
-
-    Reachable with the DEFAULT config on every futures env: the default action levels span
-    -1..+1, so +1 -> -1 in one step is an ordinary action, not an exotic path.
-
-    Alpaca is unaffected because it never RECORDS a short direction (its _step only ever
-    writes 0 or +1) -- not because the config forbids one: action_levels is an unvalidated
-    field, so 'the levels are long-only' is a default, not a constraint.
+    Every live env hand-rolled this as "increment while a position exists, reset when flat". A
+    direct flip never passes through flat, so the reset never fired and a one-step-old short
+    reported the dead long's age as account_state[3] -- which the policy conditions on.
     """
     if direction == 0:
         position.hold_counter = 0
     elif direction != position.hold_direction:
-        position.hold_counter = 1      # brand-new position: 1 step old, exactly like a fresh open
+        position.hold_counter = 1
     else:
         position.hold_counter += 1
 

--- a/torchtrade/envs/core/state.py
+++ b/torchtrade/envs/core/state.py
@@ -174,7 +174,8 @@ def advance_hold_counter(position: PositionState, direction: float) -> float:
         long  -> SHORT  a NEW position     -> 1     <-- a DIRECT flip, no flat bar between
         short -> flat   no position        -> 0
 
-    Every live env hand-rolled this as "increment while a position exists, reset when flat". A
+    The five live envs that track holding_time each hand-rolled this as "increment while a
+    position exists, reset when flat". A
     direct flip never passes through flat, so the reset never fired and a one-step-old short
     reported the dead long's age as account_state[3] -- which the policy conditions on.
     """

--- a/torchtrade/envs/live/alpaca/env.py
+++ b/torchtrade/envs/live/alpaca/env.py
@@ -5,6 +5,7 @@ import logging
 import torch
 
 logger = logging.getLogger(__name__)
+from torchtrade.envs.core.state import advance_hold_counter
 from torchtrade.envs.utils.timeframe import TimeFrame, TimeFrameUnit
 from torchtrade.envs.live.alpaca.utils import normalize_alpaca_timeframe_config
 from torchtrade.envs.live.alpaca.observation import AlpacaObservationClass
@@ -129,10 +130,9 @@ class AlpacaTorchTradingEnv(AlpacaBaseTorchTradingEnv):
         self._wait_for_next_timestamp()
 
         # Update position hold counter
-        if self.position.current_position != 0:
-            self.position.hold_counter += 1
-        else:
-            self.position.hold_counter = 0
+        # The shared rule. Spot cannot flip (levels are long-only), so this is behaviourally
+        # identical here -- but one rule with no exceptions is how it STAYS identical.
+        advance_hold_counter(self.position, int(self.position.current_position))
 
         # Get updated state
         new_portfolio_value = self._get_portfolio_value()

--- a/torchtrade/envs/live/alpaca/env.py
+++ b/torchtrade/envs/live/alpaca/env.py
@@ -130,9 +130,7 @@ class AlpacaTorchTradingEnv(AlpacaBaseTorchTradingEnv):
         self._wait_for_next_timestamp()
 
         # Update position hold counter
-        # The shared rule. Spot cannot flip (levels are long-only), so this is behaviourally
-        # identical here -- but one rule with no exceptions is how it STAYS identical.
-        advance_hold_counter(self.position, int(self.position.current_position))
+        advance_hold_counter(self.position, self.position.current_position)
 
         # Get updated state
         new_portfolio_value = self._get_portfolio_value()

--- a/torchtrade/envs/live/alpaca/env_sltp.py
+++ b/torchtrade/envs/live/alpaca/env_sltp.py
@@ -5,6 +5,7 @@ import logging
 import torch
 
 logger = logging.getLogger(__name__)
+from torchtrade.envs.core.state import advance_hold_counter
 from torchtrade.envs.utils.timeframe import TimeFrame, TimeFrameUnit
 from torchtrade.envs.live.alpaca.utils import normalize_alpaca_timeframe_config
 from torchtrade.envs.live.alpaca.observation import AlpacaObservationClass
@@ -162,10 +163,9 @@ class AlpacaSLTPTorchTradingEnv(SLTPMixin, AlpacaBaseTorchTradingEnv):
         self._wait_for_next_timestamp()
 
         # Update position hold counter
-        if self.position.current_position != 0:
-            self.position.hold_counter += 1
-        else:
-            self.position.hold_counter = 0
+        # The shared rule. Spot cannot flip (levels are long-only), so this is behaviourally
+        # identical here -- but one rule with no exceptions is how it STAYS identical.
+        advance_hold_counter(self.position, int(self.position.current_position))
 
         # Get updated state
         new_portfolio_value = self._get_portfolio_value()

--- a/torchtrade/envs/live/alpaca/env_sltp.py
+++ b/torchtrade/envs/live/alpaca/env_sltp.py
@@ -163,9 +163,7 @@ class AlpacaSLTPTorchTradingEnv(SLTPMixin, AlpacaBaseTorchTradingEnv):
         self._wait_for_next_timestamp()
 
         # Update position hold counter
-        # The shared rule. Spot cannot flip (levels are long-only), so this is behaviourally
-        # identical here -- but one rule with no exceptions is how it STAYS identical.
-        advance_hold_counter(self.position, int(self.position.current_position))
+        advance_hold_counter(self.position, self.position.current_position)
 
         # Get updated state
         new_portfolio_value = self._get_portfolio_value()

--- a/torchtrade/envs/live/binance/base.py
+++ b/torchtrade/envs/live/binance/base.py
@@ -311,6 +311,9 @@ class BinanceBaseTorchTradingEnv(TorchTradeLiveEnv):
         status = self.trader.get_status()
         position_status = status.get("position_status")
         self.position.hold_counter = 0
+        # ...and the direction it was counting, or the first step of the next episode
+        # compares against a dead episode's position.
+        self.position.hold_direction = 0
 
         self.position.current_position = position_direction_from_status(position_status)
 

--- a/torchtrade/envs/live/binance/base.py
+++ b/torchtrade/envs/live/binance/base.py
@@ -311,9 +311,6 @@ class BinanceBaseTorchTradingEnv(TorchTradeLiveEnv):
         status = self.trader.get_status()
         position_status = status.get("position_status")
         self.position.hold_counter = 0
-        # ...and the direction it was counting, or the first step of the next episode
-        # compares against a dead episode's position.
-        self.position.hold_direction = 0
 
         self.position.current_position = position_direction_from_status(position_status)
 

--- a/torchtrade/envs/live/binance/env.py
+++ b/torchtrade/envs/live/binance/env.py
@@ -184,9 +184,7 @@ class BinanceFuturesTorchTradingEnv(BinanceBaseTorchTradingEnv):
         self._wait_for_next_timestamp()
 
         # Update position hold counter
-        # THE holding_time rule -- "reset when flat" never fires on a direct long->short
-        # flip, so the brand-new position inherited the dead one's age. See core/state.py.
-        advance_hold_counter(self.position, int(self.position.current_position))
+        advance_hold_counter(self.position, self.position.current_position)
 
         # Get updated state
         new_portfolio_value = self._get_portfolio_value()

--- a/torchtrade/envs/live/binance/env.py
+++ b/torchtrade/envs/live/binance/env.py
@@ -8,6 +8,7 @@ logger = logging.getLogger(__name__)
 from tensordict import TensorDict, TensorDictBase
 from torchrl.data import Categorical
 
+from torchtrade.envs.core.state import advance_hold_counter
 from torchtrade.envs.utils.timeframe import TimeFrame
 from torchtrade.envs.live.binance.observation import BinanceObservationClass
 from torchtrade.envs.live.binance.order_executor import (
@@ -183,10 +184,9 @@ class BinanceFuturesTorchTradingEnv(BinanceBaseTorchTradingEnv):
         self._wait_for_next_timestamp()
 
         # Update position hold counter
-        if self.position.current_position != 0:
-            self.position.hold_counter += 1
-        else:
-            self.position.hold_counter = 0
+        # THE holding_time rule -- "reset when flat" never fires on a direct long->short
+        # flip, so the brand-new position inherited the dead one's age. See core/state.py.
+        advance_hold_counter(self.position, int(self.position.current_position))
 
         # Get updated state
         new_portfolio_value = self._get_portfolio_value()

--- a/torchtrade/envs/live/binance/env_sltp.py
+++ b/torchtrade/envs/live/binance/env_sltp.py
@@ -208,9 +208,7 @@ class BinanceFuturesSLTPTorchTradingEnv(SLTPMixin, BinanceBaseTorchTradingEnv):
         self._wait_for_next_timestamp()
 
         # Update position hold counter
-        # THE holding_time rule -- "reset when flat" never fires on a direct long->short
-        # flip, so the brand-new position inherited the dead one's age. See core/state.py.
-        advance_hold_counter(self.position, int(self.position.current_position))
+        advance_hold_counter(self.position, self.position.current_position)
 
         # Get updated state
         new_portfolio_value = self._get_portfolio_value()

--- a/torchtrade/envs/live/binance/env_sltp.py
+++ b/torchtrade/envs/live/binance/env_sltp.py
@@ -8,6 +8,7 @@ logger = logging.getLogger(__name__)
 from tensordict import TensorDictBase
 from torchrl.data import Categorical
 
+from torchtrade.envs.core.state import advance_hold_counter
 from torchtrade.envs.utils.timeframe import TimeFrame
 from torchtrade.envs.live.binance.observation import BinanceObservationClass
 from torchtrade.envs.live.binance.order_executor import (
@@ -207,10 +208,9 @@ class BinanceFuturesSLTPTorchTradingEnv(SLTPMixin, BinanceBaseTorchTradingEnv):
         self._wait_for_next_timestamp()
 
         # Update position hold counter
-        if self.position.current_position != 0:
-            self.position.hold_counter += 1
-        else:
-            self.position.hold_counter = 0
+        # THE holding_time rule -- "reset when flat" never fires on a direct long->short
+        # flip, so the brand-new position inherited the dead one's age. See core/state.py.
+        advance_hold_counter(self.position, int(self.position.current_position))
 
         # Get updated state
         new_portfolio_value = self._get_portfolio_value()

--- a/torchtrade/envs/live/bitget/base.py
+++ b/torchtrade/envs/live/bitget/base.py
@@ -332,9 +332,6 @@ class BitgetBaseTorchTradingEnv(TorchTradeLiveEnv):
         status = self.trader.get_status()
         position_status = status.get("position_status")
         self.position.hold_counter = 0
-        # ...and the direction it was counting, or the first step of the next episode
-        # compares against a dead episode's position.
-        self.position.hold_direction = 0
 
         self.position.current_position = position_direction_from_status(position_status)
 

--- a/torchtrade/envs/live/bitget/base.py
+++ b/torchtrade/envs/live/bitget/base.py
@@ -13,6 +13,7 @@ from torchtrade.envs.live.bitget.observation import BitgetObservationClass
 from torchtrade.envs.live.bitget.order_executor import BitgetFuturesOrderClass
 from torchtrade.envs.core.live import TorchTradeLiveEnv
 from torchtrade.envs.core.state import (
+    advance_hold_counter,
     HistoryTracker,
     PositionState,
     position_direction_from_status,
@@ -230,8 +231,12 @@ class BitgetBaseTorchTradingEnv(TorchTradeLiveEnv):
         # Dust is not a position: gating on `is None` let a 1e-12 residual left behind a
         # close take the position branch and read stale fields off it.
         position_direction = float(position_direction_from_status(position_status))
+        # THE holding_time rule. Hand-rolling it as "reset when flat" missed the direct
+        # flip: long -> short never passes through flat, so the counter kept climbing and a
+        # brand-new short reported the dead long's age. See core/state.py.
+        holding_time = advance_hold_counter(self.position, position_direction)
+
         if position_direction == 0:
-            self.position.hold_counter = 0
             position_size = 0.0
             position_value = 0.0
             entry_price = 0.0
@@ -239,9 +244,7 @@ class BitgetBaseTorchTradingEnv(TorchTradeLiveEnv):
             unrealized_pnl_pct = 0.0
             leverage = float(self.config.leverage)
             liquidation_price = 0.0
-            holding_time = 0.0
         else:
-            self.position.hold_counter += 1
             position_size = position_status.qty  # Positive=long, Negative=short
             position_value = abs(position_status.notional_value)
             entry_price = position_status.entry_price
@@ -249,7 +252,6 @@ class BitgetBaseTorchTradingEnv(TorchTradeLiveEnv):
             unrealized_pnl_pct = position_status.unrealized_pnl_pct
             leverage = float(position_status.leverage)
             liquidation_price = position_status.liquidation_price
-            holding_time = float(self.position.hold_counter)
 
         # Calculate new 6-element account state
         # Element 0: exposure_pct (position_value / portfolio_value)
@@ -330,6 +332,9 @@ class BitgetBaseTorchTradingEnv(TorchTradeLiveEnv):
         status = self.trader.get_status()
         position_status = status.get("position_status")
         self.position.hold_counter = 0
+        # ...and the direction it was counting, or the first step of the next episode
+        # compares against a dead episode's position.
+        self.position.hold_direction = 0
 
         self.position.current_position = position_direction_from_status(position_status)
 

--- a/torchtrade/envs/live/bitget/base.py
+++ b/torchtrade/envs/live/bitget/base.py
@@ -231,9 +231,6 @@ class BitgetBaseTorchTradingEnv(TorchTradeLiveEnv):
         # Dust is not a position: gating on `is None` let a 1e-12 residual left behind a
         # close take the position branch and read stale fields off it.
         position_direction = float(position_direction_from_status(position_status))
-        # THE holding_time rule. Hand-rolling it as "reset when flat" missed the direct
-        # flip: long -> short never passes through flat, so the counter kept climbing and a
-        # brand-new short reported the dead long's age. See core/state.py.
         holding_time = advance_hold_counter(self.position, position_direction)
 
         if position_direction == 0:

--- a/torchtrade/envs/live/bybit/base.py
+++ b/torchtrade/envs/live/bybit/base.py
@@ -13,6 +13,7 @@ from torchtrade.envs.live.bybit.observation import BybitObservationClass
 from torchtrade.envs.live.bybit.order_executor import BybitFuturesOrderClass
 from torchtrade.envs.core.live import TorchTradeLiveEnv
 from torchtrade.envs.core.state import (
+    advance_hold_counter,
     HistoryTracker,
     position_direction_from_status,
 )
@@ -189,24 +190,25 @@ class BybitBaseTorchTradingEnv(TorchTradeLiveEnv):
         # Dust is not a position: gating on `is None` let a 1e-12 residual left behind a
         # close take the position branch and read stale fields off it.
         position_direction = float(position_direction_from_status(position_status))
+        # THE holding_time rule. Hand-rolling it as "reset when flat" missed the direct
+        # flip: long -> short never passes through flat, so the counter kept climbing and a
+        # brand-new short reported the dead long's age. See core/state.py.
+        holding_time = advance_hold_counter(self.position, position_direction)
+
         if position_direction == 0:
-            self.position.hold_counter = 0
             position_size = 0.0
             position_value = 0.0
             current_price = self.trader.get_mark_price()
             unrealized_pnl_pct = 0.0
             leverage = float(self.config.leverage)
             liquidation_price = 0.0
-            holding_time = 0.0
         else:
-            self.position.hold_counter += 1
             position_size = position_status.qty
             position_value = abs(position_status.notional_value)
             current_price = position_status.mark_price
             unrealized_pnl_pct = position_status.unrealized_pnl_pct
             leverage = float(position_status.leverage)
             liquidation_price = position_status.liquidation_price
-            holding_time = float(self.position.hold_counter)
 
         # Build 6-element account state
         exposure_pct = position_value / total_balance if total_balance > 0 else 0.0
@@ -263,6 +265,9 @@ class BybitBaseTorchTradingEnv(TorchTradeLiveEnv):
         status = self.trader.get_status()
         position_status = status.get("position_status")
         self.position.hold_counter = 0
+        # ...and the direction it was counting, or the first step of the next episode
+        # compares against a dead episode's position.
+        self.position.hold_direction = 0
 
         self.position.current_position = position_direction_from_status(position_status)
 

--- a/torchtrade/envs/live/bybit/base.py
+++ b/torchtrade/envs/live/bybit/base.py
@@ -265,9 +265,6 @@ class BybitBaseTorchTradingEnv(TorchTradeLiveEnv):
         status = self.trader.get_status()
         position_status = status.get("position_status")
         self.position.hold_counter = 0
-        # ...and the direction it was counting, or the first step of the next episode
-        # compares against a dead episode's position.
-        self.position.hold_direction = 0
 
         self.position.current_position = position_direction_from_status(position_status)
 

--- a/torchtrade/envs/live/bybit/base.py
+++ b/torchtrade/envs/live/bybit/base.py
@@ -190,9 +190,6 @@ class BybitBaseTorchTradingEnv(TorchTradeLiveEnv):
         # Dust is not a position: gating on `is None` let a 1e-12 residual left behind a
         # close take the position branch and read stale fields off it.
         position_direction = float(position_direction_from_status(position_status))
-        # THE holding_time rule. Hand-rolling it as "reset when flat" missed the direct
-        # flip: long -> short never passes through flat, so the counter kept climbing and a
-        # brand-new short reported the dead long's age. See core/state.py.
         holding_time = advance_hold_counter(self.position, position_direction)
 
         if position_direction == 0:

--- a/torchtrade/envs/live/okx/base.py
+++ b/torchtrade/envs/live/okx/base.py
@@ -275,9 +275,6 @@ class OKXBaseTorchTradingEnv(TorchTradeLiveEnv):
         status = self.trader.get_status()
         position_status = status.get("position_status")
         self.position.hold_counter = 0
-        # ...and the direction it was counting, or the first step of the next episode
-        # compares against a dead episode's position.
-        self.position.hold_direction = 0
 
         self.position.current_position = position_direction_from_status(position_status)
 

--- a/torchtrade/envs/live/okx/base.py
+++ b/torchtrade/envs/live/okx/base.py
@@ -13,6 +13,7 @@ from torchtrade.envs.live.okx.observation import OKXObservationClass
 from torchtrade.envs.live.okx.order_executor import OKXFuturesOrderClass
 from torchtrade.envs.core.live import TorchTradeLiveEnv
 from torchtrade.envs.core.state import (
+    advance_hold_counter,
     HistoryTracker,
     position_direction_from_status,
 )
@@ -199,24 +200,25 @@ class OKXBaseTorchTradingEnv(TorchTradeLiveEnv):
         # Dust is not a position: gating on `is None` let a 1e-12 residual left behind a
         # close take the position branch and read stale fields off it.
         position_direction = float(position_direction_from_status(position_status))
+        # THE holding_time rule. Hand-rolling it as "reset when flat" missed the direct
+        # flip: long -> short never passes through flat, so the counter kept climbing and a
+        # brand-new short reported the dead long's age. See core/state.py.
+        holding_time = advance_hold_counter(self.position, position_direction)
+
         if position_direction == 0:
-            self.position.hold_counter = 0
             position_size = 0.0
             position_value = 0.0
             current_price = self.trader.get_mark_price()
             unrealized_pnl_pct = 0.0
             leverage = float(self.config.leverage)
             liquidation_price = 0.0
-            holding_time = 0.0
         else:
-            self.position.hold_counter += 1
             position_size = position_status.qty
             position_value = abs(position_status.notional_value)
             current_price = position_status.mark_price
             unrealized_pnl_pct = position_status.unrealized_pnl_pct
             leverage = float(position_status.leverage)
             liquidation_price = position_status.liquidation_price
-            holding_time = float(self.position.hold_counter)
 
         # Build 6-element account state
         exposure_pct = position_value / total_balance if total_balance > 0 else 0.0
@@ -273,6 +275,9 @@ class OKXBaseTorchTradingEnv(TorchTradeLiveEnv):
         status = self.trader.get_status()
         position_status = status.get("position_status")
         self.position.hold_counter = 0
+        # ...and the direction it was counting, or the first step of the next episode
+        # compares against a dead episode's position.
+        self.position.hold_direction = 0
 
         self.position.current_position = position_direction_from_status(position_status)
 

--- a/torchtrade/envs/live/okx/base.py
+++ b/torchtrade/envs/live/okx/base.py
@@ -200,9 +200,6 @@ class OKXBaseTorchTradingEnv(TorchTradeLiveEnv):
         # Dust is not a position: gating on `is None` let a 1e-12 residual left behind a
         # close take the position branch and read stale fields off it.
         position_direction = float(position_direction_from_status(position_status))
-        # THE holding_time rule. Hand-rolling it as "reset when flat" missed the direct
-        # flip: long -> short never passes through flat, so the counter kept climbing and a
-        # brand-new short reported the dead long's age. See core/state.py.
         holding_time = advance_hold_counter(self.position, position_direction)
 
         if position_direction == 0:


### PR DESCRIPTION
## The bug

Every live env reset `holding_time` **only when flat**:

```python
if position_direction == 0:
    hold_counter = 0
else:
    hold_counter += 1
```

A **direct flip never passes through flat**, so the reset never fires:

```
step 1-5   long     hold_counter → 1,2,3,4,5
step 6     SHORT    hold_counter → 6      ← a BRAND-NEW position, reported as 6 bars old
```

`holding_time` is **`account_state[3]`** — the policy conditions on it directly. A hold-time-aware policy reads a position it *just opened* as one it has been sitting in for six bars.

**Reachable with the default config.** Default action levels are `[-1, 0, 1]` (binance) and `[-1, -0.5, 0, 0.5, 1]` (bitget/bybit/okx), so `+1 → -1` in one step is an ordinary action, not an exotic path. Verified by running the counter, not by reading it.

Five exchanges, two different hand-rolled spellings, the same hole in all of them.

## The fix

One rule, in `core/state.py`:

| transition | holding_time |
|---|---|
| flat → long | 1 |
| long → long | 2, 3, 4, … |
| **long → SHORT** | **1** ← the case every env missed |
| → flat | 0 |

A fresh open still reports `1`, so the normal path is unchanged — the only behaviour that moves is the flip. `PositionState` gains `hold_direction` (the direction the counter is counting), which `_reset()` now clears too.

Alpaca is spot and **cannot** flip, so its rule was already correct — but it's converged onto the shared one anyway (proven behaviourally identical for long-only levels). An exception you have to remember is how drift starts; this repo has already paid for that with three divergent SLTP action maps and four copies of `_check_termination`. There's a structural guard banning `hold_counter += 1` outside the rule.

The **offline envs are unaffected**: they gate on `action_value == self._prev_action_value`, so a flip changes the action and falls through to the trade path, which resets the counter.

## The test I got wrong first, and why it matters

My first end-to-end test was **vacuous** — reverting the fix left it green.

`_step` calls `_sync_position_from_exchange` *before* the trade executes. Mocking the short for the whole step made the sync see `exchange(short) != cache(long)`, treat it as an **external** change, and reset the counter itself (PR #245's logic) — masking the bug entirely.

A real flip: at sync time the trade hasn't executed, so the exchange still shows the **old long**; only when `_get_observation` re-reads it does it show the short. Both tests now model that, and reverting the fix fails them:

- bybit — *"a one-step-old short is reported as 7.0 bars old"*
- binance — *"a one-step-old short is reported as 6.0 bars old"*

**Both** are tested because they use *different wirings* — binance advances from the env's **cached** direction, bybit/bitget/okx from the direction **observed** on the exchange. A unit test on the rule can't tell those apart; only an end-to-end assertion on `account_state[3]` can.

## Verification

- **2026 passing.**
- 5/5 unit mutations killed, plus both end-to-end wirings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)