### PR TITLE
refactor(envs): unify futures _get_observation into TorchTradeFuturesLiveEnv

### DIFF
--- a/tests/envs/bybit/test_torch_env_futures.py
+++ b/tests/envs/bybit/test_torch_env_futures.py
@@ -85,6 +85,27 @@ class TestBybitFuturesTorchTradingEnv:
         assert env.action_spec.n == 5  # [-1.0, -0.5, 0.0, 0.5, 1.0]
         assert env.action_levels == [-1.0, -0.5, 0.0, 0.5, 1.0]
 
+    def test_include_base_features_flows_through_shared_get_observation(self, mock_observer, mock_trader):
+        """The shared TorchTradeFuturesLiveEnv._get_observation passes base_features through.
+
+        The futures envs default include_base_features=False, so this branch of the now-shared
+        method was untested; one case here covers it for all four exchanges via inheritance.
+        """
+        from torchtrade.envs.live.bybit.env import (
+            BybitFuturesTorchTradingEnv,
+            BybitFuturesTradingEnvConfig,
+        )
+
+        config = BybitFuturesTradingEnvConfig(
+            symbol="BTCUSDT", demo=True, time_frames=["1m", "5m"], window_sizes=[10, 10],
+            execute_on="1m", leverage=5, include_base_features=True,
+        )
+        with patch("time.sleep"), patch.object(BybitFuturesTorchTradingEnv, "_wait_for_next_timestamp"):
+            env = BybitFuturesTorchTradingEnv(config=config, observer=mock_observer, trader=mock_trader)
+            td = env.reset()
+
+        assert "base_features" in td.keys()
+
     def test_observation_spec(self, env):
         """Test observation spec contains expected keys with correct shapes."""
         obs_spec = env.observation_spec

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -16,6 +16,7 @@ import pytest
 
 import torchtrade.envs  # noqa: F401  -- registers every live env as a subclass
 from torchtrade.envs.core.live import TorchTradeLiveEnv
+from torchtrade.envs.live.shared.futures_live_base import TorchTradeFuturesLiveEnv
 from torchtrade.envs.utils.sltp_mixin import SLTPMixin
 from torchtrade.envs.core.state import PositionState, advance_hold_counter
 
@@ -33,6 +34,14 @@ LIVE_ENVS = sorted(_subclasses(TorchTradeLiveEnv), key=lambda c: c.__name__)
 
 # The plain envs (env.py). The SLTP ones get their sync from SLTPMixin instead.
 NON_SLTP_ENVS = [c for c in LIVE_ENVS if c.__module__.endswith(".env")]
