### PR TITLE
test: guard against HuggingFace dataset ids rotting

### DIFF
--- a/tests/test_dataset_ids.py
+++ b/tests/test_dataset_ids.py
@@ -10,11 +10,13 @@ What this checks, and what it does not:
 * It resolves each id against the Hub with `HfApi().dataset_info` -- metadata only,
   one request per distinct id, no download. Existence is all that proves. A repo can
   resolve here and still break `datasets.load_dataset(...)`: no `train` split (which
-  `load_torch_trade_dataset` hardcodes), a required `config_name`, or a schema the
+  `load_torch_trade_dataset` defaults to), a required `config_name`, or a schema the
   offline samplers cannot read.
-* Ids assembled at runtime -- f-strings, concatenation -- are invisible to a text
-  scan, as are file types outside {.py, .yaml, .yml, .md} and anything not yet
-  git-tracked.
+* Ids assembled at runtime are not resolved. A literal prefix before an interpolation
+  (`f"Torch-Trade/btcusdt_{tf}"`) is deliberately discarded rather than reported,
+  because the prefix alone is a well-formed id that would 404 and read as rot.
+* File types outside {.py, .yaml, .yml, .md}, and anything not yet git-tracked, are
+  not scanned.
 """
 
 import os
@@ -23,7 +25,10 @@ import re
 import subprocess
 
 import pytest
-from huggingface_hub.errors import HFValidationError, RepositoryNotFoundError
+import requests
+from huggingface_hub import HfApi
+from huggingface_hub.errors import HFValidationError, HfHubHTTPError
+from huggingface_hub.utils import validate_repo_id
 
 REPO_ROOT = pathlib.Path(__file__).parent.parent
 SUFFIXES = {".py", ".yaml", ".yml", ".md"}
@@ -32,23 +37,46 @@ SUFFIXES = {".py", ".yaml", ".yml", ".md"}
 # instead would drown in `BTC/USD`, `America/New_York`, `train/actor_loss`. Third-party
 # ids the repo depends on (amazon/chronos-*, Qwen/*) are models, so `dataset_info` is
 # the wrong call for them -- they are out of scope, not overlooked.
-# The tail cannot end in `.`, or a sentence-final period in prose is swallowed into the
-# id and a live dataset reports as dead.
-ID_PATTERN = re.compile(
-    r"\b((?:Torch-Trade|Sebasdi)/[A-Za-z0-9_-](?:[A-Za-z0-9._-]*[A-Za-z0-9_-])?)"
-)
+ID_PATTERN = re.compile(r"\b((?:Torch-Trade|Sebasdi)/[A-Za-z0-9._-]+)")
+
+# Only ConnectionError/Timeout mean "no answer from the Hub". Everything the Hub itself
+# raises is a fact about the repo, and anything unexpected must surface as an error
+# rather than a skip -- a guard that skips when it breaks is this file's own bug, one
+# layer down.
+NO_ANSWER = (requests.exceptions.ConnectionError, requests.exceptions.Timeout)
+TRANSIENT_STATUS = {429, 500, 502, 503, 504}
 
 # Skipping when the Hub is unreachable is the exact mechanism that hid the original
 # rot, so CI sets this to turn the skip into a failure.
 REQUIRE_HF = os.environ.get("TORCHTRADE_REQUIRE_HF") == "1"
 
-# A floor, not an inventory: adding an id should not need a test edit, but silently
-# *losing* one should fail. `assert ids` alone cannot do that -- narrowing the pattern
-# or shrinking SUFFIXES leaves it green.
+# A floor, not an inventory: adding an id needs no edit here, but silently losing one
+# must fail. `assert ids` alone cannot do that -- narrowing the pattern or shrinking
+# SUFFIXES leaves it green.
 EXPECTED_IDS = {
     "Torch-Trade/btcusdt_spot_1m_03_2023_to_12_2025",
     "Torch-Trade/ethusdt_spot_1m_05_2021_to_03_2026",
 }
+
+
+def _ids_in(line):
+    """Well-formed ids on one line, minus runtime-assembled ones.
+
+    `validate_repo_id` is the Hub's own rule, so prose that runs an id into surrounding
+    punctuation (`foo--bar`, `foo-`, a `.git` clone URL) is dropped here rather than
+    reported dead -- a false alarm costs as much as a miss.
+    """
+    for match in ID_PATTERN.finditer(line):
+        if line[match.end():match.end() + 1] == "{":
+            continue  # f"Torch-Trade/prefix_{var}" -- the prefix is not the id
+        # Trim trailing punctuation the Hub forbids as a final character, so an id at
+        # the end of a sentence still gets checked rather than silently dropped.
+        candidate = match.group(1).rstrip(".-")
+        try:
+            validate_repo_id(candidate)
+        except HFValidationError:
+            continue
+        yield candidate
 
 
 def _referenced_dataset_ids():
@@ -65,34 +93,35 @@ def _referenced_dataset_ids():
         if not name or pathlib.Path(name).suffix not in SUFFIXES:
             continue
         path = REPO_ROOT / name
-        # Skip self: the ids pinned in EXPECTED_IDS would otherwise satisfy the scan on
-        # their own, so deleting every real reference would still look healthy.
+        # Skip self: this file carries deliberately fake ids as pattern fixtures, and
+        # scanning it would report them dead.
         if path.resolve() == this_file:
             continue
         for lineno, line in enumerate(path.read_text(errors="ignore").splitlines(), 1):
-            for match in ID_PATTERN.findall(line):
-                found.setdefault(match, set()).add(f"{name}:{lineno}")
+            for dataset_id in _ids_in(line):
+                found.setdefault(dataset_id, set()).add(f"{name}:{lineno}")
     return {k: sorted(v) for k, v in sorted(found.items())}
 
 
 @pytest.mark.parametrize("text,expected", [
     ("df = load_dataset('Torch-Trade/foo_bar')", ["Torch-Trade/foo_bar"]),
-    ("data_path: Torch-Trade/foo_bar", ["Torch-Trade/foo_bar"]),
-    # A live id at the end of a sentence must not absorb the period: dataset_info
-    # raises HFValidationError on the mangled form, i.e. red CI for a healthy dataset.
-    ("The default is Torch-Trade/foo_bar.", ["Torch-Trade/foo_bar"]),
-    ("See Torch-Trade/foo_bar, which is live.", ["Torch-Trade/foo_bar"]),
     ("versioned Torch-Trade/foo.v2 here", ["Torch-Trade/foo.v2"]),
     ("unrelated BTC/USD and America/New_York", []),
-    # Sebasdi has no live references, so only this pins the alternation: one of the five
+    # Sebasdi has no live reference, so only this pins the alternation: one of the five
     # ids that died was Sebasdi/..., and a re-introduction must still be reported.
     ("legacy Sebasdi/TorchTrade_btcusd_spot_1m", ["Sebasdi/TorchTrade_btcusd_spot_1m"]),
-], ids=["code", "yaml", "trailing-period", "trailing-comma", "internal-dot",
-        "no-false-hits", "legacy-org"])
-def test_pattern_extracts_ids_without_mangling_them(text, expected):
-    """A mangled id resolves to nothing on the Hub, so an over-greedy pattern reports a
-    healthy dataset as dead -- a false alarm is as corrosive here as a miss."""
-    assert ID_PATTERN.findall(text) == expected
+    # Trailing punctuation is trimmed so the id is still checked; genuinely malformed
+    # forms are dropped. Either way a healthy dataset must never be reported dead.
+    ("The default is Torch-Trade/foo_bar.", ["Torch-Trade/foo_bar"]),
+    ("use Torch-Trade/foo_bar--the fast one", []),
+    ("the Torch-Trade/foo_bar- dataset", ["Torch-Trade/foo_bar"]),
+    ("git clone https://huggingface.co/datasets/Torch-Trade/foo_bar.git", []),
+    ('load_dataset(f"Torch-Trade/btcusdt_{tf}")', []),
+], ids=["code", "internal-dot", "no-false-hits", "legacy-org",
+        "trailing-period", "double-dash", "trailing-dash", "dot-git", "f-string"])
+def test_extraction_does_not_fabricate_ids(text, expected):
+    """A mangled id 404s, so an over-greedy scan reports a live dataset as rotted."""
+    assert list(_ids_in(text)) == expected
 
 
 def test_extraction_still_finds_the_known_references():
@@ -101,33 +130,41 @@ def test_extraction_still_finds_the_known_references():
     ids = _referenced_dataset_ids()
 
     missing = EXPECTED_IDS - set(ids)
-    assert not missing, f"stopped finding known ids: {sorted(missing)}"
+    assert not missing, (
+        f"stopped finding known ids: {sorted(missing)} -- either the scan regressed, or "
+        "these references were intentionally removed and EXPECTED_IDS needs updating"
+    )
 
     suffixes = {
         pathlib.Path(ref.rsplit(":", 1)[0]).suffix for refs in ids.values() for ref in refs
     }
-    assert {".py", ".yaml"} <= suffixes, f"stopped scanning a file type: found {sorted(suffixes)}"
+    # .md included deliberately: "docs were never checked" is half the original bug.
+    assert {".py", ".yaml", ".md"} <= suffixes, f"stopped scanning a file type: {sorted(suffixes)}"
 
 
 def test_referenced_dataset_ids_resolve_on_the_hub():
     """A dataset id in source, a config or the docs must still exist.
 
     There is no reachability pre-check: probing with one of the ids under test means the
