### PR TITLE
fix(envs): unify holding_time (account_state[3]) across all environments (#49)

### DIFF
--- a/tests/envs/alpaca/test_torch_env.py
+++ b/tests/envs/alpaca/test_torch_env.py
@@ -353,8 +353,8 @@ class TestAlpacaTorchTradingEnvStep:
     def test_closing_a_position_does_not_age_the_next_one(self, env):
         """A closed position's age must not carry into the next one.
 
-        The alpaca/binance counterpart of dust_between_positions: these two manage
-        hold_counter in _step, not in the observation branch.
+        The alpaca/binance counterpart of dust_between_positions: all five live envs now age
+        hold_counter inside _get_observation() (once per _step, via advance_hold_counter).
         """
         buy = TensorDict({"action": torch.tensor(2)}, batch_size=())    # levels [0.0, 0.5, 1.0]
         flat = TensorDict({"action": torch.tensor(0)}, batch_size=())

--- a/tests/envs/alpaca/test_torch_env_sltp.py
+++ b/tests/envs/alpaca/test_torch_env_sltp.py
@@ -257,6 +257,18 @@ class TestAlpacaSLTPTradingEnvStep:
 
         assert env.position.current_position == 0
 
+    def test_holding_time_ages_from_one(self, env):
+        """holding_time reads 1 on the opening bar, then increments (#49).
+
+        alpaca is spot (no flip), so this open->hold->hold covers this SLTP env's
+        _step -> _get_observation(advance_hold=True) aging path directly."""
+        env.reset()
+        seq = []
+        for a in (1, 0, 0):  # open bracket, hold, hold
+            td = env._step(TensorDict({"action": torch.tensor(a)}, batch_size=()))
+            seq.append(td["account_state"][3].item())
+        assert seq == [1.0, 2.0, 3.0]
+
     def test_step_buy_with_sltp(self, env):
         """Test buy action with SL/TP (action > 0)."""
         env.reset()

--- a/tests/envs/binance/test_torch_env_futures.py
+++ b/tests/envs/binance/test_torch_env_futures.py
@@ -328,9 +328,9 @@ class TestBinanceFuturesTorchTradingEnv:
             aged = env.position.hold_counter
             td = env.reset()                         # position still open on the exchange
 
-        # 0 here, unlike bitget/bybit/okx: binance increments hold_counter in _step, not in
-        # _get_observation, so the reset observation does not count a bar. The bug either way
-        # is the previous episode's age surviving the reset.
+        # 0: _get_observation() only READS hold_counter now (advance_hold_counter runs exactly
+        # once per _step(), never from _reset(), which passes advance_hold=False), so a reset --
+        # even one that finds a position still open on the exchange -- never itself counts a bar.
         assert env.position.hold_counter == 0, f"reset carried {aged} bars into the new episode"
 
         # An OPEN position must look OPEN. Every other account_state assertion on this branch

--- a/tests/envs/bitget/test_torch_env_futures.py
+++ b/tests/envs/bitget/test_torch_env_futures.py
@@ -441,10 +441,12 @@ class TestBitgetFuturesTorchTradingEnv:
             aged = env.position.hold_counter
             td = env.reset()                         # position still open on the exchange
 
-        # 1, not 0: _reset zeroes the counter and then takes an observation, which legitimately
-        # counts the still-open position as bar ONE of the new episode. The bug is it reading
-        # `aged + 1` -- the previous episode's age carried across the reset.
-        assert env.position.hold_counter == 1, f"reset carried {aged} bars into the new episode"
+        # 0: _get_observation() only READS hold_counter now (advance_hold_counter is called
+        # exactly once per _step(), never from _reset()), so a reset -- even one that finds a
+        # position still open on the exchange -- never itself counts a bar. The bug this test
+        # used to pin was `_get_observation()` also advancing the counter when reset called it,
+        # which read `aged + 1` (or, coincidentally with hold_counter zeroed first, always 1).
+        assert env.position.hold_counter == 0, f"reset carried {aged} bars into the new episode"
 
         # An OPEN position must look OPEN. Every other account_state assertion on this branch
         # checks that a FLAT account reads flat; the inverse was unpinned here, so corrupting
@@ -457,7 +459,7 @@ class TestBitgetFuturesTorchTradingEnv:
         assert pnl == pytest.approx(0.0526)
         assert leverage == 20.0                       # the POSITION's, not the config's 5
         assert dist_to_liq == pytest.approx(0.1)      # (50000 - 45000) / 50000
-        assert holding_time == 1.0
+        assert holding_time == 0.0
 
     def test_reentry_after_external_close_starts_a_fresh_holding_time(self, env, mock_trader):
         """A re-entry made in the SAME step as an external close must not inherit its age.

--- a/tests/envs/bitget/test_torch_env_futures_sltp.py
+++ b/tests/envs/bitget/test_torch_env_futures_sltp.py
@@ -99,6 +99,17 @@ class TestBitgetFuturesSLTPTorchTradingEnv:
                 )
                 return env
 
+    def test_a_direct_flip_does_not_age_the_new_position(self, env, mock_trader):
+        """A long flipped straight to a short (never through flat) is one step old (#49).
+
+        Covers this SLTP env's _step -> _get_observation(advance_hold=True) aging path, which
+        is otherwise untested here."""
+        from torchtrade.envs.live.bitget.order_executor import PositionStatus
+        from tests.envs.base_exchange_tests import (
+            assert_a_direct_flip_does_not_age_the_new_position as assert_flip,
+        )
+        assert_flip(env, mock_trader, PositionStatus, long_action=1, short_action=5)
+
     def test_initialization(self, env):
         """Test environment initialization."""
         assert env.config.symbol == "BTCUSDT"

--- a/tests/envs/bybit/test_torch_env_futures.py
+++ b/tests/envs/bybit/test_torch_env_futures.py
@@ -273,10 +273,12 @@ class TestBybitFuturesTorchTradingEnv:
             aged = env.position.hold_counter
             td = env.reset()                         # position still open on the exchange
 
-        # 1, not 0: _reset zeroes the counter and then takes an observation, which legitimately
-        # counts the still-open position as bar ONE of the new episode. The bug is it reading
-        # `aged + 1` -- the previous episode's age carried across the reset.
-        assert env.position.hold_counter == 1, f"reset carried {aged} bars into the new episode"
+        # 0: _get_observation() only READS hold_counter now (advance_hold_counter is called
+        # exactly once per _step(), never from _reset()), so a reset -- even one that finds a
+        # position still open on the exchange -- never itself counts a bar. The bug this test
+        # used to pin was `_get_observation()` also advancing the counter when reset called it,
+        # which read `aged + 1` (or, coincidentally with hold_counter zeroed first, always 1).
+        assert env.position.hold_counter == 0, f"reset carried {aged} bars into the new episode"
 
         # An OPEN position must look OPEN. Every other account_state assertion on this branch
         # checks that a FLAT account reads flat; the inverse was unpinned here, so corrupting
@@ -289,7 +291,7 @@ class TestBybitFuturesTorchTradingEnv:
         assert pnl == pytest.approx(0.0526)
         assert leverage == 20.0                       # the POSITION's, not the config's 5
         assert dist_to_liq == pytest.approx(0.1)      # (50000 - 45000) / 50000
-        assert holding_time == 1.0
+        assert holding_time == 0.0
 
     def test_reentry_after_external_close_starts_a_fresh_holding_time(self, env, mock_trader):
         """A re-entry made in the SAME step as an external close must not inherit its age.

--- a/tests/envs/bybit/test_torch_env_futures_sltp.py
+++ b/tests/envs/bybit/test_torch_env_futures_sltp.py
@@ -42,6 +42,18 @@ class TestBybitFuturesSLTPTorchTradingEnv:
                     trader=mock_env_trader,
                 )
 
+    def test_a_direct_flip_does_not_age_the_new_position(self, env, mock_env_trader):
+        """A long flipped straight to a short (never through flat) is one step old (#49).
+
+        Covers this SLTP env's _step -> _get_observation(advance_hold=True) aging path, which
+        is otherwise untested here (the shared base._get_observation is exercised by the
+        non-SLTP futures file, but this env_sltp._step is not)."""
+        from torchtrade.envs.live.bybit.order_executor import PositionStatus
+        from tests.envs.base_exchange_tests import (
+            assert_a_direct_flip_does_not_age_the_new_position as assert_flip,
+        )
+        assert_flip(env, mock_env_trader, PositionStatus, long_action=1, short_action=5)
+
     def test_action_map_structure(self, env):
         """Test action map: 1 HOLD + 4 LONG (2x2) + 4 SHORT (2x2) = 9 actions."""
         assert len(env.action_map) == 9

--- a/tests/envs/offline/test_holding_time.py
+++ b/tests/envs/offline/test_holding_time.py
@@ -1,0 +1,94 @@
+"""holding_time (account_state[3]) is the SAME across every offline env — issue #49.
+
+The canonical rule (locked; see advance_hold_counter in core/state.py, which the live
+envs share):
+
+    flat            -> 0
+    the OPENING bar -> 1          <-- offline used to report 0 here; that was #49
+    each held bar   -> 2, 3, ...
+    on close        -> 0
+    a direct flip   -> 1          (new position, never passed through flat)
+
+This file is the regression guard for the OFFLINE half. The live half is already pinned by
+tests/envs/base_exchange_tests.py::assert_a_direct_flip_does_not_age_the_new_position (a fresh
+position reads 1, and ages past 1) plus the test_reset_clears_the_holding_time... test in each live exchange.
+The vectorized offline envs are covered transitively by test_vec_scalar_equivalence.py /
+test_vec_sltp_scalar_equivalence.py, which already assert vec holding_time == scalar
+holding_time step-for-step — so pinning the SCALAR sequence here fixes their expected value too.
+"""
+
+import pytest
+import torch
+
+from torchtrade.envs.offline import (
+    SequentialTradingEnv,
+    SequentialTradingEnvConfig,
+    SequentialTradingEnvSLTP,
+    SequentialTradingEnvSLTPConfig,
+)
+from torchtrade.envs.utils.timeframe import TimeFrame, TimeFrameUnit
+from tests.conftest import simple_feature_fn
+
+
+def _drive(env, actions):
+    """Step `env` through `actions`, returning [reset holding_time, *per-step holding_time]."""
+    td = env.reset()
+    seq = [td["account_state"][3].item()]
+    for a in actions:
+        td["action"] = torch.tensor(a)
+        td = env.step(td)["next"]
+        seq.append(td["account_state"][3].item())
+    return seq
+
+
+# action_levels index maps: spot [0,1] -> {flat:0, long:1}; futures [-1,0,1] -> {short:0, flat:1, long:2}
+@pytest.mark.parametrize("leverage,action_levels,actions,expected", [
+    # spot: open long, hold, hold, close
+    (1, [0, 1], [1, 1, 1, 0], [0, 1, 2, 3, 0]),
+    # futures: open long, hold, hold, close, open short (opposite), hold
+    (10, [-1, 0, 1], [2, 2, 2, 1, 0, 0], [0, 1, 2, 3, 0, 1, 2]),
+    # futures DIRECT flip: open long, hold, flip straight to short (no flat bar), hold
+    (10, [-1, 0, 1], [2, 2, 0, 0], [0, 1, 2, 1, 2]),
+])
+def test_sequential_holding_time_sequence(sample_ohlcv_df, leverage, action_levels, actions, expected):
+    """The opening bar reads 1, holds increment, close resets to 0, a reopen restarts at 1."""
+    config = SequentialTradingEnvConfig(
+        leverage=leverage,
+        action_levels=action_levels,
+        initial_cash=1000,
+        execute_on=TimeFrame(1, TimeFrameUnit.Minute),
+        time_frames=[TimeFrame(1, TimeFrameUnit.Minute)],
+        window_sizes=[10],
+        transaction_fee=0.0,
+        slippage=0.0,
+        random_start=False,
+    )
+    env = SequentialTradingEnv(sample_ohlcv_df, config, simple_feature_fn)
+    assert _drive(env, actions) == expected
+    env.close()
+
+
+@pytest.mark.parametrize("leverage", [1, 10], ids=["spot", "futures"])
+def test_sltp_holding_time_sequence(sample_ohlcv_df, leverage):
+    """SLTP env: opening a bracket reads 1 (was 0 pre-#49), then holds increment.
+
+    Wide SL/TP (-2% / +3%) against the ~0.1%/bar synthetic data guarantees the bracket does
+    NOT exit over these three bars, so the sequence is deterministic.
+    """
+    config = SequentialTradingEnvSLTPConfig(
+        leverage=leverage,
+        initial_cash=1000,
+        execute_on=TimeFrame(1, TimeFrameUnit.Minute),
+        time_frames=[TimeFrame(1, TimeFrameUnit.Minute)],
+        window_sizes=[10],
+        transaction_fee=0.0,
+        slippage=0.0,
+        random_start=False,
+        stoploss_levels=[-0.02],
+        takeprofit_levels=[0.03],
+    )
+    env = SequentialTradingEnvSLTP(sample_ohlcv_df, config, simple_feature_fn)
+    # action 1 = open the (only) SL/TP bracket; action 0 = hold
+    seq = _drive(env, [1, 0, 0])
+    assert seq == [0, 1, 2, 3]
+    env.close()

--- a/tests/envs/okx/test_torch_env_futures.py
+++ b/tests/envs/okx/test_torch_env_futures.py
@@ -221,10 +221,12 @@ class TestOKXFuturesTorchTradingEnv:
             aged = env.position.hold_counter
             td = env.reset()                         # position still open on the exchange
 
-        # 1, not 0: _reset zeroes the counter and then takes an observation, which legitimately
-        # counts the still-open position as bar ONE of the new episode. The bug is it reading
-        # `aged + 1` -- the previous episode's age carried across the reset.
-        assert env.position.hold_counter == 1, f"reset carried {aged} bars into the new episode"
+        # 0: _get_observation() only READS hold_counter now (advance_hold_counter is called
+        # exactly once per _step(), never from _reset()), so a reset -- even one that finds a
+        # position still open on the exchange -- never itself counts a bar. The bug this test
+        # used to pin was `_get_observation()` also advancing the counter when reset called it,
+        # which read `aged + 1` (or, coincidentally with hold_counter zeroed first, always 1).
+        assert env.position.hold_counter == 0, f"reset carried {aged} bars into the new episode"
 
         # An OPEN position must look OPEN. Every other account_state assertion on this branch
         # checks that a FLAT account reads flat; the inverse was unpinned here, so corrupting
@@ -237,7 +239,7 @@ class TestOKXFuturesTorchTradingEnv:
         assert pnl == pytest.approx(0.0526)
         assert leverage == 20.0                       # the POSITION's, not the config's 5
         assert dist_to_liq == pytest.approx(0.1)      # (50000 - 45000) / 50000
-        assert holding_time == 1.0
+        assert holding_time == 0.0
 
     def test_reentry_after_external_close_starts_a_fresh_holding_time(self, env, mock_env_trader):
         """A re-entry made in the SAME step as an external close must not inherit its age.

--- a/tests/envs/okx/test_torch_env_futures_sltp.py
+++ b/tests/envs/okx/test_torch_env_futures_sltp.py
@@ -29,6 +29,17 @@ class TestOKXFuturesSLTPTorchTradingEnv:
                 config=env_config, observer=mock_env_observer, trader=mock_env_trader,
             )
 
+    def test_a_direct_flip_does_not_age_the_new_position(self, env, mock_env_trader):
+        """A long flipped straight to a short (never through flat) is one step old (#49).
+
+        Covers this SLTP env's _step -> _get_observation(advance_hold=True) aging path, which
+        is otherwise untested here."""
+        from torchtrade.envs.live.okx.order_executor import PositionStatus
+        from tests.envs.base_exchange_tests import (
+            assert_a_direct_flip_does_not_age_the_new_position as assert_flip,
+        )
+        assert_flip(env, mock_env_trader, PositionStatus, long_action=1, short_action=5)
+
     def test_action_map_structure(self, env):
         """Test action map: 1 HOLD + 4 LONG (2x2) + 4 SHORT (2x2) = 9 actions."""
         assert len(env.action_map) == 9

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -250,9 +250,17 @@ def test_sync_action_level_after_reset(current_position, expected_level):
 
 # --- holding_time on a direct flip (#44) ------------------------------------- #
 
-@pytest.mark.parametrize(
-    "path", sorted(pathlib.Path("torchtrade/envs/live").rglob("*.py")), ids=str
-)
+# Every file that writes position.hold_counter must obey the two guards below. That is the
+# live envs, plus the shared live base (core/live.py) and the SLTP mixin (utils/sltp_mixin.py)
+# whose _sync_position_from_exchange methods legitimately reset it to 0 -- if those two drifted
+# to hand-rolled aging, the live-only rglob would never see it. (#49)
+_HOLD_COUNTER_FILES = sorted(pathlib.Path("torchtrade/envs/live").rglob("*.py")) + [
+    pathlib.Path("torchtrade/envs/core/live.py"),
+    pathlib.Path("torchtrade/envs/utils/sltp_mixin.py"),
+]
+
+
+@pytest.mark.parametrize("path", _HOLD_COUNTER_FILES, ids=str)
 def test_only_the_shared_rule_ages_a_position(path):
     """Nothing may age a position except advance_hold_counter().
 
@@ -283,5 +291,38 @@ def test_only_the_shared_rule_ages_a_position(path):
 
     assert not offenders, (
         f"{path} ages the position itself instead of calling advance_hold_counter():\n  "
+        + "\n  ".join(offenders)
+    )
+
+
+@pytest.mark.parametrize("path", _HOLD_COUNTER_FILES, ids=str)
+def test_hold_counter_is_only_advanced_inside_get_observation(path):
+    """advance_hold_counter() may be called ONLY from _get_observation() (#49).
+
+    The guard above bans hand-rolled aging; this bans MISUSING the sanctioned function. #49
+    was a SECOND call site: alpaca/binance aged the counter in _step() off the stale cached
+    direction -- a different get_status() snapshot than the one _get_observation() shows the
+    policy, so holding_time and position_direction could disagree in the same account_state.
+    Pinning the ONE call to _get_observation() keeps them on a single snapshot and lets
+    _reset() gate aging with advance_hold=False. A behavioural test is not a reliable backstop
+    here -- the aging code is shared per exchange by env.py and env_sltp.py, so a regression in
+    just one _step() escapes the other's tests.
+    """
+    tree = ast.parse(path.read_text())
+
+    def _callee(node):
+        f = node.func
+        return f.attr if isinstance(f, ast.Attribute) else getattr(f, "id", None)
+
+    offenders = []
+    for fn in ast.walk(tree):
+        if not isinstance(fn, (ast.FunctionDef, ast.AsyncFunctionDef)) or fn.name == "_get_observation":
+            continue
+        for node in ast.walk(fn):
+            if isinstance(node, ast.Call) and _callee(node) == "advance_hold_counter":
+                offenders.append(f"line {node.lineno} (in {fn.name}): {ast.unparse(node)}")
+
+    assert not offenders, (
+        f"{path} calls advance_hold_counter() outside _get_observation():\n  "
         + "\n  ".join(offenders)
     )

--- a/torchtrade/envs/core/state.py
+++ b/torchtrade/envs/core/state.py
@@ -166,8 +166,8 @@ class HistoryTracker:
         return len(self.base_prices)
 
 
-def advance_hold_counter(position: PositionState, direction: float) -> float:
-    """Age the CURRENT position by one step and return it as holding_time.
+def advance_hold_counter(position: PositionState, direction: float) -> None:
+    """Age the CURRENT position by one step, writing the new age to position.hold_counter.
 
         flat  -> long   a new position     -> 1
         long  -> long   the same position  -> 2, 3, 4, ...
@@ -187,4 +187,3 @@ def advance_hold_counter(position: PositionState, direction: float) -> float:
         position.hold_counter += 1
 
     position.hold_direction = direction
-    return float(position.hold_counter)

--- a/torchtrade/envs/live/alpaca/base.py
+++ b/torchtrade/envs/live/alpaca/base.py
@@ -14,6 +14,7 @@ from torchtrade.envs.core.live import TorchTradeLiveEnv
 from torchtrade.envs.core.state import (
     HistoryTracker,
     PositionState,
+    advance_hold_counter,
     position_direction_from_status,
 )
 
@@ -179,8 +180,16 @@ class AlpacaBaseTorchTradingEnv(TorchTradeLiveEnv):
             self.observation_spec.set(market_data_key, market_data_spec)
             self.market_data_keys.append(market_data_key)
 
-    def _get_observation(self) -> TensorDictBase:
-        """Get the current observation state."""
+    def _get_observation(self, advance_hold: bool = True) -> TensorDictBase:
+        """Get the current observation state.
+
+        Args:
+            advance_hold: If True (the default, used by `_step()`), ages `hold_counter`
+                by one bar using the direction observed in THIS method's single
+                `get_status()` call -- holding_time and position_direction in the
+                emitted account_state are always derived from the same snapshot.
+                `_reset()` passes False so a reset can never itself count a bar.
+        """
         # Get market data
         obs_dict = self.observer.get_observations(
             return_base_ohlc=True if self.config.include_base_features else False
@@ -193,7 +202,8 @@ class AlpacaBaseTorchTradingEnv(TorchTradeLiveEnv):
         # Get market data for each timeframe
         market_data = [obs_dict[features_name] for features_name in self.observer.get_keys()]
 
-        # Get account state from trader
+        # Get account state from trader (single fetch: holding_time and
+        # position_direction below MUST come from this same snapshot)
         status = self.trader.get_status()
         account = self.trader.client.get_account()
         cash = float(account.cash)
@@ -203,11 +213,14 @@ class AlpacaBaseTorchTradingEnv(TorchTradeLiveEnv):
         # Dust is not a position: gating on `is None` let a 1e-12 residual left behind a
         # close take the position branch and read stale fields off it.
         position_direction = float(position_direction_from_status(position_status))
+        if advance_hold:
+            advance_hold_counter(self.position, position_direction)
+        holding_time = float(self.position.hold_counter)
+
         if position_direction == 0:
             position_value = 0.0
             entry_price = 0.0
             unrealized_pnlpc = 0.0
-            holding_time = 0.0
             portfolio_value = cash
             # Get current market price even when no position
             try:
@@ -219,7 +232,6 @@ class AlpacaBaseTorchTradingEnv(TorchTradeLiveEnv):
             entry_price = position_status.avg_entry_price
             current_price = position_status.current_price
             unrealized_pnlpc = position_status.unrealized_plpc
-            holding_time = float(self.position.hold_counter)
             portfolio_value = cash + position_value
 
         # Calculate new 6-element account state
@@ -290,8 +302,9 @@ class AlpacaBaseTorchTradingEnv(TorchTradeLiveEnv):
 
         self._sync_action_level_after_reset()
 
-        # Get initial observation
-        return self._get_observation()
+        # Get initial observation. advance_hold=False: hold_counter was just zeroed
+        # above; a reset must never itself count a bar (see advance_hold docstring).
+        return self._get_observation(advance_hold=False)
 
     @abstractmethod
     def _execute_trade_if_needed(self, action) -> dict:

--- a/torchtrade/envs/live/alpaca/env.py
+++ b/torchtrade/envs/live/alpaca/env.py
@@ -5,7 +5,6 @@ import logging
 import torch
 
 logger = logging.getLogger(__name__)
-from torchtrade.envs.core.state import advance_hold_counter
 from torchtrade.envs.utils.timeframe import TimeFrame, TimeFrameUnit
 from torchtrade.envs.live.alpaca.utils import normalize_alpaca_timeframe_config
 from torchtrade.envs.live.alpaca.observation import AlpacaObservationClass
@@ -128,9 +127,6 @@ class AlpacaTorchTradingEnv(AlpacaBaseTorchTradingEnv):
 
         # Wait for next time step
         self._wait_for_next_timestamp()
-
-        # Update position hold counter
-        advance_hold_counter(self.position, self.position.current_position)
 
         # Get updated state
         new_portfolio_value = self._get_portfolio_value()

--- a/torchtrade/envs/live/alpaca/env_sltp.py
+++ b/torchtrade/envs/live/alpaca/env_sltp.py
@@ -5,7 +5,6 @@ import logging
 import torch
 
 logger = logging.getLogger(__name__)
-from torchtrade.envs.core.state import advance_hold_counter
 from torchtrade.envs.utils.timeframe import TimeFrame, TimeFrameUnit
 from torchtrade.envs.live.alpaca.utils import normalize_alpaca_timeframe_config
 from torchtrade.envs.live.alpaca.observation import AlpacaObservationClass
@@ -161,9 +160,6 @@ class AlpacaSLTPTorchTradingEnv(SLTPMixin, AlpacaBaseTorchTradingEnv):
 
         # Wait for next time step
         self._wait_for_next_timestamp()
-
-        # Update position hold counter
-        advance_hold_counter(self.position, self.position.current_position)
 
         # Get updated state
         new_portfolio_value = self._get_portfolio_value()

--- a/torchtrade/envs/live/binance/base.py
+++ b/torchtrade/envs/live/binance/base.py
@@ -15,6 +15,7 @@ from torchtrade.envs.core.live import TorchTradeLiveEnv
 from torchtrade.envs.core.state import (
     HistoryTracker,
     PositionState,
+    advance_hold_counter,
     position_direction_from_status,
 )
 
@@ -187,8 +188,16 @@ class BinanceBaseTorchTradingEnv(TorchTradeLiveEnv):
             self.observation_spec.set(market_data_key, market_data_spec)
             self.market_data_keys.append(market_data_key)
 
-    def _get_observation(self) -> TensorDictBase:
-        """Get the current observation state."""
+    def _get_observation(self, advance_hold: bool = True) -> TensorDictBase:
+        """Get the current observation state.
+
+        Args:
+            advance_hold: If True (the default, used by `_step()`), ages `hold_counter`
+                by one bar using the direction observed in THIS method's single
+                `get_status()` call -- holding_time and position_direction in the
+                emitted account_state are always derived from the same snapshot.
+                `_reset()` passes False so a reset can never itself count a bar.
+        """
         # Get market data
         obs_dict = self.observer.get_observations(
             return_base_ohlc=self.config.include_base_features
@@ -201,7 +210,8 @@ class BinanceBaseTorchTradingEnv(TorchTradeLiveEnv):
         # Get market data for each interval
         market_data = [obs_dict[features_name] for features_name in self.observer.get_keys()]
 
-        # Get account state from trader
+        # Get account state from trader (single fetch: holding_time and
+        # position_direction below MUST come from this same snapshot)
         status = self.trader.get_status()
         balance = self.trader.get_account_balance()
 
@@ -213,6 +223,10 @@ class BinanceBaseTorchTradingEnv(TorchTradeLiveEnv):
         # Dust is not a position: gating on `is None` let a 1e-12 residual left behind a
         # close take the position branch and read stale fields off it.
         position_direction = float(position_direction_from_status(position_status))
+        if advance_hold:
+            advance_hold_counter(self.position, position_direction)
+        holding_time = float(self.position.hold_counter)
+
         if position_direction == 0:
             position_size = 0.0
             position_value = 0.0
@@ -221,7 +235,6 @@ class BinanceBaseTorchTradingEnv(TorchTradeLiveEnv):
             unrealized_pnl_pct = 0.0
             leverage = float(self.config.leverage)
             liquidation_price = 0.0
-            holding_time = 0.0
         else:
             position_size = position_status.qty  # Positive=long, Negative=short
             position_value = abs(position_status.notional_value)
@@ -230,7 +243,6 @@ class BinanceBaseTorchTradingEnv(TorchTradeLiveEnv):
             unrealized_pnl_pct = position_status.unrealized_pnl_pct
             leverage = float(position_status.leverage)
             liquidation_price = position_status.liquidation_price
-            holding_time = float(self.position.hold_counter)
 
         # Calculate new 6-element account state
         # Element 0: exposure_pct (position_value / portfolio_value)
@@ -316,8 +328,9 @@ class BinanceBaseTorchTradingEnv(TorchTradeLiveEnv):
 
         self._sync_action_level_after_reset()
 
-        # Get initial observation
-        return self._get_observation()
+        # Get initial observation. advance_hold=False: hold_counter was just zeroed
+        # above; a reset must never itself count a bar (see advance_hold docstring).
+        return self._get_observation(advance_hold=False)
 
     @abstractmethod
     def _execute_trade_if_needed(self, action) -> dict:

--- a/torchtrade/envs/live/binance/env.py
+++ b/torchtrade/envs/live/binance/env.py
@@ -8,7 +8,6 @@ logger = logging.getLogger(__name__)
 from tensordict import TensorDict, TensorDictBase
 from torchrl.data import Categorical
 
-from torchtrade.envs.core.state import advance_hold_counter
 from torchtrade.envs.utils.timeframe import TimeFrame
 from torchtrade.envs.live.binance.observation import BinanceObservationClass
 from torchtrade.envs.live.binance.order_executor import (
@@ -182,9 +181,6 @@ class BinanceFuturesTorchTradingEnv(BinanceBaseTorchTradingEnv):
 
         # Wait for next time step
         self._wait_for_next_timestamp()
-
-        # Update position hold counter
-        advance_hold_counter(self.position, self.position.current_position)
 
         # Get updated state
         new_portfolio_value = self._get_portfolio_value()

--- a/torchtrade/envs/live/binance/env_sltp.py
+++ b/torchtrade/envs/live/binance/env_sltp.py
@@ -8,7 +8,6 @@ logger = logging.getLogger(__name__)
 from tensordict import TensorDictBase
 from torchrl.data import Categorical
 
-from torchtrade.envs.core.state import advance_hold_counter
 from torchtrade.envs.utils.timeframe import TimeFrame
 from torchtrade.envs.live.binance.observation import BinanceObservationClass
 from torchtrade.envs.live.binance.order_executor import (
@@ -206,9 +205,6 @@ class BinanceFuturesSLTPTorchTradingEnv(SLTPMixin, BinanceBaseTorchTradingEnv):
 
         # Wait for next time step
         self._wait_for_next_timestamp()
-
-        # Update position hold counter
-        advance_hold_counter(self.position, self.position.current_position)
 
         # Get updated state
         new_portfolio_value = self._get_portfolio_value()

--- a/torchtrade/envs/live/bitget/base.py
+++ b/torchtrade/envs/live/bitget/base.py
@@ -13,9 +13,9 @@ from torchtrade.envs.live.bitget.observation import BitgetObservationClass
 from torchtrade.envs.live.bitget.order_executor import BitgetFuturesOrderClass
 from torchtrade.envs.core.live import TorchTradeLiveEnv
 from torchtrade.envs.core.state import (
-    advance_hold_counter,
     HistoryTracker,
     PositionState,
+    advance_hold_counter,
     position_direction_from_status,
 )
 
@@ -205,8 +205,16 @@ class BitgetBaseTorchTradingEnv(TorchTradeLiveEnv):
             self.observation_spec.set(market_data_key, market_data_spec)
             self.market_data_keys.append(market_data_key)
 
-    def _get_observation(self) -> TensorDictBase:
-        """Get the current observation state."""
+    def _get_observation(self, advance_hold: bool = True) -> TensorDictBase:
+        """Get the current observation state.
+
+        Args:
+            advance_hold: If True (the default, used by `_step()`), ages `hold_counter`
+                by one bar using the direction observed in THIS method's single
+                `get_status()` call -- holding_time and position_direction in the
+                emitted account_state are always derived from the same snapshot.
+                `_reset()` passes False so a reset can never itself count a bar.
+        """
         # Get market data
         obs_dict = self.observer.get_observations(
             return_base_ohlc=self.config.include_base_features
@@ -219,7 +227,8 @@ class BitgetBaseTorchTradingEnv(TorchTradeLiveEnv):
         # Get market data for each interval
         market_data = [obs_dict[features_name] for features_name in self.observer.get_keys()]
 
-        # Get account state from trader
+        # Get account state from trader (single fetch: holding_time and
+        # position_direction below MUST come from this same snapshot)
         status = self.trader.get_status()
         balance = self.trader.get_account_balance()
 
@@ -231,7 +240,9 @@ class BitgetBaseTorchTradingEnv(TorchTradeLiveEnv):
         # Dust is not a position: gating on `is None` let a 1e-12 residual left behind a
         # close take the position branch and read stale fields off it.
         position_direction = float(position_direction_from_status(position_status))
-        holding_time = advance_hold_counter(self.position, position_direction)
+        if advance_hold:
+            advance_hold_counter(self.position, position_direction)
+        holding_time = float(self.position.hold_counter)
 
         if position_direction == 0:
             position_size = 0.0
@@ -334,8 +345,9 @@ class BitgetBaseTorchTradingEnv(TorchTradeLiveEnv):
 
         self._sync_action_level_after_reset()
 
-        # Get initial observation
-        return self._get_observation()
+        # Get initial observation. advance_hold=False: hold_counter was just zeroed
+        # above; a reset must never itself count a bar (see advance_hold docstring).
+        return self._get_observation(advance_hold=False)
 
     @abstractmethod
     def _execute_trade_if_needed(self, action) -> dict:

--- a/torchtrade/envs/live/bybit/base.py
+++ b/torchtrade/envs/live/bybit/base.py
@@ -13,8 +13,8 @@ from torchtrade.envs.live.bybit.observation import BybitObservationClass
 from torchtrade.envs.live.bybit.order_executor import BybitFuturesOrderClass
 from torchtrade.envs.core.live import TorchTradeLiveEnv
 from torchtrade.envs.core.state import (
-    advance_hold_counter,
     HistoryTracker,
+    advance_hold_counter,
     position_direction_from_status,
 )
 
@@ -169,8 +169,16 @@ class BybitBaseTorchTradingEnv(TorchTradeLiveEnv):
             self.observation_spec.set(market_data_key, market_data_spec)
             self.market_data_keys.append(market_data_key)
 
-    def _get_observation(self) -> TensorDictBase:
-        """Get the current observation state."""
+    def _get_observation(self, advance_hold: bool = True) -> TensorDictBase:
+        """Get the current observation state.
+
+        Args:
+            advance_hold: If True (the default, used by `_step()`), ages `hold_counter`
+                by one bar using the direction observed in THIS method's single
+                `get_status()` call -- holding_time and position_direction in the
+                emitted account_state are always derived from the same snapshot.
+                `_reset()` passes False so a reset can never itself count a bar.
+        """
         obs_dict = self.observer.get_observations(
             return_base_ohlc=self.config.include_base_features
         )
@@ -180,7 +188,8 @@ class BybitBaseTorchTradingEnv(TorchTradeLiveEnv):
 
         market_data = [obs_dict[features_name] for features_name in self.observer.get_keys()]
 
-        # Get account state from trader
+        # Get account state from trader (single fetch: holding_time and
+        # position_direction below MUST come from this same snapshot)
         status = self.trader.get_status()
         balance = self.trader.get_account_balance()
 
@@ -190,7 +199,9 @@ class BybitBaseTorchTradingEnv(TorchTradeLiveEnv):
         # Dust is not a position: gating on `is None` let a 1e-12 residual left behind a
         # close take the position branch and read stale fields off it.
         position_direction = float(position_direction_from_status(position_status))
-        holding_time = advance_hold_counter(self.position, position_direction)
+        if advance_hold:
+            advance_hold_counter(self.position, position_direction)
+        holding_time = float(self.position.hold_counter)
 
         if position_direction == 0:
             position_size = 0.0
@@ -270,7 +281,9 @@ class BybitBaseTorchTradingEnv(TorchTradeLiveEnv):
         # guard here can't reintroduce the silent no-op that bit bitget/binance/alpaca.
         self._sync_action_level_after_reset()
 
-        return self._get_observation()
+        # advance_hold=False: hold_counter was just zeroed above; a reset must
+        # never itself count a bar (see advance_hold docstring).
+        return self._get_observation(advance_hold=False)
 
     @abstractmethod
     def _execute_trade_if_needed(self, action) -> dict:

--- a/torchtrade/envs/live/okx/base.py
+++ b/torchtrade/envs/live/okx/base.py
@@ -13,8 +13,8 @@ from torchtrade.envs.live.okx.observation import OKXObservationClass
 from torchtrade.envs.live.okx.order_executor import OKXFuturesOrderClass
 from torchtrade.envs.core.live import TorchTradeLiveEnv
 from torchtrade.envs.core.state import (
-    advance_hold_counter,
     HistoryTracker,
+    advance_hold_counter,
     position_direction_from_status,
 )
 
@@ -179,8 +179,16 @@ class OKXBaseTorchTradingEnv(TorchTradeLiveEnv):
                 Bounded(low=-torch.inf, high=torch.inf, shape=(base_ws, 4), dtype=torch.float),
             )
 
-    def _get_observation(self) -> TensorDictBase:
-        """Get the current observation state."""
+    def _get_observation(self, advance_hold: bool = True) -> TensorDictBase:
+        """Get the current observation state.
+
+        Args:
+            advance_hold: If True (the default, used by `_step()`), ages `hold_counter`
+                by one bar using the direction observed in THIS method's single
+                `get_status()` call -- holding_time and position_direction in the
+                emitted account_state are always derived from the same snapshot.
+                `_reset()` passes False so a reset can never itself count a bar.
+        """
         obs_dict = self.observer.get_observations(
             return_base_ohlc=self.config.include_base_features
         )
@@ -190,7 +198,8 @@ class OKXBaseTorchTradingEnv(TorchTradeLiveEnv):
 
         market_data = [obs_dict[features_name] for features_name in self.observer.get_keys()]
 
-        # Get account state from trader
+        # Get account state from trader (single fetch: holding_time and
+        # position_direction below MUST come from this same snapshot)
         status = self.trader.get_status()
         balance = self.trader.get_account_balance()
 
@@ -200,7 +209,9 @@ class OKXBaseTorchTradingEnv(TorchTradeLiveEnv):
         # Dust is not a position: gating on `is None` let a 1e-12 residual left behind a
         # close take the position branch and read stale fields off it.
         position_direction = float(position_direction_from_status(position_status))
-        holding_time = advance_hold_counter(self.position, position_direction)
+        if advance_hold:
+            advance_hold_counter(self.position, position_direction)
+        holding_time = float(self.position.hold_counter)
 
         if position_direction == 0:
             position_size = 0.0
@@ -280,7 +291,9 @@ class OKXBaseTorchTradingEnv(TorchTradeLiveEnv):
         # guard here can't reintroduce the silent no-op that bit bitget/binance/alpaca.
         self._sync_action_level_after_reset()
 
-        return self._get_observation()
+        # advance_hold=False: hold_counter was just zeroed above; a reset must
+        # never itself count a bar (see advance_hold docstring).
+        return self._get_observation(advance_hold=False)
 
     @abstractmethod
     def _execute_trade_if_needed(self, action) -> dict:

--- a/torchtrade/envs/offline/sequential.py
+++ b/torchtrade/envs/offline/sequential.py
@@ -744,7 +744,9 @@ class SequentialTradingEnv(TorchTradeOfflineEnv):
         self.position.position_size = position_size
         self.position.position_value = abs(notional_value)
         self.position.entry_price = execution_price
-        self.position.hold_counter = 0
+        # The bar a position OPENS on is holding_time=1, not 0 (see advance_hold_counter
+        # docstring in core/state.py for the canonical rule this must match).
+        self.position.hold_counter = 1
 
         # Set position direction
         if not self.allows_short:

--- a/torchtrade/envs/offline/sequential_sltp.py
+++ b/torchtrade/envs/offline/sequential_sltp.py
@@ -568,7 +568,9 @@ class SequentialTradingEnvSLTP(SequentialTradingEnv):
         self.position.position_size = position_size if side == "long" else -abs(position_size)
         self.position.position_value = abs(notional_value)
         self.position.entry_price = execution_price
-        self.position.hold_counter = 0
+        # The bar a position OPENS on is holding_time=1, not 0 (see advance_hold_counter
+        # docstring in core/state.py for the canonical rule this must match).
+        self.position.hold_counter = 1
 
         # Set position direction
         if self.leverage == 1:

--- a/torchtrade/envs/offline/vectorized_sequential.py
+++ b/torchtrade/envs/offline/vectorized_sequential.py
@@ -684,7 +684,9 @@ class VectorizedSequentialTradingEnv(EnvBase):
                 self._balances.clamp_(min=0.0)
                 self._position_sizes[final_open] = new_sizes[final_open]
                 self._entry_prices[final_open] = execution_prices[final_open]
-                self._hold_counters[final_open] = 0
+                # The bar a position OPENS on is holding_time=1, not 0 (matches the
+                # scalar SequentialTradingEnv / advance_hold_counter canonical rule).
+                self._hold_counters[final_open] = 1
 
     def close(self):
         """Clean up resources."""

--- a/torchtrade/envs/offline/vectorized_sequential_sltp.py
+++ b/torchtrade/envs/offline/vectorized_sequential_sltp.py
@@ -450,7 +450,9 @@ class VectorizedSequentialTradingEnvSLTP(VectorizedSequentialTradingEnv):
                 self._balances.clamp_(min=0.0)
                 self._position_sizes[final_open] = new_sizes[final_open]
                 self._entry_prices[final_open] = trade_prices[final_open]
-                self._hold_counters[final_open] = 0
+                # The bar a position OPENS on is holding_time=1, not 0 (matches the
+                # scalar SequentialTradingEnvSLTP / advance_hold_counter canonical rule).
+                self._hold_counters[final_open] = 1
 
                 # Set bracket prices: entry * (1 + pct)
                 # E.g. Long entry=100, sl_pct=-0.05 → sl_price=95


### PR DESCRIPTION
## What

`holding_time` (element 3 of the universal `account_state` vector, which the policy conditions on **directly**) was computed inconsistently across environments — a train/deploy skew on a raw observation element (#49).

For the identical sequence `flat → open → hold → hold`:
- offline reported the opening bar as `0`, live as `1`
- bybit/bitget/okx additionally counted the reset bar

## Canonical rule (now enforced everywhere)

| state | holding_time |
|---|---|
| flat | 0 |
| opening bar | 1 |
| each held bar | 2, 3, … |
| on close | 0 |
| direct flip (long→short, no flat bar) | 1 |

## Changes

**Offline (4 envs)** — opening bar `0` → `1`, one line each.

**Live (5 envs)** — the counter now advances exactly **once per step**, from the exchange-**observed** direction (never the stale `current_position` cache), on the **single `get_status()` snapshot** that also produces `position_direction`, so the two can never disagree within one `account_state`. `_reset()` passes `advance_hold=False`, so a reset never counts a bar (fixes the bybit/bitget/okx extra-bar count). The old `_step`-level advance in alpaca/binance was removed.

**Decision (reset onto an already-open position):** reads `holding_time=0` — the true prior age is unknown and the first step corrects it. Never occurs in training (live envs reset flat).

## Tests

- `tests/envs/offline/test_holding_time.py` (new) — pins the offline sequence incl. a **direct flip**; every case mutation-verified (fails on the pre-fix `0`).
- Behavioral `holding_time` coverage added for the **4 previously-untested live SLTP envs** (alpaca/bitget/bybit/okx) — mutation-verified against a stray `advance_hold=False`.
- The AST guard in `test_live_env_base.py` **strengthened** to also ban `advance_hold_counter` misuse outside `_get_observation`, and **extended** to scan `core/live.py` + `sltp_mixin.py`.
- Full suite in the repo venv: **2118 passed, 0 failed**.

Reviewed over the mandated **3 rounds × 4 agents** (test-justification, code-simplifier, pr-test-analyzer, torchrl-engineer); Round 3 came back clean on all four.

🤖 Generated with [Claude Code](https://claude.com/claude-code)