### PR TITLE
fix(envs): use Unbounded for unbounded specs instead of Bounded(-inf, inf)

### DIFF
--- a/examples/offline_rl/iql/utils.py
+++ b/examples/offline_rl/iql/utils.py
@@ -290,8 +290,8 @@ def make_discrete_iql_model(cfg, env, device):
 
     # init nets
 
-    # Real reset obs, not observation_spec.rand(): the specs are Bounded with infinite
-    # bounds, so sampling them yields NaN.
+    # A real observation rather than observation_spec.rand(): lazy init on actual data
+    # keeps the first forward pass representative of what training will see.
     example_td = env.reset().to(device)
     with torch.no_grad(), set_exploration_type(ExplorationType.RANDOM):
         for net in model:

--- a/examples/offline_rl/iql/utils.py
+++ b/examples/offline_rl/iql/utils.py
@@ -290,8 +290,6 @@ def make_discrete_iql_model(cfg, env, device):
 
     # init nets
 
-    # A real observation rather than observation_spec.rand(): lazy init on actual data
-    # keeps the first forward pass representative of what training will see.
     example_td = env.reset().to(device)
     with torch.no_grad(), set_exploration_type(ExplorationType.RANDOM):
         for net in model:

--- a/tests/envs/test_spec_contracts.py
+++ b/tests/envs/test_spec_contracts.py
@@ -34,8 +34,8 @@ from torchtrade.envs.offline import (
     VectorizedSequentialTradingEnvSLTPConfig,
 )
 
-# examples/ too: the .rand() lazy-init idiom lives there, and that is where this bug
-# was found.
+# examples/ is scanned too: that is where this bug was found, and example code is where
+# the spec.rand() lazy-init idiom tends to reappear.
 REPO_ROOT = pathlib.Path(torchtrade.__file__).parent.parent
 SCAN_ROOTS = [REPO_ROOT / "torchtrade", REPO_ROOT / "examples"]
 
@@ -50,9 +50,9 @@ def _infinite(node):
     if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "float":
         return bool(node.args) and _infinite(node.args[0])
     if isinstance(node, ast.Constant):
-        return isinstance(node.value, (int, float)) and math.isinf(node.value) or (
-            isinstance(node.value, str) and node.value.lstrip("-").lower().startswith("inf")
-        )
+        if isinstance(node.value, str):
+            return node.value.lstrip("-").lower().startswith("inf")
+        return isinstance(node.value, float) and math.isinf(node.value)
     return False
 
 
@@ -107,9 +107,9 @@ def test_no_spec_is_bounded_by_infinity():
 def _assert_specs_sample_finite(env, label):
     """A spec must produce a sample it would itself accept.
 
-    isfinite is the load-bearing assertion; is_in is near-tautological for Unbounded
-    and Categorical (it checks shape/dtype only) but would catch a shape or dtype
-    declaration that disagrees with what the spec generates.
+    isfinite is the load-bearing assertion. is_in is a strict subset of it -- it rejects
+    the NaN a two-sided-infinite Bounded produces, but accepts the inf a one-sided one
+    does -- kept as a second net on the NaN case, not as independent coverage.
     """
     for name in ("observation_spec", "reward_spec", "action_spec", "full_done_spec"):
         spec = getattr(env, name)
@@ -149,8 +149,9 @@ def test_offline_env_specs_sample_finite(sample_ohlcv_df, env_cls, config_cls, e
 
 
 class _StubObserver:
-    """Satisfies every live observer interface the spec builders read -- alpaca derives
-    the feature width from get_observations(), the futures bases from get_features()."""
+    """Satisfies every live observer interface the spec builders read: alpaca, binance and
+    bitget take the feature width from get_observations(); bybit and okx from
+    get_features(). All five read get_keys()."""
 
     def get_keys(self):
         return ["1Minute_10", "5Minute_10"]
@@ -184,10 +185,10 @@ def test_live_env_specs_sample_finite(env_cls):
     exchange needs different broker mocks to construct, and the specs are all this
     test is about."""
     env = env_cls.__new__(env_cls)
-    object.__setattr__(env, "observer", _StubObserver())
-    object.__setattr__(
-        env, "config", types.SimpleNamespace(window_sizes=[10, 10], include_base_features=False)
-    )
+    env.observer = _StubObserver()
+    # include_base_features=True so the shared _declare_base_features_spec runs: that spec
+    # has a documented history of drifting per-exchange (#61) and is otherwise unexercised.
+    env.config = types.SimpleNamespace(window_sizes=[10, 10], include_base_features=True)
     env_cls._build_observation_specs(env)
 
     sample = env.observation_spec.rand()
@@ -196,3 +197,47 @@ def test_live_env_specs_sample_finite(env_cls):
         if value.is_floating_point():
             assert torch.isfinite(value).all(), f"{env_cls.__name__}.{key} sampled non-finite"
     assert env.observation_spec.is_in(sample)
+
+
+def test_live_env_discovery_covers_every_exchange():
+    """The parametrize above is only unskippable if discovery actually finds everything:
+    an exchange dropping out would silently shrink it and stay green."""
+    exchanges = {c.__module__.split(".")[3] for c in LIVE_ENVS}
+    assert exchanges == {"alpaca", "binance", "bitget", "bybit", "okx"}, exchanges
+    assert len(LIVE_ENVS) == 10, [c.__name__ for c in LIVE_ENVS]
+
+
+def test_transform_observation_spec_samples_finite():
+    """The transform is not an env, so the live parametrize cannot reach it -- without
+    this its spec is guarded only by the source scan."""
+    from torchrl.data import Composite
+    from torchtrade.envs.transforms.binance_ohlcv import BinanceOHLCVTransform
+    from torchtrade.envs.utils.timeframe import TimeFrame, TimeFrameUnit
+
+    transform = BinanceOHLCVTransform.__new__(BinanceOHLCVTransform)
+    transform.observer = types.SimpleNamespace(
+        time_frames=[TimeFrame(1, TimeFrameUnit.Minute), TimeFrame(5, TimeFrameUnit.Minute)],
+        window_sizes=[60, 30],
+    )
+    transform._key_prefix = "ohlcv"
+    transform._n_features = 5
+
+    spec = transform.transform_observation_spec(Composite(shape=()))
+    sample = spec.rand()
+    for key in sample.keys():
+        assert torch.isfinite(sample[key]).all(), f"transform.{key} sampled non-finite"
+
+
+def test_polymarket_env_specs_sample_finite():
+    """PolymarketBetEnv subclasses EnvBase directly, not TorchTradeLiveEnv, so it is
+    invisible to the __subclasses__ discovery above."""
+    from unittest.mock import MagicMock
+
+    from torchtrade.envs.live.polymarket import PolymarketBetEnv, PolymarketBetEnvConfig
+
+    env = PolymarketBetEnv(
+        PolymarketBetEnvConfig(market_slug_prefix="btc-updown-5m-", dry_run=True),
+        scanner=MagicMock(),
+        trader=MagicMock(),
+    )
+    _assert_specs_sample_finite(env, "PolymarketBetEnv")

--- a/tests/envs/test_spec_contracts.py
+++ b/tests/envs/test_spec_contracts.py
@@ -2,48 +2,62 @@
 
 TorchRL samples a Bounded spec as `uniform() * (high - low) + low`, so an infinite
 bound makes `.rand()` produce NaN (both bounds infinite) or inf (one bound infinite),
-and inf poisons the first forward pass just as thoroughly. `check_env_specs()` cannot
-catch either: it builds its dummy batch from `spec.zero()` and a real rollout, never
-`.rand()`. So every environment shipped a spec that could not be sampled, and the
-standard `spec.rand()` lazy-init idiom silently initialised networks on garbage.
-
-Use `Unbounded(shape=..., dtype=...)` for unbounded quantities, and finite numbers
-where a bound is real.
+and inf poisons a lazily-built network just as thoroughly. `check_env_specs()` catches
+neither: it builds its dummy batch from `spec.zero()` and a real rollout, never
+`.rand()`. Use `Unbounded(shape=..., dtype=...)`, or finite numbers where a bound is
+real.
 """
 
 import ast
+import math
 import pathlib
+import types
 
+import numpy as np
 import pytest
 import torch
 from tensordict import TensorDictBase
 
 import torchtrade
+import torchtrade.envs  # noqa: F401 -- registers every live env as a subclass
+from torchtrade.envs.core.live import TorchTradeLiveEnv
+from torchtrade.envs.offline import (
+    OneStepTradingEnv,
+    OneStepTradingEnvConfig,
+    SequentialTradingEnv,
+    SequentialTradingEnvConfig,
+    SequentialTradingEnvSLTP,
+    SequentialTradingEnvSLTPConfig,
+    VectorizedSequentialTradingEnv,
+    VectorizedSequentialTradingEnvConfig,
+    VectorizedSequentialTradingEnvSLTP,
+    VectorizedSequentialTradingEnvSLTPConfig,
+)
 
-# examples/ is scanned too: the bug was found there, in an example whose lazy init used
-# the spec.rand() idiom. Guarding only the package would leave its discovery site open.
+# examples/ too: the .rand() lazy-init idiom lives there, and that is where this bug
+# was found.
 REPO_ROOT = pathlib.Path(torchtrade.__file__).parent.parent
 SCAN_ROOTS = [REPO_ROOT / "torchtrade", REPO_ROOT / "examples"]
 
 
-def _infinite(node, consts):
-    """True for `torch.inf`, `np.inf`, `float("inf")`, their negations, and names bound
-    to any of those at module level."""
+def _infinite(node):
+    """True for `torch.inf`, `np.inf`, `float("inf")`, an overflowing literal like
+    `1e999`, and negations of any of those."""
     if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.USub):
