### PR TITLE
fix(envs): declare base_features in observation_spec for all futures envs

### DIFF
--- a/tests/envs/binance/test_torch_env_futures.py
+++ b/tests/envs/binance/test_torch_env_futures.py
@@ -133,6 +133,23 @@ class TestBinanceFuturesTorchTradingEnv:
             assert max(zero_indices) < min(pos_indices), \
                 "Zero should come before positive values"
 
+    def test_base_features_declared_in_observation_spec(self, env_config, mock_observer, mock_trader):
+        """include_base_features=True must DECLARE base_features in observation_spec, not just
+        emit it -- else spec and observation disagree and a collector pre-allocating from the
+        spec silently drops it (#61)."""
+        import dataclasses
+        from torchtrade.envs.live.binance.env import BinanceFuturesTorchTradingEnv
+
+        config = dataclasses.replace(env_config, include_base_features=True)
+        with patch("time.sleep"), patch.object(BinanceFuturesTorchTradingEnv, "_wait_for_next_timestamp"):
+            env = BinanceFuturesTorchTradingEnv(config=config, observer=mock_observer, trader=mock_trader)
+            td = env.reset()
+
+        assert "base_features" in env.observation_spec.keys()   # the fix (was missing on binance)
+        assert "base_features" in td.keys()                     # emitted -> spec & obs consistent
+        # shape must agree too: a collector pre-allocates buffers BY SHAPE from the spec
+        assert env.observation_spec["base_features"].shape == td["base_features"].shape
+
     def test_observation_spec(self, env):
         """Test observation spec contains expected keys."""
         obs_spec = env.observation_spec
@@ -140,6 +157,7 @@ class TestBinanceFuturesTorchTradingEnv:
         assert "account_state" in obs_spec.keys()
         assert "market_data_1m_10" in obs_spec.keys()
         assert "market_data_5m_10" in obs_spec.keys()
+        assert "base_features" not in obs_spec.keys()   # off by default (mirror of #61)
 
     def test_account_state_shape(self, env):
         """Test account state has correct shape (6 elements)."""

--- a/tests/envs/bitget/test_torch_env_futures.py
+++ b/tests/envs/bitget/test_torch_env_futures.py
@@ -108,6 +108,23 @@ class TestBitgetFuturesTorchTradingEnv:
         """Test action levels are correctly set."""
         assert env.action_levels == [-1.0, -0.5, 0.0, 0.5, 1.0]
 
+    def test_base_features_declared_in_observation_spec(self, env_config, mock_observer, mock_trader):
+        """include_base_features=True must DECLARE base_features in observation_spec, not just
+        emit it -- else spec and observation disagree and a collector pre-allocating from the
+        spec silently drops it (#61)."""
+        import dataclasses
+        from torchtrade.envs.live.bitget.env import BitgetFuturesTorchTradingEnv
+
+        config = dataclasses.replace(env_config, include_base_features=True)
+        with patch("time.sleep"), patch.object(BitgetFuturesTorchTradingEnv, "_wait_for_next_timestamp"):
+            env = BitgetFuturesTorchTradingEnv(config=config, observer=mock_observer, trader=mock_trader)
+            td = env.reset()
+
+        assert "base_features" in env.observation_spec.keys()   # the fix (was missing on bitget)
+        assert "base_features" in td.keys()                     # emitted -> spec & obs consistent
+        # shape must agree too: a collector pre-allocates buffers BY SHAPE from the spec
+        assert env.observation_spec["base_features"].shape == td["base_features"].shape
+
     def test_observation_spec(self, env):
         """Test observation spec contains expected keys."""
         obs_spec = env.observation_spec
@@ -115,6 +132,7 @@ class TestBitgetFuturesTorchTradingEnv:
         assert "account_state" in obs_spec.keys()
         assert "market_data_1m_10" in obs_spec.keys()
         assert "market_data_5m_10" in obs_spec.keys()
+        assert "base_features" not in obs_spec.keys()   # off by default (mirror of #61)
 
     def test_account_state_shape(self, env):
         """Test account state has correct shape (6 elements)."""

