### PR TITLE
fix(envs): exposure_pct divides by equity (total_margin_balance), not wallet balance

### DIFF
--- a/tests/envs/binance/test_torch_env_futures.py
+++ b/tests/envs/binance/test_torch_env_futures.py
@@ -375,6 +375,30 @@ class TestBinanceFuturesTorchTradingEnv:
         assert td["account_state"][1].item() == (1.0 if qty > 0 else -1.0)
         assert td["account_state"][5].item() == expected_dtl
 
+    def test_exposure_pct_uses_equity_not_wallet_balance(self, env, mock_trader):
+        """exposure_pct (account_state[0]) must divide by total_margin_balance (equity incl.
+        uPnL), not total_wallet_balance. Binance's total_wallet_balance excludes uPnL, so using
+        it read a different exposure than the other exchanges for the same position (#60)."""
+        from torchtrade.envs.live.binance.order_executor import PositionStatus
+
+        mock_trader.get_account_balance = MagicMock(return_value={
+            "total_wallet_balance": 1000.0,    # Binance: excludes unrealized PnL
+            "available_balance": 900.0,
+            "total_unrealized_profit": 100.0,
+            "total_margin_balance": 1100.0,    # equity = wallet + uPnL
+        })
+        mock_trader.get_status = MagicMock(return_value={"position_status": PositionStatus(
+            qty=0.011, notional_value=550.0, entry_price=50000.0, unrealized_pnl=100.0,
+            unrealized_pnl_pct=0.02, mark_price=50000.0, leverage=10,
+            margin_type="isolated", liquidation_price=45000.0,
+        )})
+        with patch.object(env, "_wait_for_next_timestamp"):
+            td = env.reset()
+
+        assert td["account_state"][1].item() == 1.0                 # a genuine open long
+        # equity: 550 / 1100 = 0.5. Wallet would give 550 / 1000 = 0.55 (excludes the +100 uPnL).
+        assert td["account_state"][0].item() == pytest.approx(0.5)
+
     def test_closing_a_position_does_not_age_the_next_one(self, env, mock_trader):
         """A closed position's age must not carry into the next one.
 

--- a/torchtrade/envs/live/binance/base.py
+++ b/torchtrade/envs/live/binance/base.py
@@ -35,7 +35,7 @@ class BinanceBaseTorchTradingEnv(TorchTradeFuturesLiveEnv):
      holding_time, leverage, distance_to_liquidation]
 
     Element definitions:
-        - exposure_pct: position_value / total_wallet_balance
+        - exposure_pct: position_value / total_margin_balance (equity incl. unrealized PnL)
         - position_direction: sign(position_size) (-1=short, 0=flat, +1=long)
         - unrealized_pnl_pct: percentage unrealized PnL from entry
         - holding_time: steps since position opened

--- a/torchtrade/envs/live/bitget/base.py
+++ b/torchtrade/envs/live/bitget/base.py
@@ -35,7 +35,7 @@ class BitgetBaseTorchTradingEnv(TorchTradeFuturesLiveEnv):
      holding_time, leverage, distance_to_liquidation]
 
     Element definitions:
-        - exposure_pct: position_value / total_equity
+        - exposure_pct: position_value / total_margin_balance (equity incl. unrealized PnL)
         - position_direction: sign(position_size) (-1=short, 0=flat, +1=long)
         - unrealized_pnl_pct: percentage unrealized PnL from entry
         - holding_time: steps since position opened

--- a/torchtrade/envs/live/shared/futures_live_base.py
+++ b/torchtrade/envs/live/shared/futures_live_base.py
@@ -58,7 +58,13 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
         status = self.trader.get_status()
         balance = self.trader.get_account_balance()
 
-        total_balance = balance.get("total_wallet_balance", 0)
+        # exposure_pct denominator: use total_margin_balance (equity incl. unrealized PnL),
+        # NOT total_wallet_balance. The latter's meaning diverges across exchanges -- Binance's
+        # excludes uPnL while Bitget/Bybit/OKX map equity to the same key -- which made Binance's
+        # exposure_pct read differently for the same position. total_margin_balance is uniformly
+        # equity across all four, so exposure_pct is comparable cross-exchange (and matches the
+        # portfolio value _get_portfolio_value returns).
+        total_balance = balance.get("total_margin_balance", 0)
         position_status = status.get("position_status", None)
 
         # Dust is not a position: gating on `is None` let a 1e-12 residual left behind a


### PR DESCRIPTION
## The bug (#60)

`exposure_pct` (`account_state[0]`, policy-facing) in the shared futures `_get_observation` divided `position_value` by `total_wallet_balance`. But that key means different things per exchange:

- **Binance**: `totalWalletBalance` — **excludes** unrealized PnL
- **Bitget/Bybit/OKX**: map an **equity** figure (**includes** uPnL) to the same key

So a Binance account with open uPnL reported a **different `exposure_pct`** than the other three for the same position — a cross-exchange skew on a raw observation element (same family as #49).

## The fix

Divide by **`total_margin_balance`** instead — uniformly equity-incl-uPnL across all four, and the **same figure `_get_portfolio_value()` already returns**, so `exposure_pct == position_value / portfolio_value` is now literally true (it wasn't before — an internal inconsistency too).

Behavior, traced through each executor:
- **Binance** — changes (the fix): `totalWalletBalance` → `totalMarginBalance`.
- **Bitget / OKX** — no-op: both keys are set from the same variable (`total` / `total_equity`).
- **Bybit** — shifts only toward the portfolio-value definition (its `totalMarginBalance` vs `totalEquity`).

One shared method → all four futures envs fixed at once. Also corrected the now-stale `exposure_pct` docstrings in binance/bitget `base.py`.

## Test

A binance case with `total_wallet_balance=1000` (excludes uPnL) `!=` `total_margin_balance=1100` (equity), position notional 550 → asserts `exposure == 0.5` (not `0.55`). Mutation-verified: reverting the key fails it. Asserts `direction == 1` so it can't pass via the flat branch. Testing once is sufficient — the existing `test_no_futures_env_reforks_the_shared_observation` guard proves all four run the identical shared method.

## Out of scope — logged follow-up

The torchrl-engineer found **sibling sites of the same bug class** still reading `total_wallet_balance`: `initial_portfolio_value` (feeds the bankruptcy threshold) in all 4 `base.py`, and SLTP fractional position-sizing in all 4 `env_sltp.py`. Each is a different behavior (bankruptcy denominator, trade sizing) needing its own decision, so it's tracked separately rather than smuggled in here.

Reviewed over the mandated **3 rounds × 4 agents**; Round 3 clean on all four. Full suite **2157 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)