-        return _infinite(node.operand, consts)
+        return _infinite(node.operand)
     if isinstance(node, ast.Attribute):
         return node.attr == "inf"
-    if isinstance(node, ast.Name):
-        return consts.get(node.id, False)
     if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "float":
-        return bool(node.args) and isinstance(node.args[0], ast.Constant) and str(
-            node.args[0].value
-        ).lstrip("-").lower().startswith("inf")
+        return bool(node.args) and _infinite(node.args[0])
+    if isinstance(node, ast.Constant):
+        return isinstance(node.value, (int, float)) and math.isinf(node.value) or (
+            isinstance(node.value, str) and node.value.lstrip("-").lower().startswith("inf")
+        )
     return False
 
 
-def _bounded_names(tree):
-    """`Bounded`, plus any alias it was imported under."""
+def _bounded_aliases(tree):
+    """`Bounded` plus any name it was imported under."""
     names = {"Bounded"}
     for node in ast.walk(tree):
         if isinstance(node, ast.ImportFrom):
@@ -56,39 +70,33 @@ def _infinitely_bounded_calls():
     for root in SCAN_ROOTS:
         for path in sorted(root.rglob("*.py")):
             tree = ast.parse(path.read_text(), filename=str(path))
-            names = _bounded_names(tree)
-            # Module-level `INF = torch.inf` style indirection.
-            consts = {
-                t.id: _infinite(n.value, {})
-                for n in ast.walk(tree)
-                if isinstance(n, ast.Assign)
-                for t in n.targets
-                if isinstance(t, ast.Name)
-            }
+            aliases = _bounded_aliases(tree)
             for node in ast.walk(tree):
                 if not isinstance(node, ast.Call):
                     continue
                 func = node.func