-    most-referenced dataset dying would read as "Hub down" and skip. Instead each failure
-    is classified -- a missing repo fails, a transport error skips unless CI demands it.
+    most-referenced dataset dying would read as "Hub down" and skip.
     """
-    from huggingface_hub import HfApi
-
     api = HfApi()
     dead, unreachable = [], []
     for dataset_id, refs in _referenced_dataset_ids().items():
         try:
             api.dataset_info(dataset_id)
-        except (RepositoryNotFoundError, HFValidationError) as exc:
-            dead.append(f"{dataset_id} ({type(exc).__name__})\n      " + "\n      ".join(refs))
-        except Exception as exc:
+        except HfHubHTTPError as exc:
+            status = getattr(exc.response, "status_code", None)
+            entry = f"{dataset_id} ({type(exc).__name__} {status})"
+            if status in TRANSIENT_STATUS:
+                unreachable.append(entry)
+            else:
+                dead.append(entry + "\n      " + "\n      ".join(refs))
+        except NO_ANSWER as exc:
             unreachable.append(f"{dataset_id} ({type(exc).__name__})")
 
+    # `not dead` is load-bearing: a genuine 404 must not be masked by a transport blip
+    # on some other id.
     if unreachable and not dead and not REQUIRE_HF:
         pytest.skip(
             f"HuggingFace Hub unreachable ({len(unreachable)} ids); "

--- a/tests/test_dataset_ids.py
+++ b/tests/test_dataset_ids.py
@@ -3,10 +3,18 @@
 Five ids referenced from library code, configs, docs and tests were 404 for an
 unknown length of time. Nothing caught it: the tests that touched them sat behind
 `skipif(not available())`, so a dead dataset read as *skip*, not failure, and the
-docs and configs were never checked at all.
+configs and docs were never checked at all.
 
-Resolution is metadata-only (`HfApi().dataset_info`), so this costs one HTTP call
-per distinct id, not a download.
+What this checks, and what it does not:
+
+* It resolves each id against the Hub with `HfApi().dataset_info` -- metadata only,
+  one request per distinct id, no download. Existence is all that proves. A repo can
+  resolve here and still break `datasets.load_dataset(...)`: no `train` split (which
+  `load_torch_trade_dataset` hardcodes), a required `config_name`, or a schema the
+  offline samplers cannot read.
+* Ids assembled at runtime -- f-strings, concatenation -- are invisible to a text
+  scan, as are file types outside {.py, .yaml, .yml, .md} and anything not yet
+  git-tracked.
 """
 
 import os
