### PR TITLE
fix(envs): live SLTP sizing + bankruptcy baseline use equity (total_margin_balance), like offline

### DIFF
--- a/tests/envs/binance/test_torch_env_futures_sltp.py
+++ b/tests/envs/binance/test_torch_env_futures_sltp.py
@@ -103,6 +103,27 @@ class TestBinanceFuturesSLTPTorchTradingEnv:
         assert env.active_stop_loss == 0.0
         assert env.active_take_profit == 0.0
 
+    def test_initial_portfolio_value_uses_margin_balance(self, env_config, mock_observer, mock_trader):
+        """initial_portfolio_value (the bankruptcy baseline) must be equity
+        (total_margin_balance), not total_wallet_balance -- matching offline's
+        portfolio_value basis (#65)."""
+        from torchtrade.envs.live.binance.env_sltp import BinanceFuturesSLTPTorchTradingEnv
+
+        mock_trader.get_account_balance = MagicMock(return_value={
+            "total_wallet_balance": 1000.0,
+            "available_balance": 900.0,
+            "total_unrealized_profit": 100.0,
+            "total_margin_balance": 1100.0,
+        })
+
+        with patch("time.sleep"), \
+             patch.object(BinanceFuturesSLTPTorchTradingEnv, "_wait_for_next_timestamp"):
+            env = BinanceFuturesSLTPTorchTradingEnv(
+                config=env_config, observer=mock_observer, trader=mock_trader,
+            )
+
+        assert env.initial_portfolio_value == 1100.0
+
     def test_action_map_structure(self, env):
         """Test action map has correct structure."""
         # With 2 SL levels and 2 TP levels:
@@ -1093,10 +1114,12 @@ class TestBinanceSLTPNotionalTradeMode:
         mock_trader.cancel_open_orders = MagicMock(return_value=True)
         mock_trader.close_position = MagicMock(return_value=True)
         mock_trader.get_account_balance = MagicMock(return_value={
+            # wallet != margin: sizing must use total_margin_balance (equity, incl.
+            # unrealized PnL), matching offline's portfolio_value basis (#65).
             "total_wallet_balance": 1000.0,
             "available_balance": 900.0,
-            "total_unrealized_profit": 0.0,
-            "total_margin_balance": 1000.0,
+            "total_unrealized_profit": 100.0,
+            "total_margin_balance": 1100.0,
         })
         mock_trader.get_status = MagicMock(return_value={"position_status": None})
         mock_trader.trade = MagicMock(return_value=True)
@@ -1122,8 +1145,8 @@ class TestBinanceSLTPNotionalTradeMode:
         env._execute_trade_if_needed(("long", -0.02, 0.03))
 
         call_kwargs = mock_trader.trade.call_args[1]
-        # balance=1000 * fraction=0.1 * leverage=5 / candle_close=50050 ≈ 0.00999
-        expected_qty = 1000.0 * 0.1 * 5 / 50050.0
+        # margin_balance=1100 * fraction=0.1 * leverage=5 / candle_close=50050 ≈ 0.01099
+        expected_qty = 1100.0 * 0.1 * 5 / 50050.0
         assert call_kwargs["quantity"] == pytest.approx(expected_qty, rel=1e-4)
 
 

--- a/tests/envs/bitget/test_torch_env_futures_sltp.py
+++ b/tests/envs/bitget/test_torch_env_futures_sltp.py
@@ -118,6 +118,27 @@ class TestBitgetFuturesSLTPTorchTradingEnv:
         assert env.active_stop_loss == 0.0
         assert env.active_take_profit == 0.0
 
+    def test_initial_portfolio_value_uses_margin_balance(self, env_config, mock_observer, mock_trader):
+        """initial_portfolio_value (the bankruptcy baseline) must be equity
+        (total_margin_balance), not total_wallet_balance -- matching offline's
+        portfolio_value basis (#65)."""
+        from torchtrade.envs.live.bitget.env_sltp import BitgetFuturesSLTPTorchTradingEnv
+
+        mock_trader.get_account_balance = MagicMock(return_value={
+            "total_wallet_balance": 1000.0,
+            "available_balance": 900.0,
+            "total_unrealized_profit": 100.0,
+            "total_margin_balance": 1100.0,
+        })
+
+        with patch("time.sleep"), \
+             patch.object(BitgetFuturesSLTPTorchTradingEnv, "_wait_for_next_timestamp"):
+            env = BitgetFuturesSLTPTorchTradingEnv(
+                config=env_config, observer=mock_observer, trader=mock_trader,
+            )
+
+        assert env.initial_portfolio_value == 1100.0
+
     def test_action_map_structure(self, env):
         """Test action map has correct structure."""
         # With 2 SL levels and 2 TP levels:
@@ -793,10 +814,12 @@ class TestBitgetSLTPNotionalTradeMode:
         mock_trader.cancel_open_orders = MagicMock(return_value=True)
         mock_trader.close_position = MagicMock(return_value=True)
         mock_trader.get_account_balance = MagicMock(return_value={
+            # wallet != margin: sizing must use total_margin_balance (equity, incl.
+            # unrealized PnL), matching offline's portfolio_value basis (#65).
             "total_wallet_balance": 1000.0,
             "available_balance": 900.0,
-            "total_unrealized_profit": 0.0,
-            "total_margin_balance": 1000.0,
+            "total_unrealized_profit": 100.0,
+            "total_margin_balance": 1100.0,
         })
         mock_trader.get_status = MagicMock(return_value={"position_status": None})
         mock_trader.trade = MagicMock(return_value=True)
@@ -822,8 +845,8 @@ class TestBitgetSLTPNotionalTradeMode:
         env._execute_trade_if_needed(("long", -0.02, 0.03))
 
         call_kwargs = mock_trader.trade.call_args[1]
-        # balance=1000 * fraction=0.1 * leverage=5 / candle_close=50050 ≈ 0.00999
-        expected_qty = 1000.0 * 0.1 * 5 / 50050.0
+        # margin_balance=1100 * fraction=0.1 * leverage=5 / candle_close=50050 ≈ 0.01099
+        expected_qty = 1100.0 * 0.1 * 5 / 50050.0
         assert call_kwargs["quantity"] == pytest.approx(expected_qty, rel=1e-4)
 
 

--- a/tests/envs/bybit/test_torch_env_futures_sltp.py
+++ b/tests/envs/bybit/test_torch_env_futures_sltp.py
@@ -60,6 +60,27 @@ class TestBybitFuturesSLTPTorchTradingEnv:
         assert env.action_spec.n == 9
         assert env.action_map[0] == (None, None, None)  # HOLD
 
+    def test_initial_portfolio_value_uses_margin_balance(self, env_config, mock_env_observer, mock_env_trader):
+        """initial_portfolio_value (the bankruptcy baseline) must be equity
+        (total_margin_balance), not total_wallet_balance -- matching offline's
+        portfolio_value basis (#65)."""
+        from torchtrade.envs.live.bybit.env_sltp import BybitFuturesSLTPTorchTradingEnv
+
+        mock_env_trader.get_account_balance = MagicMock(return_value={
+            "total_wallet_balance": 1000.0,
+            "available_balance": 900.0,
+            "total_unrealized_profit": 100.0,
+            "total_margin_balance": 1100.0,
+        })
+
+        with patch("time.sleep"), \
+             patch.object(BybitFuturesSLTPTorchTradingEnv, "_wait_for_next_timestamp"):
+            env = BybitFuturesSLTPTorchTradingEnv(
+                config=env_config, observer=mock_env_observer, trader=mock_env_trader,
+            )
+
+        assert env.initial_portfolio_value == 1100.0
+
     def test_action_map_long_actions(self, env):
         """Test long actions have negative SL and positive TP."""
         for i in range(1, 5):
@@ -614,10 +635,12 @@ class TestBybitSLTPNotionalTradeMode:
 
         mock_env_trader.get_mark_price = MagicMock(return_value=50000.0)
         mock_env_trader.get_account_balance = MagicMock(return_value={
+            # wallet != margin: sizing must use total_margin_balance (equity, incl.
+            # unrealized PnL), matching offline's portfolio_value basis (#65).
             "total_wallet_balance": 1000.0,
             "available_balance": 900.0,
-            "total_unrealized_profit": 0.0,
-            "total_margin_balance": 1000.0,
+            "total_unrealized_profit": 100.0,
+            "total_margin_balance": 1100.0,
         })
 
         with patch.object(env, "_wait_for_next_timestamp"):
