### PR TITLE
fix(envs): aggregate execution-bar OHLC instead of taking the last sub-bar

### DIFF
--- a/tests/envs/offline/test_sampler.py
+++ b/tests/envs/offline/test_sampler.py
@@ -433,6 +433,34 @@ class TestSamplerBaseFeatures:
             assert source["high"].max() > source["high"].iloc[-1]
             assert source["low"].min() < source["low"].iloc[-1]
 
+    def test_gap_bar_is_flat_rather_than_a_replay_of_the_previous_range(self, sample_ohlcv_df):
+        """A bar with no source rows must not inherit the previous bar's high/low.
+
+        Forward-filling the range would hand SL/TP the excursion the position already
+        lived through one bar earlier, letting a single move stop it out twice.
+        """
+        execute_on = TimeFrame(15, TimeFrameUnit.Minute)
+        gap_start, gap_end = pd.Timestamp("2024-01-01 03:00"), pd.Timestamp("2024-01-01 03:15")
+        df = sample_ohlcv_df[
+            (sample_ohlcv_df["timestamp"] < gap_start) | (sample_ohlcv_df["timestamp"] >= gap_end)
+        ]
+
+        with pytest.warns(UserWarning, match="DATA GAPS"):
+            sampler = MarketDataObservationSampler(
+                df=df, time_frames=[execute_on], window_sizes=[5], execute_on=execute_on,
+            )
+
+        gap = sampler.get_base_features(gap_start)
+        previous = sampler.get_base_features(gap_start - pd.Timedelta("15min"))
+
+        assert gap["close"] == pytest.approx(previous["close"])
+        assert gap["open"] == pytest.approx(gap["close"])
+        assert gap["high"] == pytest.approx(gap["close"])
+        assert gap["low"] == pytest.approx(gap["close"])
+        assert gap["volume"] == 0.0
+        # Only meaningful if the bar it copies from actually had a range to inherit.
+        assert previous["high"] > previous["low"]
+
 
 class TestSamplerHelperMethods:
     """Tests for helper methods."""

--- a/tests/envs/offline/test_sampler.py
+++ b/tests/envs/offline/test_sampler.py
@@ -395,17 +395,14 @@ class TestSamplerObservations:
 class TestSamplerBaseFeatures:
     """Tests for base feature retrieval."""
 
-    @pytest.mark.parametrize("execute_on,sub_bars", [
-        (TimeFrame(1, TimeFrameUnit.Minute), 1),
-        (TimeFrame(1, TimeFrameUnit.Hour), 60),
-    ], ids=["source-frequency", "coarser"])
-    def test_execution_bar_aggregates_its_sub_bars(self, sample_ohlcv_df, execute_on, sub_bars):
+    def test_execution_bar_aggregates_its_sub_bars(self, sample_ohlcv_df):
         """Execution bars must aggregate their sub-bars, not copy the final one.
 
         .last() collapses high/low onto the last sub-bar, so the SL/TP and liquidation
-        checks that read this range would never fire. The source-frequency case is the
-        config every SLTP and replay test uses, where the two agree.
+        checks that read this range would never fire. Only a coarse execute_on can show
+        this; at source frequency the two agree, which is why the bug survived.
         """
+        execute_on = TimeFrame(1, TimeFrameUnit.Hour)
         sampler = MarketDataObservationSampler(
             df=sample_ohlcv_df,
             time_frames=[execute_on],
@@ -421,8 +418,6 @@ class TestSamplerBaseFeatures:
             (indexed.index >= timestamp)
             & (indexed.index < timestamp + pd.Timedelta(execute_on.to_pandas_freq()))
         ]
-        assert len(source) == sub_bars
-
         # approx, not ==: execute_base_tensor is float32 over a float64 source.
         assert base_features["open"] == pytest.approx(source["open"].iloc[0])
         assert base_features["high"] == pytest.approx(source["high"].max())
@@ -430,11 +425,10 @@ class TestSamplerBaseFeatures:
         assert base_features["close"] == pytest.approx(source["close"].iloc[-1])
         assert base_features["volume"] == pytest.approx(source["volume"].sum())
 