--- a/tests/envs/bybit/test_torch_env_futures.py
+++ b/tests/envs/bybit/test_torch_env_futures.py
@@ -106,6 +106,23 @@ class TestBybitFuturesTorchTradingEnv:
 
         assert "base_features" in td.keys()
 
+    def test_base_features_declared_in_observation_spec(self, env_config, mock_observer, mock_trader):
+        """include_base_features=True must DECLARE base_features in observation_spec, not just
+        emit it -- else spec and observation disagree and a collector pre-allocating from the
+        spec silently drops it (#61)."""
+        import dataclasses
+        from torchtrade.envs.live.bybit.env import BybitFuturesTorchTradingEnv
+
+        config = dataclasses.replace(env_config, include_base_features=True)
+        with patch("time.sleep"), patch.object(BybitFuturesTorchTradingEnv, "_wait_for_next_timestamp"):
+            env = BybitFuturesTorchTradingEnv(config=config, observer=mock_observer, trader=mock_trader)
+            td = env.reset()
+
+        assert "base_features" in env.observation_spec.keys()   # the fix (was missing on bybit)
+        assert "base_features" in td.keys()                     # emitted -> spec & obs consistent
+        # shape must agree too: a collector pre-allocates buffers BY SHAPE from the spec
+        assert env.observation_spec["base_features"].shape == td["base_features"].shape
+
     def test_observation_spec(self, env):
         """Test observation spec contains expected keys with correct shapes."""
         obs_spec = env.observation_spec
@@ -113,6 +130,7 @@ class TestBybitFuturesTorchTradingEnv:
         assert "market_data_1Minute_10" in obs_spec.keys()
         assert "market_data_5Minute_10" in obs_spec.keys()
         assert obs_spec["account_state"].shape == (6,)
+        assert "base_features" not in obs_spec.keys()   # off by default (mirror of #61)
 
     def test_reset(self, env, mock_trader):
         """Test environment reset returns expected keys and shapes."""

--- a/tests/envs/okx/test_torch_env_futures.py
+++ b/tests/envs/okx/test_torch_env_futures.py
@@ -56,6 +56,23 @@ class TestOKXFuturesTorchTradingEnv:
         assert env.action_spec.n == 5
         assert env.action_levels == [-1.0, -0.5, 0.0, 0.5, 1.0]
 
+    def test_base_features_declared_in_observation_spec(self, env_config, mock_observer, mock_env_trader):
+        """include_base_features=True must DECLARE base_features in observation_spec, not just
+        emit it -- else spec and observation disagree and a collector pre-allocating from the
+        spec silently drops it (#61). okx already declared it -- this is its regression lock."""
+        import dataclasses
+        from torchtrade.envs.live.okx.env import OKXFuturesTorchTradingEnv
+
+        config = dataclasses.replace(env_config, include_base_features=True)
+        with patch("time.sleep"), patch.object(OKXFuturesTorchTradingEnv, "_wait_for_next_timestamp"):
+            env = OKXFuturesTorchTradingEnv(config=config, observer=mock_observer, trader=mock_env_trader)
+            td = env.reset()
+
+        assert "base_features" in env.observation_spec.keys()
+        assert "base_features" in td.keys()                     # emitted -> spec & obs consistent
+        # shape must agree too: a collector pre-allocates buffers BY SHAPE from the spec
+        assert env.observation_spec["base_features"].shape == td["base_features"].shape
+
     def test_observation_spec(self, env):
         """Test observation spec contains expected keys with correct shapes."""
         obs_spec = env.observation_spec
@@ -63,6 +80,7 @@ class TestOKXFuturesTorchTradingEnv:
         assert "market_data_1Minute_10" in obs_spec.keys()
         assert "market_data_5Minute_10" in obs_spec.keys()
         assert obs_spec["account_state"].shape == (6,)
+        assert "base_features" not in obs_spec.keys()   # off by default (mirror of #61)
 
     def test_reset(self, env, mock_env_trader):
         """Test environment reset returns expected keys and shapes."""

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -162,6 +162,36 @@ def test_no_futures_env_reforks_the_shared_observation(env_cls, method):
     )
 
 