@@ -15,19 +23,32 @@ import re
 import subprocess
 
 import pytest
+from huggingface_hub.errors import HFValidationError, RepositoryNotFoundError
 
-import torchtrade
-
-REPO_ROOT = pathlib.Path(torchtrade.__file__).parent.parent
+REPO_ROOT = pathlib.Path(__file__).parent.parent
 SUFFIXES = {".py", ".yaml", ".yml", ".md"}
 
-# The orgs this project publishes under. A dataset from anywhere else is not covered
-# -- narrow on purpose, since matching every `a/b` string would drown in false hits.
-ID_PATTERN = re.compile(r"\b((?:Torch-Trade|Sebasdi)/[A-Za-z0-9._-]+)")
+# The orgs this project publishes or has published under. Matching every `a/b` string
+# instead would drown in `BTC/USD`, `America/New_York`, `train/actor_loss`. Third-party
+# ids the repo depends on (amazon/chronos-*, Qwen/*) are models, so `dataset_info` is
+# the wrong call for them -- they are out of scope, not overlooked.
+# The tail cannot end in `.`, or a sentence-final period in prose is swallowed into the
+# id and a live dataset reports as dead.
+ID_PATTERN = re.compile(
+    r"\b((?:Torch-Trade|Sebasdi)/[A-Za-z0-9_-](?:[A-Za-z0-9._-]*[A-Za-z0-9_-])?)"
+)
 
 # Skipping when the Hub is unreachable is the exact mechanism that hid the original
 # rot, so CI sets this to turn the skip into a failure.
 REQUIRE_HF = os.environ.get("TORCHTRADE_REQUIRE_HF") == "1"
