### PR TITLE
fix(envs): binance/bitget read a short as AT liquidation when liq_price is 0

### DIFF
--- a/tests/envs/binance/test_torch_env_futures.py
+++ b/tests/envs/binance/test_torch_env_futures.py
@@ -349,6 +349,32 @@ class TestBinanceFuturesTorchTradingEnv:
         assert dist_to_liq == pytest.approx(0.1)     # (50000 - 45000) / 50000
         assert holding_time == 0.0
 
+    @pytest.mark.parametrize("qty,liq_price,expected_dtl", [
+        (0.001, 45000.0, pytest.approx(0.1018, rel=1e-2)),   # long normal: (50100-45000)/50100
+        (0.001, 0.0, 1.0),                                   # long zero-liq -> unknown -> 1.0
+        (-0.001, 55000.0, pytest.approx(0.0978, rel=1e-2)),  # short normal: (55000-50100)/50100
+        (-0.001, 0.0, 1.0),                                  # short zero-liq -> unknown -> 1.0 (the fix)
+    ], ids=["long-normal", "long-zero-liq", "short-normal", "short-zero-liq"])
+    def test_distance_to_liquidation(self, env, mock_trader, qty, liq_price, expected_dtl):
+        """distance_to_liquidation (account_state[5]) across long/short x normal/zero-liq.
+
+        A zero/absent liq price (cross-margin, or .get(..., 0)) must read 1.0 -- for a short the
+        unguarded (0 - price)/price = 0.0 would falsely signal AT liquidation. Matches bybit/okx.
+        """
+        from torchtrade.envs.live.binance.order_executor import PositionStatus
+
+        mock_trader.get_status = MagicMock(return_value={"position_status": PositionStatus(
+            qty=qty, notional_value=50.1, entry_price=50000.0, unrealized_pnl=0.1,
+            unrealized_pnl_pct=0.002, mark_price=50100.0, leverage=10,
+            margin_type="isolated", liquidation_price=liq_price,
+        )})
+        with patch.object(env, "_wait_for_next_timestamp"):
+            td = env.reset()
+
+        # direction proves a genuine OPEN position, so dtl==1.0 can't pass via the flat branch
+        assert td["account_state"][1].item() == (1.0 if qty > 0 else -1.0)
+        assert td["account_state"][5].item() == expected_dtl
+
     def test_closing_a_position_does_not_age_the_next_one(self, env, mock_trader):
         """A closed position's age must not carry into the next one.
 

--- a/tests/envs/bitget/test_torch_env_futures.py
+++ b/tests/envs/bitget/test_torch_env_futures.py
@@ -345,6 +345,32 @@ class TestBitgetFuturesTorchTradingEnv:
             # The agent still wants to be long -> the env must actually re-enter.
             mock_trader.trade.assert_called()
 
+    @pytest.mark.parametrize("qty,liq_price,expected_dtl", [
+        (0.001, 45000.0, pytest.approx(0.1018, rel=1e-2)),   # long normal: (50100-45000)/50100
+        (0.001, 0.0, 1.0),                                   # long zero-liq -> unknown -> 1.0
+        (-0.001, 55000.0, pytest.approx(0.0978, rel=1e-2)),  # short normal: (55000-50100)/50100
+        (-0.001, 0.0, 1.0),                                  # short zero-liq -> unknown -> 1.0 (the fix)
+    ], ids=["long-normal", "long-zero-liq", "short-normal", "short-zero-liq"])
+    def test_distance_to_liquidation(self, env, mock_trader, qty, liq_price, expected_dtl):
+        """distance_to_liquidation (account_state[5]) across long/short x normal/zero-liq.
+
+        A zero/absent liq price (cross-margin, or .get(..., 0)) must read 1.0 -- for a short the
+        unguarded (0 - price)/price = 0.0 would falsely signal AT liquidation. Matches bybit/okx.
+        """
+        from torchtrade.envs.live.bitget.order_executor import PositionStatus
+
+        mock_trader.get_status = MagicMock(return_value={"position_status": PositionStatus(
+            qty=qty, notional_value=50.1, entry_price=50000.0, unrealized_pnl=0.1,
+            unrealized_pnl_pct=0.002, mark_price=50100.0, leverage=10,
+            margin_mode="isolated", liquidation_price=liq_price,
+        )})
+        with patch.object(env, "_wait_for_next_timestamp"):
+            td = env.reset()
+
+        # direction proves a genuine OPEN position, so dtl==1.0 can't pass via the flat branch
+        assert td["account_state"][1].item() == (1.0 if qty > 0 else -1.0)
+        assert td["account_state"][5].item() == expected_dtl
+
     def test_reset_reads_dust_as_flat(self, env, mock_trader):
         """A dust residual (1e-12) left behind a close must read as FLAT, not as a position.
 

