### PR TITLE
fix(envs): alpaca base_features full-window (window,4) matching futures + shared spec helper

### DIFF
--- a/tests/envs/alpaca/test_obs_class.py
+++ b/tests/envs/alpaca/test_obs_class.py
@@ -65,7 +65,10 @@ class TestAlpacaObservationClass(BaseObservationClassTests):
         observations = obs.get_observations(return_base_ohlc=True)
         assert "base_features" in observations
         assert "base_timestamps" in observations
-        assert observations["base_features"].shape[1] == 4
+        # (window, 4), not the full 600-bar lookback: base_features must be windowed like
+        # market_data, or it disagrees with the env's declared (window, 4) spec (#69).
+        assert observations["base_features"].shape == (10, 4)
+        assert observations["base_timestamps"].shape == (10,)
 
     def test_get_features_default_names(self):
         """Default preprocessing yields the four named OHLC features."""

--- a/tests/envs/alpaca/test_torch_env.py
+++ b/tests/envs/alpaca/test_torch_env.py
@@ -78,6 +78,7 @@ class TestAlpacaTorchTradingEnvInitialization:
         # Check market data keys
         market_keys = [k for k in env.observation_spec.keys() if "market_data" in k]
         assert len(market_keys) == 1
+        assert "base_features" not in env.observation_spec.keys()  # off by default (mirror of #61)
 
     def test_reward_spec(self):
         """Test that reward spec is correctly defined."""
@@ -162,6 +163,9 @@ class TestAlpacaTorchTradingEnvReset:
         td = env.reset()
 
         assert isinstance(td, TensorDict)
+        # include_base_features is off by default -> the key is neither declared nor emitted
+        # (the emission side of the off-by-default symmetry the spec test pins the other half of)
+        assert "base_features" not in td.keys()
 
     def test_reset_contains_market_data(self, env):
         """Test that reset returns market data."""
@@ -667,8 +671,11 @@ class TestAlpacaTorchTradingEnvPositionTracking:
 class TestAlpacaTorchTradingEnvBaseFeatures:
     """Tests for base features inclusion."""
 
-    def test_include_base_features(self):
-        """Test that base features are included when configured."""
+    def test_base_features_declared_in_observation_spec(self):
+        """include_base_features=True must DECLARE base_features in observation_spec (not just
+        emit it) AND emit the full (window, 4) window -- not the last-bar (4,) slice. Either
+        mismatch means spec and observation disagree and a collector pre-allocating from the
+        spec drops or misshapes it (#61, #69)."""
         config = AlpacaTradingEnvConfig(
             symbol="BTC/USD",
             window_sizes=[10],
@@ -686,7 +693,9 @@ class TestAlpacaTorchTradingEnvBaseFeatures:
 
         td = env.reset()
 
+        assert "base_features" in env.observation_spec.keys()
         assert "base_features" in td.keys()
+        assert env.observation_spec["base_features"].shape == td["base_features"].shape == (10, 4)
 
 
 class TestAlpacaTorchTradingEnvClose:

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -162,22 +162,27 @@ def test_no_futures_env_reforks_the_shared_observation(env_cls, method):
     )
 
 