+# Every futures exchange that defines its own _build_observation_specs -- auto-discovered from the
+# discovered FUTURES_ENVS (base + SLTP variants collapse to the 4 defining base classes), so a
+# future 5th futures exchange is covered without editing this list.
+_FUTURES_SPEC_CLASSES = sorted(
+    {c for c in FUTURES_ENVS if "_build_observation_specs" in vars(c)},
+    key=lambda c: c.__module__.split(".")[-2],
+)
+
+
+@pytest.mark.parametrize("env_cls", _FUTURES_SPEC_CLASSES, ids=lambda c: c.__module__.split(".")[-2])
+def test_every_futures_env_declares_base_features_via_the_shared_helper(env_cls):
+    """Every futures _build_observation_specs must call the shared _declare_base_features_spec.
+
+    #61 was a class-level defect: base_features is EMITTED by the shared _get_observation but was
+    DECLARED in observation_spec only by okx (3 of 4 forgot), so spec and observation disagreed
+    and a collector pre-allocating from the spec silently dropped it. The per-exchange behavioural
+    tests each guard only their own exchange; this catches a FUTURE exchange that forgets the call.
+    AST, not source text (like the guards above), so a comment mentioning the method can't satisfy it.
+    """
+    tree = ast.parse(inspect.getsource(env_cls.__dict__["_build_observation_specs"]).lstrip())
+    called = {
+        node.func.attr for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
+    }
+    assert "_declare_base_features_spec" in called, (
+        f"{env_cls.__name__}._build_observation_specs never calls _declare_base_features_spec -- "
+        f"base_features would be emitted but not declared in observation_spec (#61)."
+    )
+
+
 @pytest.mark.parametrize("env_cls", NON_SLTP_ENVS, ids=lambda c: c.__name__)
 def test_non_sltp_step_syncs_before_it_trades(env_cls):
     """Every non-SLTP _step reconciles with the exchange BEFORE the duplicate-action guard.

--- a/torchtrade/envs/live/binance/base.py
+++ b/torchtrade/envs/live/binance/base.py
@@ -187,6 +187,8 @@ class BinanceBaseTorchTradingEnv(TorchTradeFuturesLiveEnv):
             self.observation_spec.set(market_data_key, market_data_spec)
             self.market_data_keys.append(market_data_key)
 
+        self._declare_base_features_spec(window_sizes[0])
+
     def _reset(self, tensordict: TensorDictBase, **kwargs) -> TensorDictBase:
         """Reset the environment."""
         # Cancel all orders

--- a/torchtrade/envs/live/bitget/base.py
+++ b/torchtrade/envs/live/bitget/base.py
@@ -204,6 +204,8 @@ class BitgetBaseTorchTradingEnv(TorchTradeFuturesLiveEnv):
             self.observation_spec.set(market_data_key, market_data_spec)
             self.market_data_keys.append(market_data_key)
 
+        self._declare_base_features_spec(window_sizes[0])
+
     def _reset(self, tensordict: TensorDictBase, **kwargs) -> TensorDictBase:
         """Reset the environment."""
         # Cancel all orders

--- a/torchtrade/envs/live/bybit/base.py
+++ b/torchtrade/envs/live/bybit/base.py
@@ -168,6 +168,8 @@ class BybitBaseTorchTradingEnv(TorchTradeFuturesLiveEnv):
             self.observation_spec.set(market_data_key, market_data_spec)
             self.market_data_keys.append(market_data_key)
 
+        self._declare_base_features_spec(window_sizes[0])
+
     def _reset(self, tensordict: TensorDictBase, **kwargs) -> TensorDictBase:
         """Reset the environment."""
         if not self.trader.cancel_open_orders():

--- a/torchtrade/envs/live/okx/base.py
+++ b/torchtrade/envs/live/okx/base.py
@@ -170,13 +170,7 @@ class OKXBaseTorchTradingEnv(TorchTradeFuturesLiveEnv):
             self.observation_spec.set(market_data_key, market_data_spec)
             self.market_data_keys.append(market_data_key)
 
-        # Base features spec (raw OHLC from first timeframe)
-        if self.config.include_base_features:
-            base_ws = window_sizes[0]
-            self.observation_spec.set(
-                "base_features",
-                Bounded(low=-torch.inf, high=torch.inf, shape=(base_ws, 4), dtype=torch.float),
-            )
+        self._declare_base_features_spec(window_sizes[0])
 
     def _reset(self, tensordict: TensorDictBase, **kwargs) -> TensorDictBase:
         """Reset the environment."""

--- a/torchtrade/envs/live/shared/futures_live_base.py
+++ b/torchtrade/envs/live/shared/futures_live_base.py
@@ -11,6 +11,7 @@ inherits `TorchTradeLiveEnv` directly.
 """
 import torch
 from tensordict import TensorDict, TensorDictBase