+
+# The 4 futures exchanges (base + SLTP) share ONE _get_observation via TorchTradeFuturesLiveEnv;
+# the intermediate base itself is excluded (it IS the shared impl). alpaca (spot) is absent by
+# construction -- it does not subclass TorchTradeFuturesLiveEnv.
+FUTURES_ENVS = [
+    c for c in LIVE_ENVS
+    if issubclass(c, TorchTradeFuturesLiveEnv) and c is not TorchTradeFuturesLiveEnv
+]
 
 
 @pytest.mark.parametrize("done_on_bankruptcy,portfolio_value,expected", [
@@ -107,8 +116,14 @@ def test_discovery_covers_every_live_exchange():
     silently, and the guard would still pass green while covering less. Fail here instead.
     Adding exchange #6 is meant to fail this -- it forces you to confirm the newcomer
     inherits the shared bankruptcy check rather than re-forking it.
+
+    Abstract intermediate bases (e.g. TorchTradeFuturesLiveEnv) live under
+    torchtrade/envs/live/shared/ and are not themselves an exchange -- they never define
+    _reset or _init_trading_clients, so every other guard in this file already skips or
+    passes them via inheritance. Only this set-of-exchanges check needs to filter "shared"
+    out explicitly, or a real newcomer exchange could hide behind it.
     """
-    exchanges = {cls.__module__.split(".")[-2] for cls in LIVE_ENVS}
+    exchanges = {cls.__module__.split(".")[-2] for cls in LIVE_ENVS} - {"shared"}
     assert exchanges == {"alpaca", "binance", "bitget", "bybit", "okx"}
     # NON_SLTP_ENVS drives the call-site guard below, and an empty parametrize SKIPS rather
     # than fails -- a module rename would silently retire that guard.
@@ -128,6 +143,22 @@ def test_no_live_env_overrides_shared_method(env_cls, method):
     assert getattr(env_cls, method) is getattr(TorchTradeLiveEnv, method), (
         f"{env_cls.__name__} overrides {method}. Either drop the override, or give that "
         f"exchange its own tests -- the single shared test above no longer covers it."
+    )
+
+
+@pytest.mark.parametrize("method", ["_get_observation", "_get_portfolio_value"])
+@pytest.mark.parametrize("env_cls", FUTURES_ENVS, ids=lambda c: c.__name__)
+def test_no_futures_env_reforks_the_shared_observation(env_cls, method):
+    """The 4 futures exchanges share ONE _get_observation/_get_portfolio_value.
+
+    The whole point of TorchTradeFuturesLiveEnv is that an account_state fix lands ONCE. If an
+    exchange re-adds its own copy, that guarantee is silently lost and every per-exchange
+    account_state test still passes -- so fail here instead. (alpaca is spot: it keeps its own
+    _get_observation and is correctly absent from FUTURES_ENVS.)
+    """
+    assert getattr(env_cls, method) is getattr(TorchTradeFuturesLiveEnv, method), (
+        f"{env_cls.__name__} re-forks {method} instead of sharing TorchTradeFuturesLiveEnv's. "
+        f"Drop the override, or the unification no longer covers it."
     )
 
 

--- a/torchtrade/envs/live/binance/base.py
+++ b/torchtrade/envs/live/binance/base.py
@@ -4,23 +4,22 @@ from abc import abstractmethod
 from typing import Callable, List, Optional
 
 import torch
-from tensordict import TensorDict, TensorDictBase
+from tensordict import TensorDictBase
 from torchrl.data import Bounded
 from torchrl.data import Composite
 
 from torchtrade.envs.utils.timeframe import timeframe_to_seconds
 from torchtrade.envs.live.binance.observation import BinanceObservationClass
 from torchtrade.envs.live.binance.order_executor import BinanceFuturesOrderClass
-from torchtrade.envs.core.live import TorchTradeLiveEnv
+from torchtrade.envs.live.shared.futures_live_base import TorchTradeFuturesLiveEnv
 from torchtrade.envs.core.state import (
     HistoryTracker,
     PositionState,
-    advance_hold_counter,
     position_direction_from_status,
 )
 
 
-class BinanceBaseTorchTradingEnv(TorchTradeLiveEnv):
+class BinanceBaseTorchTradingEnv(TorchTradeFuturesLiveEnv):
     """
     Base class for Binance trading environments.
 
@@ -187,123 +186,6 @@ class BinanceBaseTorchTradingEnv(TorchTradeLiveEnv):
             )
             self.observation_spec.set(market_data_key, market_data_spec)
             self.market_data_keys.append(market_data_key)
-
-    def _get_observation(self, advance_hold: bool = True) -> TensorDictBase:
-        """Get the current observation state.
-
-        Args:
-            advance_hold: If True (the default, used by `_step()`), ages `hold_counter`
-                by one bar using the direction observed in THIS method's single
-                `get_status()` call -- holding_time and position_direction in the
-                emitted account_state are always derived from the same snapshot.
-                `_reset()` passes False so a reset can never itself count a bar.
-        """
-        # Get market data
-        obs_dict = self.observer.get_observations(
-            return_base_ohlc=self.config.include_base_features
-        )
-
-        # Extract base features if requested
-        if self.config.include_base_features:
-            base_features = obs_dict.get("base_features")
-
-        # Get market data for each interval
-        market_data = [obs_dict[features_name] for features_name in self.observer.get_keys()]
-
-        # Get account state from trader (single fetch: holding_time and
-        # position_direction below MUST come from this same snapshot)
-        status = self.trader.get_status()
-        balance = self.trader.get_account_balance()
-
-        cash = balance.get("available_balance", 0)
-        total_balance = balance.get("total_wallet_balance", 0)
-
-        position_status = status.get("position_status", None)
-
-        # Dust is not a position: gating on `is None` let a 1e-12 residual left behind a
-        # close take the position branch and read stale fields off it.
-        position_direction = float(position_direction_from_status(position_status))
-        if advance_hold:
-            advance_hold_counter(self.position, position_direction)
-        holding_time = float(self.position.hold_counter)
-
-        if position_direction == 0:
-            position_size = 0.0
-            position_value = 0.0
-            entry_price = 0.0
-            current_price = self.trader.get_mark_price()
-            unrealized_pnl_pct = 0.0
-            leverage = float(self.config.leverage)
-            liquidation_price = 0.0
-        else:
-            position_size = position_status.qty  # Positive=long, Negative=short
-            position_value = abs(position_status.notional_value)
-            entry_price = position_status.entry_price
-            current_price = position_status.mark_price
-            unrealized_pnl_pct = position_status.unrealized_pnl_pct
-            leverage = float(position_status.leverage)
-            liquidation_price = position_status.liquidation_price
-
-        # Calculate new 6-element account state
-        # Element 0: exposure_pct (position_value / portfolio_value)
-        exposure_pct = position_value / total_balance if total_balance > 0 else 0.0
-
-        # Element 2: unrealized_pnl_pct (from Binance API)
-
-        # Element 3: holding_time
-
-        # Element 4: leverage
-
-        # Element 5: distance_to_liquidation
-        # liquidation_price <= 0 means "no liquidation price": the exchange omitted the field
-        # (-> .get(..., 0)) or reports "0" for cross-margin. A short must then read 1.0, not
-        # (0 - price)/price = 0.0, which would falsely tell the policy it is AT liquidation.
-        if position_size == 0 or current_price == 0 or liquidation_price <= 0:
-            distance_to_liquidation = 1.0
-        else:
-            if position_size > 0:
-                # Long position - liquidated if price drops below liquidation_price
-                distance_to_liquidation = (current_price - liquidation_price) / current_price
-            else:
-                # Short position - liquidated if price rises above liquidation_price
-                distance_to_liquidation = (liquidation_price - current_price) / current_price
-            # Clamp to [0, inf)
-            distance_to_liquidation = max(0.0, distance_to_liquidation)
-
-        # Build 6-element account state tensor
-        # [exposure_pct, position_direction, unrealized_pnl_pct,
-        #  holding_time, leverage, distance_to_liquidation]
-        account_state = torch.tensor(
-            [
-                exposure_pct,
-                position_direction,
-                unrealized_pnl_pct,
-                holding_time,
-                leverage,
-                distance_to_liquidation,
-            ],
-            dtype=torch.float,
-        )
-
-        # Build output TensorDict
-        out_td = TensorDict({self.account_state_key: account_state}, batch_size=())
-        for market_data_name, data in zip(self.market_data_keys, market_data):
-            out_td.set(market_data_name, torch.from_numpy(data))
-
-        # Add base features if requested
-        if self.config.include_base_features and base_features is not None:
-            out_td.set("base_features", torch.from_numpy(base_features))
-
-        return out_td
-
-    def _get_portfolio_value(self) -> float:
-        """
-        Calculate total portfolio value for Binance futures.
-
-        Returns total_margin_balance (includes unrealized PnL).
-        """
-        balance = self.trader.get_account_balance()
-        return balance.get("total_margin_balance", 0)
 
     def _reset(self, tensordict: TensorDictBase, **kwargs) -> TensorDictBase:
         """Reset the environment."""

--- a/torchtrade/envs/live/bitget/base.py
+++ b/torchtrade/envs/live/bitget/base.py
@@ -4,23 +4,22 @@ from abc import abstractmethod
 from typing import Callable, List, Optional
 
 import torch
-from tensordict import TensorDict, TensorDictBase
+from tensordict import TensorDictBase
 from torchrl.data import Bounded
 from torchrl.data.tensor_specs import Composite
 
 from torchtrade.envs.utils.timeframe import TimeFrame
 from torchtrade.envs.live.bitget.observation import BitgetObservationClass
 from torchtrade.envs.live.bitget.order_executor import BitgetFuturesOrderClass
-from torchtrade.envs.core.live import TorchTradeLiveEnv
+from torchtrade.envs.live.shared.futures_live_base import TorchTradeFuturesLiveEnv
 from torchtrade.envs.core.state import (
     HistoryTracker,
     PositionState,
-    advance_hold_counter,
     position_direction_from_status,
 )
 
 
-class BitgetBaseTorchTradingEnv(TorchTradeLiveEnv):
+class BitgetBaseTorchTradingEnv(TorchTradeFuturesLiveEnv):
     """
     Base class for Bitget trading environments.
 
@@ -204,123 +203,6 @@ class BitgetBaseTorchTradingEnv(TorchTradeLiveEnv):
             )
             self.observation_spec.set(market_data_key, market_data_spec)
             self.market_data_keys.append(market_data_key)
-
-    def _get_observation(self, advance_hold: bool = True) -> TensorDictBase:
-        """Get the current observation state.
-
-        Args:
-            advance_hold: If True (the default, used by `_step()`), ages `hold_counter`
-                by one bar using the direction observed in THIS method's single
-                `get_status()` call -- holding_time and position_direction in the
-                emitted account_state are always derived from the same snapshot.
-                `_reset()` passes False so a reset can never itself count a bar.
-        """
-        # Get market data
-        obs_dict = self.observer.get_observations(
-            return_base_ohlc=self.config.include_base_features
-        )
-
-        # Extract base features if requested
-        if self.config.include_base_features:
-            base_features = obs_dict.get("base_features")
-
-        # Get market data for each interval
-        market_data = [obs_dict[features_name] for features_name in self.observer.get_keys()]
-
-        # Get account state from trader (single fetch: holding_time and
-        # position_direction below MUST come from this same snapshot)
-        status = self.trader.get_status()
-        balance = self.trader.get_account_balance()
-
-        cash = balance.get("available_balance", 0)
-        total_balance = balance.get("total_wallet_balance", 0)
-
-        position_status = status.get("position_status", None)
-
-        # Dust is not a position: gating on `is None` let a 1e-12 residual left behind a
-        # close take the position branch and read stale fields off it.
-        position_direction = float(position_direction_from_status(position_status))
-        if advance_hold:
-            advance_hold_counter(self.position, position_direction)
-        holding_time = float(self.position.hold_counter)
-
-        if position_direction == 0:
-            position_size = 0.0
-            position_value = 0.0
-            entry_price = 0.0
-            current_price = self.trader.get_mark_price()
-            unrealized_pnl_pct = 0.0
-            leverage = float(self.config.leverage)
-            liquidation_price = 0.0
-        else:
-            position_size = position_status.qty  # Positive=long, Negative=short
-            position_value = abs(position_status.notional_value)
-            entry_price = position_status.entry_price
-            current_price = position_status.mark_price
-            unrealized_pnl_pct = position_status.unrealized_pnl_pct
-            leverage = float(position_status.leverage)
-            liquidation_price = position_status.liquidation_price
-
-        # Calculate new 6-element account state
-        # Element 0: exposure_pct (position_value / portfolio_value)
-        exposure_pct = position_value / total_balance if total_balance > 0 else 0.0
-
-        # Element 2: unrealized_pnl_pct (from Bitget API)
-
-        # Element 3: holding_time
-
-        # Element 4: leverage
-
-        # Element 5: distance_to_liquidation
-        # liquidation_price <= 0 means "no liquidation price": the exchange omitted the field
-        # (-> .get(..., 0)) or reports "0" for cross-margin. A short must then read 1.0, not
-        # (0 - price)/price = 0.0, which would falsely tell the policy it is AT liquidation.
-        if position_size == 0 or current_price == 0 or liquidation_price <= 0:
-            distance_to_liquidation = 1.0
-        else:
-            if position_size > 0:
-                # Long position - liquidated if price drops below liquidation_price
-                distance_to_liquidation = (current_price - liquidation_price) / current_price
-            else:
-                # Short position - liquidated if price rises above liquidation_price
-                distance_to_liquidation = (liquidation_price - current_price) / current_price
-            # Clamp to [0, inf)
-            distance_to_liquidation = max(0.0, distance_to_liquidation)
-
-        # Build 6-element account state tensor
-        # [exposure_pct, position_direction, unrealized_pnl_pct,
-        #  holding_time, leverage, distance_to_liquidation]
-        account_state = torch.tensor(
-            [
-                exposure_pct,
-                position_direction,
-                unrealized_pnl_pct,
-                holding_time,
-                leverage,
-                distance_to_liquidation,
-            ],
-            dtype=torch.float,
-        )
-
-        # Build output TensorDict
-        out_td = TensorDict({self.account_state_key: account_state}, batch_size=())
-        for market_data_name, data in zip(self.market_data_keys, market_data):
-            out_td.set(market_data_name, torch.from_numpy(data))
-
-        # Add base features if requested
-        if self.config.include_base_features and base_features is not None:
-            out_td.set("base_features", torch.from_numpy(base_features))
-
-        return out_td
-
-    def _get_portfolio_value(self) -> float:
-        """
-        Calculate total portfolio value for Bitget futures.
-
-        Returns total_margin_balance (includes unrealized PnL).
-        """
-        balance = self.trader.get_account_balance()
-        return balance.get("total_margin_balance", 0)
 
     def _reset(self, tensordict: TensorDictBase, **kwargs) -> TensorDictBase:
         """Reset the environment."""

--- a/torchtrade/envs/live/bybit/base.py
+++ b/torchtrade/envs/live/bybit/base.py
@@ -5,23 +5,22 @@ from abc import abstractmethod
 from typing import Callable, List, Optional
 
 import torch
-from tensordict import TensorDict, TensorDictBase
+from tensordict import TensorDictBase
 from torchrl.data import Bounded
 from torchrl.data.tensor_specs import Composite
 
 from torchtrade.envs.live.bybit.observation import BybitObservationClass
 from torchtrade.envs.live.bybit.order_executor import BybitFuturesOrderClass
-from torchtrade.envs.core.live import TorchTradeLiveEnv
+from torchtrade.envs.live.shared.futures_live_base import TorchTradeFuturesLiveEnv
 from torchtrade.envs.core.state import (
     HistoryTracker,
-    advance_hold_counter,
     position_direction_from_status,
 )
 
 logger = logging.getLogger(__name__)
 
 
-class BybitBaseTorchTradingEnv(TorchTradeLiveEnv):
+class BybitBaseTorchTradingEnv(TorchTradeFuturesLiveEnv):
     """
     Base class for Bybit trading environments.
 
@@ -168,93 +167,6 @@ class BybitBaseTorchTradingEnv(TorchTradeLiveEnv):
             )
             self.observation_spec.set(market_data_key, market_data_spec)
             self.market_data_keys.append(market_data_key)