-                is_bounded = (
-                    (isinstance(func, ast.Name) and func.id in names)
+                if not (
+                    (isinstance(func, ast.Name) and func.id in aliases)
                     or (isinstance(func, ast.Attribute) and func.attr == "Bounded")
-                )
-                if not is_bounded:
-                    continue
-                kw = {k.arg: k.value for k in node.keywords}
-                # Bounded(low, high, ...) may pass either positionally.
-                low = kw.get("low", node.args[0] if len(node.args) > 0 else None)
-                high = kw.get("high", node.args[1] if len(node.args) > 1 else None)
-                if (low is not None and _infinite(low, consts)) or (
-                    high is not None and _infinite(high, consts)
                 ):
+                    continue
+                kw = {k.arg: k.value for k in node.keywords if k.arg}
+                low = kw.get("low", node.args[0] if node.args else None)
+                high = kw.get("high", node.args[1] if len(node.args) > 1 else None)
+                if (low is not None and _infinite(low)) or (high is not None and _infinite(high)):
                     yield f"{path.relative_to(REPO_ROOT)}:{node.lineno}"
 
 
 def test_no_spec_is_bounded_by_infinity():
-    """An infinite bound on either side makes .rand() unsamplable (NaN, or inf that
-    becomes NaN downstream). Catches aliased, qualified and positional spellings, so
-    it cannot be sidestepped by writing the same thing a different way."""
+    """An infinite bound on either side makes .rand() unsamplable.
+
+    Catches the spellings a person plausibly writes: keyword or positional, aliased
+    import, qualified `module.Bounded`, `torch.inf`/`np.inf`/`float("inf")`/`1e999`.
+    It does NOT resolve indirection -- `partial(Bounded, ...)`, a Bounded subclass,
+    a name assigned from Bounded, or `**kwargs` unpacking all escape it, and only
+    `.py` files under torchtrade/ and examples/ are scanned. It is a guard against
+    re-introducing the pattern, not an adversarial sandbox.
+    """
     offenders = list(_infinitely_bounded_calls())
     assert not offenders, (
         "Bounded with an infinite bound cannot be sampled; use Unbounded(shape=..., "
@@ -96,57 +104,95 @@ def test_no_spec_is_bounded_by_infinity():
     )
 
 
-def _offline_envs(df):
-    """One instance per offline env family. Built here rather than fixtured so a new
-    family shows up as an import error instead of silently going uncovered."""
-    from torchtrade.envs.offline import (
-        OneStepTradingEnv, SequentialTradingEnv, SequentialTradingEnvSLTP,
-        VectorizedSequentialTradingEnv,
-    )
+def _assert_specs_sample_finite(env, label):
+    """A spec must produce a sample it would itself accept.
 
-    common = dict(
-        time_frames=["5Min", "15Min"], window_sizes=[10, 10],
-        execute_on="5Min", initial_cash=1000,
-    )
-    from torchtrade.envs.offline import (
-        OneStepTradingEnvConfig, SequentialTradingEnvConfig,
-        SequentialTradingEnvSLTPConfig, VectorizedSequentialTradingEnvConfig,
-    )
-    return {
-        "sequential": SequentialTradingEnv(df, SequentialTradingEnvConfig(**common)),
-        "sequential_sltp": SequentialTradingEnvSLTP(df, SequentialTradingEnvSLTPConfig(**common)),
-        "onestep": OneStepTradingEnv(df, OneStepTradingEnvConfig(**common)),
-        "vectorized": VectorizedSequentialTradingEnv(
-            df, VectorizedSequentialTradingEnvConfig(**common, num_envs=2)
-        ),
-    }
-
-
-@pytest.fixture
-def offline_envs(sample_ohlcv_df):
-    return _offline_envs(sample_ohlcv_df)
-
-
-@pytest.mark.parametrize(
-    "family", ["sequential", "sequential_sltp", "onestep", "vectorized"]
-)
-def test_env_specs_sample_finite_values(offline_envs, family):
-    """The behaviour the structural guard protects, checked per env family: a spec must
-    produce a sample it would itself accept. The guard proves no infinite Bounded is
-    written down; this proves the specs are actually samplable."""
-    env = offline_envs[family]
-
+    isfinite is the load-bearing assertion; is_in is near-tautological for Unbounded
+    and Categorical (it checks shape/dtype only) but would catch a shape or dtype
+    declaration that disagrees with what the spec generates.
+    """
     for name in ("observation_spec", "reward_spec", "action_spec", "full_done_spec"):
-        spec = getattr(env, name, None)
-        if spec is None:
-            continue
+        spec = getattr(env, name)
         sample = spec.rand()
         values = (
-            sample.values(include_nested=True, leaves_only=True)
+            list(sample.values(include_nested=True, leaves_only=True))
             if isinstance(sample, TensorDictBase)
             else [sample]
         )
         for value in values:
             if value.is_floating_point():
-                assert torch.isfinite(value).all(), f"{family}.{name} sampled non-finite"
-        assert spec.is_in(sample), f"{family}.{name} rejects its own sample"
+                assert torch.isfinite(value).all(), f"{label}.{name} sampled non-finite"
+        assert spec.is_in(sample), f"{label}.{name} rejects its own sample"
+
+
+OFFLINE_ENVS = [
+    (SequentialTradingEnv, SequentialTradingEnvConfig, {}),
+    (SequentialTradingEnvSLTP, SequentialTradingEnvSLTPConfig, {}),
+    (OneStepTradingEnv, OneStepTradingEnvConfig, {}),
+    (VectorizedSequentialTradingEnv, VectorizedSequentialTradingEnvConfig, {"num_envs": 2}),
+    (VectorizedSequentialTradingEnvSLTP, VectorizedSequentialTradingEnvSLTPConfig, {"num_envs": 2}),
+]
+
+
+@pytest.mark.parametrize(
+    "env_cls,config_cls,extra", OFFLINE_ENVS, ids=[e[0].__name__ for e in OFFLINE_ENVS]
+)
+def test_offline_env_specs_sample_finite(sample_ohlcv_df, env_cls, config_cls, extra):
+    env = env_cls(
+        sample_ohlcv_df,
+        config_cls(
+            time_frames=["5Min", "15Min"], window_sizes=[10, 10],
+            execute_on="5Min", initial_cash=1000, **extra,
+        ),
+    )
+    _assert_specs_sample_finite(env, env_cls.__name__)
+
+
+class _StubObserver:
+    """Satisfies every live observer interface the spec builders read -- alpaca derives
+    the feature width from get_observations(), the futures bases from get_features()."""
+
+    def get_keys(self):
+        return ["1Minute_10", "5Minute_10"]
+
+    def get_features(self):
+        return {"observation_features": ["a", "b", "c", "d", "e"]}
+
+    def get_observations(self):
+        return {k: np.zeros((10, 5)) for k in self.get_keys()}
+
+
+def _concrete_live_envs():
+    """Discovered, not hand-listed, so exchange #6 cannot skip this by being forgotten."""
+    def walk(cls):
+        for sub in cls.__subclasses__():
+            yield sub
+            yield from walk(sub)
+
+    return sorted(
+        (c for c in set(walk(TorchTradeLiveEnv)) if not getattr(c, "__abstractmethods__", None)),
+        key=lambda c: c.__name__,
+    )
+
+
+LIVE_ENVS = _concrete_live_envs()
+
+
+@pytest.mark.parametrize("env_cls", LIVE_ENVS, ids=[c.__name__ for c in LIVE_ENVS])
+def test_live_env_specs_sample_finite(env_cls):
+    """Built via __new__ + the unbound spec builder rather than a full env: every
+    exchange needs different broker mocks to construct, and the specs are all this
+    test is about."""
+    env = env_cls.__new__(env_cls)
+    object.__setattr__(env, "observer", _StubObserver())
+    object.__setattr__(
+        env, "config", types.SimpleNamespace(window_sizes=[10, 10], include_base_features=False)
+    )
+    env_cls._build_observation_specs(env)
+
+    sample = env.observation_spec.rand()
+    for key in sample.keys():
+        value = sample[key]
+        if value.is_floating_point():
+            assert torch.isfinite(value).all(), f"{env_cls.__name__}.{key} sampled non-finite"
+    assert env.observation_spec.is_in(sample)

--- a/tests/envs/test_spec_contracts.py
+++ b/tests/envs/test_spec_contracts.py
@@ -20,6 +20,7 @@ from tensordict import TensorDictBase
 
 import torchtrade
 import torchtrade.envs  # noqa: F401 -- registers every live env as a subclass
+from tests.envs.test_live_env_base import _subclasses
 from torchtrade.envs.core.live import TorchTradeLiveEnv
 from torchtrade.envs.offline import (
     OneStepTradingEnv,
@@ -94,8 +95,11 @@ def test_no_spec_is_bounded_by_infinity():
     import, qualified `module.Bounded`, `torch.inf`/`np.inf`/`float("inf")`/`1e999`.
     It does NOT resolve indirection -- `partial(Bounded, ...)`, a Bounded subclass,
     a name assigned from Bounded, or `**kwargs` unpacking all escape it, and only
-    `.py` files under torchtrade/ and examples/ are scanned. It is a guard against
-    re-introducing the pattern, not an adversarial sandbox.
+    `.py` files under torchtrade/ and examples/ are scanned. Those are left alone
+    deliberately: each is caught by the behavioural tests below (verified), and an
+    earlier attempt to resolve name indirection here introduced both false positives
+    and false negatives. This guards against re-introducing the pattern; it is not an
+    adversarial sandbox.
     """
     offenders = list(_infinitely_bounded_calls())
     assert not offenders, (
@@ -167,14 +171,10 @@ class _StubObserver:
 
 
 def _concrete_live_envs():
-    """Discovered, not hand-listed, so exchange #6 cannot skip this by being forgotten."""
-    def walk(cls):
-        for sub in cls.__subclasses__():
-            yield sub
-            yield from walk(sub)
-
+    """Discovered, not hand-listed, so exchange #6 cannot skip this by being forgotten.
+    Abstract bases are dropped -- EnvBase.__new__ rejects them."""
     return sorted(
-        (c for c in set(walk(TorchTradeLiveEnv)) if not getattr(c, "__abstractmethods__", None)),
+        (c for c in set(_subclasses(TorchTradeLiveEnv)) if not getattr(c, "__abstractmethods__", None)),
         key=lambda c: c.__name__,
     )
 

--- a/tests/envs/test_spec_contracts.py
+++ b/tests/envs/test_spec_contracts.py
@@ -1,16 +1,14 @@
 """Contract tests for observation/reward spec declarations.
 
-`Bounded(low=-inf, high=inf)` is not a harmless spelling of "unconstrained": TorchRL
-samples a Bounded spec as `uniform() * (high - low) + low`, so infinite bounds make
-every `.rand()` draw NaN and the spec rejects its own sample. Nothing in the normal
-test path catches it -- `check_env_specs()` builds its dummy batch from `spec.zero()`,
-never `.rand()` -- so it survived across every environment until an example that used
-the standard `spec.rand()` lazy-init idiom silently initialised its nets on NaN.
+TorchRL samples a Bounded spec as `uniform() * (high - low) + low`, so an infinite
+bound makes `.rand()` produce NaN (both bounds infinite) or inf (one bound infinite),
+and inf poisons the first forward pass just as thoroughly. `check_env_specs()` cannot
+catch either: it builds its dummy batch from `spec.zero()` and a real rollout, never
+`.rand()`. So every environment shipped a spec that could not be sampled, and the
+standard `spec.rand()` lazy-init idiom silently initialised networks on garbage.
 
-The structural guard is source-level on purpose. Two attempts to sweep this by hand
-missed sites: once because the sweep was driven by a file list, and once because a file
-spelled infinity `float("inf")` instead of `torch.inf`. A guard that parses every file
-in the package cannot be escaped by either.
+Use `Unbounded(shape=..., dtype=...)` for unbounded quantities, and finite numbers
+where a bound is real.
 """
 
 import ast
@@ -18,77 +16,137 @@ import pathlib
 
 import pytest
 import torch
+from tensordict import TensorDictBase
 
 import torchtrade
 
-PACKAGE_ROOT = pathlib.Path(torchtrade.__file__).parent
+# examples/ is scanned too: the bug was found there, in an example whose lazy init used
+# the spec.rand() idiom. Guarding only the package would leave its discovery site open.
+REPO_ROOT = pathlib.Path(torchtrade.__file__).parent.parent
+SCAN_ROOTS = [REPO_ROOT / "torchtrade", REPO_ROOT / "examples"]
 
 
-def _is_infinite(node):
-    """True for `torch.inf`, `np.inf`, `float("inf")` and their negations."""
+def _infinite(node, consts):
+    """True for `torch.inf`, `np.inf`, `float("inf")`, their negations, and names bound
+    to any of those at module level."""
     if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.USub):
-        return _is_infinite(node.operand)
-    if isinstance(node, ast.Attribute) and node.attr == "inf":
-        return True
-    if (
-        isinstance(node, ast.Call)
-        and isinstance(node.func, ast.Name)
-        and node.func.id == "float"
-        and node.args
-        and isinstance(node.args[0], ast.Constant)
-        and str(node.args[0].value).lower().lstrip("-") in {"inf", "infinity"}
-    ):
-        return True
-    return isinstance(node, ast.Constant) and node.value in (float("inf"), float("-inf"))
+        return _infinite(node.operand, consts)
+    if isinstance(node, ast.Attribute):
+        return node.attr == "inf"
+    if isinstance(node, ast.Name):
+        return consts.get(node.id, False)
+    if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "float":
+        return bool(node.args) and isinstance(node.args[0], ast.Constant) and str(
+            node.args[0].value
+        ).lstrip("-").lower().startswith("inf")
+    return False
 
 
-def _infinite_bounded_calls():
-    """Every `Bounded(...)` in the package whose low AND high are both infinite."""
-    for path in sorted(PACKAGE_ROOT.rglob("*.py")):
-        tree = ast.parse(path.read_text(), filename=str(path))
-        for node in ast.walk(tree):
-            if not (isinstance(node, ast.Call) and isinstance(node.func, ast.Name)):
-                continue
-            if node.func.id != "Bounded":
-                continue
-            kw = {k.arg: k.value for k in node.keywords}
-            if "low" in kw and "high" in kw and _is_infinite(kw["low"]) and _is_infinite(kw["high"]):
-                yield f"{path.relative_to(PACKAGE_ROOT.parent)}:{node.lineno}"
+def _bounded_names(tree):
+    """`Bounded`, plus any alias it was imported under."""
+    names = {"Bounded"}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            names.update(a.asname or a.name for a in node.names if a.name == "Bounded")
+    return names
+
+
+def _infinitely_bounded_calls():
+    """Every `Bounded(...)` under the scan roots with an infinite low or high."""
+    for root in SCAN_ROOTS:
+        for path in sorted(root.rglob("*.py")):
+            tree = ast.parse(path.read_text(), filename=str(path))
+            names = _bounded_names(tree)
+            # Module-level `INF = torch.inf` style indirection.
+            consts = {
+                t.id: _infinite(n.value, {})
+                for n in ast.walk(tree)
+                if isinstance(n, ast.Assign)
+                for t in n.targets
+                if isinstance(t, ast.Name)
+            }
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.Call):
+                    continue
+                func = node.func
+                is_bounded = (
+                    (isinstance(func, ast.Name) and func.id in names)
+                    or (isinstance(func, ast.Attribute) and func.attr == "Bounded")
+                )
+                if not is_bounded:
+                    continue
+                kw = {k.arg: k.value for k in node.keywords}
+                # Bounded(low, high, ...) may pass either positionally.
+                low = kw.get("low", node.args[0] if len(node.args) > 0 else None)
+                high = kw.get("high", node.args[1] if len(node.args) > 1 else None)
+                if (low is not None and _infinite(low, consts)) or (
+                    high is not None and _infinite(high, consts)
+                ):
+                    yield f"{path.relative_to(REPO_ROOT)}:{node.lineno}"
 
 
 def test_no_spec_is_bounded_by_infinity():