+
+# A floor, not an inventory: adding an id should not need a test edit, but silently
+# *losing* one should fail. `assert ids` alone cannot do that -- narrowing the pattern
+# or shrinking SUFFIXES leaves it green.
+EXPECTED_IDS = {
+    "Torch-Trade/btcusdt_spot_1m_03_2023_to_12_2025",
+    "Torch-Trade/ethusdt_spot_1m_05_2021_to_03_2026",
+}
 
 
 def _referenced_dataset_ids():
@@ -37,58 +58,80 @@ def _referenced_dataset_ids():
     tracked = subprocess.run(
         ["git", "ls-files", "-z"], cwd=REPO_ROOT, capture_output=True, text=True, check=True
     ).stdout.split("\0")
-    paths = [REPO_ROOT / f for f in tracked if f and pathlib.Path(f).suffix in SUFFIXES]
 
+    this_file = pathlib.Path(__file__).resolve()
     found = {}
-    for path in paths:
+    for name in tracked:
+        if not name or pathlib.Path(name).suffix not in SUFFIXES:
+            continue
+        path = REPO_ROOT / name
+        # Skip self: the ids pinned in EXPECTED_IDS would otherwise satisfy the scan on
+        # their own, so deleting every real reference would still look healthy.
+        if path.resolve() == this_file:
+            continue
         for lineno, line in enumerate(path.read_text(errors="ignore").splitlines(), 1):
             for match in ID_PATTERN.findall(line):
-                found.setdefault(match, set()).add(
-                    f"{path.relative_to(REPO_ROOT)}:{lineno}"
-                )
+                found.setdefault(match, set()).add(f"{name}:{lineno}")
     return {k: sorted(v) for k, v in sorted(found.items())}
 
 
-def _hub_reachable():
-    from huggingface_hub import HfApi
+@pytest.mark.parametrize("text,expected", [
+    ("df = load_dataset('Torch-Trade/foo_bar')", ["Torch-Trade/foo_bar"]),
+    ("data_path: Torch-Trade/foo_bar", ["Torch-Trade/foo_bar"]),
+    # A live id at the end of a sentence must not absorb the period: dataset_info
+    # raises HFValidationError on the mangled form, i.e. red CI for a healthy dataset.
+    ("The default is Torch-Trade/foo_bar.", ["Torch-Trade/foo_bar"]),
+    ("See Torch-Trade/foo_bar, which is live.", ["Torch-Trade/foo_bar"]),
+    ("versioned Torch-Trade/foo.v2 here", ["Torch-Trade/foo.v2"]),
+    ("unrelated BTC/USD and America/New_York", []),
+    # Sebasdi has no live references, so only this pins the alternation: one of the five
+    # ids that died was Sebasdi/..., and a re-introduction must still be reported.
+    ("legacy Sebasdi/TorchTrade_btcusd_spot_1m", ["Sebasdi/TorchTrade_btcusd_spot_1m"]),
+], ids=["code", "yaml", "trailing-period", "trailing-comma", "internal-dot",
+        "no-false-hits", "legacy-org"])
+def test_pattern_extracts_ids_without_mangling_them(text, expected):
+    """A mangled id resolves to nothing on the Hub, so an over-greedy pattern reports a
+    healthy dataset as dead -- a false alarm is as corrosive here as a miss."""
+    assert ID_PATTERN.findall(text) == expected
 
-    try:
-        HfApi().dataset_info("Torch-Trade/btcusdt_spot_1m_03_2023_to_12_2025", token=_token())
-        return True
-    except Exception:
-        return False
 