@@ -625,8 +648,8 @@ class TestBybitSLTPNotionalTradeMode:
             env._execute_trade_if_needed(("long", -0.02, 0.03))
 
             call_kwargs = mock_env_trader.trade.call_args[1]
-            # balance=1000 * fraction=0.1 * leverage=5 / price=50000 = 0.01
-            assert call_kwargs["quantity"] == pytest.approx(0.01, rel=1e-4)
+            # margin_balance=1100 * fraction=0.1 * leverage=5 / price=50000 = 0.011
+            assert call_kwargs["quantity"] == pytest.approx(0.011, rel=1e-4)
 
 
 class TestBybitSLTPLockPosition:

--- a/tests/envs/okx/test_torch_env_futures_sltp.py
+++ b/tests/envs/okx/test_torch_env_futures_sltp.py
@@ -46,6 +46,25 @@ class TestOKXFuturesSLTPTorchTradingEnv:
         assert env.action_spec.n == 9
         assert env.action_map[0] == (None, None, None)  # HOLD
 
+    def test_initial_portfolio_value_uses_margin_balance(self, env_config, mock_env_observer, mock_env_trader):
+        """initial_portfolio_value (the bankruptcy baseline) must be equity
+        (total_margin_balance), not total_wallet_balance -- matching offline's
+        portfolio_value basis (#65)."""
+        from torchtrade.envs.live.okx.env_sltp import OKXFuturesSLTPTorchTradingEnv
+
+        mock_env_trader.get_account_balance = MagicMock(return_value={
+            "total_wallet_balance": 1000.0, "available_balance": 900.0,
+            "total_unrealized_profit": 100.0, "total_margin_balance": 1100.0,
+        })
+
+        with patch("time.sleep"), \
+             patch.object(OKXFuturesSLTPTorchTradingEnv, "_wait_for_next_timestamp"):
+            env = OKXFuturesSLTPTorchTradingEnv(
+                config=env_config, observer=mock_env_observer, trader=mock_env_trader,
+            )
+
+        assert env.initial_portfolio_value == 1100.0
+
     def test_action_spec_long_only(self, env_config, mock_env_observer, mock_env_trader):
         """Test action spec when short positions disabled: 1 HOLD + 4 LONG = 5."""
         from torchtrade.envs.live.okx.env_sltp import OKXFuturesSLTPTorchTradingEnv
@@ -331,14 +350,16 @@ class TestOKXSLTPNotionalTradeMode:
 
         mock_env_trader.get_mark_price = MagicMock(return_value=50000.0)
         mock_env_trader.get_account_balance = MagicMock(return_value={
+            # wallet != margin: sizing must use total_margin_balance (equity, incl.
+            # unrealized PnL), matching offline's portfolio_value basis (#65).
             "total_wallet_balance": 1000.0, "available_balance": 900.0,
-            "total_unrealized_profit": 0.0, "total_margin_balance": 1000.0,
+            "total_unrealized_profit": 100.0, "total_margin_balance": 1100.0,
         })
         with patch.object(env, "_wait_for_next_timestamp"):
             env.reset()
             env._execute_trade_if_needed(("long", -0.02, 0.03))
-            # balance=1000 * fraction=0.1 * leverage=5 / price=50000 = 0.01
-            assert mock_env_trader.trade.call_args[1]["quantity"] == pytest.approx(0.01, rel=1e-4)
+            # margin_balance=1100 * fraction=0.1 * leverage=5 / price=50000 = 0.011
+            assert mock_env_trader.trade.call_args[1]["quantity"] == pytest.approx(0.011, rel=1e-4)
 
 
 class TestOKXSLTPLockPosition:

--- a/torchtrade/envs/live/binance/base.py
+++ b/torchtrade/envs/live/binance/base.py
@@ -98,9 +98,11 @@ class BinanceBaseTorchTradingEnv(TorchTradeFuturesLiveEnv):
         if config.close_position_on_init:
             self.trader.close_position()
 
-        # Get initial portfolio value
+        # Bankruptcy baseline on total_margin_balance (equity), matching offline's
+        # portfolio_value and the current side of the check. Binance's total_wallet_balance
+        # excludes unrealized PnL (a real skew here); bitget/bybit/okx map both keys to equity.
         balance = self.trader.get_account_balance()