-    """Use Unbounded instead: a doubly-infinite Bounded samples NaN from .rand().
-
-    Half-infinite bounds are deliberately allowed -- e.g. polymarket's market_state is
-    Bounded(low=0.0, high=inf), where the lower bound is a real constraint (prices and
-    sizes are non-negative) and .rand() yields inf rather than NaN.
-    """
-    offenders = list(_infinite_bounded_calls())
+    """An infinite bound on either side makes .rand() unsamplable (NaN, or inf that
+    becomes NaN downstream). Catches aliased, qualified and positional spellings, so
+    it cannot be sidestepped by writing the same thing a different way."""
+    offenders = list(_infinitely_bounded_calls())
     assert not offenders, (
-        "Bounded(low=-inf, high=inf) samples NaN; use Unbounded(shape=..., dtype=...):\n  "
-        + "\n  ".join(offenders)
+        "Bounded with an infinite bound cannot be sampled; use Unbounded(shape=..., "
+        "dtype=...) or a finite bound:\n  " + "\n  ".join(offenders)
     )
 
 
-def test_offline_env_specs_sample_finite_values(sample_ohlcv_df):
-    """The behaviour the structural guard exists to protect: a spec must be able to
-    produce a sample it would itself accept. check_env_specs() cannot catch this."""
-    from torchtrade.envs.offline import SequentialTradingEnv, SequentialTradingEnvConfig
+def _offline_envs(df):
+    """One instance per offline env family. Built here rather than fixtured so a new
+    family shows up as an import error instead of silently going uncovered."""
+    from torchtrade.envs.offline import (
+        OneStepTradingEnv, SequentialTradingEnv, SequentialTradingEnvSLTP,
+        VectorizedSequentialTradingEnv,
+    )
 