-
-    def _get_observation(self, advance_hold: bool = True) -> TensorDictBase:
-        """Get the current observation state.
-
-        Args:
-            advance_hold: If True (the default, used by `_step()`), ages `hold_counter`
-                by one bar using the direction observed in THIS method's single
-                `get_status()` call -- holding_time and position_direction in the
-                emitted account_state are always derived from the same snapshot.
-                `_reset()` passes False so a reset can never itself count a bar.
-        """
-        obs_dict = self.observer.get_observations(
-            return_base_ohlc=self.config.include_base_features
-        )
-
-        if self.config.include_base_features:
-            base_features = obs_dict.get("base_features")
-
-        market_data = [obs_dict[features_name] for features_name in self.observer.get_keys()]
-
-        # Get account state from trader (single fetch: holding_time and
-        # position_direction below MUST come from this same snapshot)
-        status = self.trader.get_status()
-        balance = self.trader.get_account_balance()
-
-        total_balance = balance.get("total_wallet_balance", 0)
-        position_status = status.get("position_status", None)
-
-        # Dust is not a position: gating on `is None` let a 1e-12 residual left behind a
-        # close take the position branch and read stale fields off it.
-        position_direction = float(position_direction_from_status(position_status))
-        if advance_hold:
-            advance_hold_counter(self.position, position_direction)
-        holding_time = float(self.position.hold_counter)
-
-        if position_direction == 0:
-            position_size = 0.0
-            position_value = 0.0
-            current_price = self.trader.get_mark_price()
-            unrealized_pnl_pct = 0.0
-            leverage = float(self.config.leverage)
-            liquidation_price = 0.0
-        else:
-            position_size = position_status.qty
-            position_value = abs(position_status.notional_value)
-            current_price = position_status.mark_price
-            unrealized_pnl_pct = position_status.unrealized_pnl_pct
-            leverage = float(position_status.leverage)
-            liquidation_price = position_status.liquidation_price
-
-        # Build 6-element account state
-        exposure_pct = position_value / total_balance if total_balance > 0 else 0.0
-
-        if position_size == 0 or current_price == 0 or liquidation_price <= 0:
-            distance_to_liquidation = 1.0
-        else:
-            if position_size > 0:
-                distance_to_liquidation = (current_price - liquidation_price) / current_price
-            else:
-                distance_to_liquidation = (liquidation_price - current_price) / current_price
-            distance_to_liquidation = max(0.0, distance_to_liquidation)
-
-        account_state = torch.tensor(
-            [
-                exposure_pct,
-                position_direction,
-                unrealized_pnl_pct,
-                holding_time,
-                leverage,
-                distance_to_liquidation,
-            ],
-            dtype=torch.float,
-        )
-
-        out_td = TensorDict({self.account_state_key: account_state}, batch_size=())
-        for market_data_name, data in zip(self.market_data_keys, market_data):
-            out_td.set(market_data_name, torch.from_numpy(data))
-
-        if self.config.include_base_features and base_features is not None:
-            out_td.set("base_features", torch.from_numpy(base_features))
-
-        return out_td
-
-    def _get_portfolio_value(self) -> float:
-        """Calculate total portfolio value (includes unrealized PnL)."""
-        balance = self.trader.get_account_balance()
-        return balance.get("total_margin_balance", 0)
 
     def _reset(self, tensordict: TensorDictBase, **kwargs) -> TensorDictBase:
         """Reset the environment."""