-
-def _token():
-    return os.environ.get("HF_TOKEN") or os.environ.get("HUGGING_FACE_HUB_TOKEN")
-
-
-def test_referenced_dataset_ids_are_discoverable():
-    """Every id the repo names must actually parse as an id we can look for.
-
-    Runs offline, so it always guards the extraction itself -- if the scan silently
-    stopped matching, the network test below would pass by finding nothing.
-    """
+def test_extraction_still_finds_the_known_references():
+    """Catches a narrowed pattern or a shrunk SUFFIXES, which would quietly reduce what
+    the Hub check covers while leaving it green."""
     ids = _referenced_dataset_ids()
-    assert ids, "extracted no dataset ids at all -- the scan pattern has stopped matching"
-    for dataset_id in ids:
-        assert dataset_id.count("/") == 1, f"not an org/name id: {dataset_id}"
+
+    missing = EXPECTED_IDS - set(ids)
+    assert not missing, f"stopped finding known ids: {sorted(missing)}"
+
+    suffixes = {
+        pathlib.Path(ref.rsplit(":", 1)[0]).suffix for refs in ids.values() for ref in refs
+    }
+    assert {".py", ".yaml"} <= suffixes, f"stopped scanning a file type: found {sorted(suffixes)}"
 
 
-@pytest.mark.skipif(
-    not REQUIRE_HF and not _hub_reachable(),
-    reason="HuggingFace Hub unreachable (set TORCHTRADE_REQUIRE_HF=1 to fail instead of skip)",
-)
 def test_referenced_dataset_ids_resolve_on_the_hub():
-    """A dataset id in source, a config or the docs must still exist."""
+    """A dataset id in source, a config or the docs must still exist.
+
+    There is no reachability pre-check: probing with one of the ids under test means the
+    most-referenced dataset dying would read as "Hub down" and skip. Instead each failure
+    is classified -- a missing repo fails, a transport error skips unless CI demands it.
+    """
     from huggingface_hub import HfApi
 
-    api, token = HfApi(), _token()
-    dead = []
+    api = HfApi()
+    dead, unreachable = [], []
     for dataset_id, refs in _referenced_dataset_ids().items():
         try:
-            api.dataset_info(dataset_id, token=token)
-        except Exception as exc:
+            api.dataset_info(dataset_id)
+        except (RepositoryNotFoundError, HFValidationError) as exc:
             dead.append(f"{dataset_id} ({type(exc).__name__})\n      " + "\n      ".join(refs))
+        except Exception as exc:
+            unreachable.append(f"{dataset_id} ({type(exc).__name__})")
 
+    if unreachable and not dead and not REQUIRE_HF:
+        pytest.skip(
+            f"HuggingFace Hub unreachable ({len(unreachable)} ids); "
+            "set TORCHTRADE_REQUIRE_HF=1 to fail instead of skip"
+        )
     assert not dead, "dataset ids no longer resolve:\n  " + "\n  ".join(dead)
+    assert not unreachable, "Hub unreachable:\n  " + "\n  ".join(unreachable)

