### PR TITLE
docs: add Bybit/OKX/Bitget referral links to signup URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,23 +160,23 @@ paper-only** — see its entry.
 - **Commission:** Maker 0.02% / Taker 0.04% (with BNB discount)
 - **Get Started:** [Sign up for Binance](https://accounts.binance.com/register?ref=25015935)
 
-**[Bitget](https://www.bitget.com/)** - Fast-growing cryptocurrency exchange
+**[Bitget](https://share.bitget.com/u/VGN302X2)** - Fast-growing cryptocurrency exchange
 - **Supported by:** `BitgetFuturesTorchTradingEnv`, `BitgetFuturesSLTPTorchTradingEnv`
 - **Features:** Futures trading with up to 125x leverage, testnet for safe testing
 - **Commission:** Maker 0.02% / Taker 0.06%
-- **Get Started:** [Sign up for Bitget](https://www.bitget.com/)
+- **Get Started:** [Sign up for Bitget](https://share.bitget.com/u/VGN302X2)
 
-**[Bybit](https://www.bybit.com/)** - Top cryptocurrency derivatives exchange
+**[Bybit](https://www.bybit.eu/invite?ref=MX42GRV)** - Top cryptocurrency derivatives exchange
 - **Supported by:** `BybitFuturesTorchTradingEnv`, `BybitFuturesSLTPTorchTradingEnv`
 - **Features:** Futures trading with up to 100x leverage, native bracket orders (SL/TP), testnet for safe testing
 - **Commission:** Maker 0.02% / Taker 0.055%
-- **Get Started:** [Sign up for Bybit](https://www.bybit.com/)
+- **Get Started:** [Sign up for Bybit](https://www.bybit.eu/invite?ref=MX42GRV)
 
-**[OKX](https://www.okx.com/)** - Leading global cryptocurrency exchange
+**[OKX](https://my.okx.com/en-eu/join/52629853)** - Leading global cryptocurrency exchange
 - **Supported by:** `OKXFuturesTorchTradingEnv`, `OKXFuturesSLTPTorchTradingEnv`
 - **Features:** Futures trading with up to 125x leverage, bracket orders via attachAlgoOrds, demo trading
 - **Commission:** Maker 0.02% / Taker 0.05%
-- **Get Started:** [Sign up for OKX](https://www.okx.com/)
+- **Get Started:** [Sign up for OKX](https://my.okx.com/en-eu/join/52629853)
 
 ### 🔮 Prediction Markets
 

--- a/docs/environments/online.md
+++ b/docs/environments/online.md
@@ -15,9 +15,9 @@ Online environments connect to real trading APIs for paper trading or live execu
 
 - **[Alpaca](https://alpaca.markets/)** - Commission-free US stocks and crypto with paper trading
 - **[Binance](https://accounts.binance.com/register?ref=25015935)** - Cryptocurrency futures with high leverage and testnet
-- **[Bitget](https://www.bitget.com/)** - Cryptocurrency futures with competitive fees and testnet
-- **[Bybit](https://www.bybit.com/)** - Cryptocurrency derivatives with native bracket orders and testnet
-- **[OKX](https://www.okx.com/)** - Global cryptocurrency exchange with bracket orders via attachAlgoOrds and demo trading
+- **[Bitget](https://share.bitget.com/u/VGN302X2)** - Cryptocurrency futures with competitive fees and testnet
+- **[Bybit](https://www.bybit.eu/invite?ref=MX42GRV)** - Cryptocurrency derivatives with native bracket orders and testnet
+- **[OKX](https://my.okx.com/en-eu/join/52629853)** - Global cryptocurrency exchange with bracket orders via attachAlgoOrds and demo trading
 - **[Polymarket](https://polymarket.com/)** - Decentralized prediction markets on Polygon (CLOB), with dry-run paper trading
 
 ## Overview
@@ -154,7 +154,7 @@ env = BinanceFuturesSLTPTorchTradingEnv(config)
 
 ## Bitget Environments
 
-[Bitget](https://www.bitget.com/) provides cryptocurrency futures trading with competitive fees and testnet support. TorchTrade uses [CCXT](https://github.com/ccxt/ccxt) to interface with Bitget's V2 API.
+[Bitget](https://share.bitget.com/u/VGN302X2) provides cryptocurrency futures trading with competitive fees and testnet support. TorchTrade uses [CCXT](https://github.com/ccxt/ccxt) to interface with Bitget's V2 API.
 
 !!! note "CCXT Symbol Format"
     Bitget uses CCXT's perpetual swap format: `"BTC/USDT:USDT"` (not `"BTCUSDT"`).
@@ -230,7 +230,7 @@ env = BitgetFuturesSLTPTorchTradingEnv(
 
 ## Bybit Environments
 
-[Bybit](https://www.bybit.com/) provides cryptocurrency derivatives trading with native bracket order support (stop-loss/take-profit set directly on orders). TorchTrade uses [pybit](https://github.com/bybit-exchange/pybit), Bybit's official Python SDK, for direct v5 API access.
+[Bybit](https://www.bybit.eu/invite?ref=MX42GRV) provides cryptocurrency derivatives trading with native bracket order support (stop-loss/take-profit set directly on orders). TorchTrade uses [pybit](https://github.com/bybit-exchange/pybit), Bybit's official Python SDK, for direct v5 API access.
 
 !!! note "Symbol Format"
     Bybit uses simple concatenated symbols: `"BTCUSDT"` (not `"BTC/USDT:USDT"`).
@@ -301,7 +301,7 @@ env = BybitFuturesSLTPTorchTradingEnv(
 
 ## OKX Environments
 
-[OKX](https://www.okx.com/) provides global cryptocurrency trading with up to 125x leverage and demo trading support. TorchTrade uses [python-okx](https://pypi.org/project/python-okx/), OKX's official Python SDK. Bracket orders (SL/TP) are placed atomically via OKX's `attachAlgoOrds` parameter.
+[OKX](https://my.okx.com/en-eu/join/52629853) provides global cryptocurrency trading with up to 125x leverage and demo trading support. TorchTrade uses [python-okx](https://pypi.org/project/python-okx/), OKX's official Python SDK. Bracket orders (SL/TP) are placed atomically via OKX's `attachAlgoOrds` parameter.
 
 !!! note "Symbol Format"
     OKX uses dash-separated symbols with swap suffix: `"BTC-USDT-SWAP"`. The environment auto-normalizes common formats (`"BTCUSDT"`, `"BTC/USDT"`, `"BTC-USDT"`) to the correct OKX format.


### PR DESCRIPTION
## What

Adds affiliate referral codes to the Bybit, OKX, and Bitget signup/"Get Started" links across `README.md` and `docs/environments/online.md`. Binance already carried its referral (`ref=25015935`); this brings the other three exchanges to parity so no live-trading referral is left on the table.

| Exchange | Link used |
|---|---|
| Bybit | `https://www.bybit.eu/invite?ref=MX42GRV` |
| OKX | `https://my.okx.com/en-eu/join/52629853` |
| Bitget | `https://share.bitget.com/u/VGN302X2` |

## Scope / safety

- **Only landing + "Get Started" links** were changed (4 sites each). These are exactly where a reader is about to open an account to trade.
- **Deep links left plain** (functional, not signup): exchange API-management pages and the Bitget support article.
- **Alpaca & Polymarket unchanged** — Polymarket is paper-only (`dry_run`), so there is no live volume to earn on.
- **Entity domains kept as issued** by each affiliate dashboard (`bybit.eu`, `my.okx.com/en-eu`) so attribution credits correctly; `utm_`/`shareTo` tracking params were stripped for clean docs.

## Why no code review agents

Docs-only change (README + markdown), no code or tests touched — the code-focused review workflow doesn't apply. Verified instead that every referral link is well-formed, no plain landing links remain, and functional deep links + Alpaca/Polymarket are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)