### PR TITLE
docs(readme): correct holding_time account_state description (#49 convention)

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,7 +467,7 @@ observation = {
 #   - exposure_pct: position_value / portfolio_value (0-1+ with leverage)
 #   - position_direction: sign(position_size) (-1=short, 0=flat, +1=long)
 #   - unrealized_pnl_pct: (current_price - entry_price) / entry_price * direction
-#   - holding_time: steps since position opened
+#   - holding_time: bars the current position has been held (1 on the opening bar, 0 when flat)
 #   - leverage: 1.0 for spot, 1-125 for futures
 #   - distance_to_liquidation: normalized distance (1.0 for spot/no position)
 #


### PR DESCRIPTION
`README.md`'s account_state reference described `holding_time` as **"steps since position opened"** — which reads as `0` on the opening bar. Since **#49 / PR #252**, `holding_time` reads **`1` on the opening bar** (and `0` when flat), so that line was stale.

Corrected to: *"bars the current position has been held (1 on the opening bar, 0 when flat)"* — verified against the `holding_time` code (`advance_hold_counter` / the offline envs).

The other lines in that block are accurate as-is; notably `exposure_pct: position_value / portfolio_value` is now *exactly* true after the equity-denominator fix (#256).

Doc-only, one line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)