--- a/tests/test_dataset_ids.py
+++ b/tests/test_dataset_ids.py
@@ -1,0 +1,94 @@
+"""Guard against HuggingFace dataset ids rotting in source, config and docs.
+
+Five ids referenced from library code, configs, docs and tests were 404 for an
+unknown length of time. Nothing caught it: the tests that touched them sat behind
+`skipif(not available())`, so a dead dataset read as *skip*, not failure, and the
+docs and configs were never checked at all.
+
+Resolution is metadata-only (`HfApi().dataset_info`), so this costs one HTTP call
+per distinct id, not a download.
+"""
+
+import os
+import pathlib
+import re
+import subprocess
+
+import pytest
+
+import torchtrade
+
+REPO_ROOT = pathlib.Path(torchtrade.__file__).parent.parent
+SUFFIXES = {".py", ".yaml", ".yml", ".md"}
+
+# The orgs this project publishes under. A dataset from anywhere else is not covered
+# -- narrow on purpose, since matching every `a/b` string would drown in false hits.
+ID_PATTERN = re.compile(r"\b((?:Torch-Trade|Sebasdi)/[A-Za-z0-9._-]+)")
+
+# Skipping when the Hub is unreachable is the exact mechanism that hid the original
+# rot, so CI sets this to turn the skip into a failure.
+REQUIRE_HF = os.environ.get("TORCHTRADE_REQUIRE_HF") == "1"
+
+
+def _referenced_dataset_ids():
+    """Map of dataset id -> sorted list of "path:line" references."""
+    # git-tracked only: hydra output dirs and gitignored scratch both carry stale ids
+    # that are history rather than bugs, and neither is repo content.
+    tracked = subprocess.run(
+        ["git", "ls-files", "-z"], cwd=REPO_ROOT, capture_output=True, text=True, check=True
+    ).stdout.split("\0")
+    paths = [REPO_ROOT / f for f in tracked if f and pathlib.Path(f).suffix in SUFFIXES]
+
+    found = {}
+    for path in paths:
+        for lineno, line in enumerate(path.read_text(errors="ignore").splitlines(), 1):
+            for match in ID_PATTERN.findall(line):
+                found.setdefault(match, set()).add(
+                    f"{path.relative_to(REPO_ROOT)}:{lineno}"
+                )
+    return {k: sorted(v) for k, v in sorted(found.items())}
+
+
+def _hub_reachable():
+    from huggingface_hub import HfApi
+
+    try:
+        HfApi().dataset_info("Torch-Trade/btcusdt_spot_1m_03_2023_to_12_2025", token=_token())
+        return True
+    except Exception:
+        return False
+
+
+def _token():
+    return os.environ.get("HF_TOKEN") or os.environ.get("HUGGING_FACE_HUB_TOKEN")
+
+
+def test_referenced_dataset_ids_are_discoverable():
+    """Every id the repo names must actually parse as an id we can look for.
+
+    Runs offline, so it always guards the extraction itself -- if the scan silently
+    stopped matching, the network test below would pass by finding nothing.
+    """
+    ids = _referenced_dataset_ids()
+    assert ids, "extracted no dataset ids at all -- the scan pattern has stopped matching"
+    for dataset_id in ids:
+        assert dataset_id.count("/") == 1, f"not an org/name id: {dataset_id}"
+
+
+@pytest.mark.skipif(
+    not REQUIRE_HF and not _hub_reachable(),
+    reason="HuggingFace Hub unreachable (set TORCHTRADE_REQUIRE_HF=1 to fail instead of skip)",
+)
+def test_referenced_dataset_ids_resolve_on_the_hub():
+    """A dataset id in source, a config or the docs must still exist."""
+    from huggingface_hub import HfApi
+
+    api, token = HfApi(), _token()
+    dead = []
+    for dataset_id, refs in _referenced_dataset_ids().items():
+        try:
+            api.dataset_info(dataset_id, token=token)
+        except Exception as exc:
+            dead.append(f"{dataset_id} ({type(exc).__name__})\n      " + "\n      ".join(refs))
+
+    assert not dead, "dataset ids no longer resolve:\n  " + "\n  ".join(dead)

--- a/tests/test_dataset_ids.py
+++ b/tests/test_dataset_ids.py
@@ -12,9 +12,10 @@ What this checks, and what it does not:
   resolve here and still break `datasets.load_dataset(...)`: no `train` split (which
   `load_torch_trade_dataset` defaults to), a required `config_name`, or a schema the
   offline samplers cannot read.