-        if sub_bars > 1:
-            # Without a real excursion beyond the last sub-bar the assertions above
-            # hold under .last() too, and the case stops discriminating.
-            assert source["high"].max() > source["high"].iloc[-1]
-            assert source["low"].min() < source["low"].iloc[-1]
+        # Without a real excursion beyond the last sub-bar the assertions above hold
+        # under .last() too, and the test stops discriminating.
+        assert source["high"].max() > source["high"].iloc[-1]
+        assert source["low"].min() < source["low"].iloc[-1]
 
     def test_gap_bar_is_flat_rather_than_a_replay_of_the_previous_range(self, sample_ohlcv_df):
         """A bar with no source rows must not inherit the previous bar's high/low.

--- a/tests/envs/offline/test_sampler.py
+++ b/tests/envs/offline/test_sampler.py
@@ -213,6 +213,9 @@ class TestAuxiliaryColumns:
         assert ohlcv.open > 50  # Prices start at ~100, not funding_rate ~0.001
         assert ohlcv.close > 50
         assert ohlcv.volume == 1000
+        # Positions 1 and 2 specifically: the vectorized envs read high/low by hardcoded
+        # column index, so swapping them in ohlcv_agg would invert every SL/TP check.
+        assert ohlcv.high >= ohlcv.close >= ohlcv.low
 
     def test_auxiliary_resampling_uses_last(self, ohlcv_with_aux_df):
         """Auxiliary columns should use 'last' aggregation when resampled."""
@@ -458,8 +461,9 @@ class TestSamplerBaseFeatures:
         assert gap["high"] == pytest.approx(gap["close"])
         assert gap["low"] == pytest.approx(gap["close"])
         assert gap["volume"] == 0.0
-        # Only meaningful if the bar it copies from actually had a range to inherit.
-        assert previous["high"] > previous["low"]
+        # Both the high and low assertions only discriminate if the bar they would have
+        # been filled from sits strictly inside its own range.
+        assert previous["high"] > previous["close"] > previous["low"]
 
 
 class TestSamplerHelperMethods:

--- a/tests/envs/offline/test_sampler.py
+++ b/tests/envs/offline/test_sampler.py
@@ -392,62 +392,17 @@ class TestSamplerObservations:
 class TestSamplerBaseFeatures:
     """Tests for base feature retrieval."""
 
-    def test_get_base_features_returns_ohlcv(
-        self, sample_ohlcv_df, default_timeframes, default_window_sizes, execute_timeframe
-    ):
-        """get_base_features should return OHLCV dict."""
-        sampler = MarketDataObservationSampler(
-            df=sample_ohlcv_df,
-            time_frames=default_timeframes,
-            window_sizes=default_window_sizes,
-            execute_on=execute_timeframe,
-        )
-        sampler.reset(random_start=False)
-
-        _, timestamp, _ = sampler.get_sequential_observation()
-        base_features = sampler.get_base_features(timestamp)
-
-        assert "open" in base_features
-        assert "high" in base_features
-        assert "low" in base_features
-        assert "close" in base_features
-        assert "volume" in base_features
-
-    def test_base_features_are_valid_numbers(
-        self, sample_ohlcv_df, default_timeframes, default_window_sizes, execute_timeframe
-    ):
-        """Base features should be valid positive numbers."""
-        sampler = MarketDataObservationSampler(
-            df=sample_ohlcv_df,
-            time_frames=default_timeframes,
-            window_sizes=default_window_sizes,
-            execute_on=execute_timeframe,
-        )
-        sampler.reset(random_start=False)
-
-        _, timestamp, _ = sampler.get_sequential_observation()
-        base_features = sampler.get_base_features(timestamp)
-
-        assert base_features["open"] > 0
-        assert base_features["high"] >= base_features["low"]
-        assert base_features["close"] > 0
-        assert base_features["volume"] >= 0
-
-    @pytest.mark.parametrize("exec_value,exec_unit", [
-        (15, TimeFrameUnit.Minute),
-        (1, TimeFrameUnit.Hour),
-    ], ids=["15min", "1hour"])
-    def test_execution_bar_is_aggregated_not_last_sub_bar(
-        self, sample_ohlcv_df, exec_value, exec_unit
-    ):
+    @pytest.mark.parametrize("execute_on,sub_bars", [
+        (TimeFrame(1, TimeFrameUnit.Minute), 1),
+        (TimeFrame(1, TimeFrameUnit.Hour), 60),
+    ], ids=["source-frequency", "coarser"])
+    def test_execution_bar_aggregates_its_sub_bars(self, sample_ohlcv_df, execute_on, sub_bars):
         """Execution bars must aggregate their sub-bars, not copy the final one.
 