-    env = SequentialTradingEnv(
-        sample_ohlcv_df,
-        SequentialTradingEnvConfig(
-            time_frames=["5Min", "15Min"], window_sizes=[10, 10],
-            execute_on="5Min", initial_cash=1000, action_levels=[0, 1],
+    common = dict(
+        time_frames=["5Min", "15Min"], window_sizes=[10, 10],
+        execute_on="5Min", initial_cash=1000,
+    )
+    from torchtrade.envs.offline import (
+        OneStepTradingEnvConfig, SequentialTradingEnvConfig,
+        SequentialTradingEnvSLTPConfig, VectorizedSequentialTradingEnvConfig,
+    )
+    return {
+        "sequential": SequentialTradingEnv(df, SequentialTradingEnvConfig(**common)),
+        "sequential_sltp": SequentialTradingEnvSLTP(df, SequentialTradingEnvSLTPConfig(**common)),
+        "onestep": OneStepTradingEnv(df, OneStepTradingEnvConfig(**common)),
+        "vectorized": VectorizedSequentialTradingEnv(
+            df, VectorizedSequentialTradingEnvConfig(**common, num_envs=2)
         ),
-    )
+    }
 
-    sample = env.observation_spec.rand()
-    for key in sample.keys():
-        value = sample[key]
-        if value.is_floating_point():
-            assert torch.isfinite(value).all(), f"{key} sampled non-finite values"
-    assert env.observation_spec.is_in(sample), "spec rejects its own sample"
 
-    reward = env.reward_spec.rand()
-    assert torch.isfinite(reward).all(), "reward_spec sampled non-finite values"
+@pytest.fixture
+def offline_envs(sample_ohlcv_df):
+    return _offline_envs(sample_ohlcv_df)
+
+
+@pytest.mark.parametrize(
+    "family", ["sequential", "sequential_sltp", "onestep", "vectorized"]
+)
+def test_env_specs_sample_finite_values(offline_envs, family):
+    """The behaviour the structural guard protects, checked per env family: a spec must
+    produce a sample it would itself accept. The guard proves no infinite Bounded is
+    written down; this proves the specs are actually samplable."""
+    env = offline_envs[family]
+
+    for name in ("observation_spec", "reward_spec", "action_spec", "full_done_spec"):
+        spec = getattr(env, name, None)
+        if spec is None:
+            continue
+        sample = spec.rand()
+        values = (
+            sample.values(include_nested=True, leaves_only=True)
+            if isinstance(sample, TensorDictBase)
+            else [sample]
+        )
+        for value in values:
+            if value.is_floating_point():
+                assert torch.isfinite(value).all(), f"{family}.{name} sampled non-finite"
+        assert spec.is_in(sample), f"{family}.{name} rejects its own sample"

--- a/tests/envs/test_spec_contracts.py
+++ b/tests/envs/test_spec_contracts.py
@@ -1,0 +1,94 @@
+"""Contract tests for observation/reward spec declarations.
+
+`Bounded(low=-inf, high=inf)` is not a harmless spelling of "unconstrained": TorchRL
+samples a Bounded spec as `uniform() * (high - low) + low`, so infinite bounds make
+every `.rand()` draw NaN and the spec rejects its own sample. Nothing in the normal
+test path catches it -- `check_env_specs()` builds its dummy batch from `spec.zero()`,
+never `.rand()` -- so it survived across every environment until an example that used
+the standard `spec.rand()` lazy-init idiom silently initialised its nets on NaN.
+
+The structural guard is source-level on purpose. Two attempts to sweep this by hand
+missed sites: once because the sweep was driven by a file list, and once because a file
+spelled infinity `float("inf")` instead of `torch.inf`. A guard that parses every file
+in the package cannot be escaped by either.
+"""
+
+import ast
+import pathlib
+
+import pytest
+import torch
+
+import torchtrade
+
+PACKAGE_ROOT = pathlib.Path(torchtrade.__file__).parent
+
+
+def _is_infinite(node):
+    """True for `torch.inf`, `np.inf`, `float("inf")` and their negations."""
+    if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.USub):
+        return _is_infinite(node.operand)
+    if isinstance(node, ast.Attribute) and node.attr == "inf":
+        return True
+    if (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "float"
+        and node.args
+        and isinstance(node.args[0], ast.Constant)
+        and str(node.args[0].value).lower().lstrip("-") in {"inf", "infinity"}
+    ):
+        return True
+    return isinstance(node, ast.Constant) and node.value in (float("inf"), float("-inf"))
+
+
+def _infinite_bounded_calls():
+    """Every `Bounded(...)` in the package whose low AND high are both infinite."""
+    for path in sorted(PACKAGE_ROOT.rglob("*.py")):
+        tree = ast.parse(path.read_text(), filename=str(path))
+        for node in ast.walk(tree):
+            if not (isinstance(node, ast.Call) and isinstance(node.func, ast.Name)):
+                continue
+            if node.func.id != "Bounded":
+                continue
+            kw = {k.arg: k.value for k in node.keywords}
+            if "low" in kw and "high" in kw and _is_infinite(kw["low"]) and _is_infinite(kw["high"]):
+                yield f"{path.relative_to(PACKAGE_ROOT.parent)}:{node.lineno}"
+
+
+def test_no_spec_is_bounded_by_infinity():
+    """Use Unbounded instead: a doubly-infinite Bounded samples NaN from .rand().
+
+    Half-infinite bounds are deliberately allowed -- e.g. polymarket's market_state is
+    Bounded(low=0.0, high=inf), where the lower bound is a real constraint (prices and
+    sizes are non-negative) and .rand() yields inf rather than NaN.
+    """
+    offenders = list(_infinite_bounded_calls())
+    assert not offenders, (
+        "Bounded(low=-inf, high=inf) samples NaN; use Unbounded(shape=..., dtype=...):\n  "
+        + "\n  ".join(offenders)
+    )
+
+
+def test_offline_env_specs_sample_finite_values(sample_ohlcv_df):
+    """The behaviour the structural guard exists to protect: a spec must be able to
+    produce a sample it would itself accept. check_env_specs() cannot catch this."""
+    from torchtrade.envs.offline import SequentialTradingEnv, SequentialTradingEnvConfig
+
+    env = SequentialTradingEnv(
+        sample_ohlcv_df,
+        SequentialTradingEnvConfig(
+            time_frames=["5Min", "15Min"], window_sizes=[10, 10],
+            execute_on="5Min", initial_cash=1000, action_levels=[0, 1],
+        ),
+    )
+
+    sample = env.observation_spec.rand()
+    for key in sample.keys():
+        value = sample[key]
+        if value.is_floating_point():
+            assert torch.isfinite(value).all(), f"{key} sampled non-finite values"
+    assert env.observation_spec.is_in(sample), "spec rejects its own sample"
+
+    reward = env.reward_spec.rand()
+    assert torch.isfinite(reward).all(), "reward_spec sampled non-finite values"

--- a/tests/envs/test_spec_contracts.py
+++ b/tests/envs/test_spec_contracts.py
@@ -125,6 +125,9 @@ def _assert_specs_sample_finite(env, label):
         assert spec.is_in(sample), f"{label}.{name} rejects its own sample"
 
 