--- a/torchtrade/envs/live/binance/base.py
+++ b/torchtrade/envs/live/binance/base.py
@@ -255,9 +255,10 @@ class BinanceBaseTorchTradingEnv(TorchTradeLiveEnv):
         # Element 4: leverage
 
         # Element 5: distance_to_liquidation
-        if position_size == 0:
-            distance_to_liquidation = 1.0
-        elif current_price == 0:
+        # liquidation_price <= 0 means "no liquidation price": the exchange omitted the field
+        # (-> .get(..., 0)) or reports "0" for cross-margin. A short must then read 1.0, not
+        # (0 - price)/price = 0.0, which would falsely tell the policy it is AT liquidation.
+        if position_size == 0 or current_price == 0 or liquidation_price <= 0:
             distance_to_liquidation = 1.0
         else:
             if position_size > 0:

--- a/torchtrade/envs/live/bitget/base.py
+++ b/torchtrade/envs/live/bitget/base.py
@@ -272,9 +272,10 @@ class BitgetBaseTorchTradingEnv(TorchTradeLiveEnv):
         # Element 4: leverage
 
         # Element 5: distance_to_liquidation
-        if position_size == 0:
-            distance_to_liquidation = 1.0
-        elif current_price == 0:
+        # liquidation_price <= 0 means "no liquidation price": the exchange omitted the field
+        # (-> .get(..., 0)) or reports "0" for cross-margin. A short must then read 1.0, not
+        # (0 - price)/price = 0.0, which would falsely tell the policy it is AT liquidation.
+        if position_size == 0 or current_price == 0 or liquidation_price <= 0:
             distance_to_liquidation = 1.0
         else:
             if position_size > 0:


### PR DESCRIPTION
## The bug

binance and bitget computed `distance_to_liquidation` (`account_state[5]`, which the policy conditions on **directly**) without guarding `liquidation_price <= 0`.

Both executors read it via `float(pos.get("liquidationPrice", 0))` — so an **absent field**, or the `"0"` Binance/Bitget return for **cross-margin** positions, yields `liquidation_price = 0` on an **open** position. For a **short**:

```
(liquidation_price - current_price) / current_price = (0 - price)/price = -1  →  max(0, ·) = 0.0
```

→ the policy is told the short is **at liquidation**. (A long computes `(price - 0)/price = 1.0`, so the bug was short-only.) This is an invariant-#3 defect: an open position reads a wrong `account_state` element.

## The fix

Add `or liquidation_price <= 0` to the guard so it returns `1.0` ("no liquidation risk"), making binance/bitget **byte-identical** to the guard **bybit/okx already have**. Alpaca is spot (hardcodes `1.0`) — correctly untouched.

## Tests

Adopt the bybit/okx **4-row parametrized `test_distance_to_liquidation`** (`long/short × normal/zero-liq`) on binance/bitget — which also closes a **pre-existing gap**: the short-*normal* arithmetic branch was untested on these two envs. Each row additionally asserts `position_direction` (`account_state[1]`) to prove a genuine **open** position, so a `dtl == 1.0` result can't sneak through the flat branch.

Mutation-verified:
- reverting the guard → `short-zero-liq` row fails
- flipping the short arithmetic sign → `short-normal` row fails

(The `short-zero-liq` row is what pins the guard; `long-zero-liq` reaches `1.0` arithmetically too, so it's the symmetric documentation row.)

Full suite: **2126 passed, 0 failed**. Reviewed over the mandated **3 rounds × 4 agents**; Round 3 clean on all four.

🤖 Generated with [Claude Code](https://claude.com/claude-code)