### PR TITLE
feat(losses): SAO single-rollout LLM RL loss + observation critic (arXiv:2607.07508)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ TorchTrade provides modular environments for both live trading with major exchan
 - 🔴 **Live Trading** - Direct Alpaca, Binance, Bitget, Bybit, and OKX integrations (Polymarket is paper-only)
 - 🧠 **LLM Integration** - Use GPT-4o-mini or local LLMs as trading agents
 - 🔧 **LLM Tool Use** - Let LLM agents call tools mid-reasoning (e.g. live Google News for sentiment) before choosing an action
-- 🎓 **LLM GRPO Fine-tuning** - Train/finetune a local LLM actor on your data with GRPO ([guide](docs/guides/llm-grpo-training.md))
+- 🎓 **LLM Fine-Tuning** - Train/fine-tune a local LLM actor on your own data with GRPO or [SAO](https://arxiv.org/abs/2607.07508) ([guide](docs/guides/llm-grpo-training.md))
 - 📐 **Rule-Based Actors** - Hard-coded strategies for imitation learning and baselines
 - 🔮 **Pretrained Encoder Transforms** - Foundation model embeddings for time series
 - 📦 **Ready-to-Use Datasets** - Pre-processed OHLCV data at [HuggingFace/Torch-Trade](https://huggingface.co/Torch-Trade)

--- a/docs/components/losses.md
+++ b/docs/components/losses.md
@@ -138,14 +138,15 @@ $$
 ```python
 from torchtrade.llm.train import LLMTrainer
 
-LLMTrainer(df=df, config=config, loss="sao", num_generations=4,  # 4 = distinct bars/step
-           loss_kwargs={"epsilon_low": 0.3, "epsilon_high": 5.0}).train()
+# defaults are the paper's math/TIR values (ε_l=0.3, ε_h=5.0, entropy off);
+# override any via loss_kwargs, e.g. loss_kwargs={"epsilon_low": 0.8, "epsilon_high": 3.0} for the SWE-Bench setting.
+LLMTrainer(df=df, config=config, loss="sao", num_generations=4).train()  # 4 = distinct bars/step
 ```
 
 | Parameter | Default | Description |
 |-----------|---------|-------------|
-| `epsilon_low` | 0.2 | Lower trust-region half-width $\varepsilon_l$ |
-| `epsilon_high` | 0.2 | Upper trust-region half-width $\varepsilon_h$ (widen for clip-higher) |
+| `epsilon_low` | 0.3 | Lower trust-region half-width $\varepsilon_l$ (paper's math/TIR value) |
+| `epsilon_high` | 5.0 | Upper trust-region half-width $\varepsilon_h$ — the asymmetric "clip-higher" is the point of DIS (paper: 5.0 math/TIR, 3.0 SWE-Bench) |
 | `entropy_bonus` | False | Add an entropy bonus (paper's objective has none) |
 | `masking_strategy` | `"rlhf"` | Score assistant/answer tokens only |
 

--- a/docs/components/losses.md
+++ b/docs/components/losses.md
@@ -8,6 +8,7 @@ TorchTrade provides specialized loss functions for training RL trading agents, b
 |---------------|------|----------|
 | [**DGLoss**](https://github.com/TorchTrade/torchtrade/blob/main/torchtrade/losses/dg_loss.py) | Policy Gradient | Delight-gated updates — no importance sampling needed |
 | [**GroupRelativePGLoss**](https://github.com/TorchTrade/torchtrade/blob/main/torchtrade/losses/group_relative_pg_loss.py) | Policy Gradient | One-step RL with SLTP environments |
+| [**SAOLoss**](https://github.com/TorchTrade/torchtrade/blob/main/torchtrade/losses/sao_loss.py) | Policy Gradient (LLM) | Single-rollout LLM RL with a critic baseline — no K-sample group needed |
 | [**CTRLLoss**](https://github.com/TorchTrade/torchtrade/blob/main/torchtrade/losses/ctrl.py) | Representation Learning | Self-supervised encoder training |
 | [**CTRLPPOLoss**](https://github.com/TorchTrade/torchtrade/blob/main/torchtrade/losses/ctrl.py) | Combined | Joint policy + representation learning |
 
@@ -113,6 +114,45 @@ for batch in collector:
 ```
 
 **Paper**: [DeepSeekMath (arXiv:2402.03300)](https://arxiv.org/abs/2402.03300) — Section 2.2
+
+---
+
+## SAOLoss
+
+Single-Rollout Asynchronous Optimization for **LLM** trading actors. Where the LLM GRPO path builds its baseline from a **group of K completions of the same bar**, SAO trains on **one rollout per bar** and recovers the baseline from a learned **critic** $V(s)$ instead. This removes the K-fold *generation* cost of the group baseline — the dominant expense when the actor is an LLM — at the price of a small critic.
+
+`SAOLoss` is a thin subclass of TorchRL's LLM `GRPOLoss` that reuses the entire pipeline (assistant-token masking, per-token log-weights, aggregation, ESS) and overrides only the policy objective:
+
+$$
+\begin{aligned}
+r_t &= \exp\!\left(\log \pi_\theta(a_t|s) - \log \pi_{\text{rollout}}(a_t|s)\right) \\
+f(r_t) &= \begin{cases} r_t & \text{if } 1-\varepsilon_l < r_t < 1+\varepsilon_h \\ 0 & \text{otherwise} \end{cases} \\
+\mathcal{L} &= -\mathbb{E}_t\left[ f(r_t)\cdot \hat{A} \right], \qquad \hat{A} = R - V(s)
+\end{aligned}
+$$
+
+**Two swaps vs GRPO.** (1) **Clip → DIS mask (Eq. 3):** in-band, $f$ is the *identity* (the ratio is retained as an off-policy weight); out-of-band tokens are **masked to zero**, not clamped to the boundary — permitting the aggressive asymmetric "clip-higher" the paper relies on. (2) **Group baseline → critic advantage:** $\hat{A} = R - V(s)$, where $V(s)$ is supplied by the trainer per bar. There is no entropy or KL term by default, matching the paper's objective.
+
+**Run it via `LLMTrainer(loss="sao")`** — the trainer wires the single-rollout collection, the `ObservationCritic` on the numeric bar state (a valid action-independent baseline; the LLM is only the policy), and the critic's own optimizer on the paper's faster-value schedule (`critic_updates=2`):
+
+```python
+from torchtrade.llm.train import LLMTrainer
+
+LLMTrainer(df=df, config=config, loss="sao", num_generations=4,  # 4 = distinct bars/step
+           loss_kwargs={"epsilon_low": 0.3, "epsilon_high": 5.0}).train()
+```
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `epsilon_low` | 0.2 | Lower trust-region half-width $\varepsilon_l$ |
+| `epsilon_high` | 0.2 | Upper trust-region half-width $\varepsilon_h$ (widen for clip-higher) |
+| `entropy_bonus` | False | Add an entropy bonus (paper's objective has none) |
+| `masking_strategy` | `"rlhf"` | Score assistant/answer tokens only |
+
+!!! note
+    `SAOLoss` pulls the LLM/vllm stack, so it is not exported from `torchtrade.losses`; import it from `torchtrade.losses.sao_loss` or use `LLMTrainer(loss="sao")`.
+
+**Paper**: [Single-Rollout Asynchronous Optimization (arXiv:2607.07508)](https://arxiv.org/abs/2607.07508)
 
 ---
 

--- a/docs/guides/llm-grpo-training.md
+++ b/docs/guides/llm-grpo-training.md
@@ -80,10 +80,17 @@ LLMTrainer(df=df, config=config,
 ```python
 LLMTrainer(df=df, config=config,
            method="qlora",         # "full" | "lora" | "qlora"
-           loss="grpo",            # "grpo", or a factory f(actor) -> LossModule
+           loss="grpo",            # "grpo" | "sao", or a factory f(actor) -> LossModule
            loss_kwargs={...},      # forwarded to the loss constructor
            num_generations=8)      # GRPO group size (K completions per bar)
 ```
+
+`loss="sao"` swaps the GRPO group baseline for **[SAO](https://arxiv.org/abs/2607.07508)**
+(single-rollout with a learned critic): it trains on **one** rollout per bar and recovers the
+baseline from an `ObservationCritic` instead of K completions, removing the K-fold generation cost
+— the dominant expense with an LLM actor. Same call, same dataset; the trainer wires the critic and
+its optimizer for you. See [Loss Functions → SAOLoss](../components/losses.md#saoloss) for the
+objective and the full parameter set.
 
 ## Timeframe — train on daily (or coarser) bars
 

--- a/tests/llm/train/test_llm_trainer.py
+++ b/tests/llm/train/test_llm_trainer.py
@@ -10,31 +10,84 @@ from torchtrade.llm.train.trading_env import TradingRewardParser
 _THINK = "the daily trend is up, price is above the SMA and momentum looks constructive"  # >=40 chars
 
 
-def test_rejects_num_generations_below_two():
-    with pytest.raises(ValueError, match="num_generations"):
-        LLMTrainer(df=None, config=None, num_generations=1)
+@pytest.mark.parametrize("loss,num_generations,should_raise", [
+    ("grpo", 1, True),   # GRPO needs a group of >= 2: undefined group-relative baseline for 1
+    ("sao", 1, False),   # SAO's baseline is the critic, so a group of 1 is legal
+    ("sao", 0, True),    # SAO waives the >=2 group check but still needs >=1 bar per step
+], ids=["grpo-below-two-raises", "sao-one-ok", "sao-zero-raises"])
+def test_num_generations_guard(loss, num_generations, should_raise):
+    """num_generations validation differs by loss: GRPO's guard must fire for a group of 1
+    (group-relative advantage undefined); SAO's must NOT (the critic is the baseline instead
+    of a same-prompt group), but SAO still floors at >=1 bar per step."""
+    kwargs = dict(df=None, config=None, loss=loss, num_generations=num_generations)
+    if should_raise:
+        with pytest.raises(ValueError, match="num_generations"):
+            LLMTrainer(**kwargs)
+    else:
+        LLMTrainer(**kwargs)  # must not raise
 
 
-def test_sao_allows_num_generations_one():
-    """SAO is single-rollout — its baseline is the critic, so a group of 1 is legal. The
-    num_generations>=2 guard must NOT fire for loss='sao' (it must for grpo, above)."""
-    LLMTrainer(df=None, config=None, loss="sao", num_generations=1)  # must not raise
+@pytest.mark.parametrize("bad_kwarg,value", [
+    ("critic_updates", 0),
+    ("critic_warmup", -1),
+], ids=["critic_updates", "critic_warmup"])
+def test_sao_config_validation(bad_kwarg, value):
+    with pytest.raises(ValueError, match=bad_kwarg):
+        LLMTrainer(df=None, config=None, loss="sao", num_generations=1, **{bad_kwarg: value})
 
 
-def test_sao_rejects_num_generations_zero():
-    """SAO waives the >=2 group check but still needs >=1 bar per step."""
-    with pytest.raises(ValueError, match="num_generations"):
-        LLMTrainer(df=None, config=None, loss="sao", num_generations=0)
+def test_sao_advantage_baseline_predates_critic_fit_and_stays_detached():
+    """Pins the Finding 1 fix in `_sao_advantage`: V(s) must be snapshotted from the
+    PRE-update critic, not the just-fitted one. With critic_updates high enough and a fast
+    optimizer, a critic that read V AFTER fitting reward_flat on these exact B rows would
+    nearly memorize the targets and collapse the advantage toward 0 — the ordering under
+    test is what prevents that. Also pins: advantage shape [B,1,1] for B != K (SAO's
+    distinct=True gives B = max_steps*K, unrelated to num_generations), full detachment (no
+    grad reaches the critic from a downstream use of the advantage), and that critic_opt.step
+    fires exactly `critic_updates` times."""
+    import torch
+    from tensordict import TensorDict
 
+    from torchtrade.models.observation_critic import ObservationCritic
 
-def test_rejects_critic_updates_below_one():
-    with pytest.raises(ValueError, match="critic_updates"):
-        LLMTrainer(df=None, config=None, loss="sao", num_generations=1, critic_updates=0)
+    B, K = 6, 4  # B != K on purpose
+    trainer = LLMTrainer(df=None, config=None, loss="sao", num_generations=K,
+                        critic_updates=20, critic_lr=0.5)
 
+    critic = ObservationCritic(["market_data_1Min"], hidden_size=16)
+    obs_batch = TensorDict(
+        {"market_data_1Min": torch.randn(B, 10, 4), "account_state": torch.randn(B, 6)},
+        batch_size=[B],
+    )
+    with torch.no_grad():
+        critic(obs_batch)  # materialize LazyLinear before building the optimizer
+    critic_opt = torch.optim.Adam(critic.parameters(), lr=trainer.critic_lr)
 
-def test_rejects_negative_critic_warmup():
-    with pytest.raises(ValueError, match="critic_warmup"):
-        LLMTrainer(df=None, config=None, loss="sao", num_generations=1, critic_warmup=-1)
+    step_count = {"n": 0}
+    real_step = critic_opt.step
+
+    def counted_step(*args, **kwargs):
+        step_count["n"] += 1
+        return real_step(*args, **kwargs)
+
+    critic_opt.step = counted_step
+
+    reward_flat = torch.randn(B, 1)
+    with torch.no_grad():
+        v_before = critic(obs_batch).clone()  # the PRE-fit baseline the helper must snapshot
+    advantage, v_pred, critic_loss = trainer._sao_advantage(reward_flat, obs_batch, critic, critic_opt)
+
+    assert advantage.shape == (B, 1, 1)
+    assert step_count["n"] == trainer.critic_updates == 20
+    assert advantage.grad_fn is None  # detached leaf (no critic graph reaches the policy loss)
+
+    # THE load-bearing assertion for Finding 1: the returned baseline is the critic's value
+    # BEFORE this step's fit, not after. Under the buggy read-after-fit ordering the 20 Adam
+    # steps move the critic, so v_pred != v_before — this exact-equality check is what fails on
+    # the regression (a magnitude check does not: smooth_l1's clipped gradient leaves the
+    # post-fit residual far above any threshold).
+    assert torch.allclose(v_pred, v_before)
+    assert torch.allclose(advantage, (reward_flat - v_before).reshape(-1, 1, 1))
 
 
 def test_base_load_kwargs_uses_transformers_compatible_dtype():

--- a/tests/llm/train/test_llm_trainer.py
+++ b/tests/llm/train/test_llm_trainer.py
@@ -26,6 +26,11 @@ def test_rejects_critic_updates_below_one():
         LLMTrainer(df=None, config=None, loss="sao", num_generations=1, critic_updates=0)
 
 
+def test_rejects_negative_critic_warmup():
+    with pytest.raises(ValueError, match="critic_warmup"):
+        LLMTrainer(df=None, config=None, loss="sao", num_generations=1, critic_warmup=-1)
+
+
 def test_base_load_kwargs_uses_transformers_compatible_dtype():
     """Regression: transformers>=4.30 (the [llm] floor) accepts torch_dtype, not dtype (added
     ~4.56), so build_train_policy must pass torch_dtype to from_pretrained."""

--- a/tests/llm/train/test_llm_trainer.py
+++ b/tests/llm/train/test_llm_trainer.py
@@ -15,6 +15,17 @@ def test_rejects_num_generations_below_two():
         LLMTrainer(df=None, config=None, num_generations=1)
 
 
+def test_sao_allows_num_generations_one():
+    """SAO is single-rollout — its baseline is the critic, so a group of 1 is legal. The
+    num_generations>=2 guard must NOT fire for loss='sao' (it must for grpo, above)."""
+    LLMTrainer(df=None, config=None, loss="sao", num_generations=1)  # must not raise
+
+
+def test_rejects_critic_updates_below_one():
+    with pytest.raises(ValueError, match="critic_updates"):
+        LLMTrainer(df=None, config=None, loss="sao", num_generations=1, critic_updates=0)
+
+
 def test_base_load_kwargs_uses_transformers_compatible_dtype():
     """Regression: transformers>=4.30 (the [llm] floor) accepts torch_dtype, not dtype (added
     ~4.56), so build_train_policy must pass torch_dtype to from_pretrained."""
@@ -160,3 +171,9 @@ def test_render_group_prompts_builds_contiguous_k_blocks(sample_ohlcv_df):
         assert prompts[i] == prompts[i + 1] == prompts[i + 2]
     assert len({bars[i] for i in range(0, 12, 3)}) == 4   # 4 distinct bars
     assert all(b >= 1 for b in bars)             # valid bar_index range
+
+    # SAO (distinct=True): max_steps*K DISTINCT bars, each rendered ONCE — not the K-repeat
+    # blocks. `len(set) > max_steps` is the tell it isn't the GRPO grouping (which gives exactly 4).
+    _, sao_prompts, sao_bars = trainer._render_group_prompts(env, pb, distinct=True)
+    assert len(sao_prompts) == 4 * 3 and len(sao_bars) == 4 * 3
+    assert len(set(sao_bars)) > 4

--- a/tests/llm/train/test_llm_trainer.py
+++ b/tests/llm/train/test_llm_trainer.py
@@ -21,6 +21,12 @@ def test_sao_allows_num_generations_one():
     LLMTrainer(df=None, config=None, loss="sao", num_generations=1)  # must not raise
 
 
+def test_sao_rejects_num_generations_zero():
+    """SAO waives the >=2 group check but still needs >=1 bar per step."""
+    with pytest.raises(ValueError, match="num_generations"):
+        LLMTrainer(df=None, config=None, loss="sao", num_generations=0)
+
+
 def test_rejects_critic_updates_below_one():
     with pytest.raises(ValueError, match="critic_updates"):
         LLMTrainer(df=None, config=None, loss="sao", num_generations=1, critic_updates=0)

--- a/tests/llm/train/test_losses.py
+++ b/tests/llm/train/test_losses.py
@@ -16,10 +16,26 @@ def test_grpo_name_resolves_and_forwards_kwargs(monkeypatch):
     assert loss.actor == "ACTOR" and loss.kw == {"clip_epsilon": 0.2}
 
 
+def test_sao_name_resolves_and_forwards_kwargs(monkeypatch):
+    import torchtrade.losses.sao_loss as m
+    monkeypatch.setattr(m, "SAOLoss", _StubLoss)  # resolve_loss imports SAOLoss lazily at call time
+    loss = resolve_loss("sao", actor_network="ACTOR",
+                        loss_kwargs={"epsilon_low": 0.3, "epsilon_high": 5.0})
+    assert isinstance(loss, _StubLoss)
+    assert loss.actor == "ACTOR" and loss.kw == {"epsilon_low": 0.3, "epsilon_high": 5.0}
+
+
 def test_callable_factory_is_used():
     sentinel = object()
     loss = resolve_loss(lambda actor: sentinel, actor_network="ACTOR")
     assert loss is sentinel
+
+
+def test_callable_factory_receives_kwargs():
+    """resolve_loss threads loss_kwargs into the factory (needed for SAOLoss-style factories)."""
+    loss = resolve_loss(lambda actor, **kw: _StubLoss(actor, **kw),
+                        actor_network="ACTOR", loss_kwargs={"epsilon_high": 5.0})
+    assert isinstance(loss, _StubLoss) and loss.kw == {"epsilon_high": 5.0}
 
 
 def test_unknown_name_raises():

--- a/tests/llm/train/test_losses.py
+++ b/tests/llm/train/test_losses.py
@@ -25,16 +25,17 @@ def test_sao_name_resolves_and_forwards_kwargs(monkeypatch):
     assert loss.actor == "ACTOR" and loss.kw == {"epsilon_low": 0.3, "epsilon_high": 5.0}
 
 
-def test_callable_factory_is_used():
+def test_callable_factory_is_used_and_receives_kwargs():
+    """resolve_loss calls the factory with actor_network (identity passthrough) AND threads
+    loss_kwargs into it (needed for SAOLoss-style factories) — pinned in one test."""
     sentinel = object()
-    loss = resolve_loss(lambda actor: sentinel, actor_network="ACTOR")
-    assert loss is sentinel
 
+    def factory(actor, **kw):
+        assert actor == "ACTOR"
+        return sentinel if not kw else _StubLoss(actor, **kw)
 
-def test_callable_factory_receives_kwargs():
-    """resolve_loss threads loss_kwargs into the factory (needed for SAOLoss-style factories)."""
-    loss = resolve_loss(lambda actor, **kw: _StubLoss(actor, **kw),
-                        actor_network="ACTOR", loss_kwargs={"epsilon_high": 5.0})
+    assert resolve_loss(factory, actor_network="ACTOR") is sentinel
+    loss = resolve_loss(factory, actor_network="ACTOR", loss_kwargs={"epsilon_high": 5.0})
     assert isinstance(loss, _StubLoss) and loss.kw == {"epsilon_high": 5.0}
 
 

--- a/tests/losses/test_sao_loss.py
+++ b/tests/losses/test_sao_loss.py
@@ -40,6 +40,19 @@ def test_out_of_band_tokens_masked_to_zero():
     assert masked_fraction.item() == pytest.approx(1.0)
 
 
+def test_extreme_out_of_band_stays_finite():
+    """An extreme out-of-band log-weight (exp overflows fp32) must be masked to a finite
+    zero, NOT become inf*0=nan that poisons the whole batch loss. Regression for the
+    DIS-mask overflow (PR #261 review): exp() must be clamped before the mask multiply."""
+    loss = _loss()
+    log_weight = torch.tensor([[[0.0], [100.0]]])  # in-band, then exp(100)=inf without the clamp
+    advantage = torch.ones(1, 1, 1)
+    neg_gain, masked_fraction = loss._compute_policy_objective(log_weight, advantage)
+    assert torch.isfinite(neg_gain).all(), "masked out-of-band token produced a non-finite gain"
+    assert neg_gain[0, 1, 0].item() == 0.0          # the extreme token contributes exactly 0
+    assert masked_fraction.item() == pytest.approx(0.5)
+
+
 def test_asymmetric_band_keeps_high_ratio():
     """Clip-higher: with ε_high large, a high ratio stays in-band; ε_low small
     masks a modestly-low ratio. Catches a low/high operand swap."""

--- a/tests/losses/test_sao_loss.py
+++ b/tests/losses/test_sao_loss.py
@@ -78,6 +78,16 @@ def test_gradient_flows_through_in_band_ratio_only():
     assert log_weight.grad[0, 1, 0].item() == 0.0   # masked token: no gradient
 
 
+@pytest.mark.parametrize("epsilon_low", [1.0, 1.5])
+def test_epsilon_low_at_or_above_one_raises(epsilon_low):
+    """eps_low >= 1 would make 1 - eps_low <= 0 -> log1p(-eps_low) is -inf/nan, which would
+    mask EVERY token as out-of-band (or worse, silently corrupt the band). SAOLoss doesn't
+    re-derive this guard itself; it must inherit GRPOLoss's `eps_low < 1` validation
+    (grpo.py) so the contract propagates through the subclass rather than silently NaN-ing."""
+    with pytest.raises(ValueError, match="clip_epsilon"):
+        SAOLoss(actor_network=None, epsilon_low=epsilon_low, epsilon_high=5.0)
+
+
 def test_defaults_are_paper_faithful():
     """The class defaults match the paper (arXiv:2607.07508 §4.1, math/TIR): no
     entropy, rlhf masking, and the asymmetric clip-higher band ε_l=0.3, ε_h=5.0

--- a/tests/losses/test_sao_loss.py
+++ b/tests/losses/test_sao_loss.py
@@ -1,0 +1,72 @@
+"""Tests for SAOLoss — the LLM-actor SAO loss (subclass of TorchRL GRPOLoss).
+
+The only behavior that differs from GRPO is `_compute_policy_objective` (the DIS
+mask vs GRPO's clamp), so that is what these tests pin. The full LLM pipeline
+(masking, aggregation, ESS) is inherited from GRPOLoss and tested by TorchRL; a
+model-in-the-loop test belongs in the trainer smoke test, not here.
+"""
+
+import pytest
+import torch
+
+from torchtrade.losses.sao_loss import SAOLoss
+
+
+def _loss(epsilon_low=0.2, epsilon_high=0.2):
+    # actor_network=None is enough to exercise _compute_policy_objective directly.
+    return SAOLoss(actor_network=None, epsilon_low=epsilon_low, epsilon_high=epsilon_high)
+
+
+def test_in_band_gain_equals_ratio_times_advantage():
+    """In-band, f(x)=x: gain = ratio·Â elementwise (identity), NOT a 0/1 gate. A vector of
+    distinct in-band ratios pins the exact value, the ratio-scaling, AND the per-sequence→
+    per-token advantage broadcast in one shot — a gate-only impl (gain=Â) fails on any ratio≠1."""
+    loss = _loss()
+    ratios = torch.tensor([0.9, 1.0, 1.1])  # all in-band for eps 0.2 (band 0.8-1.2)
+    log_weight = ratios.log().reshape(1, 3, 1)
+    advantage = torch.full((1, 1, 1), 2.0)  # broadcasts [1,1,1] -> [1,3,1] across the token dim
+    neg_gain, masked_fraction = loss._compute_policy_objective(log_weight, advantage)
+    assert torch.allclose(neg_gain, -(ratios.reshape(1, 3, 1) * 2.0), atol=1e-6)
+    assert masked_fraction.item() == pytest.approx(0.0)
+
+
+def test_out_of_band_tokens_masked_to_zero():
+    """Out-of-band -> gain exactly 0 (masked, not clamped to a nonzero boundary)."""
+    loss = _loss()
+    log_weight = torch.full((1, 4, 1), 5.0)  # ratio = e^5, far above 1+eps
+    advantage = torch.full((1, 1, 1), 3.0)
+    neg_gain, masked_fraction = loss._compute_policy_objective(log_weight, advantage)
+    assert (neg_gain == 0.0).all()
+    assert masked_fraction.item() == pytest.approx(1.0)
+
+
+def test_asymmetric_band_keeps_high_ratio():
+    """Clip-higher: with ε_high large, a high ratio stays in-band; ε_low small
+    masks a modestly-low ratio. Catches a low/high operand swap."""
+    loss = _loss(epsilon_low=0.1, epsilon_high=5.0)  # band (0.9, 6.0)
+    import math
+    log_weight = torch.tensor([[[math.log(4.0)], [math.log(0.5)]]])  # 4.0 kept, 0.5 masked
+    advantage = torch.ones(1, 1, 1)
+    neg_gain, masked_fraction = loss._compute_policy_objective(log_weight, advantage)
+    assert neg_gain[0, 0, 0].item() != 0.0          # 4.0 in-band (< 6.0)
+    assert neg_gain[0, 1, 0].item() == 0.0          # 0.5 masked (< 0.9)
+    assert masked_fraction.item() == pytest.approx(0.5)
+
+
+def test_gradient_flows_through_in_band_ratio_only():
+    """Gradient reaches log_weight for in-band tokens (via the differentiable
+    ratio) and is exactly zero for masked tokens."""
+    loss = _loss()
+    log_weight = torch.tensor([[[0.0], [5.0]]], requires_grad=True)  # in-band, out-of-band
+    advantage = torch.ones(1, 1, 1)
+    neg_gain, _ = loss._compute_policy_objective(log_weight, advantage)
+    neg_gain.sum().backward()
+    assert log_weight.grad[0, 0, 0].item() != 0.0   # in-band token trained
+    assert log_weight.grad[0, 1, 0].item() == 0.0   # masked token: no gradient
+
+
+def test_defaults_are_paper_faithful():
+    """entropy_bonus off and rlhf masking by default (vs GRPO's True / 'sft')."""
+    loss = _loss()
+    assert loss.entropy_bonus is False
+    assert loss.masking_strategy == "rlhf"

--- a/tests/losses/test_sao_loss.py
+++ b/tests/losses/test_sao_loss.py
@@ -66,7 +66,11 @@ def test_gradient_flows_through_in_band_ratio_only():
 
 
 def test_defaults_are_paper_faithful():
-    """entropy_bonus off and rlhf masking by default (vs GRPO's True / 'sft')."""
-    loss = _loss()
+    """The class defaults match the paper (arXiv:2607.07508 §4.1, math/TIR): no
+    entropy, rlhf masking, and the asymmetric clip-higher band ε_l=0.3, ε_h=5.0
+    (NOT a tight symmetric band — the wide upper bound is the point of DIS)."""
+    loss = SAOLoss(actor_network=None)  # NO epsilon args -> exercise the class defaults
     assert loss.entropy_bonus is False
     assert loss.masking_strategy == "rlhf"
+    assert float(loss.clip_epsilon_low) == pytest.approx(0.3)
+    assert float(loss.clip_epsilon_high) == pytest.approx(5.0)

--- a/tests/models/test_observation_critic.py
+++ b/tests/models/test_observation_critic.py
@@ -28,21 +28,16 @@ def env(sample_ohlcv_df):
     e.close()
 
 
-def test_value_of_a_real_single_observation(env):
-    """A single env observation -> scalar V(s) of shape (1,)."""
+@pytest.mark.parametrize("bars,expected_shape", [
+    (5, (1,)),                  # single real observation, batch_size []
+    ((3, 5, 7, 9), (4, 1)),     # stacked batch of B bars (how the trainer feeds it)
+], ids=["single", "stacked-batch"])
+def test_value_of_a_real_observation(env, bars, expected_shape):
+    """A real observation (single or stacked batch) -> finite V(s) of the expected shape."""
     critic = ObservationCritic(env.market_data_keys)
-    obs = env.obs_at(5)  # real reset td at bar 5, batch_size []
+    obs = env.obs_at(bars) if isinstance(bars, int) else torch.stack([env.obs_at(b) for b in bars])
     value = critic(obs)
-    assert value.shape == (1,)
-    assert torch.isfinite(value).all()
-
-
-def test_value_of_a_stacked_batch(env):
-    """A batch of B bars (how the trainer feeds it) -> V(s) of shape (B, 1)."""
-    critic = ObservationCritic(env.market_data_keys)
-    batch = torch.stack([env.obs_at(b) for b in (3, 5, 7, 9)])  # batch_size [4]
-    value = critic(batch)
-    assert value.shape == (4, 1)
+    assert value.shape == expected_shape
     assert torch.isfinite(value).all()
 
 
@@ -65,31 +60,35 @@ def test_critic_learns_a_constant_target(env):
 
 
 def test_ignores_extra_keys():
-    """Reads only market_data + account_state; other keys in the td are ignored."""
+    """An extra td key must NOT change V (reads only the declared market_data + account_state).
+    Asserts value-invariance, not just shape: LazyLinear absorbs any input width, so a mutation
+    that concatenated every td key would still yield shape (2,1) — only the value check catches it."""
     critic = ObservationCritic(["market_data_1Min"])
-    td = TensorDict(
-        {
-            "market_data_1Min": torch.randn(2, 10, 4),
-            "account_state": torch.randn(2, 6),
-            "reward": torch.randn(2, 1),  # extraneous, must be ignored
-        },
+    base = TensorDict(
+        {"market_data_1Min": torch.randn(2, 10, 4), "account_state": torch.randn(2, 6)},
         batch_size=[2],
     )
-    assert critic(td).shape == (2, 1)
+    with_extra = base.clone()
+    with_extra["reward"] = torch.randn(2, 1)  # extraneous key that must be ignored
+    with torch.no_grad():
+        critic(base)  # materialize LazyLinear on the declared-keys width first
+        assert torch.allclose(critic(base), critic(with_extra))
 
 
-def test_every_market_data_key_affects_the_value():
-    """Multi-timeframe (differing flattened widths): EVERY market_data key must influence V.
-    Guards the concat path against a dropped key — a regression that hardcoded keys[0] would
-    still pass shape checks (LazyLinear masks the narrower input), so only value-sensitivity
-    catches it."""
+@pytest.mark.parametrize("perturb_key", ["market_data_a", "market_data_b", "account_state"])
+def test_every_declared_input_affects_the_value(perturb_key):
+    """EVERY declared input — each market_data key AND account_state — must influence V. Guards
+    the concat path against a dropped input: a hardcoded keys[0] OR a dropped account_state still
+    passes shape checks (LazyLinear masks the narrower input), so only value-sensitivity per input
+    catches it. account_state carries position/exposure/pnl — the state a trading baseline most needs."""
     critic = ObservationCritic(["market_data_a", "market_data_b"])
     td = TensorDict(
         {"market_data_a": torch.randn(2, 10, 4), "market_data_b": torch.randn(2, 8, 3),  # widths 40 vs 24
          "account_state": torch.randn(2, 6)},
         batch_size=[2],
     )
-    v0 = critic(td)
-    perturbed = td.clone()
-    perturbed["market_data_b"] = torch.randn(2, 8, 3)  # change ONLY the second key
-    assert not torch.allclose(v0, critic(perturbed)), "V ignores market_data_b — a key was dropped"
+    with torch.no_grad():
+        v0 = critic(td)  # materializes LazyLinear
+        perturbed = td.clone()
+        perturbed[perturb_key] = torch.randn_like(td[perturb_key])  # change ONLY this input
+        assert not torch.allclose(v0, critic(perturbed)), f"V ignores {perturb_key} — an input was dropped"

--- a/tests/models/test_observation_critic.py
+++ b/tests/models/test_observation_critic.py
@@ -1,0 +1,95 @@
+"""Tests for ObservationCritic — the SAO state-value baseline.
+
+Tested against a REAL OneStepTradingEnv observation (not a hand-built mock), so a
+drift in the env's obs structure surfaces here rather than only on the Spark.
+"""
+
+import pytest
+import torch
+from tensordict import TensorDict
+
+from torchtrade.envs.offline import OneStepTradingEnv, OneStepTradingEnvConfig
+from torchtrade.models.observation_critic import ObservationCritic
+from tests.conftest import simple_feature_fn
+
+
+@pytest.fixture
+def env(sample_ohlcv_df):
+    config = OneStepTradingEnvConfig(
+        initial_cash=1000,
+        time_frames=["1Min"],
+        window_sizes=[10],
+        execute_on="1Min",
+        seed=42,
+        random_start=False,
+    )
+    e = OneStepTradingEnv(df=sample_ohlcv_df, config=config, feature_preprocessing_fn=simple_feature_fn)
+    yield e
+    e.close()
+
+
+def test_value_of_a_real_single_observation(env):
+    """A single env observation -> scalar V(s) of shape (1,)."""
+    critic = ObservationCritic(env.market_data_keys)
+    obs = env.obs_at(5)  # real reset td at bar 5, batch_size []
+    value = critic(obs)
+    assert value.shape == (1,)
+    assert torch.isfinite(value).all()
+
+
+def test_value_of_a_stacked_batch(env):
+    """A batch of B bars (how the trainer feeds it) -> V(s) of shape (B, 1)."""
+    critic = ObservationCritic(env.market_data_keys)
+    batch = torch.stack([env.obs_at(b) for b in (3, 5, 7, 9)])  # batch_size [4]
+    value = critic(batch)
+    assert value.shape == (4, 1)
+    assert torch.isfinite(value).all()
+
+
+def test_critic_learns_a_constant_target(env):
+    """MSE-regressing V toward a fixed target must reduce the loss — the training
+    signal the SAO trainer relies on to build a useful baseline."""
+    critic = ObservationCritic(env.market_data_keys, hidden_size=32)
+    batch = torch.stack([env.obs_at(b) for b in (3, 5, 7, 9)])
+    target = torch.tensor([[0.5], [-0.5], [0.2], [-0.1]])
+    opt = torch.optim.Adam(critic.parameters(), lr=1e-2)
+
+    critic(batch)  # materialize LazyLinear before capturing loss_before
+    loss_before = torch.nn.functional.mse_loss(critic(batch), target).item()
+    for _ in range(50):
+        opt.zero_grad()
+        torch.nn.functional.mse_loss(critic(batch), target).backward()
+        opt.step()
+    loss_after = torch.nn.functional.mse_loss(critic(batch), target).item()
+    assert loss_after < loss_before * 0.5
+
+
+def test_ignores_extra_keys():
+    """Reads only market_data + account_state; other keys in the td are ignored."""
+    critic = ObservationCritic(["market_data_1Min"])
+    td = TensorDict(
+        {
+            "market_data_1Min": torch.randn(2, 10, 4),
+            "account_state": torch.randn(2, 6),
+            "reward": torch.randn(2, 1),  # extraneous, must be ignored
+        },
+        batch_size=[2],
+    )
+    assert critic(td).shape == (2, 1)
+
+
+def test_every_market_data_key_affects_the_value():
+    """Multi-timeframe (differing flattened widths): EVERY market_data key must influence V.
+    Guards the concat path against a dropped key — a regression that hardcoded keys[0] would
+    still pass shape checks (LazyLinear masks the narrower input), so only value-sensitivity
+    catches it."""
+    critic = ObservationCritic(["market_data_a", "market_data_b"])
+    td = TensorDict(
+        {"market_data_a": torch.randn(2, 10, 4), "market_data_b": torch.randn(2, 8, 3),  # widths 40 vs 24
+         "account_state": torch.randn(2, 6)},
+        batch_size=[2],
+    )
+    v0 = critic(td)
+    perturbed = td.clone()
+    perturbed["market_data_b"] = torch.randn(2, 8, 3)  # change ONLY the second key
+    assert not torch.allclose(v0, critic(perturbed)), "V ignores market_data_b — a key was dropped"

--- a/torchtrade/llm/train/llm_trainer.py
+++ b/torchtrade/llm/train/llm_trainer.py
@@ -165,6 +165,25 @@ class LLMTrainer:
             bar_indices += [b] * reps
         return sysp, prompts, bar_indices
 
+    def _sao_advantage(self, reward_flat, obs_batch, critic, critic_opt):
+        """SAO advantage R - V(s). Baseline V is read from the PRE-update critic so this step's
+        fit can't shrink its own advantage toward zero (SAO has one rollout per bar); the critic
+        is then fit toward the realized reward for future steps. Returns (advantage[B,1,1]
+        detached, v_pred, critic_loss)."""
+        with torch.no_grad():
+            v_pred = critic(obs_batch)  # baseline BEFORE this step's fit
+        critic_loss = None
+        for _ in range(self.critic_updates):
+            # smooth_l1 (Huber), not MSE: trading rewards are heavy-tailed (a -1.0
+            # liquidation among ~1e-2 log-returns would dominate a plain MSE over the
+            # small K-row batch and distort V for every row). The paper uses MSE, but its
+            # rewards are bounded 0/1 accuracy — ours are not.
+            critic_loss = torch.nn.functional.smooth_l1_loss(critic(obs_batch), reward_flat)
+            critic_opt.zero_grad()
+            critic_loss.backward()
+            critic_opt.step()
+        return (reward_flat - v_pred).reshape(-1, 1, 1), v_pred, critic_loss
+
     def train(self):
         from transformers import AutoTokenizer
         from torchrl.data import LazyStackStorage, ReplayBuffer, SamplerWithoutReplacement
@@ -211,8 +230,6 @@ class LLMTrainer:
         # GRPOLoss defaults to "sft"; override unless the user set it explicitly in loss_kwargs.
         loss_kwargs = dict(self.loss_kwargs or {})
         if self.loss in ("grpo", "sao"):
-            # train-time recompute must score the same assistant/answer tokens the rollout mask
-            # used (rlhf), or log-probs won't line up with the sampled tokens.
             loss_kwargs.setdefault("masking_strategy", "rlhf")
         loss_fn = resolve_loss(self.loss, train_policy, loss_kwargs)
         opt = torch.optim.Adam([p for p in hf.parameters() if p.requires_grad], lr=self.lr)
@@ -220,9 +237,9 @@ class LLMTrainer:
         sao = self.loss == "sao"
         if sao:
             # SAO baseline: a small critic V(bar) on the NUMERIC market state (NOT an LLM head),
-            # trained by MSE against the realized reward. Its own optimizer, never folded into
-            # `opt` (no shared params with the LoRA policy), updated `critic_updates` times per
-            # policy step — the paper's faster-value schedule.
+            # trained (smooth_l1/Huber, see _sao_advantage) against the realized reward. Its own
+            # optimizer, never folded into `opt` (no shared params with the LoRA policy), updated
+            # `critic_updates` times per policy step — the paper's faster-value schedule.
             from torchtrade.models.observation_critic import ObservationCritic
             critic = ObservationCritic(score_env.market_data_keys,
                                        account_state_key=score_env.account_state_key,
@@ -276,25 +293,17 @@ class LLMTrainer:
                     completion_rows.append([step, text, extract_action(text, num_actions), r])
             flat = data.reshape(-1)  # drop the (T=1) time dim -> K rows
             if sao:
-                # SAO advantage = reward - V(bar). Fetch each bar's NUMERIC obs, train the critic
-                # (MSE vs the realized reward), then take a DETACHED V for the baseline. Shape the
-                # advantage [B,1,1] so it broadcasts across the answer tokens (matches GRPO's).
+                # SAO advantage = reward - V(bar), baseline snapshotted BEFORE this step's critic
+                # fit (see _sao_advantage). Shape [B,1,1] so it broadcasts across the answer
+                # tokens (matches GRPO's).
                 batch = flat.to(device)
                 bars = flat.get("bar_index").tolist()  # int64 tensor -> python ints
                 obs_batch = torch.stack([score_env.obs_at(b) for b in bars]).to(device)
                 reward_flat = batch.get(("next", "reward")).reshape(len(bars), 1)  # (B,1)
-                for _ in range(self.critic_updates):
-                    # smooth_l1 (Huber), not MSE: trading rewards are heavy-tailed (a -1.0
-                    # liquidation among ~1e-2 log-returns would dominate a plain MSE over the
-                    # small K-row batch and distort V for every row). The paper uses MSE, but its
-                    # rewards are bounded 0/1 accuracy — ours are not.
-                    critic_loss = torch.nn.functional.smooth_l1_loss(critic(obs_batch), reward_flat)
-                    critic_opt.zero_grad()
-                    critic_loss.backward()
-                    critic_opt.step()
-                with torch.no_grad():
-                    v_pred = critic(obs_batch)  # (B,1), detached baseline
-                batch.set("advantage", (reward_flat - v_pred).reshape(len(bars), 1, 1))
+                advantage, v_pred, critic_loss = self._sao_advantage(
+                    reward_flat, obs_batch, critic, critic_opt
+                )
+                batch.set("advantage", advantage)
                 print(f"[LLMTrainer]   sao critic_loss={float(critic_loss):.5f} "
                       f"V_mean={float(v_pred.mean()):.5f} R_mean={float(reward_flat.mean()):.5f}",
                       flush=True)

--- a/torchtrade/llm/train/llm_trainer.py
+++ b/torchtrade/llm/train/llm_trainer.py
@@ -44,13 +44,19 @@ class LLMTrainer:
                  reward_fn=None, system_prompt=None, user_prompt_fn=None,
                  feature_preprocessing_fn=None, feature_keys=None,
                  loss="grpo", loss_kwargs=None, num_generations=4, lr=1e-5,
+                 critic_lr=1e-3, critic_updates=2, critic_hidden=128,
                  max_steps=50, max_tokens=1024, max_model_len=4096, gpu_memory_utilization=0.5,
                  constrain_actions=False, enforce_eager=False, logprob_chunk_size=1024,
                  output_dir="./llm_grpo_out", use_wandb=True, wandb_project="torchtrade-grpo",
                  log_completions_every=5, n_completions_log=2):
-        validate_num_generations(num_generations)
+        # SAO is single-rollout (a critic supplies the baseline), so it does NOT need a
+        # group of >= 2. Everything else (grpo + any group-relative factory) keeps the guard.
+        if loss != "sao":
+            validate_num_generations(num_generations)
         if method not in ("full", "lora", "qlora"):
             raise ValueError(f"method must be 'full'|'lora'|'qlora', got {method!r}")
+        if critic_updates < 1:
+            raise ValueError(f"critic_updates must be >= 1, got {critic_updates}")
 
         self.df, self.config, self.model = df, config, model
         self.method, self.reward_fn = method, reward_fn
@@ -59,6 +65,7 @@ class LLMTrainer:
         self.feature_keys = feature_keys
         self.loss, self.loss_kwargs = loss, loss_kwargs
         self.K = num_generations
+        self.critic_lr, self.critic_updates, self.critic_hidden = critic_lr, critic_updates, critic_hidden
         self.lr, self.max_steps, self.max_tokens = lr, max_steps, max_tokens
         self.max_model_len = max_model_len
         self.gpu_memory_utilization = gpu_memory_utilization
@@ -131,18 +138,25 @@ class LLMTrainer:
             user_prompt_fn=self.user_prompt_fn,
         )
 
-    def _render_group_prompts(self, score_env, pb):
-        """Pick `max_steps` bars, render each bar's prompt, and repeat it K times so each
-        consecutive K-block is one bar's GRPO group."""
+    def _render_group_prompts(self, score_env, pb, distinct=False):
+        """Render per-step prompt batches of size K.
+
+        GRPO (``distinct=False``): ``max_steps`` bars, each repeated K times, so each
+        consecutive K-block is one bar's GRPO group (K completions of the SAME bar).
+        SAO (``distinct=True``): ``max_steps * K`` DISTINCT bars, each rendered once, so each
+        consecutive K-block is K DIFFERENT single-rollout bars (no group — the critic is the
+        baseline, so there is nothing to gain from repeating a bar)."""
         prompts, bar_indices = [], []
         sysp = pb._resolve_system_prompt()
         max_bar = score_env.sampler._max_organic_start_idx() + 1
-        step_bars = torch.linspace(1, max_bar, self.max_steps).long().tolist()
+        n_bars = self.max_steps * self.K if distinct else self.max_steps
+        reps = 1 if distinct else self.K
+        step_bars = torch.linspace(1, max_bar, n_bars).long().tolist()
         for b in step_bars:
-            td = score_env.obs_at(int(b))
+            td = score_env.obs_at(b)
             user = pb._build_user_prompt(td)
-            prompts += [user] * self.K
-            bar_indices += [int(b)] * self.K
+            prompts += [user] * reps
+            bar_indices += [b] * reps
         return sysp, prompts, bar_indices
 
     def train(self):
@@ -165,7 +179,8 @@ class LLMTrainer:
             tokenizer.add_special_tokens({"pad_token": "<|pad|>"})
         tokenizer.padding_side = "left"
 
-        sysp, prompts, bar_indices = self._render_group_prompts(score_env, pb)
+        sysp, prompts, bar_indices = self._render_group_prompts(score_env, pb,
+                                                                distinct=(self.loss == "sao"))
         env = make_trading_env(score_env, tokenizer, prompts, bar_indices, sysp, num_actions,
                                self.K, reward_fn=self.reward_fn)
 
@@ -189,17 +204,34 @@ class LLMTrainer:
         # tokens (the <think>.../<answer>N</answer> the model generated), not the prompt. Stock
         # GRPOLoss defaults to "sft"; override unless the user set it explicitly in loss_kwargs.
         loss_kwargs = dict(self.loss_kwargs or {})
-        if self.loss == "grpo":
+        if self.loss in ("grpo", "sao"):
+            # train-time recompute must score the same assistant/answer tokens the rollout mask
+            # used (rlhf), or log-probs won't line up with the sampled tokens.
             loss_kwargs.setdefault("masking_strategy", "rlhf")
         loss_fn = resolve_loss(self.loss, train_policy, loss_kwargs)
-        # Buffer holds exactly one group (K completions of one bar), matching torchrl's canonical
-        # grpo-sync recipe: sample(K) then returns the just-collected group with no cross-round
-        # mixing — a larger buffer + SamplerWithoutReplacement would blend up to several prior
-        # (staler) groups into each minibatch.
-        rb = ReplayBuffer(storage=LazyStackStorage(self.K),
-                          sampler=SamplerWithoutReplacement(),
-                          transform=MCAdvantage(grpo_size=self.K))
         opt = torch.optim.Adam([p for p in hf.parameters() if p.requires_grad], lr=self.lr)
+
+        sao = self.loss == "sao"
+        if sao:
+            # SAO baseline: a small critic V(bar) on the NUMERIC market state (NOT an LLM head),
+            # trained by MSE against the realized reward. Its own optimizer, never folded into
+            # `opt` (no shared params with the LoRA policy), updated `critic_updates` times per
+            # policy step — the paper's faster-value schedule.
+            from torchtrade.models.observation_critic import ObservationCritic
+            critic = ObservationCritic(score_env.market_data_keys,
+                                       account_state_key=score_env.account_state_key,
+                                       hidden_size=self.critic_hidden).to(device)
+            with torch.no_grad():  # materialize LazyLinear before building the optimizer
+                critic(score_env.obs_at(1).to(device))
+            critic_opt = torch.optim.Adam(critic.parameters(), lr=self.critic_lr)
+        else:
+            # Buffer holds exactly one group (K completions of one bar), matching torchrl's canonical
+            # grpo-sync recipe: sample(K) then returns the just-collected group with no cross-round
+            # mixing — a larger buffer + SamplerWithoutReplacement would blend up to several prior
+            # (staler) groups into each minibatch.
+            rb = ReplayBuffer(storage=LazyStackStorage(self.K),
+                              sampler=SamplerWithoutReplacement(),
+                              transform=MCAdvantage(grpo_size=self.K))
 
         logger = None
         if self.use_wandb:
@@ -236,11 +268,36 @@ class LLMTrainer:
                 for h, r in list(zip(histories, rewards))[:self.n_completions_log]:
                     text = str(TradingRewardParser._response_text(h))
                     completion_rows.append([step, text, extract_action(text, num_actions), r])
-            # MCAdvantage computes the group-relative advantage at extend() time (grouped by the
-            # shared prompt), so it is baked in before sampling; with a K-sized buffer, sample(K)
-            # returns exactly this step's group.
-            rb.extend(data.reshape(-1))
-            batch = rb.sample(self.K).to(device)
+            flat = data.reshape(-1)  # drop the (T=1) time dim -> K rows
+            if sao:
+                # SAO advantage = reward - V(bar). Fetch each bar's NUMERIC obs, train the critic
+                # (MSE vs the realized reward), then take a DETACHED V for the baseline. Shape the
+                # advantage [B,1,1] so it broadcasts across the answer tokens (matches GRPO's).
+                batch = flat.to(device)
+                bars = flat.get("bar_index").tolist()  # int64 tensor -> python ints
+                obs_batch = torch.stack([score_env.obs_at(b) for b in bars]).to(device)
+                reward_flat = batch.get(("next", "reward")).reshape(len(bars), 1)  # (B,1)
+                for _ in range(self.critic_updates):
+                    # smooth_l1 (Huber), not MSE: trading rewards are heavy-tailed (a -1.0
+                    # liquidation among ~1e-2 log-returns would dominate a plain MSE over the
+                    # small K-row batch and distort V for every row). The paper uses MSE, but its
+                    # rewards are bounded 0/1 accuracy — ours are not.
+                    critic_loss = torch.nn.functional.smooth_l1_loss(critic(obs_batch), reward_flat)
+                    critic_opt.zero_grad()
+                    critic_loss.backward()
+                    critic_opt.step()
+                with torch.no_grad():
+                    v_pred = critic(obs_batch)  # (B,1), detached baseline
+                batch.set("advantage", (reward_flat - v_pred).reshape(len(bars), 1, 1))
+                print(f"[LLMTrainer]   sao critic_loss={float(critic_loss):.5f} "
+                      f"V_mean={float(v_pred.mean()):.5f} R_mean={float(reward_flat.mean()):.5f}",
+                      flush=True)
+            else:
+                # MCAdvantage computes the group-relative advantage at extend() time (grouped by the
+                # shared prompt), so it is baked in before sampling; with a K-sized buffer, sample(K)
+                # returns exactly this step's group.
+                rb.extend(flat)
+                batch = rb.sample(self.K).to(device)
             # generation throughput: assistant mask marks the model-generated (completion) tokens
             # across all K completions; tokens/s = those tokens / the rollout wall-time.
             gen_tokens = int(batch.get(("masks", "all_assistant_mask"), as_padded_tensor=True,
@@ -268,8 +325,9 @@ class LLMTrainer:
             else:
                 synced = sync_weights_to_vllm(engine, hf, path=os.path.join(self.output_dir, "_full.pt"))
             mean_r = sum(rewards) / len(rewards)
-            # advantage = the group-relative signal MCAdvantage baked in; log its magnitude
-            # (mean |adv|) — ~0 on a degenerate all-agree group, positive when the group disagrees.
+            # advantage = the group-relative signal MCAdvantage baked in (GRPO) or R − V(s) from
+            # the critic (SAO); log its magnitude (mean |adv|) — ~0 when the baseline matches the
+            # reward, larger when the policy's action beat/missed the baseline.
             adv = batch.get("advantage", None)
             adv_mag = float(adv.float().abs().mean()) if adv is not None else float("nan")
             dt = time.time() - t0

--- a/torchtrade/llm/train/llm_trainer.py
+++ b/torchtrade/llm/train/llm_trainer.py
@@ -50,9 +50,12 @@ class LLMTrainer:
                  output_dir="./llm_grpo_out", use_wandb=True, wandb_project="torchtrade-grpo",
                  log_completions_every=5, n_completions_log=2):
         # SAO is single-rollout (a critic supplies the baseline), so it does NOT need a
-        # group of >= 2. Everything else (grpo + any group-relative factory) keeps the guard.
+        # group of >= 2 — but it still needs >= 1 bar per step. Everything else (grpo + any
+        # group-relative factory) keeps the >= 2 guard.
         if loss != "sao":
             validate_num_generations(num_generations)
+        elif num_generations < 1:
+            raise ValueError(f"num_generations must be >= 1 for SAO, got {num_generations}")
         if method not in ("full", "lora", "qlora"):
             raise ValueError(f"method must be 'full'|'lora'|'qlora', got {method!r}")
         if critic_updates < 1:

--- a/torchtrade/llm/train/llm_trainer.py
+++ b/torchtrade/llm/train/llm_trainer.py
@@ -44,7 +44,7 @@ class LLMTrainer:
                  reward_fn=None, system_prompt=None, user_prompt_fn=None,
                  feature_preprocessing_fn=None, feature_keys=None,
                  loss="grpo", loss_kwargs=None, num_generations=4, lr=1e-5,
-                 critic_lr=1e-3, critic_updates=2, critic_hidden=128,
+                 critic_lr=1e-3, critic_updates=2, critic_hidden=128, critic_warmup=0,
                  max_steps=50, max_tokens=1024, max_model_len=4096, gpu_memory_utilization=0.5,
                  constrain_actions=False, enforce_eager=False, logprob_chunk_size=1024,
                  output_dir="./llm_grpo_out", use_wandb=True, wandb_project="torchtrade-grpo",
@@ -57,6 +57,8 @@ class LLMTrainer:
             raise ValueError(f"method must be 'full'|'lora'|'qlora', got {method!r}")
         if critic_updates < 1:
             raise ValueError(f"critic_updates must be >= 1, got {critic_updates}")
+        if critic_warmup < 0:
+            raise ValueError(f"critic_warmup must be >= 0, got {critic_warmup}")
 
         self.df, self.config, self.model = df, config, model
         self.method, self.reward_fn = method, reward_fn
@@ -66,6 +68,7 @@ class LLMTrainer:
         self.loss, self.loss_kwargs = loss, loss_kwargs
         self.K = num_generations
         self.critic_lr, self.critic_updates, self.critic_hidden = critic_lr, critic_updates, critic_hidden
+        self.critic_warmup = critic_warmup
         self.lr, self.max_steps, self.max_tokens = lr, max_steps, max_tokens
         self.max_model_len = max_model_len
         self.gpu_memory_utilization = gpu_memory_utilization
@@ -298,6 +301,13 @@ class LLMTrainer:
                 # returns exactly this step's group.
                 rb.extend(flat)
                 batch = rb.sample(self.K).to(device)
+            if sao and step < self.critic_warmup:
+                # Critic warmup (paper §4.1's cold-start mitigation): keep training V(s) on real
+                # rollout rewards but hold the POLICY frozen, so the baseline is sane before it
+                # drives updates. Default off — the small MLP critic converges in ~1 step (smoke:
+                # critic_loss 0.46->0.02 by step 1), unlike the paper's cold LLM value head.
+                print(f"[LLMTrainer] step {step}: CRITIC WARMUP — policy frozen", flush=True)
+                continue
             # generation throughput: assistant mask marks the model-generated (completion) tokens
             # across all K completions; tokens/s = those tokens / the rollout wall-time.
             gen_tokens = int(batch.get(("masks", "all_assistant_mask"), as_padded_tensor=True,

--- a/torchtrade/llm/train/losses.py
+++ b/torchtrade/llm/train/losses.py
@@ -7,6 +7,9 @@ DPO) is a new recipe, not a loss_kwargs change.
 
 
 def validate_num_generations(n: int) -> None:
+    """GRPO needs a group of >= 2 (the group-relative baseline is undefined for one
+    sample). SAO is single-rollout — its baseline comes from a critic, not a group —
+    so this check must NOT be applied to the SAO path (see LLMTrainer.__init__)."""
     if n < 2:
         raise ValueError(
             f"num_generations must be >= 2 for GRPO (got {n}); the group-relative "
@@ -15,11 +18,17 @@ def validate_num_generations(n: int) -> None:
 
 
 def resolve_loss(loss, actor_network, loss_kwargs=None):
-    """Resolve `loss` to a constructed LossModule for `actor_network`: the name ``"grpo"``, or a
-    factory callable ``f(actor) -> LossModule`` for anything else."""
+    """Resolve `loss` to a constructed LossModule for `actor_network`: the names ``"grpo"`` /
+    ``"sao"``, or a factory callable ``f(actor, **loss_kwargs) -> LossModule`` for anything else."""
     if callable(loss) and not isinstance(loss, str):
-        return loss(actor_network)
+        return loss(actor_network, **(loss_kwargs or {}))
     if loss == "grpo":
         from torchrl.objectives.llm import GRPOLoss  # lazy: pulls heavy LLM deps
         return GRPOLoss(actor_network, **(loss_kwargs or {}))
-    raise ValueError(f"unknown loss {loss!r}; use 'grpo' or a factory callable f(actor) -> LossModule")
+    if loss == "sao":
+        from torchtrade.losses.sao_loss import SAOLoss  # lazy: pulls heavy LLM deps
+        return SAOLoss(actor_network, **(loss_kwargs or {}))
+    raise ValueError(
+        f"unknown loss {loss!r}; use 'grpo', 'sao', or a factory callable "
+        "f(actor, **loss_kwargs) -> LossModule"
+    )

--- a/torchtrade/losses/__init__.py
+++ b/torchtrade/losses/__init__.py
@@ -1,3 +1,7 @@
 from torchtrade.losses.ctrl import CTRLLoss, CTRLPPOLoss
 from torchtrade.losses.dg_loss import DGLoss
 from torchtrade.losses.group_relative_pg_loss import GroupRelativePGLoss
+
+# SAOLoss (torchtrade.losses.sao_loss) is intentionally NOT imported here: it
+# subclasses torchrl's LLM GRPOLoss and pulls the heavy LLM/vllm stack. Import it directly
+# or use it via LLMTrainer(loss="sao").

--- a/torchtrade/losses/sao_loss.py
+++ b/torchtrade/losses/sao_loss.py
@@ -45,11 +45,14 @@ class SAOLoss(GRPOLoss):
     Args:
         actor_network: the LLM policy wrapper (e.g. ``ChunkedTransformersWrapper``).
         epsilon_low: lower trust-region half-width ε_l — tokens with
-            ``ratio ≤ 1 − ε_l`` are masked. Must be in [0, 1). Default 0.2.
+            ``ratio ≤ 1 − ε_l`` are masked. Must be in [0, 1). Default 0.3 (the
+            paper's math/TIR value).
         epsilon_high: upper trust-region half-width ε_h — tokens with
-            ``ratio ≥ 1 + ε_h`` are masked. Default 0.2. The paper uses aggressive
-            asymmetric "clip-higher" values (e.g. ε_l=0.3, ε_h=5.0); widen
-            ``epsilon_high`` to opt in.
+            ``ratio ≥ 1 + ε_h`` are masked. Default 5.0 (the paper's math/TIR
+            value). SAO's DIS is deliberately an **asymmetric "clip-higher"**
+            (ε_h ≫ ε_l): the wide upper bound keeps large positive-advantage
+            updates while the tight lower bound gates negative off-policy drift.
+            The paper also reports ε_l=0.8, ε_h=3.0 for SWE-Bench.
         entropy_bonus: default ``False`` (the paper's objective has no entropy
             term), overriding GRPO's ``True``.
         masking_strategy: default ``"rlhf"`` (score assistant/answer tokens only),
@@ -58,6 +61,20 @@ class SAOLoss(GRPOLoss):
 
     All other keyword arguments (``aggregation``, ``kl_to_ref_coeff``,
     ``reduction``, ``device`` …) pass straight through to ``GRPOLoss``.
+
+    Deviations from the paper (arXiv:2607.07508), all deliberate for the
+    single-shot trading setting — the LLM emits one ``<answer>`` per one-step
+    OneStepTradingEnv bar, so several of the paper's multi-turn/LLM-value-head
+    mechanisms do not apply:
+
+    - **Frozen-attention critic** and **value pretraining**: N/A — the SAO
+      trainer's critic is a small MLP on the numeric bar state, not an LLM value
+      head, so there are no attention layers to freeze. Cold start is cheap here
+      (empirically the MLP converges in ~1 step), so the paper's 10-step value
+      warmup defaults off; it is available as the trainer's ``critic_warmup`` knob.
+    - **Skip-observation token-level GAE (Eq 4-5)** and the length-adaptive
+      ``λ_policy``: N/A — a single action per episode means no cross-action GAE.
+    - The paper's **faster-value schedule (K=2)** IS applied, in the trainer.
     """
 
     output_type = SAOLossOutput
@@ -66,8 +83,8 @@ class SAOLoss(GRPOLoss):
         self,
         actor_network=None,
         *,
-        epsilon_low: float = 0.2,
-        epsilon_high: float = 0.2,
+        epsilon_low: float = 0.3,
+        epsilon_high: float = 5.0,
         entropy_bonus: bool = False,
         masking_strategy: str = "rlhf",
         **kwargs,

--- a/torchtrade/losses/sao_loss.py
+++ b/torchtrade/losses/sao_loss.py
@@ -110,6 +110,12 @@ class SAOLoss(GRPOLoss):
         """
         low, high = self._clip_bounds  # (log(1 - ε_l), log(1 + ε_h))
         in_band = (log_weight > low) & (log_weight < high)  # per-token, Eq. 3 open interval
-        gain = log_weight.exp() * advantage * in_band.to(log_weight.dtype)
+        # Clamp the log-weight to the trust bounds BEFORE exp: an extreme out-of-band weight
+        # would overflow to inf, and inf * 0(mask) = nan would then poison the whole masked
+        # batch loss. In-band weights lie strictly inside [low, high] so clamping leaves them
+        # untouched; out-of-band weights are zeroed by the mask anyway, so clamping their
+        # (unused) value is harmless. Mirrors GRPOLoss's own clamp-before-exp.
+        ratio = log_weight.clamp(low, high).exp()
+        gain = ratio * advantage * in_band.to(log_weight.dtype)
         masked_fraction = (~in_band).to(log_weight.dtype).mean()
         return -gain, masked_fraction

--- a/torchtrade/losses/sao_loss.py
+++ b/torchtrade/losses/sao_loss.py
@@ -1,0 +1,98 @@
+"""SAO loss — Single-Rollout Asynchronous Optimization for LLM trading actors.
+
+SAO (arXiv:2607.07508) is an LLM RL loss at its core, like TorchRL's ``GRPOLoss``.
+It is a thin subclass of TorchRL's LLM ``GRPOLoss`` that reuses the
+entire proven pipeline — ``masking_strategy`` → the wrapper's ``_get_rlhf_dist``
+hook, per-token log-weights, token/prompt aggregation, ESS, entropy, optional KL
+— and overrides ONLY the policy objective, exactly as TorchRL's own ``CISPOLoss``
+does. Two swaps vs GRPO:
+
+1. **Clip → DIS mask (Eq. 3).** GRPO clamps the importance ratio to the trust
+   region; SAO instead **masks out-of-band tokens to zero** and keeps the ratio
+   as the off-policy weight in-band (``f(x)=x`` in-band, ``0`` outside).
+2. **Group baseline → critic advantage.** GRPO's advantage is group-relative
+   (``MCAdvantage`` over K samples of one prompt); SAO's is ``Â = R − V(s)`` from
+   a critic, computed by the trainer and written to the ``advantage`` key. This
+   loss consumes ``advantage`` exactly as GRPO does (per-sequence, shape
+   ``[B,1,1]``, broadcast across the answer tokens) — it does not care how the
+   advantage was produced, so the "single rollout + critic" story lives in the
+   trainer, not here.
+
+The per-token DIS mask matches the paper's token-level ``f(r_t)``. There is no
+entropy or KL term by default (the paper's objective has neither).
+"""
+
+from __future__ import annotations
+
+from torchrl.objectives.llm.grpo import GRPOLoss, GRPOLossOutput
+
+
+class SAOLossOutput(GRPOLossOutput):
+    """SAO loss output. Same fields as GRPO; ``clip_fraction`` carries the DIS
+    **masked fraction** (tokens outside the trust region)."""
+
+
+class SAOLoss(GRPOLoss):
+    """SAO objective for LLM actors: DIS-masked single-rollout PG with a critic advantage.
+
+    ``_compute_policy_objective`` is the only override. In-band the gain is the
+    differentiable ``ratio · advantage`` (the standard PPO-surrogate form, whose
+    gradient equals ``ratio · Â · ∇log π_θ`` — the SAO/importance-weighted PG
+    gradient); out-of-band tokens are zeroed, contributing no loss and no
+    gradient. The returned second value (stored by the parent under the
+    ``clip_fraction`` key) is the fraction of tokens masked out.
+
+    Args:
+        actor_network: the LLM policy wrapper (e.g. ``ChunkedTransformersWrapper``).
+        epsilon_low: lower trust-region half-width ε_l — tokens with
+            ``ratio ≤ 1 − ε_l`` are masked. Must be in [0, 1). Default 0.2.
+        epsilon_high: upper trust-region half-width ε_h — tokens with
+            ``ratio ≥ 1 + ε_h`` are masked. Default 0.2. The paper uses aggressive
+            asymmetric "clip-higher" values (e.g. ε_l=0.3, ε_h=5.0); widen
+            ``epsilon_high`` to opt in.
+        entropy_bonus: default ``False`` (the paper's objective has no entropy
+            term), overriding GRPO's ``True``.
+        masking_strategy: default ``"rlhf"`` (score assistant/answer tokens only),
+            overriding GRPO's ``"sft"`` — this is the answer-token training the
+            trainer already uses.
+
+    All other keyword arguments (``aggregation``, ``kl_to_ref_coeff``,
+    ``reduction``, ``device`` …) pass straight through to ``GRPOLoss``.
+    """
+
+    output_type = SAOLossOutput
+
+    def __init__(
+        self,
+        actor_network=None,
+        *,
+        epsilon_low: float = 0.2,
+        epsilon_high: float = 0.2,
+        entropy_bonus: bool = False,
+        masking_strategy: str = "rlhf",
+        **kwargs,
+    ):
+        # Reuse GRPO's asymmetric clip machinery: it registers clip_epsilon_low /
+        # clip_epsilon_high buffers and exposes _clip_bounds = (log(1-ε_l),
+        # log(1+ε_h)), which is exactly the log-space trust region the DIS mask
+        # tests against. (GRPO validates ε_l < 1 so 1-ε_l > 0 — fine for SAO.)
+        super().__init__(
+            actor_network,
+            clip_epsilon=(epsilon_low, epsilon_high),
+            entropy_bonus=entropy_bonus,
+            masking_strategy=masking_strategy,
+            **kwargs,
+        )
+
+    def _compute_policy_objective(self, log_weight, advantage):
+        """SAO Eq. 1+3: in-band gain = ratio·Â (identity f), out-of-band = 0.
+
+        Returns ``(-gain, masked_fraction)``. ``log_weight`` is the per-token
+        log importance ratio ``[B, seq, 1]``; ``advantage`` broadcasts from
+        ``[B, 1, 1]`` across the token dim.
+        """
+        low, high = self._clip_bounds  # (log(1 - ε_l), log(1 + ε_h))
+        in_band = (log_weight > low) & (log_weight < high)  # per-token, Eq. 3 open interval
+        gain = log_weight.exp() * advantage * in_band.to(log_weight.dtype)
+        masked_fraction = (~in_band).to(log_weight.dtype).mean()
+        return -gain, masked_fraction

--- a/torchtrade/models/observation_critic.py
+++ b/torchtrade/models/observation_critic.py
@@ -4,7 +4,7 @@ Used by the LLM SAO trainer: the LLM is the policy (it picks the action), while
 this small critic supplies the variance-reducing baseline V(s) ≈ E[R | bar]. It
 reads only the pre-decision market state (``market_data_*`` windows +
 ``account_state``), never the sampled action/tokens, so ``R − V(s)`` is an
-unbiased advantage. Trained by MSE against the realized reward.
+unbiased advantage. Trained (smooth_l1/Huber) against the realized reward.
 
 A plain LayerNorm MLP (no BatchNorm) so it works for any batch size, including 1;
 the input width is inferred lazily on the first forward, so it adapts to whatever
@@ -26,7 +26,6 @@ class ObservationCritic(nn.Module):
             ``(window, features)`` tensor, batched as ``(B, window, features)``).
         account_state_key: the account-state key. Default ``"account_state"``.
         hidden_size: MLP width. Default 128.
-        num_layers: number of hidden layers. Default 2.
     """
 
     def __init__(
@@ -34,18 +33,15 @@ class ObservationCritic(nn.Module):
         market_data_keys,
         account_state_key: str = "account_state",
         hidden_size: int = 128,
-        num_layers: int = 2,
     ):
         super().__init__()
-        if num_layers < 1:
-            raise ValueError(f"num_layers must be >= 1, got {num_layers}")
         self.market_data_keys = list(market_data_keys)
         self.account_state_key = account_state_key
-        layers = [nn.LazyLinear(hidden_size), nn.LayerNorm(hidden_size), nn.GELU()]
-        for _ in range(num_layers - 1):
-            layers += [nn.Linear(hidden_size, hidden_size), nn.LayerNorm(hidden_size), nn.GELU()]
-        layers.append(nn.Linear(hidden_size, 1))
-        self.net = nn.Sequential(*layers)
+        self.net = nn.Sequential(
+            nn.LazyLinear(hidden_size), nn.LayerNorm(hidden_size), nn.GELU(),
+            nn.Linear(hidden_size, hidden_size), nn.LayerNorm(hidden_size), nn.GELU(),
+            nn.Linear(hidden_size, 1),
+        )
 
     def _flatten_features(self, td: TensorDictBase) -> torch.Tensor:
         # each market_data window is (..., window, features) -> (..., window*features)

--- a/torchtrade/models/observation_critic.py
+++ b/torchtrade/models/observation_critic.py
@@ -1,0 +1,58 @@
+"""State-value critic V(s) over a numeric trading observation — the SAO baseline.
+
+Used by the LLM SAO trainer: the LLM is the policy (it picks the action), while
+this small critic supplies the variance-reducing baseline V(s) ≈ E[R | bar]. It
+reads only the pre-decision market state (``market_data_*`` windows +
+``account_state``), never the sampled action/tokens, so ``R − V(s)`` is an
+unbiased advantage. Trained by MSE against the realized reward.
+
+A plain LayerNorm MLP (no BatchNorm) so it works for any batch size, including 1;
+the input width is inferred lazily on the first forward, so it adapts to whatever
+timeframes/window sizes the env produces without wiring shapes by hand.
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.nn as nn
+from tensordict import TensorDictBase
+
+
+class ObservationCritic(nn.Module):
+    """Scalar V(s) over ``market_data_*`` windows + ``account_state``.
+
+    Args:
+        market_data_keys: the env's market-data observation keys (each a
+            ``(window, features)`` tensor, batched as ``(B, window, features)``).
+        account_state_key: the account-state key. Default ``"account_state"``.
+        hidden_size: MLP width. Default 128.
+        num_layers: number of hidden layers. Default 2.
+    """
+
+    def __init__(
+        self,
+        market_data_keys,
+        account_state_key: str = "account_state",
+        hidden_size: int = 128,
+        num_layers: int = 2,
+    ):
+        super().__init__()
+        if num_layers < 1:
+            raise ValueError(f"num_layers must be >= 1, got {num_layers}")
+        self.market_data_keys = list(market_data_keys)
+        self.account_state_key = account_state_key
+        layers = [nn.LazyLinear(hidden_size), nn.LayerNorm(hidden_size), nn.GELU()]
+        for _ in range(num_layers - 1):
+            layers += [nn.Linear(hidden_size, hidden_size), nn.LayerNorm(hidden_size), nn.GELU()]
+        layers.append(nn.Linear(hidden_size, 1))
+        self.net = nn.Sequential(*layers)
+
+    def _flatten_features(self, td: TensorDictBase) -> torch.Tensor:
+        # each market_data window is (..., window, features) -> (..., window*features)
+        feats = [td.get(k).flatten(start_dim=-2) for k in self.market_data_keys]
+        feats.append(td.get(self.account_state_key))
+        return torch.cat(feats, dim=-1)
+
+    def forward(self, td: TensorDictBase) -> torch.Tensor:
+        """Return V(s) with shape ``(*batch, 1)``."""
+        return self.net(self._flatten_features(td))


### PR DESCRIPTION
## What

Implements **SAO (Single-Rollout Asynchronous Optimization, [arXiv:2607.07508](https://arxiv.org/abs/2607.07508))** for TorchTrade's LLM training path.

Where the LLM GRPO trainer builds its baseline from a **group of K completions of the same bar**, SAO trains on **one rollout per bar** and recovers the baseline from a learned **critic** V(s). This removes the K-fold *generation* cost — the dominant expense with an LLM actor — at the price of a small critic.

## How

- **`torchtrade/losses/sao_loss.py` — `SAOLoss`**: SAO is an LLM RL loss at its core, like TorchRL's `GRPOLoss`. It subclasses TorchRL's LLM `GRPOLoss` and overrides **only** `_compute_policy_objective` (the same seam TorchRL uses for `CISPOLoss`), reusing the entire rlhf-masking / per-token log-weight / aggregation / ESS pipeline. Two swaps vs GRPO:
  1. **Clip → DIS mask** (Eq. 3): in-band, `f(r)=r` (the ratio is retained as an off-policy weight); out-of-band tokens are **masked to zero**, not clamped — enabling the paper's asymmetric "clip-higher".
  2. **Group baseline → critic advantage** `Â = R − V(s)`.
  Paper-faithful defaults: `entropy_bonus=False`, `masking_strategy="rlhf"`.
- **`torchtrade/models/observation_critic.py` — `ObservationCritic`**: an MLP on the numeric bar state (`market_data_* + account_state`) → V(s). Action-independent, so `R − V(s)` is an unbiased baseline; the LLM is only the policy.
- **`llm_trainer.py` — `loss="sao"`**: single-rollout collection (distinct bars, no `MCAdvantage`), the critic on its own optimizer with the paper's **K=2 faster-value schedule** (Huber loss — trading rewards are heavy-tailed), advantage injected per bar as `[B,1,1]`. **The GRPO path is unchanged.**
- **`losses.py`**: `resolve_loss("sao")` + factory `loss_kwargs` threading; the group-size ≥ 2 guard is scoped off SAO (single-rollout is legal).

## Verification

- **Trained on the DGX Spark** (Qwen3-8B QLoRA, `loss="sao"`): 6 steps, critic loss converging (~0.2 → ~0.02), live non-zero advantage, finite policy loss, LoRA adapters hot-swapping, no errors.
- **31 CPU unit tests** covering the DIS-mask math (identity-not-gate, out-of-band zero, asymmetric band, gradient gating), the critic (learnability + a multi-key value-sensitivity guard), and the trainer wiring (SAO K=1 allowed, GRPO K=1 rejected, `resolve_loss("sao")`).
- Reviewed over 3 rounds × 4 agents (test-justification, code-simplifier, pr-test-analyzer, torchrl-engineer); final round clean.

## Notes

- `SAOLoss` pulls the LLM/vllm stack, so it is **not** exported from `torchtrade.losses` — import from `torchtrade.losses.sao_loss` or use `LLMTrainer(loss="sao")`.
- Docs: new `SAOLoss` section in `docs/components/losses.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