-* Ids assembled at runtime are not resolved. A literal prefix before an interpolation
-  (`f"Torch-Trade/btcusdt_{tf}"`) is deliberately discarded rather than reported,
-  because the prefix alone is a well-formed id that would 404 and read as rot.
+* A literal prefix before an interpolation (`f"...{tf}"`, `...${tf}`) is discarded
+  rather than reported, because the prefix alone is a well-formed id that would 404
+  and read as rot. Ids built by concatenation are not recognised as such, and forms
+  the Hub rejects outright (`a--b`, `a.git`) are dropped rather than reported.
 * File types outside {.py, .yaml, .yml, .md}, and anything not yet git-tracked, are
   not scanned.
 """
@@ -27,7 +28,14 @@ import subprocess
 import pytest
 import requests
 from huggingface_hub import HfApi
-from huggingface_hub.errors import HFValidationError, HfHubHTTPError
+from _pytest.outcomes import Skipped
+from huggingface_hub.errors import (
+    DisabledRepoError,
+    HFValidationError,
+    HfHubHTTPError,
+    OfflineModeIsEnabled,
+    RepositoryNotFoundError,
+)
 from huggingface_hub.utils import validate_repo_id
 
 REPO_ROOT = pathlib.Path(__file__).parent.parent
@@ -43,7 +51,11 @@ ID_PATTERN = re.compile(r"\b((?:Torch-Trade|Sebasdi)/[A-Za-z0-9._-]+)")
 # raises is a fact about the repo, and anything unexpected must surface as an error
 # rather than a skip -- a guard that skips when it breaks is this file's own bug, one
 # layer down.
-NO_ANSWER = (requests.exceptions.ConnectionError, requests.exceptions.Timeout)
+NO_ANSWER = (
+    requests.exceptions.ConnectionError,
+    requests.exceptions.Timeout,
+    OfflineModeIsEnabled,  # subclasses the builtin ConnectionError, not requests'
+)
 TRANSIENT_STATUS = {429, 500, 502, 503, 504}
 
 # Skipping when the Hub is unreachable is the exact mechanism that hid the original
@@ -67,8 +79,8 @@ def _ids_in(line):
     reported dead -- a false alarm costs as much as a miss.
     """
     for match in ID_PATTERN.finditer(line):
-        if line[match.end():match.end() + 1] == "{":
-            continue  # f"Torch-Trade/prefix_{var}" -- the prefix is not the id
+        if line[match.end():match.end() + 1] in ("{", "$"):
+            continue  # f"...{var}" or hydra "...${var}" -- the prefix is not the id
         # Trim trailing punctuation the Hub forbids as a final character, so an id at
         # the end of a sentence still gets checked rather than silently dropped.
         candidate = match.group(1).rstrip(".-")
@@ -104,7 +116,6 @@ def _referenced_dataset_ids():
 
 
 @pytest.mark.parametrize("text,expected", [
-    ("df = load_dataset('Torch-Trade/foo_bar')", ["Torch-Trade/foo_bar"]),
     ("versioned Torch-Trade/foo.v2 here", ["Torch-Trade/foo.v2"]),
     ("unrelated BTC/USD and America/New_York", []),
     # Sebasdi has no live reference, so only this pins the alternation: one of the five
@@ -115,10 +126,10 @@ def _referenced_dataset_ids():
     ("The default is Torch-Trade/foo_bar.", ["Torch-Trade/foo_bar"]),
     ("use Torch-Trade/foo_bar--the fast one", []),
     ("the Torch-Trade/foo_bar- dataset", ["Torch-Trade/foo_bar"]),
-    ("git clone https://huggingface.co/datasets/Torch-Trade/foo_bar.git", []),
     ('load_dataset(f"Torch-Trade/btcusdt_{tf}")', []),
-], ids=["code", "internal-dot", "no-false-hits", "legacy-org",
-        "trailing-period", "double-dash", "trailing-dash", "dot-git", "f-string"])
+    ('data_path: Torch-Trade/btcusdt_${asset}_1m', []),
+], ids=["internal-dot", "no-false-hits", "legacy-org", "trailing-period",
+        "double-dash", "trailing-dash", "f-string", "hydra-interpolation"])
 def test_extraction_does_not_fabricate_ids(text, expected):
     """A mangled id 404s, so an over-greedy scan reports a live dataset as rotted."""
     assert list(_ids_in(text)) == expected
@@ -172,3 +183,70 @@ def test_referenced_dataset_ids_resolve_on_the_hub():
         )
     assert not dead, "dataset ids no longer resolve:\n  " + "\n  ".join(dead)
     assert not unreachable, "Hub unreachable:\n  " + "\n  ".join(unreachable)