-        self.initial_portfolio_value = balance.get("total_wallet_balance", 0)
+        self.initial_portfolio_value = balance.get("total_margin_balance", 0)
 
         # Build observation specs
         self._build_observation_specs()

--- a/torchtrade/envs/live/binance/env_sltp.py
+++ b/torchtrade/envs/live/binance/env_sltp.py
@@ -286,7 +286,10 @@ class BinanceFuturesSLTPTorchTradingEnv(SLTPMixin, BinanceBaseTorchTradingEnv):
 
         # Resolve quantity based on trade_mode
         if self.config.trade_mode == "fractional":
-            balance = float(self.trader.get_account_balance()["total_wallet_balance"])
+            # Size on total_margin_balance (equity), matching offline sizing and the non-SLTP
+            # live path. Binance's total_wallet_balance excludes unrealized PnL and would under-size;
+            # bitget/bybit/okx map both keys to equity, so the switch is a no-op there.
+            balance = float(self.trader.get_account_balance()["total_margin_balance"])
             if current_price <= 0 or balance <= 0:
                 logger.error(f"Invalid price={current_price} or balance={balance} for {self.config.symbol}")
                 trade_info["success"] = False

--- a/torchtrade/envs/live/bitget/base.py
+++ b/torchtrade/envs/live/bitget/base.py
@@ -107,9 +107,11 @@ class BitgetBaseTorchTradingEnv(TorchTradeFuturesLiveEnv):
         if config.close_position_on_init:
             self.trader.close_position()
 
-        # Get initial portfolio value
+        # Bankruptcy baseline on total_margin_balance (equity), matching offline's
+        # portfolio_value and the current side of the check. Binance's total_wallet_balance
+        # excludes unrealized PnL (a real skew here); bitget/bybit/okx map both keys to equity.
         balance = self.trader.get_account_balance()
-        self.initial_portfolio_value = balance.get("total_wallet_balance", 0)
+        self.initial_portfolio_value = balance.get("total_margin_balance", 0)
 
         # Build observation specs
         self._build_observation_specs()

--- a/torchtrade/envs/live/bitget/env_sltp.py
+++ b/torchtrade/envs/live/bitget/env_sltp.py
@@ -290,7 +290,10 @@ class BitgetFuturesSLTPTorchTradingEnv(SLTPMixin, BitgetBaseTorchTradingEnv):
 
         # Resolve quantity based on trade_mode
         if self.config.trade_mode == "fractional":
-            balance = float(self.trader.get_account_balance()["total_wallet_balance"])
+            # Size on total_margin_balance (equity), matching offline sizing and the non-SLTP
+            # live path. Binance's total_wallet_balance excludes unrealized PnL and would under-size;
+            # bitget/bybit/okx map both keys to equity, so the switch is a no-op there.
+            balance = float(self.trader.get_account_balance()["total_margin_balance"])
             if current_price <= 0 or balance <= 0:
                 logger.error(f"Invalid price={current_price} or balance={balance} for {self.config.symbol}")
                 trade_info["success"] = False

--- a/torchtrade/envs/live/bybit/base.py
+++ b/torchtrade/envs/live/bybit/base.py
@@ -86,9 +86,11 @@ class BybitBaseTorchTradingEnv(TorchTradeFuturesLiveEnv):
         if config.close_position_on_init:
             self.trader.close_position()
 
-        # Get initial portfolio value
+        # Bankruptcy baseline on total_margin_balance (equity), matching offline's
+        # portfolio_value and the current side of the check. Binance's total_wallet_balance
+        # excludes unrealized PnL (a real skew here); bitget/bybit/okx map both keys to equity.
         balance = self.trader.get_account_balance()
-        self.initial_portfolio_value = balance.get("total_wallet_balance", 0)
+        self.initial_portfolio_value = balance.get("total_margin_balance", 0)
 
         # Build observation specs
         self._build_observation_specs()

--- a/torchtrade/envs/live/bybit/env_sltp.py
+++ b/torchtrade/envs/live/bybit/env_sltp.py
@@ -260,7 +260,10 @@ class BybitFuturesSLTPTorchTradingEnv(SLTPMixin, BybitBaseTorchTradingEnv):
 
         # Resolve quantity based on trade_mode
         if self.config.trade_mode == "fractional":