-# Every futures exchange that defines its own _build_observation_specs -- auto-discovered from the
-# discovered FUTURES_ENVS (base + SLTP variants collapse to the 4 defining base classes), so a
-# future 5th futures exchange is covered without editing this list.
-_FUTURES_SPEC_CLASSES = sorted(
-    {c for c in FUTURES_ENVS if "_build_observation_specs" in vars(c)},
+# Every live env that defines its own _build_observation_specs -- auto-discovered from LIVE_ENVS
+# (base + SLTP variants collapse to their defining base classes), so a future exchange, or a new
+# non-futures env, is covered without editing this list. This spans both the 4 futures exchanges
+# AND alpaca (spot) -- alpaca declares base_features via the same shared helper too.
+_BASE_FEATURES_SPEC_CLASSES = sorted(
+    {c for c in LIVE_ENVS if "_build_observation_specs" in vars(c)},
     key=lambda c: c.__module__.split(".")[-2],
 )
 
 
-@pytest.mark.parametrize("env_cls", _FUTURES_SPEC_CLASSES, ids=lambda c: c.__module__.split(".")[-2])
-def test_every_futures_env_declares_base_features_via_the_shared_helper(env_cls):
-    """Every futures _build_observation_specs must call the shared _declare_base_features_spec.
+@pytest.mark.parametrize(
+    "env_cls", _BASE_FEATURES_SPEC_CLASSES, ids=lambda c: c.__module__.split(".")[-2]
+)
+def test_every_live_env_declares_base_features_via_the_shared_helper(env_cls):
+    """Every live env's _build_observation_specs must call the shared _declare_base_features_spec.
 
     #61 was a class-level defect: base_features is EMITTED by the shared _get_observation but was
-    DECLARED in observation_spec only by okx (3 of 4 forgot), so spec and observation disagreed
-    and a collector pre-allocating from the spec silently dropped it. The per-exchange behavioural
+    DECLARED in observation_spec only by okx (3 of 4 futures exchanges forgot), so spec and
+    observation disagreed and a collector pre-allocating from the spec silently dropped it. The
+    helper now lives on TorchTradeLiveEnv (the common ancestor of both the futures base and
+    alpaca), so this guard spans every live env, not just futures. The per-exchange behavioural
     tests each guard only their own exchange; this catches a FUTURE exchange that forgets the call.
     AST, not source text (like the guards above), so a comment mentioning the method can't satisfy it.
     """

--- a/torchtrade/envs/core/live.py
+++ b/torchtrade/envs/core/live.py
@@ -5,7 +5,9 @@ from abc import abstractmethod
 from datetime import datetime, timedelta
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
+import torch
 from tensordict import TensorDictBase
+from torchrl.data import Bounded
 
 from torchtrade.envs.core.base import TorchTradeBaseEnv
 from torchtrade.envs.core.state import PositionState, position_direction_from_status
@@ -216,6 +218,21 @@ class TorchTradeLiveEnv(TorchTradeBaseEnv):
             self.position.hold_counter = 0
 
         self.position.current_position = observed
+
+    def _declare_base_features_spec(self, base_window: int) -> None:
+        """Declare the base_features spec (raw OHLC, first timeframe) -- shape (base_window, 4).
+
+        _get_observation emits base_features when include_base_features is set, so every live
+        env's _build_observation_specs MUST call this or observation_spec disagrees with the
+        emitted observation: check_env_specs fails and a collector pre-allocating from the spec
+        silently drops the key. Shared here alongside the emitter so the spec cannot drift
+        per-exchange -- the exact drift that left 3 of 4 futures exchanges undeclared (#61).
+        """
+        if self.config.include_base_features:
+            self.observation_spec.set(
+                "base_features",
+                Bounded(low=-torch.inf, high=torch.inf, shape=(base_window, 4), dtype=torch.float),
+            )
 
     def _check_termination(self, portfolio_value: float) -> bool:
         """Terminate when the portfolio falls below bankrupt_threshold * its initial value."""

--- a/torchtrade/envs/live/alpaca/base.py
+++ b/torchtrade/envs/live/alpaca/base.py
@@ -180,6 +180,8 @@ class AlpacaBaseTorchTradingEnv(TorchTradeLiveEnv):
             self.observation_spec.set(market_data_key, market_data_spec)
             self.market_data_keys.append(market_data_key)
 
+        self._declare_base_features_spec(window_sizes[0])
+
     def _get_observation(self, advance_hold: bool = True) -> TensorDictBase:
         """Get the current observation state.
 
@@ -192,12 +194,12 @@ class AlpacaBaseTorchTradingEnv(TorchTradeLiveEnv):
         """
         # Get market data
         obs_dict = self.observer.get_observations(
-            return_base_ohlc=True if self.config.include_base_features else False
+            return_base_ohlc=self.config.include_base_features
         )
 
         # Extract base features if requested
         if self.config.include_base_features:
-            base_features = obs_dict["base_features"][-1]
+            base_features = obs_dict.get("base_features")
 
         # Get market data for each timeframe
         market_data = [obs_dict[features_name] for features_name in self.observer.get_keys()]
@@ -260,7 +262,7 @@ class AlpacaBaseTorchTradingEnv(TorchTradeLiveEnv):
             out_td.set(market_data_name, torch.from_numpy(data))
 
         # Add base features if requested
-        if self.config.include_base_features:
+        if self.config.include_base_features and base_features is not None:
             out_td.set("base_features", torch.from_numpy(base_features))
 
         return out_td

--- a/torchtrade/envs/live/alpaca/observation.py
+++ b/torchtrade/envs/live/alpaca/observation.py
@@ -154,11 +154,14 @@ class AlpacaObservationClass:
                 base_df = df.reset_index()
                 base_df.dropna(inplace=True)
                 base_df.drop_duplicates(inplace=True)
+                # Window base_features to the first timeframe's window, matching the futures
+                # observer (futures_base_obs.py) -- the env declares a (window, 4) spec, so an
+                # unwindowed emission (the full lookback) would disagree with it (#69).
                 observations['base_features'] = self._get_numpy_obs(
-                    base_df, 
+                    base_df,
                     columns=['open', 'high', 'low', 'close']
-                )
-                observations['base_timestamps'] = base_df['timestamp'].values
+                )[-window_size:]
+                observations['base_timestamps'] = base_df['timestamp'].values[-window_size:]
             processed_df = self.feature_preprocessing_fn(df)
             # apply window size
             processed_df = processed_df.iloc[-window_size:]

--- a/torchtrade/envs/live/shared/futures_live_base.py
+++ b/torchtrade/envs/live/shared/futures_live_base.py
@@ -11,7 +11,6 @@ inherits `TorchTradeLiveEnv` directly.
 """
 import torch
 from tensordict import TensorDict, TensorDictBase
-from torchrl.data import Bounded
 
 from torchtrade.envs.core.live import TorchTradeLiveEnv
 from torchtrade.envs.core.state import advance_hold_counter, position_direction_from_status
@@ -127,18 +126,3 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
         """Calculate total portfolio value (includes unrealized PnL)."""
         balance = self.trader.get_account_balance()
         return balance.get("total_margin_balance", 0)
-
-    def _declare_base_features_spec(self, base_window: int) -> None:
-        """Declare the base_features spec (raw OHLC, first timeframe) -- shape (base_window, 4).
-
-        _get_observation (shared, above) emits base_features when include_base_features is set, so
-        every futures exchange's _build_observation_specs MUST call this or observation_spec
-        disagrees with the emitted observation: check_env_specs fails and a collector
-        pre-allocating from the spec silently drops the key. Shared here alongside the emitter so
-        the spec cannot drift per-exchange -- the exact drift that left 3 of 4 undeclared (#61).
-        """
-        if self.config.include_base_features:
-            self.observation_spec.set(
-                "base_features",
-                Bounded(low=-torch.inf, high=torch.inf, shape=(base_window, 4), dtype=torch.float),
-            )


### PR DESCRIPTION
## Decision

Per your call: alpaca's `base_features` should emit the **full window `(window, 4)`** like every futures env, not the single last bar `(4,)`.

## Two independent bugs made alpaca disagree with its spec

1. **The alpaca observer never windowed `base_features`.** `observation.py` emitted the *full lookback* (e.g. `(600,4)`, `(5000,4)`) while `market_data` was windowed. Now sliced `[-window_size:]` (with `base_timestamps` in lockstep), matching `futures_base_obs.py`.
2. **`_get_observation` sliced `[-1]`** to a single bar `(4,)`. Now emits the full window, matching the shared futures `_get_observation`.

Both were **hidden by the mock**: the env-level `MockObserver` hardcoded `base_features` to `(window,4)`. The observer-level test now feeds **600 bars** and pins `(window,4)`, so it exercises the *real* observer.

## Also: declare the spec + share the helper (the #61 fix, extended to alpaca)

`_declare_base_features_spec` **moved up** from `TorchTradeFuturesLiveEnv` to the common base `TorchTradeLiveEnv`, so alpaca + all 4 futures share **one** helper. The class-level AST guard is **generalized** from `FUTURES_ENVS` to all live envs — it now covers alpaca and auto-covers a future 5th exchange.

## Tests (all mutation-verified)

- **Observer-level** windowing (real observer, 600 bars → `(10,4)`; `base_timestamps` `(10,)`).
- **Env-level**: spec + shape + emission (on), and negative spec + emission (off — both directions).
- Generalized guard over all 5 live envs.
- Removed a duplicate env-level test whose coverage is a strict subset of the spec/shape test.

## Review note

This is the one where the review earned its keep: **Round 1 caught that the initial implementation was spec-only and still broken in production** (the observer wasn't windowing — the other two agents passed it because they trusted the mock; the torchrl-engineer tested the real observer). The observer fix + observer-level test close it end-to-end.

Reviewed over the mandated **3 rounds × 4 agents**; Round 3 clean. Full suite **2166 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)