+# One per family, though 3 of the 5 currently share TorchTradeOfflineEnv's builder, so a
+# defect there fails 3 cases. Kept per the all-environments rule: a family that later
+# overrides spec construction is then already covered.
 OFFLINE_ENVS = [
     (SequentialTradingEnv, SequentialTradingEnvConfig, {}),
     (SequentialTradingEnvSLTP, SequentialTradingEnvSLTPConfig, {}),
@@ -183,7 +186,12 @@ LIVE_ENVS = _concrete_live_envs()
 def test_live_env_specs_sample_finite(env_cls):
     """Built via __new__ + the unbound spec builder rather than a full env: every
     exchange needs different broker mocks to construct, and the specs are all this
-    test is about."""
+    test is about.
+
+    The 10 cases resolve to 5 builders (no SLTP variant overrides one), so a defect
+    fails 2 cases. Deduplicating would need a hand-maintained MRO map, which is exactly
+    what the __subclasses__ discovery exists to avoid.
+    """
     env = env_cls.__new__(env_cls)
     env.observer = _StubObserver()
     # include_base_features=True so the shared _declare_base_features_spec runs: that spec

--- a/torchtrade/envs/core/README.md
+++ b/torchtrade/envs/core/README.md
@@ -197,11 +197,11 @@ Environments must define their observation space:
 
 ```python
 def _make_observation_space(self):
-    return spaces.Box(
-        low=-np.inf,
-        high=np.inf,
+    # Unbounded, not Bounded(low=-inf, high=inf): TorchRL samples a Bounded spec as
+    # uniform() * (high - low) + low, so infinite bounds make every .rand() draw NaN.
+    return Unbounded(
         shape=(self.window_size, self.n_features),
-        dtype=np.float32
+        dtype=torch.float32,
     )
 ```
 

--- a/torchtrade/envs/core/README.md
+++ b/torchtrade/envs/core/README.md
@@ -197,11 +197,11 @@ Environments must define their observation space:
 
 ```python
 def _make_observation_space(self):
-    # Unbounded, not Bounded(low=-inf, high=inf): TorchRL samples a Bounded spec as
-    # uniform() * (high - low) + low, so infinite bounds make every .rand() draw NaN.
-    return Unbounded(
+    return spaces.Box(
+        low=-np.inf,
+        high=np.inf,
         shape=(self.window_size, self.n_features),
-        dtype=torch.float32,
+        dtype=np.float32
     )
 ```
 

--- a/torchtrade/envs/core/base.py
+++ b/torchtrade/envs/core/base.py
@@ -6,7 +6,7 @@ from typing import Any, Optional
 
 import numpy as np
 import torch
-from torchrl.data import Bounded
+from torchrl.data import Unbounded
 from torchrl.envs import EnvBase
 
 logger = logging.getLogger(__name__)
@@ -52,12 +52,7 @@ class TorchTradeBaseEnv(EnvBase):
             self.slippage = config.slippage
 
         # Create reward spec (common across all environments)
-        self.reward_spec = Bounded(
-            low=-torch.inf,
-            high=torch.inf,
-            shape=(1,),
-            dtype=torch.float
-        )
+        self.reward_spec = Unbounded(shape=(1,), dtype=torch.float)
 
         super().__init__()
 

--- a/torchtrade/envs/core/live.py
+++ b/torchtrade/envs/core/live.py
@@ -7,7 +7,7 @@ from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 import torch
 from tensordict import TensorDictBase
-from torchrl.data import Bounded
+from torchrl.data import Unbounded
 
 from torchtrade.envs.core.base import TorchTradeBaseEnv
 from torchtrade.envs.core.state import PositionState, position_direction_from_status
@@ -231,7 +231,7 @@ class TorchTradeLiveEnv(TorchTradeBaseEnv):
         if self.config.include_base_features:
             self.observation_spec.set(
                 "base_features",
-                Bounded(low=-torch.inf, high=torch.inf, shape=(base_window, 4), dtype=torch.float),
+                Unbounded(shape=(base_window, 4), dtype=torch.float),
             )
 
     def _check_termination(self, portfolio_value: float) -> bool:

--- a/torchtrade/envs/core/offline_base.py
+++ b/torchtrade/envs/core/offline_base.py
@@ -7,7 +7,7 @@ import numpy as np
 import pandas as pd
 import torch
 from tensordict import TensorDictBase
-from torchrl.data import Bounded
+from torchrl.data import Unbounded
 from torchrl.data import Categorical, Composite, Unbounded
 
 from torchtrade.envs.core.base import TorchTradeBaseEnv
@@ -138,12 +138,7 @@ class TorchTradeOfflineEnv(TorchTradeBaseEnv):
         # Account state spec
         self.account_state_key = "account_state"
         self.account_state = account_state
-        account_state_spec = Bounded(
-            low=-torch.inf,
-            high=torch.inf,
-            shape=(len(account_state),),
-            dtype=torch.float
-        )
+        account_state_spec = Unbounded(shape=(len(account_state),), dtype=torch.float)
         self.observation_spec.set(self.account_state_key, account_state_spec)
 
         # Market data specs (one per timeframe)
@@ -169,11 +164,8 @@ class TorchTradeOfflineEnv(TorchTradeBaseEnv):
             else:
                 tf_num_features = num_features
 
-            market_data_spec = Bounded(
-                low=-torch.inf,
-                high=torch.inf,
-                shape=(self.config.window_sizes[i], tf_num_features),
-                dtype=torch.float
+            market_data_spec = Unbounded(
+                shape=(self.config.window_sizes[i], tf_num_features), dtype=torch.float
             )
             self.observation_spec.set(market_data_key, market_data_spec)
             self.market_data_keys.append(market_data_key)

--- a/torchtrade/envs/core/offline_base.py
+++ b/torchtrade/envs/core/offline_base.py
@@ -11,7 +11,6 @@ from torchrl.data import Categorical, Composite, Unbounded
 
 from torchtrade.envs.core.base import TorchTradeBaseEnv
 from torchtrade.envs.core.state import HistoryTracker, PositionState
-from tensordict import TensorDict
 
 
 class TorchTradeOfflineEnv(TorchTradeBaseEnv):

--- a/torchtrade/envs/core/offline_base.py
+++ b/torchtrade/envs/core/offline_base.py
@@ -7,7 +7,6 @@ import numpy as np
 import pandas as pd
 import torch
 from tensordict import TensorDictBase
-from torchrl.data import Unbounded
 from torchrl.data import Categorical, Composite, Unbounded
 
 from torchtrade.envs.core.base import TorchTradeBaseEnv

--- a/torchtrade/envs/live/alpaca/base.py
+++ b/torchtrade/envs/live/alpaca/base.py
@@ -5,8 +5,7 @@ from typing import Callable, List, Optional
 
 import torch
 from tensordict import TensorDict, TensorDictBase
-from torchrl.data import Unbounded
-from torchrl.data import Composite
+from torchrl.data import Composite, Unbounded
 
 from torchtrade.envs.live.alpaca.observation import AlpacaObservationClass
 from torchtrade.envs.live.alpaca.order_executor import AlpacaOrderClass

--- a/torchtrade/envs/live/alpaca/base.py
+++ b/torchtrade/envs/live/alpaca/base.py
@@ -5,7 +5,7 @@ from typing import Callable, List, Optional
 
 import torch
 from tensordict import TensorDict, TensorDictBase
-from torchrl.data import Bounded
+from torchrl.data import Unbounded
 from torchrl.data import Composite
 
 from torchtrade.envs.live.alpaca.observation import AlpacaObservationClass
@@ -157,12 +157,7 @@ class AlpacaBaseTorchTradingEnv(TorchTradeLiveEnv):
         self.account_state = self.ACCOUNT_STATE
 
         # Account state spec
-        account_state_spec = Bounded(
-            low=-torch.inf,
-            high=torch.inf,
-            shape=(len(self.ACCOUNT_STATE),),
-            dtype=torch.float
-        )
+        account_state_spec = Unbounded(shape=(len(self.ACCOUNT_STATE),), dtype=torch.float)
         self.observation_spec.set(self.account_state_key, account_state_spec)
 
         # Market data specs (one per timeframe)
@@ -171,12 +166,7 @@ class AlpacaBaseTorchTradingEnv(TorchTradeLiveEnv):
         for i, market_data_name in enumerate(market_data_names):
             market_data_key = "market_data_" + market_data_name
             window_size = window_sizes[i] if i < len(window_sizes) else window_sizes[0]
-            market_data_spec = Bounded(
-                low=-torch.inf,
-                high=torch.inf,
-                shape=(window_size, num_features),
-                dtype=torch.float
-            )
+            market_data_spec = Unbounded(shape=(window_size, num_features), dtype=torch.float)
             self.observation_spec.set(market_data_key, market_data_spec)
             self.market_data_keys.append(market_data_key)
 

--- a/torchtrade/envs/live/binance/base.py
+++ b/torchtrade/envs/live/binance/base.py
@@ -5,8 +5,7 @@ from typing import Callable, List, Optional
 
 import torch
 from tensordict import TensorDictBase
-from torchrl.data import Unbounded
-from torchrl.data import Composite
+from torchrl.data import Composite, Unbounded
 
 from torchtrade.envs.utils.timeframe import timeframe_to_seconds
 from torchtrade.envs.live.binance.observation import BinanceObservationClass

--- a/torchtrade/envs/live/binance/base.py
+++ b/torchtrade/envs/live/binance/base.py
@@ -5,7 +5,7 @@ from typing import Callable, List, Optional
 
 import torch
 from tensordict import TensorDictBase
-from torchrl.data import Bounded
+from torchrl.data import Unbounded
 from torchrl.data import Composite
 
 from torchtrade.envs.utils.timeframe import timeframe_to_seconds
@@ -167,12 +167,7 @@ class BinanceBaseTorchTradingEnv(TorchTradeFuturesLiveEnv):
         self.account_state_key = "account_state"
 
         # Account state spec (6 elements)
-        account_state_spec = Bounded(
-            low=-torch.inf,
-            high=torch.inf,
-            shape=(len(self.ACCOUNT_STATE),),
-            dtype=torch.float
-        )
+        account_state_spec = Unbounded(shape=(len(self.ACCOUNT_STATE),), dtype=torch.float)
         self.observation_spec.set(self.account_state_key, account_state_spec)
 
         # Market data specs (one per interval/timeframe)
@@ -180,12 +175,7 @@ class BinanceBaseTorchTradingEnv(TorchTradeFuturesLiveEnv):
         for i, market_data_name in enumerate(market_data_names):
             market_data_key = "market_data_" + market_data_name
             ws = window_sizes[i] if i < len(window_sizes) else window_sizes[0]
-            market_data_spec = Bounded(
-                low=-torch.inf,
-                high=torch.inf,
-                shape=(ws, num_features),
-                dtype=torch.float
-            )
+            market_data_spec = Unbounded(shape=(ws, num_features), dtype=torch.float)
             self.observation_spec.set(market_data_key, market_data_spec)
             self.market_data_keys.append(market_data_key)
 

--- a/torchtrade/envs/live/bitget/base.py
+++ b/torchtrade/envs/live/bitget/base.py
@@ -5,7 +5,7 @@ from typing import Callable, List, Optional
 
 import torch
 from tensordict import TensorDictBase
-from torchrl.data import Bounded
+from torchrl.data import Unbounded
 from torchrl.data.tensor_specs import Composite
 
 from torchtrade.envs.utils.timeframe import TimeFrame
@@ -184,12 +184,7 @@ class BitgetBaseTorchTradingEnv(TorchTradeFuturesLiveEnv):
         self.account_state_key = "account_state"
 
         # Account state spec (6 elements)
-        account_state_spec = Bounded(
-            low=-torch.inf,
-            high=torch.inf,
-            shape=(len(self.ACCOUNT_STATE),),
-            dtype=torch.float
-        )
+        account_state_spec = Unbounded(shape=(len(self.ACCOUNT_STATE),), dtype=torch.float)
         self.observation_spec.set(self.account_state_key, account_state_spec)
 
         # Market data specs (one per interval/timeframe)
@@ -197,12 +192,7 @@ class BitgetBaseTorchTradingEnv(TorchTradeFuturesLiveEnv):
         for i, market_data_name in enumerate(market_data_names):
             market_data_key = "market_data_" + market_data_name
             ws = window_sizes[i] if i < len(window_sizes) else window_sizes[0]
-            market_data_spec = Bounded(
-                low=-torch.inf,
-                high=torch.inf,
-                shape=(ws, num_features),
-                dtype=torch.float
-            )
+            market_data_spec = Unbounded(shape=(ws, num_features), dtype=torch.float)
             self.observation_spec.set(market_data_key, market_data_spec)
             self.market_data_keys.append(market_data_key)
 

--- a/torchtrade/envs/live/bybit/base.py
+++ b/torchtrade/envs/live/bybit/base.py
@@ -6,7 +6,7 @@ from typing import Callable, List, Optional
 
 import torch
 from tensordict import TensorDictBase
-from torchrl.data import Bounded
+from torchrl.data import Unbounded
 from torchrl.data.tensor_specs import Composite
 
 from torchtrade.envs.live.bybit.observation import BybitObservationClass
@@ -148,12 +148,7 @@ class BybitBaseTorchTradingEnv(TorchTradeFuturesLiveEnv):
         self.account_state_key = "account_state"
 
         # Account state spec (6 elements)
-        account_state_spec = Bounded(
-            low=-torch.inf,
-            high=torch.inf,
-            shape=(len(self.ACCOUNT_STATE),),
-            dtype=torch.float
-        )
+        account_state_spec = Unbounded(shape=(len(self.ACCOUNT_STATE),), dtype=torch.float)
         self.observation_spec.set(self.account_state_key, account_state_spec)
 
         # Market data specs (one per interval/timeframe)
@@ -161,12 +156,7 @@ class BybitBaseTorchTradingEnv(TorchTradeFuturesLiveEnv):
         for i, market_data_name in enumerate(market_data_names):
             market_data_key = "market_data_" + market_data_name
             ws = window_sizes[i] if i < len(window_sizes) else window_sizes[0]
-            market_data_spec = Bounded(
-                low=-torch.inf,
-                high=torch.inf,
-                shape=(ws, num_features),
-                dtype=torch.float
-            )
+            market_data_spec = Unbounded(shape=(ws, num_features), dtype=torch.float)
             self.observation_spec.set(market_data_key, market_data_spec)
             self.market_data_keys.append(market_data_key)
 

--- a/torchtrade/envs/live/okx/base.py
+++ b/torchtrade/envs/live/okx/base.py
@@ -6,7 +6,7 @@ from typing import Callable, List, Optional
 
 import torch
 from tensordict import TensorDictBase
-from torchrl.data import Bounded
+from torchrl.data import Unbounded
 from torchrl.data.tensor_specs import Composite
 
 from torchtrade.envs.live.okx.observation import OKXObservationClass
@@ -150,12 +150,7 @@ class OKXBaseTorchTradingEnv(TorchTradeFuturesLiveEnv):
         self.account_state_key = "account_state"
 
         # Account state spec (6 elements)
-        account_state_spec = Bounded(
-            low=-torch.inf,
-            high=torch.inf,
-            shape=(len(self.ACCOUNT_STATE),),
-            dtype=torch.float
-        )
+        account_state_spec = Unbounded(shape=(len(self.ACCOUNT_STATE),), dtype=torch.float)
         self.observation_spec.set(self.account_state_key, account_state_spec)
 
         # Market data specs (one per interval/timeframe)
@@ -163,12 +158,7 @@ class OKXBaseTorchTradingEnv(TorchTradeFuturesLiveEnv):
         for i, market_data_name in enumerate(market_data_names):
             market_data_key = "market_data_" + market_data_name
             ws = window_sizes[i] if i < len(window_sizes) else window_sizes[0]
-            market_data_spec = Bounded(
-                low=-torch.inf,
-                high=torch.inf,
-                shape=(ws, num_features),
-                dtype=torch.float
-            )
+            market_data_spec = Unbounded(shape=(ws, num_features), dtype=torch.float)
             self.observation_spec.set(market_data_key, market_data_spec)
             self.market_data_keys.append(market_data_key)
 

--- a/torchtrade/envs/live/polymarket/env.py
+++ b/torchtrade/envs/live/polymarket/env.py
@@ -32,7 +32,7 @@ from typing import Optional
 import requests
 import torch
 from tensordict import TensorDict, TensorDictBase
-from torchrl.data import Binary, Bounded, Categorical, Unbounded
+from torchrl.data import Binary, Categorical, Unbounded
 from torchrl.data.tensor_specs import Composite
 from torchrl.envs import EnvBase
 

--- a/torchtrade/envs/live/polymarket/env.py
+++ b/torchtrade/envs/live/polymarket/env.py
@@ -242,9 +242,7 @@ class PolymarketBetEnv(EnvBase):
         # Specs, Binary for bool flags (per TorchRL spec semantics) and
         # reward inside a Composite so RewardSum-style transforms work.
         self.observation_spec = Composite(
-            market_state=Bounded(
-                low=0.0, high=float("inf"), shape=(4,), dtype=torch.float32
-            ),
+            market_state=Unbounded(shape=(4,), dtype=torch.float32),
             shape=(),
         )
         self.action_spec = Categorical(2)
@@ -351,7 +349,9 @@ class PolymarketBetEnv(EnvBase):
     def _market_state(market: PolymarketMarket) -> torch.Tensor:
         """4-element market state: [yes_price, spread, volume_24h, liquidity]."""
         return torch.tensor(
-            [market.yes_price, market.spread, market.volume_24h, market.liquidity], dtype=torch.float32)
+            [market.yes_price, market.spread, market.volume_24h, market.liquidity],
+            dtype=torch.float32,
+        )
 
     def _fetch_next_market(self) -> Optional[PolymarketMarket]:
         """Get the next upcoming market, sleeping and retrying on ``None``.

--- a/torchtrade/envs/live/polymarket/env.py
+++ b/torchtrade/envs/live/polymarket/env.py
@@ -32,7 +32,7 @@ from typing import Optional
 import requests
 import torch
 from tensordict import TensorDict, TensorDictBase
-from torchrl.data import Binary, Bounded, Categorical
+from torchrl.data import Binary, Bounded, Categorical, Unbounded
 from torchrl.data.tensor_specs import Composite
 from torchrl.envs import EnvBase
 
@@ -249,9 +249,7 @@ class PolymarketBetEnv(EnvBase):
         )
         self.action_spec = Categorical(2)
         self.reward_spec = Composite(
-            reward=Bounded(
-                low=-float("inf"), high=float("inf"), shape=(1,), dtype=torch.float32
-            ),
+            reward=Unbounded(shape=(1,), dtype=torch.float32),
             shape=(),
         )
         # Declare only terminated/truncated; TorchRL derives `done` automatically