-            balance = float(self.trader.get_account_balance()["total_wallet_balance"])
+            # Size on total_margin_balance (equity), matching offline sizing and the non-SLTP
+            # live path. Binance's total_wallet_balance excludes unrealized PnL and would under-size;
+            # bitget/bybit/okx map both keys to equity, so the switch is a no-op there.
+            balance = float(self.trader.get_account_balance()["total_margin_balance"])
             if current_price <= 0 or balance <= 0:
                 logger.error(f"Invalid price={current_price} or balance={balance} for {self.config.symbol}")
                 trade_info["success"] = False

--- a/torchtrade/envs/live/okx/base.py
+++ b/torchtrade/envs/live/okx/base.py
@@ -89,9 +89,11 @@ class OKXBaseTorchTradingEnv(TorchTradeFuturesLiveEnv):
         if config.close_position_on_init:
             self.trader.close_position()
 
-        # Get initial portfolio value
+        # Bankruptcy baseline on total_margin_balance (equity), matching offline's
+        # portfolio_value and the current side of the check. Binance's total_wallet_balance
+        # excludes unrealized PnL (a real skew here); bitget/bybit/okx map both keys to equity.
         balance = self.trader.get_account_balance()
-        self.initial_portfolio_value = balance.get("total_wallet_balance", 0)
+        self.initial_portfolio_value = balance.get("total_margin_balance", 0)
 
         # Build observation specs
         self._build_observation_specs()

--- a/torchtrade/envs/live/okx/env_sltp.py
+++ b/torchtrade/envs/live/okx/env_sltp.py
@@ -259,7 +259,10 @@ class OKXFuturesSLTPTorchTradingEnv(SLTPMixin, OKXBaseTorchTradingEnv):
 
         # Resolve quantity based on trade_mode
         if self.config.trade_mode == "fractional":
-            balance = float(self.trader.get_account_balance()["total_wallet_balance"])
+            # Size on total_margin_balance (equity), matching offline sizing and the non-SLTP
+            # live path. Binance's total_wallet_balance excludes unrealized PnL and would under-size;
+            # bitget/bybit/okx map both keys to equity, so the switch is a no-op there.
+            balance = float(self.trader.get_account_balance()["total_margin_balance"])
             if current_price <= 0 or balance <= 0:
                 logger.error(f"Invalid price={current_price} or balance={balance} for {self.config.symbol}")
                 trade_info["success"] = False


### PR DESCRIPTION
## What & why

The **offline** training env computes `portfolio_value` as **equity** (`balance + margin + unrealized_pnl`) and uses it for **both** position sizing and the bankruptcy check. The non-SLTP live sizing already uses `total_margin_balance` (#256), as does `exposure_pct`. But two live sites still read `total_wallet_balance`, creating a **train/deploy skew on Binance** (whose `totalWalletBalance` excludes uPnL — unlike the equity figure the other 3 exchanges map to that key):

- **SLTP fractional sizing** (`env_sltp.py`, 4 futures): the *same policy action* sized a *different position* in SLTP-live than in training / non-SLTP-live whenever a position had open uPnL. Now sizes on `total_margin_balance` (equity), matching offline.
- **`initial_portfolio_value` / bankruptcy baseline** (`base.py`, 4 futures): the check compared *current* equity (`_get_portfolio_value` = `total_margin_balance`) against a *wallet* baseline. Now equity-vs-equity, matching offline's `portfolio_value`-vs-`initial_cash`.

## Behavior impact (honest scope)

The behavior change is **real only on Binance** (its wallet ≠ margin). On bitget/bybit/okx both keys already map to equity, so it's a **consistency no-op** there. alpaca (spot, reads `cash`) is untouched. The non-SLTP `env.py` sizing was already correct (#256).

## Tests

- Updated `test_fractional_converts_balance_to_quantity` in each SLTP file to mock `wallet(1000) != margin(1100)` — the old `1000==1000` mock couldn't distinguish the two keys, so it tolerated the bug. Now pins equity-based sizing.
- Added `test_initial_portfolio_value_uses_margin_balance` (×4).
- **Mutation-verified: 8/8 kills** (2 sites × 4 exchanges).

Each changed line carries a comment scoping the Binance-specific skew (a review round caught an earlier comment that wrongly implied the wallet/equity split held for all 4 exchanges).

Reviewed over the mandated **3 rounds × 4 agents**; Round 3 clean on all four. Full suite **2170 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)