-        Resampling with .last() takes the last valid value per column, so high/low
-        collapse to the final sub-bar's range. Every SL/TP and liquidation check reads
-        this range, so a too-narrow bar means stops that fire in reality never fire in
-        the backtest.
+        .last() collapses high/low onto the last sub-bar, so the SL/TP and liquidation
+        checks that read this range would never fire. The source-frequency case is the
+        config every SLTP and replay test uses, where the two agree.
         """
-        execute_on = TimeFrame(exec_value, exec_unit)
         sampler = MarketDataObservationSampler(
             df=sample_ohlcv_df,
             time_frames=[execute_on],
@@ -458,21 +413,25 @@ class TestSamplerBaseFeatures:
         _, timestamp, _ = sampler.get_sequential_observation()
         base_features = sampler.get_base_features(timestamp)
 
-        source = sample_ohlcv_df.set_index("timestamp").loc[
-            timestamp:timestamp + pd.Timedelta(execute_on.to_pandas_freq()) - pd.Timedelta("1min")
+        indexed = sample_ohlcv_df.set_index("timestamp")
+        source = indexed[
+            (indexed.index >= timestamp)
+            & (indexed.index < timestamp + pd.Timedelta(execute_on.to_pandas_freq()))
         ]
-        assert len(source) > 1, "bar must span multiple sub-bars for this to discriminate"
+        assert len(source) == sub_bars
 
+        # approx, not ==: execute_base_tensor is float32 over a float64 source.
         assert base_features["open"] == pytest.approx(source["open"].iloc[0])
         assert base_features["high"] == pytest.approx(source["high"].max())
         assert base_features["low"] == pytest.approx(source["low"].min())
         assert base_features["close"] == pytest.approx(source["close"].iloc[-1])
         assert base_features["volume"] == pytest.approx(source["volume"].sum())
 
-        # The bug is silent unless the aggregate genuinely differs from the last
-        # sub-bar: close matches either way, so only the range can discriminate.
-        assert source["high"].max() > source["high"].iloc[-1]
-        assert source["low"].min() < source["low"].iloc[-1]
+        if sub_bars > 1:
+            # Without a real excursion beyond the last sub-bar the assertions above
+            # hold under .last() too, and the case stops discriminating.
+            assert source["high"].max() > source["high"].iloc[-1]
+            assert source["low"].min() < source["low"].iloc[-1]
 
 
 class TestSamplerHelperMethods:

--- a/tests/envs/offline/test_sampler.py
+++ b/tests/envs/offline/test_sampler.py
@@ -459,6 +459,29 @@ class TestSamplerBaseFeatures:
         # been filled from sits strictly inside its own range.
         assert previous["high"] > previous["close"] > previous["low"]
 
+    def test_bar_without_a_usable_close_keeps_its_real_range(self, sample_ohlcv_df):
+        """Only bars with no source rows are flattened.
+
+        A bar whose close is unusable still traded, and its high/low are the range SL/TP
+        must see. Flattening it would re-create the too-narrow range this aggregation
+        exists to fix.
+        """
+        execute_on = TimeFrame(15, TimeFrameUnit.Minute)
+        bar_start, bar_end = pd.Timestamp("2024-01-01 03:00"), pd.Timestamp("2024-01-01 03:15")
+        df = sample_ohlcv_df.copy()
+        in_bar = (df["timestamp"] >= bar_start) & (df["timestamp"] < bar_end)
+        df.loc[in_bar, "close"] = np.nan
+        df.loc[in_bar, "low"] = 42.0  # a real excursion a stop must still see
+
+        with pytest.warns(UserWarning, match="DATA GAPS"):
+            sampler = MarketDataObservationSampler(
+                df=df, time_frames=[execute_on], window_sizes=[5], execute_on=execute_on,
+            )
+
+        bar = sampler.get_base_features(bar_start)
+        assert bar["low"] == pytest.approx(42.0)
+        assert bar["high"] > bar["low"], "a bar that traded must not be flattened"
+
 
 class TestSamplerHelperMethods:
     """Tests for helper methods."""

--- a/tests/envs/offline/test_sampler.py
+++ b/tests/envs/offline/test_sampler.py
@@ -433,6 +433,47 @@ class TestSamplerBaseFeatures:
         assert base_features["close"] > 0
         assert base_features["volume"] >= 0
 
+    @pytest.mark.parametrize("exec_value,exec_unit", [
+        (15, TimeFrameUnit.Minute),
+        (1, TimeFrameUnit.Hour),
+    ], ids=["15min", "1hour"])
+    def test_execution_bar_is_aggregated_not_last_sub_bar(
+        self, sample_ohlcv_df, exec_value, exec_unit
+    ):
+        """Execution bars must aggregate their sub-bars, not copy the final one.
+
+        Resampling with .last() takes the last valid value per column, so high/low
+        collapse to the final sub-bar's range. Every SL/TP and liquidation check reads
+        this range, so a too-narrow bar means stops that fire in reality never fire in
+        the backtest.
+        """
+        execute_on = TimeFrame(exec_value, exec_unit)
+        sampler = MarketDataObservationSampler(
+            df=sample_ohlcv_df,
+            time_frames=[execute_on],
+            window_sizes=[5],
+            execute_on=execute_on,
+        )
+        sampler.reset(random_start=False)
+        _, timestamp, _ = sampler.get_sequential_observation()
+        base_features = sampler.get_base_features(timestamp)
+
+        source = sample_ohlcv_df.set_index("timestamp").loc[
+            timestamp:timestamp + pd.Timedelta(execute_on.to_pandas_freq()) - pd.Timedelta("1min")
+        ]
+        assert len(source) > 1, "bar must span multiple sub-bars for this to discriminate"
+
+        assert base_features["open"] == pytest.approx(source["open"].iloc[0])
+        assert base_features["high"] == pytest.approx(source["high"].max())
+        assert base_features["low"] == pytest.approx(source["low"].min())
+        assert base_features["close"] == pytest.approx(source["close"].iloc[-1])
+        assert base_features["volume"] == pytest.approx(source["volume"].sum())
+
+        # The bug is silent unless the aggregate genuinely differs from the last
+        # sub-bar: close matches either way, so only the range can discriminate.
+        assert source["high"].max() > source["high"].iloc[-1]
+        assert source["low"].min() < source["low"].iloc[-1]
+
 
 class TestSamplerHelperMethods:
     """Tests for helper methods."""

--- a/tests/envs/offline/test_sequential_sltp.py
+++ b/tests/envs/offline/test_sequential_sltp.py
@@ -395,6 +395,71 @@ class TestSLTPEdgeCases:
 class TestSLTPRegression:
     """Regression tests for known SLTP issues."""
 
+    @pytest.mark.parametrize("leverage,stoploss_pct,wick_low", [
+        (1, -0.02, 95.0),    # SL at 98, no liquidation at 1x
+        (10, -0.50, 88.0),   # SL at 50 untouched; liquidation (~90.5) fires
+    ], ids=["stop-loss", "liquidation"])
+    def test_exit_fires_on_a_mid_bar_wick_when_execute_on_is_coarse(
+        self, leverage, stoploss_pct, wick_low
+    ):
+        """A wick inside the execution bar must close the position (issue #267).
+
+        The sampler built execution bars with .last(), so high/low collapsed onto the
+        final sub-bar and any excursion earlier in the bar was invisible. Both exits
+        that read that range are covered here, because the sampler feeds them both.
+
+        The wick sits mid-bar, not on the last sub-bar, so it is only visible once the
+        bar aggregates its sub-bars.
+        """
+        import numpy as np
+        import pandas as pd
+
+        n = 600
+        prices = np.full(n, 100.0)
+        df = pd.DataFrame({
+            "timestamp": pd.date_range("2024-01-01", periods=n, freq="1min"),
+            "open": prices.copy(),
+            "high": prices.copy(),
+            "low": prices.copy(),
+            "close": prices.copy(),
+            "volume": np.ones(n) * 1000,
+        })
+        # Minute 183 sits inside the 03:00 bar (minutes 180-194), which is the first
+        # bar the position is exposed to, and is not that bar's final sub-bar.
+        df.loc[183, "low"] = wick_low
+
+        config = SequentialTradingEnvSLTPConfig(
+            leverage=leverage,
+            initial_cash=10000,
+            execute_on=TimeFrame(15, TimeFrameUnit.Minute),
+            time_frames=[TimeFrame(15, TimeFrameUnit.Minute)],
+            window_sizes=[10],
+            transaction_fee=0.0,
+            slippage=0.0,
+            seed=42,
+            random_start=False,
+            stoploss_levels=[stoploss_pct],
+            takeprofit_levels=[0.50],
+        )
+        env = SequentialTradingEnvSLTP(df, config, simple_feature_fn)
+        td = env.reset()
+
+        long_idx = next(i for i, v in env.action_map.items() if v[0] == "long")
+        open_td = td.clone()
+        open_td["action"] = torch.tensor(long_idx)
+        td_next = env.step(open_td)
+        assert env.position.position_size > 0, "long should be open before the wick bar"
+
+        hold_td = td_next["next"].clone()
+        hold_td["action"] = torch.tensor(0)
+        env.step(hold_td)
+
+        assert env.position.position_size == 0, (
+            f"wick to {wick_low} inside the execution bar must close the position, "
+            f"but position_size={env.position.position_size}"
+        )
+        env.close()
+
     def test_short_bracket_prices_not_inverted(self, sample_ohlcv_df):
         """Short positions must have SL above entry and TP below entry (issue #149)."""
         config = SequentialTradingEnvSLTPConfig(

--- a/tests/envs/offline/test_sequential_sltp.py
+++ b/tests/envs/offline/test_sequential_sltp.py
@@ -395,12 +395,12 @@ class TestSLTPEdgeCases:
 class TestSLTPRegression:
     """Regression tests for known SLTP issues."""
 
-    @pytest.mark.parametrize("leverage,stoploss_pct,wick_low", [
-        (1, -0.02, 95.0),    # SL at 98, no liquidation at 1x
-        (10, -0.50, 88.0),   # SL at 50 untouched; liquidation (~90.5) fires
+    @pytest.mark.parametrize("leverage,stoploss_pct,wick_low,expected_exit,expected_balance", [
+        (1, -0.02, 95.0, "sltp_sl", 9800.0),      # SL at 98, no liquidation at 1x
+        (10, -0.50, 88.0, "liquidation", 400.0),  # SL at 50 untouched; liquidation at 90.4
     ], ids=["stop-loss", "liquidation"])
     def test_exit_fires_on_a_mid_bar_wick_when_execute_on_is_coarse(
-        self, leverage, stoploss_pct, wick_low
+        self, leverage, stoploss_pct, wick_low, expected_exit, expected_balance
     ):
         """A wick inside the execution bar must close the position (issue #267).
 
@@ -414,7 +414,7 @@ class TestSLTPRegression:
         import numpy as np
         import pandas as pd
 
-        n = 600
+        n = 240
         prices = np.full(n, 100.0)
         df = pd.DataFrame({
             "timestamp": pd.date_range("2024-01-01", periods=n, freq="1min"),
@@ -454,10 +454,21 @@ class TestSLTPRegression:
         hold_td["action"] = torch.tensor(0)
         env.step(hold_td)
 
+        # Pinned so the two ways this can break report themselves, rather than surfacing
+        # as an unexplained still-open position below.
+        assert env._cached_base_features["low"] == pytest.approx(wick_low), (
+            "the bar the position is checked against must report the wick: either the "
+            "step landed on a different bar, or the bar did not aggregate its sub-bars"
+        )
         assert env.position.position_size == 0, (
             f"wick to {wick_low} inside the execution bar must close the position, "
             f"but position_size={env.position.position_size}"
         )
+        # Without this the parametrize labels live only in prose: any exit satisfies the
+        # assertion above, so a change making SL leverage-scaled would silently turn the
+        # liquidation case into a second stop-loss case.
+        assert env.history.action_types[-1] == expected_exit
+        assert env.balance == pytest.approx(expected_balance)
         env.close()
 
     def test_short_bracket_prices_not_inverted(self, sample_ohlcv_df):

--- a/tests/envs/offline/test_vectorized_sequential_sltp.py
+++ b/tests/envs/offline/test_vectorized_sequential_sltp.py
@@ -217,6 +217,12 @@ class TestVecSLTPTriggers:
         hold_td["action"] = torch.zeros(2, dtype=torch.long)
         env.step(hold_td)
 
+        # Column 2 is low: pinning it here separates a mislanded step from a bar that
+        # did not aggregate, and checks the hardcoded index this env reads by.
+        assert torch.allclose(env._base_tensor[env._step_indices, 2], torch.tensor(95.0)), (
+            "the bar the position is checked against must report the wick: either the "
+            "step landed on a different bar, or the bar did not aggregate its sub-bars"
+        )
         assert (env._position_sizes == 0).all(), (
             "wick to 95.0 inside the execution bar must close the position"
         )

--- a/tests/envs/offline/test_vectorized_sequential_sltp.py
+++ b/tests/envs/offline/test_vectorized_sequential_sltp.py
@@ -169,6 +169,59 @@ class TestVecSLTPTriggers:
         assert (env._tp_prices == 0).all(), "TP price should be cleared"
         env.close()
 
+    def test_sl_fires_on_a_mid_bar_wick_when_execute_on_is_coarse(self):
+        """A wick inside the execution bar must close the position (issue #267).
+
+        This env never calls get_base_features: it slices execute_base_tensor by
+        hardcoded column index and re-implements the trigger in tensor form, so it is an
+        independent consumer of both the aggregation and the column order.
+        """
+        n = 240
+        prices = np.full(n, 100.0)
+        df = pd.DataFrame({
+            "timestamp": pd.date_range("2024-01-01", periods=n, freq="1min"),
+            "open": prices.copy(),
+            "high": prices.copy(),
+            "low": prices.copy(),
+            "close": prices.copy(),
+            "volume": np.ones(n) * 1000,
+        })
+        # Mid-bar, not the final sub-bar, of the 03:00 execution bar.
+        df.loc[183, "low"] = 95.0
+
+        tf_15min = TimeFrame(15, TimeFrameUnit.Minute)
+        config = VectorizedSequentialTradingEnvSLTPConfig(
+            num_envs=2,
+            leverage=1,
+            stoploss_levels=[-0.02],
+            takeprofit_levels=[0.50],
+            initial_cash=10000,
+            time_frames=[tf_15min],
+            window_sizes=[10],
+            execute_on=tf_15min,
+            transaction_fee=0.0,
+            slippage=0.0,
+            seed=42,
+            random_start=False,
+        )
+        env = VectorizedSequentialTradingEnvSLTP(df, config, simple_feature_fn)
+        td = env.reset()
+
+        long_idx = next(i for i, v in env.action_map.items() if v[0] == "long")
+        action_td = td.clone()
+        action_td["action"] = torch.full((2,), long_idx, dtype=torch.long)
+        td = env.step(action_td)
+        assert (env._position_sizes > 0).all(), "long should be open before the wick bar"
+
+        hold_td = td["next"].clone()
+        hold_td["action"] = torch.zeros(2, dtype=torch.long)
+        env.step(hold_td)
+
+        assert (env._position_sizes == 0).all(), (
+            "wick to 95.0 inside the execution bar must close the position"
+        )
+        env.close()
+
 
 # ============================================================================
 # PARTIAL RESET TESTS

--- a/torchtrade/envs/offline/infrastructure/sampler.py
+++ b/torchtrade/envs/offline/infrastructure/sampler.py
@@ -145,9 +145,8 @@ class MarketDataObservationSampler:
         self.min_start_time = latest_first_step + self.max_lookback + max_offset
         self.exec_times = exec_times[exec_times >= self.min_start_time]
         # create base features of execution time frame (we'll keep DataFrame for column names but also build tensors)
-        # Must aggregate like resampled_dfs: .last() would take the final sub-bar's
-        # OHLCV, collapsing the bar's true high/low range that SL/TP and liquidation
-        # checks depend on.
+        # SL/TP and liquidation checks read this bar's high/low, so it must span the
+        # whole bar, not just the final sub-bar.
         execute_base_raw = self.df.resample(execute_on.to_pandas_freq()).agg(full_agg)
 
         # Detect and warn about data gaps

--- a/torchtrade/envs/offline/infrastructure/sampler.py
+++ b/torchtrade/envs/offline/infrastructure/sampler.py
@@ -42,7 +42,8 @@ class MarketDataObservationSampler:
                 f"Got columns: {list(df.columns)}"
             )
 
-        # Reorder: OHLCV first, then auxiliary (preserves row[:5] slicing for base features)
+        # Canonical OHLCV-first order for self.df. The row[:5] contract itself comes from
+        # ohlcv_agg's key order, since pandas orders .agg(dict) output by dict key.
         ohlcv_cols = ["open", "high", "low", "close", "volume"]
         aux_cols = [c for c in df.columns if c not in required_columns]
         df = df[["timestamp"] + ohlcv_cols + aux_cols]
@@ -144,7 +145,6 @@ class MarketDataObservationSampler:
         exec_times = self.df.resample(execute_on.to_pandas_freq()).first().index
         self.min_start_time = latest_first_step + self.max_lookback + max_offset
         self.exec_times = exec_times[exec_times >= self.min_start_time]
-        # create base features of execution time frame (we'll keep DataFrame for column names but also build tensors)
         # SL/TP and liquidation checks read this bar's high/low, so it must span the
         # whole bar, not just the final sub-bar. Only OHLCV is ever read here (aux
         # features reach observations via resampled_dfs), and excluding aux keeps the

--- a/torchtrade/envs/offline/infrastructure/sampler.py
+++ b/torchtrade/envs/offline/infrastructure/sampler.py
@@ -146,8 +146,10 @@ class MarketDataObservationSampler:
         self.exec_times = exec_times[exec_times >= self.min_start_time]
         # create base features of execution time frame (we'll keep DataFrame for column names but also build tensors)
         # SL/TP and liquidation checks read this bar's high/low, so it must span the
-        # whole bar, not just the final sub-bar.
-        execute_base_raw = self.df.resample(execute_on.to_pandas_freq()).agg(full_agg)
+        # whole bar, not just the final sub-bar. Only OHLCV is ever read here (aux
+        # features reach observations via resampled_dfs), and excluding aux keeps the
+        # row[:5] positional contract exact rather than merely conventional.
+        execute_base_raw = self.df.resample(execute_on.to_pandas_freq()).agg(ohlcv_agg)
 
         # Detect and warn about data gaps
         nan_mask = execute_base_raw["close"].isna()
@@ -194,14 +196,10 @@ class MarketDataObservationSampler:
                 warnings.warn(warning_msg, UserWarning, stacklevel=2)
 
         execute_base_filled = execute_base_raw.ffill()
-        # A gap bar has no trades to derive a range from, and forward-filling one would
-        # re-trigger SL/TP on the excursion the position already lived through in the
-        # previous bar. Collapse it to a flat bar at the last known price.
-        for col in ("open", "high", "low"):
-            execute_base_filled.loc[nan_mask, col] = execute_base_filled.loc[nan_mask, "close"]
+        # A gap bar has no trades of its own; forward-filling its range would let SL/TP
+        # re-trigger on the excursion the position already lived through one bar earlier.
+        execute_base_filled.loc[nan_mask, ["open", "high", "low"]] = execute_base_filled.loc[nan_mask, "close"]
         self.execute_base_features_df = execute_base_filled[self.min_start_time:]
-        if aux_cols:
-            self.execute_base_features_df[aux_cols] = self.execute_base_features_df[aux_cols].fillna(0)
         if len(self.execute_base_features_df) == 0:
             raise ValueError("No execute_on base features available after min_start_time")
 

--- a/torchtrade/envs/offline/infrastructure/sampler.py
+++ b/torchtrade/envs/offline/infrastructure/sampler.py
@@ -145,8 +145,10 @@ class MarketDataObservationSampler:
         self.min_start_time = latest_first_step + self.max_lookback + max_offset
         self.exec_times = exec_times[exec_times >= self.min_start_time]
         # create base features of execution time frame (we'll keep DataFrame for column names but also build tensors)
-        # Use ffill() to handle any NaN values from missing data periods
-        execute_base_raw = self.df.resample(execute_on.to_pandas_freq()).last()
+        # Must aggregate like resampled_dfs: .last() would take the final sub-bar's
+        # OHLCV, collapsing the bar's true high/low range that SL/TP and liquidation
+        # checks depend on.
+        execute_base_raw = self.df.resample(execute_on.to_pandas_freq()).agg(full_agg)
 
         # Detect and warn about data gaps
         nan_mask = execute_base_raw["close"].isna()

--- a/torchtrade/envs/offline/infrastructure/sampler.py
+++ b/torchtrade/envs/offline/infrastructure/sampler.py
@@ -196,9 +196,13 @@ class MarketDataObservationSampler:
                 warnings.warn(warning_msg, UserWarning, stacklevel=2)
 
         execute_base_filled = execute_base_raw.ffill()
-        # A gap bar has no trades of its own; forward-filling its range would let SL/TP
-        # re-trigger on the excursion the position already lived through one bar earlier.
-        execute_base_filled.loc[nan_mask, ["open", "high", "low"]] = execute_base_filled.loc[nan_mask, "close"]
+        # A bar with no source rows has no trades of its own; forward-filling its range
+        # would let SL/TP re-trigger on the excursion the position already lived through
+        # one bar earlier. Narrower than nan_mask on purpose: a bar that merely lacks a
+        # usable close still has a real high/low, and discarding that would re-create the
+        # too-narrow range this aggregation exists to fix.
+        empty_bars = self.df.resample(execute_on.to_pandas_freq()).size() == 0
+        execute_base_filled.loc[empty_bars, ["open", "high", "low"]] = execute_base_filled.loc[empty_bars, "close"]
         self.execute_base_features_df = execute_base_filled[self.min_start_time:]
         if len(self.execute_base_features_df) == 0:
             raise ValueError("No execute_on base features available after min_start_time")

--- a/torchtrade/envs/offline/infrastructure/sampler.py
+++ b/torchtrade/envs/offline/infrastructure/sampler.py
@@ -193,7 +193,13 @@ class MarketDataObservationSampler:
 """
                 warnings.warn(warning_msg, UserWarning, stacklevel=2)
 
-        self.execute_base_features_df = execute_base_raw.ffill()[self.min_start_time:]
+        execute_base_filled = execute_base_raw.ffill()
+        # A gap bar has no trades to derive a range from, and forward-filling one would
+        # re-trigger SL/TP on the excursion the position already lived through in the
+        # previous bar. Collapse it to a flat bar at the last known price.
+        for col in ("open", "high", "low"):
+            execute_base_filled.loc[nan_mask, col] = execute_base_filled.loc[nan_mask, "close"]
+        self.execute_base_features_df = execute_base_filled[self.min_start_time:]
         if aux_cols:
             self.execute_base_features_df[aux_cols] = self.execute_base_features_df[aux_cols].fillna(0)
         if len(self.execute_base_features_df) == 0:


### PR DESCRIPTION
Closes #267.

## The bug

`sampler.py` built the execution timeframe's bars with `resample(...).last()`, which takes the last valid value **per column** — the final sub-bar's OHLCV, not the bar's aggregate. `close` is coincidentally correct; `open`, `high`, `low` and `volume` are not.

Every SL/TP and liquidation check reads this bar's high/low range, so the range was systematically too narrow. Measured on 30 days of synthetic 1-minute data resampled to 1 hour:

| | buggy (`.last()`) | correct |
|---|---|---|
| mean intrabar range | 0.139% | 0.688% (**5x wider**) |
| 0.5% stop-loss hits detected | 73 | 155 |

So roughly **half of all stop-hits were invisible**, and the error is one-directional: stops and liquidations that trigger in reality never triggered in backtest. The exact ratio depends on the volatility of the series — the mechanism, not the multiplier, is the point.

The correct aggregation dict already existed and was used for the observation windows; only the execution bar skipped it. Observations were never affected, so this is not a leakage fix.

**Why it survived:** every SLTP and replay test uses `execute_on` equal to the source frequency, where `resample` is an identity op and `.last()` is coincidentally correct.

## The fix

Three changes in `sampler.py`, all in the same block:

1. Aggregate with `ohlcv_agg` (`open:first, high:max, low:min, close:last, volume:sum`).
2. Exclude aux columns from the execution bar. Nothing ever read them from this frame (aux reaches observations via `resampled_dfs`), so this makes the `row[:5]` positional contract exact rather than conventional, and deletes a now-dead `fillna` block.
3. Collapse bars with no source rows to flat. Empty bins are forward-filled, so such a bar used to inherit the previous bar's high/low — and widening that range meant it could re-trigger SL/TP on the excursion the position already lived through, stopping it out twice on one move. A bar with no trades has no range of its own.

Point 3 keys on a genuinely empty bin, not on `nan_mask` (which means "no usable close"). A bar that traded but lacks a usable close still has a real high/low, and flattening it would re-create the too-narrow range this PR exists to fix.

The vectorized envs read `execute_base_tensor` directly, so they inherit the fix with no changes.

## Tests

Each was verified by mutation — revert the fix, watch the specific test fail, with the mutation itself asserted to have applied.

| Test | Covers |
|---|---|
| `test_execution_bar_aggregates_its_sub_bars` | OHLCV vs an independently recomputed aggregate at coarse `execute_on` |
| `test_gap_bar_is_flat_rather_than_a_replay_of_the_previous_range` | the collapse |
| `test_bar_without_a_usable_close_keeps_its_real_range` | the collapse does *not* over-reach |
| `test_exit_fires_on_a_mid_bar_wick_when_execute_on_is_coarse` | end-to-end: stop-loss at 1x and liquidation at 10x, exit type and balance both pinned |
| `test_sl_fires_on_a_mid_bar_wick_when_execute_on_is_coarse` | vectorized SLTP — an independent consumer that slices the tensor by hardcoded column index |

The wick sits mid-bar, not on the final sub-bar, so it is visible only once the bar aggregates. Two tests whose assertions were subsumed were deleted; both were pinned at the degenerate config, which is why neither could ever have caught this.

Full suite: **2246 passed, 18 skipped.**

## Notes for the reviewer

- **This PR does three things**, not one. Points 2 and 3 above are not what #267 asked for — they are consequences the fix exposed (3 is a regression the fix would otherwise introduce; 2 removes a wart it uncovered). Happy to split if you'd rather review them separately.
- **Gap-through fill price** is a separate, pre-existing problem: an exit still books at the bracket price even when the market gaps past it, measured at 8% of capital in one case. Deferred to #280 with the evidence recorded there rather than expanded into this PR.
- The `open_price` branches in `_check_sltp_trigger` are unreachable — `low = min` over sub-bars means the low/high checks always fire first. Noted on #280, since a gap-aware fill has to change the execution price rather than add a trigger branch.
- The OHLCV column reorder in `__init__` is no longer what enforces `row[:5]` (pandas orders `.agg(dict)` output by dict key). Kept deliberately as a canonical order for the public `self.df`, with its comment corrected to stop claiming a guarantee it no longer provides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