+from torchrl.data import Bounded
 
 from torchtrade.envs.core.live import TorchTradeLiveEnv
 from torchtrade.envs.core.state import advance_hold_counter, position_direction_from_status
@@ -126,3 +127,18 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
         """Calculate total portfolio value (includes unrealized PnL)."""
         balance = self.trader.get_account_balance()
         return balance.get("total_margin_balance", 0)
+
+    def _declare_base_features_spec(self, base_window: int) -> None:
+        """Declare the base_features spec (raw OHLC, first timeframe) -- shape (base_window, 4).
+
+        _get_observation (shared, above) emits base_features when include_base_features is set, so
+        every futures exchange's _build_observation_specs MUST call this or observation_spec
+        disagrees with the emitted observation: check_env_specs fails and a collector
+        pre-allocating from the spec silently drops the key. Shared here alongside the emitter so
+        the spec cannot drift per-exchange -- the exact drift that left 3 of 4 undeclared (#61).
+        """
+        if self.config.include_base_features:
+            self.observation_spec.set(
+                "base_features",
+                Bounded(low=-torch.inf, high=torch.inf, shape=(base_window, 4), dtype=torch.float),
+            )


### PR DESCRIPTION
## The bug (#61)

With `include_base_features=True` the shared futures `_get_observation` **emits** a `base_features` observation key — but only **okx**'s `_build_observation_specs` **declared** it; binance/bitget/bybit never did. So `observation_spec` disagreed with the actual observation for 3 of 4 exchanges:
- `check_env_specs` fails, and
- a collector / `TransformedEnv` that pre-allocates buffers **from the spec** silently **drops** `base_features` → a policy trained expecting those inputs loses them with no error.

## The fix (root cause, not just the instances)

The **emitter** is already shared (`TorchTradeFuturesLiveEnv._get_observation`), so the spec belongs next to it. Added a shared **`_declare_base_features_spec(base_window)`** helper (`Bounded`, shape `(base_window, 4)`, guarded by `include_base_features`) that all 4 futures `_build_observation_specs` call — one source of truth that **cannot drift per-exchange** (which is exactly how 3 of 4 came to be undeclared). okx's inline block is replaced by the same call.

## Tests (all mutation-verified)

- **Per-exchange** `test_base_features_declared_in_observation_spec` — asserts `base_features` is in `observation_spec` **and** the reset obs **and** that their **shapes agree** (a collector pre-allocates *by shape*).
- Each `test_observation_spec` now asserts `base_features` is **not** in the spec when the flag is off (the mirror bug).
- **AST class-level guard** `test_every_futures_env_declares_base_features_via_the_shared_helper` — auto-discovered from `FUTURES_ENVS`, fails if a **future** futures exchange forgets the call. (AST, not source-text, per this file's documented standard — so a comment mentioning the method can't satisfy it. It caught a real dropped call during review.)

Mutations checked: drop the call → its row fails; drop the helper's guard → negative test fails; wrong shape `(base_window,5)` → shape assert fails; comment-only mention → AST guard still fails.

## Out of scope — logged follow-up

**Alpaca** has the same latent bug, but its `_get_observation` emits only the *last bar* (`base_features[-1]`, shape `(4,)`), so it needs a **semantics decision** (single-bar vs full-window), not a copy of the futures block. Tracked separately.

Reviewed over the mandated **3 rounds × 4 agents**; Round 3 clean (I adjudicated one 3-way split toward AST per the file's own documented standard). Full suite **2165 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)