@@ -353,9 +351,7 @@ class PolymarketBetEnv(EnvBase):
     def _market_state(market: PolymarketMarket) -> torch.Tensor:
         """4-element market state: [yes_price, spread, volume_24h, liquidity]."""
         return torch.tensor(
-            [market.yes_price, market.spread, market.volume_24h, market.liquidity],
-            dtype=torch.float32,
-        )
+            [market.yes_price, market.spread, market.volume_24h, market.liquidity], dtype=torch.float32)
 
     def _fetch_next_market(self) -> Optional[PolymarketMarket]:
         """Get the next upcoming market, sleeping and retrying on ``None``.

--- a/torchtrade/envs/offline/vectorized_sequential.py
+++ b/torchtrade/envs/offline/vectorized_sequential.py
@@ -17,7 +17,7 @@ from typing import Callable, List, Optional, Tuple, Union
 import pandas as pd
 import torch
 from tensordict import TensorDict, TensorDictBase
-from torchrl.data import Bounded, Categorical, Composite
+from torchrl.data import Categorical, Composite, Unbounded
 from torchrl.envs import EnvBase
 
 from torchtrade.envs.offline.infrastructure.sampler import MarketDataObservationSampler
@@ -200,12 +200,7 @@ class VectorizedSequentialTradingEnv(EnvBase):
         observation_spec = Composite(shape=batch)
         observation_spec.set(
             "account_state",
-            Bounded(
-                low=-torch.inf,
-                high=torch.inf,
-                shape=batch + torch.Size([6]),
-                dtype=torch.float32,
-            ),
+            Unbounded(shape=batch + torch.Size([6]), dtype=torch.float32),
         )
         for i, tf in enumerate(self._time_frames):
             tf_key = tf.obs_key_freq()
@@ -213,9 +208,7 @@ class VectorizedSequentialTradingEnv(EnvBase):
             md_key = self._market_data_keys[i]
             observation_spec.set(
                 md_key,
-                Bounded(
-                    low=-torch.inf,
-                    high=torch.inf,
+                Unbounded(
                     shape=batch + torch.Size([self._window_sizes[i], n_features]),
                     dtype=torch.float32,
                 ),
@@ -223,12 +216,7 @@ class VectorizedSequentialTradingEnv(EnvBase):
         self.observation_spec = observation_spec
 
         # Reward spec
-        self.reward_spec = Bounded(
-            low=-torch.inf,
-            high=torch.inf,
-            shape=batch + torch.Size([1]),
-            dtype=torch.float32,
-        )
+        self.reward_spec = Unbounded(shape=batch + torch.Size([1]), dtype=torch.float32)
 
         # Done spec
         self.full_done_spec = Composite(

--- a/torchtrade/envs/transforms/binance_ohlcv.py
+++ b/torchtrade/envs/transforms/binance_ohlcv.py
@@ -20,7 +20,7 @@ from typing import Callable, List, Optional
 import numpy as np
 import torch
 from tensordict import TensorDictBase
-from torchrl.data import Bounded
+from torchrl.data import Unbounded
 from torchrl.envs.transforms import Transform
 
 from torchtrade.envs.live.binance.observation import BinanceObservationClass
@@ -158,11 +158,6 @@ class BinanceOHLCVTransform(Transform):
         ):
             observation_spec.set(
                 self._key(tf, window),
-                Bounded(
-                    low=-float("inf"),
-                    high=float("inf"),
-                    shape=(window, self._n_features),
-                    dtype=torch.float32,
-                ),
+                Unbounded(shape=(window, self._n_features), dtype=torch.float32),
             )
         return observation_spec

--- a/torchtrade/envs/transforms/binance_ohlcv.py
+++ b/torchtrade/envs/transforms/binance_ohlcv.py
@@ -36,7 +36,7 @@ class BinanceOHLCVTransform(Transform):
     :meth:`BinanceObservationClass.get_observations` and writes one tensor per
     ``(timeframe, window)`` pair into the next-step TensorDict, keyed
     ``{key_prefix}_{TimeFrame.obs_key_freq()}_{window}``. The
-    ``observation_spec`` is extended with matching ``Bounded`` entries so
+    ``observation_spec`` is extended with matching ``Unbounded`` entries so
     ``check_env_specs`` passes.
 
     Args:


### PR DESCRIPTION
Closes #264.

## The bug

TorchRL samples a `Bounded` spec as `uniform() * (high - low) + low`. An infinite bound makes `.rand()` produce **NaN** (both sides infinite) or **inf** (one side), and inf poisons a lazily-built network just as thoroughly:

```python
>>> Bounded(low=-torch.inf, high=torch.inf, shape=(2,3)).rand()   # all NaN
>>> Bounded(low=0.0, high=torch.inf, shape=(4,)).rand()           # all inf
>>> nn.Linear(4, 8)(that)   # tensor([inf, nan, nan, nan, nan, nan, nan, nan])
```

`check_env_specs()` cannot catch either — it builds its dummy batch from `spec.zero()` and a real rollout, never `.rand()`. So every environment shipped a spec that could not be sampled, and the standard `spec.rand()` lazy-init idiom silently initialised networks on garbage. That is how it surfaced, in the offline IQL example (#263).

`Unbounded` is the correct spec and a verified drop-in — identical on `zero`, `is_in`, `project`, `expand`, `to`, `dtype`, `Composite` interaction, pickling across `ParallelEnv` process boundaries, `squeeze`/`unsqueeze`, `type_check` and `encode`.

## Scope

**21 sites across 12 files** — the shared spec builders in `core/`, the vectorized env, all five live exchange base classes, a transform, and both polymarket specs.

The issue as filed undercounted twice: its list came from a `low=-torch.inf` grep (missing the `float("inf")` spelling in polymarket) and my first sweep was driven by that *file list* (missing `transforms/binance_ohlcv.py` entirely). The final sweep is pattern-driven across the whole package.

**Polymarket's `market_state` is converted too.** I initially argued to keep it as `Bounded(low=0.0, high=inf)` because the lower bound looked like a real constraint. Review showed it still poisons lazy init via `inf`.

The bound was consulted — `check_env_specs` calls `spec.contains(td)` on a real rollout, and `tests/envs/polymarket/test_env.py` exercises that path — but it never fired: every fixture market uses positive prices, spreads, volumes and liquidity, so the `low=0.0` boundary was never tested even before this PR. Converting trades a validation that structurally could have caught a negative-liquidity glitch, but never did, for a spec that can actually be sampled. The guard now has **zero exemptions**.

## A side effect worth knowing

`RewardScaling.transform_reward_spec` and `RewardClipping.transform_reward_spec` both `raise NotImplementedError` unless `reward_spec` is `Unbounded`. Before this PR every env's reward spec was `Bounded`, so wrapping *any* env in either transform was silently broken. This fixes that.

## Guards

**Structural** — an AST scan of every `.py` under `torchtrade/` and `examples/`, rejecting any `Bounded` with an infinite bound on either side. Source-level rather than a list of environments, because hand-sweeping escaped me twice. It catches keyword and positional args, aliased imports, qualified `module.Bounded`, and `torch.inf` / `np.inf` / `float("inf")` / `1e999`. Its docstring states what it does **not** resolve — `partial()`, subclassing, name rebinding, `**kwargs` — rather than claiming unescapability.

**Behavioural** — 18 tests across 15 envs plus the transform, asserting each spec produces a sample it would itself accept. Every one of the 21 converted sites fails a behavioural test if poisoned, verified by mutation (with the `Bounded` import restored, so the mutation measures the bound and not a `NameError`).

Live envs are discovered via `__subclasses__` and built with `__new__` + the unbound spec builder, so exchange #6 cannot skip the test by being forgotten — with a companion assertion that discovery still finds all five, since an empty parametrize skips rather than fails.

## Verification

```
Full suite (CUDA_VISIBLE_DEVICES=""):  2224 passed, 18 skipped, 0 failed
CI (3.11):                             pass
```

Run against `.venv/bin/python` (torchrl 0.13.2, matching the pin) — not the conda interpreter on `PATH`, which carries torchrl 0.10.1.

## Review

Three full rounds of code-simplifier, pr-test-analyzer, torchrl-engineer, and test-justification, with findings fixed between each. The rounds earned their keep: round 1 found my regex had caused collateral damage and the guard had five escapes; round 2 found that closing those six opened a seventh (`1e999`) and that poisoning bybit, the transform or polymarket failed **zero** behavioural tests; round 3 closed the last three uncovered sites, including `core/live.py`'s `base_features` — the one spec shared by all five exchanges, whose own docstring records that drift there already cost 3 of 4 exchanges in #61.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