--- a/torchtrade/envs/live/okx/base.py
+++ b/torchtrade/envs/live/okx/base.py
@@ -5,23 +5,22 @@ from abc import abstractmethod
 from typing import Callable, List, Optional
 
 import torch
-from tensordict import TensorDict, TensorDictBase
+from tensordict import TensorDictBase
 from torchrl.data import Bounded
 from torchrl.data.tensor_specs import Composite
 
 from torchtrade.envs.live.okx.observation import OKXObservationClass
 from torchtrade.envs.live.okx.order_executor import OKXFuturesOrderClass
-from torchtrade.envs.core.live import TorchTradeLiveEnv
+from torchtrade.envs.live.shared.futures_live_base import TorchTradeFuturesLiveEnv
 from torchtrade.envs.core.state import (
     HistoryTracker,
-    advance_hold_counter,
     position_direction_from_status,
 )
 
 logger = logging.getLogger(__name__)
 
 
-class OKXBaseTorchTradingEnv(TorchTradeLiveEnv):
+class OKXBaseTorchTradingEnv(TorchTradeFuturesLiveEnv):
     """
     Base class for OKX trading environments.
 
@@ -178,93 +177,6 @@ class OKXBaseTorchTradingEnv(TorchTradeLiveEnv):
                 "base_features",
                 Bounded(low=-torch.inf, high=torch.inf, shape=(base_ws, 4), dtype=torch.float),
             )
-
-    def _get_observation(self, advance_hold: bool = True) -> TensorDictBase:
-        """Get the current observation state.
-
-        Args:
-            advance_hold: If True (the default, used by `_step()`), ages `hold_counter`
-                by one bar using the direction observed in THIS method's single
-                `get_status()` call -- holding_time and position_direction in the
-                emitted account_state are always derived from the same snapshot.
-                `_reset()` passes False so a reset can never itself count a bar.
-        """
-        obs_dict = self.observer.get_observations(
-            return_base_ohlc=self.config.include_base_features
-        )
-
-        if self.config.include_base_features:
-            base_features = obs_dict.get("base_features")
-
-        market_data = [obs_dict[features_name] for features_name in self.observer.get_keys()]
-
-        # Get account state from trader (single fetch: holding_time and
-        # position_direction below MUST come from this same snapshot)
-        status = self.trader.get_status()
-        balance = self.trader.get_account_balance()
-
-        total_balance = balance.get("total_wallet_balance", 0)
-        position_status = status.get("position_status", None)
-
-        # Dust is not a position: gating on `is None` let a 1e-12 residual left behind a
-        # close take the position branch and read stale fields off it.
-        position_direction = float(position_direction_from_status(position_status))
-        if advance_hold:
-            advance_hold_counter(self.position, position_direction)
-        holding_time = float(self.position.hold_counter)
-
-        if position_direction == 0:
-            position_size = 0.0
-            position_value = 0.0
-            current_price = self.trader.get_mark_price()
-            unrealized_pnl_pct = 0.0
-            leverage = float(self.config.leverage)
-            liquidation_price = 0.0
-        else:
-            position_size = position_status.qty
-            position_value = abs(position_status.notional_value)
-            current_price = position_status.mark_price
-            unrealized_pnl_pct = position_status.unrealized_pnl_pct
-            leverage = float(position_status.leverage)
-            liquidation_price = position_status.liquidation_price
-
-        # Build 6-element account state
-        exposure_pct = position_value / total_balance if total_balance > 0 else 0.0
-
-        if position_size == 0 or current_price == 0 or liquidation_price <= 0:
-            distance_to_liquidation = 1.0
-        else:
-            if position_size > 0:
-                distance_to_liquidation = (current_price - liquidation_price) / current_price
-            else:
-                distance_to_liquidation = (liquidation_price - current_price) / current_price
-            distance_to_liquidation = max(0.0, distance_to_liquidation)
-
-        account_state = torch.tensor(
-            [
-                exposure_pct,
-                position_direction,
-                unrealized_pnl_pct,
-                holding_time,
-                leverage,
-                distance_to_liquidation,
-            ],
-            dtype=torch.float,
-        )
-
-        out_td = TensorDict({self.account_state_key: account_state}, batch_size=())
-        for market_data_name, data in zip(self.market_data_keys, market_data):
-            out_td.set(market_data_name, torch.from_numpy(data))
-
-        if self.config.include_base_features and base_features is not None:
-            out_td.set("base_features", torch.from_numpy(base_features))
-
-        return out_td
-
-    def _get_portfolio_value(self) -> float:
-        """Calculate total portfolio value (includes unrealized PnL)."""
-        balance = self.trader.get_account_balance()
-        return balance.get("total_margin_balance", 0)
 
     def _reset(self, tensordict: TensorDictBase, **kwargs) -> TensorDictBase:
         """Reset the environment."""

--- a/torchtrade/envs/live/shared/futures_live_base.py
+++ b/torchtrade/envs/live/shared/futures_live_base.py
@@ -1,0 +1,122 @@
+"""Shared base class for live futures trading environments.
+
+Post-#253, the `_get_observation` bodies of all four futures exchanges (Binance, Bitget,
+Bybit, OKX) are functionally identical -- the only differences were two dead locals
+(`cash`, `entry_price`) in binance/bitget and cosmetic comments. This class holds the one
+shared implementation so a future account_state fix only needs to land once.
+
+Alpaca (spot) is NOT a futures env: it hardcodes leverage=1 and distance_to_liquidation=1.0
+and reads cash rather than total_wallet_balance. It keeps its own `_get_observation` and
+inherits `TorchTradeLiveEnv` directly.
+"""
+import torch
+from tensordict import TensorDict, TensorDictBase
+
+from torchtrade.envs.core.live import TorchTradeLiveEnv
+from torchtrade.envs.core.state import advance_hold_counter, position_direction_from_status
+
+
+class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
+    """Base class for live futures trading environments (Binance, Bitget, Bybit, OKX).
+
+    Holds the single _get_observation (account_state assembly) and _get_portfolio_value
+    (total_margin_balance) shared by all four futures exchanges, so an account_state fix
+    lands once here instead of in four drifting copies.
+
+    Standard account state (6 elements):
+    [exposure_pct, position_direction, unrealized_pnl_pct,
+     holding_time, leverage, distance_to_liquidation]
+
+    Subclasses (per-exchange base envs) must still implement:
+    - _init_trading_clients(): Provider-specific client initialization
+    - _build_observation_specs(): Provider-specific spec construction
+    - _execute_trade_if_needed(): Trade execution logic
+    - _reset(): Provider-specific reset scaffolding
+    """
+
+    def _get_observation(self, advance_hold: bool = True) -> TensorDictBase:
+        """Get the current observation state.
+
+        Args:
+            advance_hold: If True (the default, used by `_step()`), ages `hold_counter`
+                by one bar using the direction observed in THIS method's single
+                `get_status()` call -- holding_time and position_direction in the
+                emitted account_state are always derived from the same snapshot.
+                `_reset()` passes False so a reset can never itself count a bar.
+        """
+        obs_dict = self.observer.get_observations(
+            return_base_ohlc=self.config.include_base_features
+        )
+
+        if self.config.include_base_features:
+            base_features = obs_dict.get("base_features")
+
+        market_data = [obs_dict[features_name] for features_name in self.observer.get_keys()]
+
+        # Get account state from trader (single fetch: holding_time and
+        # position_direction below MUST come from this same snapshot)
+        status = self.trader.get_status()
+        balance = self.trader.get_account_balance()
+
+        total_balance = balance.get("total_wallet_balance", 0)
+        position_status = status.get("position_status", None)
+
+        # Dust is not a position: gating on `is None` let a 1e-12 residual left behind a
+        # close take the position branch and read stale fields off it.
+        position_direction = float(position_direction_from_status(position_status))
+        if advance_hold:
+            advance_hold_counter(self.position, position_direction)
+        holding_time = float(self.position.hold_counter)
+
+        if position_direction == 0:
+            position_size = 0.0
+            position_value = 0.0
+            current_price = self.trader.get_mark_price()
+            unrealized_pnl_pct = 0.0
+            leverage = float(self.config.leverage)
+            liquidation_price = 0.0
+        else:
+            position_size = position_status.qty
+            position_value = abs(position_status.notional_value)
+            current_price = position_status.mark_price
+            unrealized_pnl_pct = position_status.unrealized_pnl_pct
+            leverage = float(position_status.leverage)
+            liquidation_price = position_status.liquidation_price
+
+        # Build 6-element account state
+        exposure_pct = position_value / total_balance if total_balance > 0 else 0.0
+
+        if position_size == 0 or current_price == 0 or liquidation_price <= 0:
+            distance_to_liquidation = 1.0
+        else:
+            if position_size > 0:
+                distance_to_liquidation = (current_price - liquidation_price) / current_price
+            else:
+                distance_to_liquidation = (liquidation_price - current_price) / current_price
+            distance_to_liquidation = max(0.0, distance_to_liquidation)
+
+        account_state = torch.tensor(
+            [
+                exposure_pct,
+                position_direction,
+                unrealized_pnl_pct,
+                holding_time,
+                leverage,
+                distance_to_liquidation,
+            ],
+            dtype=torch.float,
+        )
+
+        out_td = TensorDict({self.account_state_key: account_state}, batch_size=())
+        for market_data_name, data in zip(self.market_data_keys, market_data):
+            out_td.set(market_data_name, torch.from_numpy(data))
+
+        if self.config.include_base_features and base_features is not None:
+            out_td.set("base_features", torch.from_numpy(base_features))
+
+        return out_td
+
+    def _get_portfolio_value(self) -> float:
+        """Calculate total portfolio value (includes unrealized PnL)."""
+        balance = self.trader.get_account_balance()
+        return balance.get("total_margin_balance", 0)


### PR DESCRIPTION
## What

The 4 live **futures** envs (binance/bitget/bybit/okx) each hand-rolled a **byte-identical** `_get_observation` + `_get_portfolio_value` (~90–120 lines apiece). Every `account_state` fix therefore had to land in 4 copies — the "fix the instance, not the class" trap that made `holding_time` (#252) and the liq-distance guard (#253) 4-way sweeps.

This lifts one shared copy into a new intermediate base **`TorchTradeFuturesLiveEnv(TorchTradeLiveEnv)`**; the 4 futures base envs inherit it and delete their copies.

## Behavior-preserving

- The shared body is **byte-identical to the old bybit/okx** `_get_observation`.
- binance/bitget differed **only** by two dead locals (`cash`, `entry_price` — assigned, never read), which are removed.
- **Alpaca (spot) is untouched** — it keeps its own `_get_observation` (leverage=1, no liquidation, cash-based) and does not inherit the futures base.

Verified: shared method diffed byte-for-byte against the old per-exchange versions; the precise per-exchange `account_state` assertions (exposure, leverage, dist_to_liq, holding_time, dust) all still pass.

## Net −283 LOC (`+187 / −425`)

## Guardrails

- **New structural guard** `test_no_futures_env_reforks_the_shared_observation` — asserts all **12** futures classes (base + Futures + FuturesSLTP × 4) resolve `_get_observation`/`_get_portfolio_value` to the shared base **by identity**, so a future re-fork fails loudly instead of silently un-doing the dedup. Mutation-verified.
- The existing AST hold-counter guards already scan the new file (via the `live/**` rglob) — confirmed by mutation (hand-rolled aging in the shared file is flagged).
- Added a test for the now-consolidated `include_base_features=True` passthrough branch (previously dark; futures configs default it off).

## Two pre-existing bugs surfaced during review — logged, NOT fixed here

This PR is deliberately behavior-preserving; both get their own PR + sign-off:
1. **`exposure_pct` denominator** (`account_state[0]`): Binance's `total_wallet_balance` **excludes** unrealized PnL, while bitget/bybit/okx map equity (incl. uPnL) to the same key → cross-exchange skew. Fix: use `total_margin_balance` (uniformly equity).
2. **`base_features` spec mismatch**: binance/bitget/bybit emit a `base_features` observation key absent from their `observation_spec` (only okx declares it) → `check_env_specs` fails for those 3.

Reviewed over the mandated **3 rounds × 4 agents**; Round 3 clean on all four. Full suite **2156 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)