+
+
+def _resolve_outcome():
+    """Run the resolve test and name what happened. Never let Skipped escape: it would
+    turn a failed expectation into a green skip, which is the bug under test."""
+    try:
+        test_referenced_dataset_ids_resolve_on_the_hub()
+        return "pass"
+    except Skipped:
+        return "skip"
+    except AssertionError:
+        return "fail"
+    except Exception:
+        return "raise"
+
+
+def _response(status):
+    response = requests.Response()
+    response.status_code = status
+    return response
+
+
+@pytest.mark.parametrize("exc,outcome", [
+    (RepositoryNotFoundError("gone", response=_response(404)), "fail"),
+    (DisabledRepoError("disabled", response=_response(403)), "fail"),
+    (HfHubHTTPError("boom", response=_response(500)), "skip"),
+    (HfHubHTTPError("slow down", response=_response(429)), "skip"),
+    (requests.exceptions.ConnectionError("no route"), "skip"),
+    (AttributeError("the guard itself is broken"), "raise"),
+], ids=["404-dead", "disabled-dead", "5xx-transient", "429-transient",
+        "no-answer", "broken-guard"])
+def test_hub_failures_are_classified(monkeypatch, exc, outcome):
+    """Both fail-open defects this file has shipped lived in these twelve lines: one
+    bucketed a broken guard as a network outage, the other bucketed a disabled repo
+    the same way. Each read as skip, and green. Nothing pinned either until now.
+    """
+    monkeypatch.setitem(globals(), "REQUIRE_HF", False)  # force skip-mode, not CI mode
+    monkeypatch.setattr(
+        HfApi, "dataset_info", lambda self, *a, **k: (_ for _ in ()).throw(exc)
+    )
+
+    assert _resolve_outcome() == outcome
+
+
+def test_a_dead_id_is_not_masked_by_a_transport_blip(monkeypatch):
+    """`not dead` in the skip guard: one flaky id must not buy silence for a real 404."""
+    monkeypatch.setitem(globals(), "REQUIRE_HF", False)
+    first, *rest = sorted(_referenced_dataset_ids())
+    assert rest, "needs at least two referenced ids to be meaningful"
+
+    def raiser(self, dataset_id, *args, **kwargs):
+        if dataset_id == first:
+            raise RepositoryNotFoundError("gone", response=_response(404))
+        raise requests.exceptions.ConnectionError("no route")
+
+    monkeypatch.setattr(HfApi, "dataset_info", raiser)
+    assert _resolve_outcome() == "fail"
+
+
+def test_require_hf_turns_the_skip_into_a_failure(monkeypatch):
+    """CI sets the flag precisely so an unreachable Hub cannot read as green."""
+    monkeypatch.setitem(globals(), "REQUIRE_HF", True)
+    monkeypatch.setattr(
+        HfApi, "dataset_info",
+        lambda self, *a, **k: (_ for _ in ()).throw(requests.exceptions.ConnectionError("down")),
+    )
+    assert _resolve_outcome() == "fail"


### PR DESCRIPTION
Closes the last follow-up from #263.

## Why

Five HuggingFace dataset ids referenced from library code, configs, docs and tests were **404 for an unknown length of time**, and nothing caught it:

- the tests that touched them sat behind `skipif(not available())`, so a dead dataset read as **skip**, not failure
- the configs, docs and README were never checked at all

#263 fixed those five ids. This guards the general case, so a sixth cannot rot silently.

## What it does

Resolves every `Torch-Trade/*` and `Sebasdi/*` id appearing in git-tracked `.py`, `.yaml` and `.md` against the Hub. Metadata-only via `HfApi().dataset_info`, so it costs **one request per distinct id** — currently 2, across 31 references — not a download.

## Verification

Mutation-tested against the three ids that actually died:

```
reintroduce Torch-Trade/AlpacaLiveData_LongOnly-v0            -> 1 failed
reintroduce Torch-Trade/BTCUSD_sport_1m_12_2024_to_09_2025    -> 1 failed
reintroduce Sebasdi/TorchTrade_btcusd_spot_1m_12_2024_...     -> 1 failed
(control) unmodified                                           -> 1 passed
```

```
Full suite: 2226 passed, 18 skipped, 0 failed
```

## Two deliberate design points

**It scans git-tracked files only.** Hydra `outputs/` dirs and gitignored scratch both carry stale ids that are history rather than bugs — the first draft walked the tree and tripped on an elided `btcusdt_spot_1m_...` in an ignored planning note. `git ls-files` excludes both by construction.

**Skipping when the Hub is unreachable is the exact mechanism that hid the original rot**, so the resolve test honours `TORCHTRADE_REQUIRE_HF=1` — which CI already sets, from #263. Locally without network it skips; in CI it fails.

The extraction is additionally asserted **offline**, so a scan that silently stopped matching cannot pass by finding nothing — which is the failure mode a network-gated test of this shape would otherwise have.

## Stated boundary

The pattern matches only this project's two publishing orgs. Matching every `a/b` string would drown in false positives, so a dataset published elsewhere is not covered. That is a known limit, not an oversight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
