### PR TITLE
fix(envs): check SLTP exits on the bar a position is opened into

### DIFF
--- a/tests/envs/offline/test_sequential_sltp.py
+++ b/tests/envs/offline/test_sequential_sltp.py
@@ -397,17 +397,21 @@ class TestSLTPRegression:
 
     @pytest.mark.parametrize("bars_after_entry", [1, 2], ids=["next-bar", "two-bars-later"])
     @pytest.mark.parametrize(
-        "leverage,stoploss_pct,wick_low,fee,expected_exit,expected_balance,expected_terminated", [
+        "leverage,sl_pct,tp_pct,wick_low,wick_high,fee,"
+        "expected_exit,expected_balance,expected_terminated", [
             # The fee rows pin exact values because the next-bar path is the only place
             # an entry fee and an exit fee land in one step; "cheaper than free" would
             # hold just as well if one were charged twice.
-            (1, -0.025, 80.0, 0.0, "sltp_sl", 9750.0, False),
-            (1, -0.025, 80.0, 0.001, "sltp_sl", 9730.519481, False),
-            (10, -0.50, 88.0, 0.0, "liquidation", 400.0, True),
-            (10, -0.50, 88.0, 0.001, "liquidation", 306.534653, True),
-        ], ids=["stop-loss", "stop-loss-fee", "liquidation", "liquidation-fee"])
+            (1, -0.025, 0.50, 80.0, None, 0.0, "sltp_sl", 9750.0, False),
+            (1, -0.025, 0.50, 80.0, None, 0.001, "sltp_sl", 9730.519481, False),
+            (10, -0.50, 0.50, 88.0, None, 0.0, "liquidation", 400.0, True),
+            (10, -0.50, 0.50, 88.0, None, 0.001, "liquidation", 306.534653, True),
+            # The fix repeats the trigger->fill-price mapping, so pin the take-profit
+            # side too: a wrong fill here is invisible to every other assertion.
+            (1, -0.50, 0.025, None, 120.0, 0.0, "sltp_tp", 10250.0, False),
+        ], ids=["stop-loss", "stop-loss-fee", "liquidation", "liquidation-fee", "take-profit"])
     def test_exit_fires_on_the_first_bar_the_position_is_exposed_to(
-        self, bars_after_entry, leverage, stoploss_pct, wick_low, fee,
+        self, bars_after_entry, leverage, sl_pct, tp_pct, wick_low, wick_high, fee,
         expected_exit, expected_balance, expected_terminated
     ):
         """The outcome must not depend on how soon after entry the crash lands (#268).
@@ -431,7 +435,10 @@ class TestSLTPRegression:
             "close": prices.copy(),
             "volume": np.ones(n) * 1000,
         })
-        df.loc[crash_bar, "low"] = wick_low
+        if wick_low is not None:
+            df.loc[crash_bar, "low"] = wick_low
+        else:
+            df.loc[crash_bar, "high"] = wick_high
 
         config = SequentialTradingEnvSLTPConfig(
             leverage=leverage,
@@ -443,8 +450,8 @@ class TestSLTPRegression:
             slippage=0.0,
             seed=42,
             random_start=False,
-            stoploss_levels=[stoploss_pct],
-            takeprofit_levels=[0.50],
+            stoploss_levels=[sl_pct],
+            takeprofit_levels=[tp_pct],
         )
         env = SequentialTradingEnvSLTP(df, config, simple_feature_fn)
         td = env.reset()
@@ -461,7 +468,7 @@ class TestSLTPRegression:
             td = env.step(action_td)
 
         assert env.position.position_size == 0, (
-            f"a wick to {wick_low} {bars_after_entry} bar(s) after entry must close the "
+            f"a wick {bars_after_entry} bar(s) after entry must close the "
             f"position, but position_size={env.position.position_size}"
         )
         assert env.history.action_types[-1] == expected_exit
@@ -481,7 +488,9 @@ class TestSLTPRegression:
         assert account_state[0].item() == pytest.approx(0.0), "exposure_pct must read flat"
         assert account_state[1].item() == pytest.approx(0.0), "direction must read flat"
         assert account_state[3].item() == pytest.approx(0.0), "holding_time must read flat"
-        assert td["next"]["reward"].item() < 0, "the round trip lost money"
+        assert (td["next"]["reward"].item() < 0) is (expected_balance < 10000), (
+            "the reward must carry the sign of the round trip"
+        )
         assert bool(td["next"]["terminated"].item()) is expected_terminated
         env.close()
 

--- a/tests/envs/offline/test_sequential_sltp.py
+++ b/tests/envs/offline/test_sequential_sltp.py
@@ -488,7 +488,11 @@ class TestSLTPRegression:
         assert account_state[0].item() == pytest.approx(0.0), "exposure_pct must read flat"
         assert account_state[1].item() == pytest.approx(0.0), "direction must read flat"
         assert account_state[3].item() == pytest.approx(0.0), "holding_time must read flat"
-        assert (td["next"]["reward"].item() < 0) is (expected_balance < 10000), (
+        reward = td["next"]["reward"].item()
+        # Non-zero first: on the take-profit row the sign check alone reads
+        # `False is False` for a reward frozen at 0, so it would pass a stale reward.
+        assert reward != 0.0, "an exit that moved the balance must move the reward"
+        assert (reward < 0) is (expected_balance < 10000), (
             "the reward must carry the sign of the round trip"
         )
         assert bool(td["next"]["terminated"].item()) is expected_terminated

--- a/tests/envs/offline/test_sequential_sltp.py
+++ b/tests/envs/offline/test_sequential_sltp.py
@@ -489,13 +489,11 @@ class TestSLTPRegression:
         assert account_state[1].item() == pytest.approx(0.0), "direction must read flat"
         assert account_state[3].item() == pytest.approx(0.0), "holding_time must read flat"
         reward = td["next"]["reward"].item()
-        # Non-zero first: on the take-profit row the sign check alone reads
-        # `False is False` for a reward frozen at 0, so it would pass a stale reward.
-        assert reward != 0.0, "an exit that moved the balance must move the reward"
-        assert (reward < 0) is (expected_balance < 10000), (
-            "the reward must carry the sign of the round trip"
-        )
-        assert bool(td["next"]["terminated"].item()) is expected_terminated
+        if expected_balance < 10000:
+            assert reward < 0, "a losing round trip must produce a negative reward"
+        else:
+            assert reward > 0, "a winning round trip must produce a positive reward"
+        assert bool(td["next"]["terminated"].item()) == expected_terminated
         env.close()
 
     @pytest.mark.parametrize("leverage,stoploss_pct,wick_low,expected_exit,expected_balance", [

--- a/tests/envs/offline/test_sequential_sltp.py
+++ b/tests/envs/offline/test_sequential_sltp.py
@@ -399,9 +399,9 @@ class TestSLTPRegression:
     @pytest.mark.parametrize(
         "leverage,sl_pct,tp_pct,wick_low,wick_high,fee,"
         "expected_exit,expected_balance,expected_terminated", [
-            # The fee rows pin exact values because the next-bar path is the only place
-            # an entry fee and an exit fee land in one step; "cheaper than free" would
-            # hold just as well if one were charged twice.
+            # The fee rows pin exact values rather than an inequality: a double-charged
+            # fee is also "cheaper than free". On the next-bar arm both fees land in a
+            # single step, which happens nowhere else in the codebase.
             (1, -0.025, 0.50, 80.0, None, 0.0, "sltp_sl", 9750.0, False),
             (1, -0.025, 0.50, 80.0, None, 0.001, "sltp_sl", 9730.519481, False),
             (10, -0.50, 0.50, 88.0, None, 0.0, "liquidation", 400.0, True),

--- a/tests/envs/offline/test_sequential_sltp.py
+++ b/tests/envs/offline/test_sequential_sltp.py
@@ -396,14 +396,18 @@ class TestSLTPRegression:
     """Regression tests for known SLTP issues."""
 
     @pytest.mark.parametrize("bars_after_entry", [1, 2], ids=["next-bar", "two-bars-later"])
-    @pytest.mark.parametrize("fee", [0.0, 0.001], ids=["no-fee", "with-fee"])
     @pytest.mark.parametrize(
-        "leverage,stoploss_pct,wick_low,expected_exit,expected_balance,expected_terminated", [
-            (1, -0.025, 80.0, "sltp_sl", 9750.0, False),
-            (10, -0.50, 88.0, "liquidation", 400.0, True),
-        ], ids=["stop-loss", "liquidation"])
+        "leverage,stoploss_pct,wick_low,fee,expected_exit,expected_balance,expected_terminated", [
+            # The fee rows pin exact values because the next-bar path is the only place
+            # an entry fee and an exit fee land in one step; "cheaper than free" would
+            # hold just as well if one were charged twice.
+            (1, -0.025, 80.0, 0.0, "sltp_sl", 9750.0, False),
+            (1, -0.025, 80.0, 0.001, "sltp_sl", 9730.519481, False),
+            (10, -0.50, 88.0, 0.0, "liquidation", 400.0, True),
+            (10, -0.50, 88.0, 0.001, "liquidation", 306.534653, True),
+        ], ids=["stop-loss", "stop-loss-fee", "liquidation", "liquidation-fee"])
     def test_exit_fires_on_the_first_bar_the_position_is_exposed_to(
-        self, bars_after_entry, fee, leverage, stoploss_pct, wick_low,
+        self, bars_after_entry, leverage, stoploss_pct, wick_low, fee,
         expected_exit, expected_balance, expected_terminated
     ):
         """The outcome must not depend on how soon after entry the crash lands (#268).
@@ -467,13 +471,7 @@ class TestSLTPRegression:
         # earlier, so trade counts drawn from action_types under-count entries -- pinned
         # here so that stays a decision rather than a surprise.
         assert env.history.action_types.count("long") == (0 if bars_after_entry == 1 else 1)
-        if fee == 0.0:
-            assert env.balance == pytest.approx(expected_balance)
-        else:
-            # Entry and exit fees both land in one step on the next-bar path, which is
-            # the only place in the codebase that happens. Pin that it costs the same
-            # either way rather than being charged twice or dropped.
-            assert env.balance < expected_balance
+        assert env.balance == pytest.approx(expected_balance)
 
         # The exit must be applied BEFORE the observation, reward and termination are
         # built. Nothing else pins that: with the exit moved after them the internal

--- a/tests/envs/offline/test_sequential_sltp.py
+++ b/tests/envs/offline/test_sequential_sltp.py
@@ -395,6 +395,72 @@ class TestSLTPEdgeCases:
 class TestSLTPRegression:
     """Regression tests for known SLTP issues."""
 
+    @pytest.mark.parametrize("bars_after_entry", [1, 2], ids=["next-bar", "two-bars-later"])
+    @pytest.mark.parametrize("leverage,stoploss_pct,wick_low,expected_exit,expected_balance", [
+        (1, -0.025, 80.0, "sltp_sl", 9750.0),
+        (10, -0.50, 88.0, "liquidation", 400.0),
+    ], ids=["stop-loss", "liquidation"])
+    def test_exit_fires_on_the_first_bar_the_position_is_exposed_to(
+        self, bars_after_entry, leverage, stoploss_pct, wick_low, expected_exit, expected_balance
+    ):
+        """The outcome must not depend on how soon after entry the crash lands (#268).
+
+        _step advanced the sampler and checked triggers against bar N+1 *before* opening
+        the position at bar N's close, so a position opened one bar before a crash had
+        its first check on bar N+2 and rode straight through it. Entering two bars early
+        exited correctly, which is what made the two paths disagree on identical data.
+        """
+        import numpy as np
+        import pandas as pd
+
+        n = 50
+        crash_bar = 20
+        prices = np.full(n, 100.0)
+        df = pd.DataFrame({
+            "timestamp": pd.date_range("2024-01-01", periods=n, freq="1min"),
+            "open": prices.copy(),
+            "high": prices.copy(),
+            "low": prices.copy(),
+            "close": prices.copy(),
+            "volume": np.ones(n) * 1000,
+        })
+        df.loc[crash_bar, "low"] = wick_low
+
+        config = SequentialTradingEnvSLTPConfig(
+            leverage=leverage,
+            initial_cash=10000,
+            execute_on=TimeFrame(1, TimeFrameUnit.Minute),
+            time_frames=[TimeFrame(1, TimeFrameUnit.Minute)],
+            window_sizes=[10],
+            transaction_fee=0.0,
+            slippage=0.0,
+            seed=42,
+            random_start=False,
+            stoploss_levels=[stoploss_pct],
+            takeprofit_levels=[0.50],
+        )
+        env = SequentialTradingEnvSLTP(df, config, simple_feature_fn)
+        td = env.reset()
+
+        # reset caches bar 10 (window_sizes=[10]), so step k executes at bar 10+k and
+        # advances onto bar 11+k. The crash bar is therefore reached during exit_step
+        # whatever bar the position was opened on — that sameness is the point.
+        exit_step = crash_bar - 10 - 1
+        open_step = crash_bar - bars_after_entry - 10
+        long_idx = next(i for i, v in env.action_map.items() if v[0] == "long")
+        for step in range(exit_step + 1):
+            action_td = (td if step == 0 else td["next"]).clone()
+            action_td["action"] = torch.tensor(long_idx if step == open_step else 0)
+            td = env.step(action_td)
+
+        assert env.position.position_size == 0, (
+            f"a wick to {wick_low} {bars_after_entry} bar(s) after entry must close the "
+            f"position, but position_size={env.position.position_size}"
+        )
+        assert env.history.action_types[-1] == expected_exit
+        assert env.balance == pytest.approx(expected_balance)
+        env.close()
+
     @pytest.mark.parametrize("leverage,stoploss_pct,wick_low,expected_exit,expected_balance", [
         (1, -0.02, 95.0, "sltp_sl", 9800.0),      # SL at 98, no liquidation at 1x
         (10, -0.50, 88.0, "liquidation", 400.0),  # SL at 50 untouched; liquidation at 90.4

--- a/tests/envs/offline/test_sequential_sltp.py
+++ b/tests/envs/offline/test_sequential_sltp.py
@@ -396,12 +396,15 @@ class TestSLTPRegression:
     """Regression tests for known SLTP issues."""
 
     @pytest.mark.parametrize("bars_after_entry", [1, 2], ids=["next-bar", "two-bars-later"])
-    @pytest.mark.parametrize("leverage,stoploss_pct,wick_low,expected_exit,expected_balance", [
-        (1, -0.025, 80.0, "sltp_sl", 9750.0),
-        (10, -0.50, 88.0, "liquidation", 400.0),
-    ], ids=["stop-loss", "liquidation"])
+    @pytest.mark.parametrize("fee", [0.0, 0.001], ids=["no-fee", "with-fee"])
+    @pytest.mark.parametrize(
+        "leverage,stoploss_pct,wick_low,expected_exit,expected_balance,expected_terminated", [
+            (1, -0.025, 80.0, "sltp_sl", 9750.0, False),
+            (10, -0.50, 88.0, "liquidation", 400.0, True),
+        ], ids=["stop-loss", "liquidation"])
     def test_exit_fires_on_the_first_bar_the_position_is_exposed_to(
-        self, bars_after_entry, leverage, stoploss_pct, wick_low, expected_exit, expected_balance
+        self, bars_after_entry, fee, leverage, stoploss_pct, wick_low,
+        expected_exit, expected_balance, expected_terminated
     ):
         """The outcome must not depend on how soon after entry the crash lands (#268).
 
@@ -432,7 +435,7 @@ class TestSLTPRegression:
             execute_on=TimeFrame(1, TimeFrameUnit.Minute),
             time_frames=[TimeFrame(1, TimeFrameUnit.Minute)],
             window_sizes=[10],
-            transaction_fee=0.0,
+            transaction_fee=fee,
             slippage=0.0,
             seed=42,
             random_start=False,
@@ -458,7 +461,30 @@ class TestSLTPRegression:
             f"position, but position_size={env.position.position_size}"
         )
         assert env.history.action_types[-1] == expected_exit
-        assert env.balance == pytest.approx(expected_balance)
+        # An entry-bar exit records only the exit. HistoryTracker has one row per step
+        # and the exit is what determines the ending state, matching what already
+        # happens when a previously-held position triggers. It is now reachable one bar
+        # earlier, so trade counts drawn from action_types under-count entries -- pinned
+        # here so that stays a decision rather than a surprise.
+        assert env.history.action_types.count("long") == (0 if bars_after_entry == 1 else 1)
+        if fee == 0.0:
+            assert env.balance == pytest.approx(expected_balance)
+        else:
+            # Entry and exit fees both land in one step on the next-bar path, which is
+            # the only place in the codebase that happens. Pin that it costs the same
+            # either way rather than being charged twice or dropped.
+            assert env.balance < expected_balance
+
+        # The exit must be applied BEFORE the observation, reward and termination are
+        # built. Nothing else pins that: with the exit moved after them the internal
+        # balance is still right, so every other assertion here passes while the policy
+        # is handed an open levered position on a step the env already closed.
+        account_state = td["next"]["account_state"]
+        assert account_state[0].item() == pytest.approx(0.0), "exposure_pct must read flat"
+        assert account_state[1].item() == pytest.approx(0.0), "direction must read flat"
+        assert account_state[3].item() == pytest.approx(0.0), "holding_time must read flat"
+        assert td["next"]["reward"].item() < 0, "the round trip lost money"
+        assert bool(td["next"]["terminated"].item()) is expected_terminated
         env.close()
 
     @pytest.mark.parametrize("leverage,stoploss_pct,wick_low,expected_exit,expected_balance", [

--- a/tests/envs/offline/test_vec_sltp_scalar_equivalence.py
+++ b/tests/envs/offline/test_vec_sltp_scalar_equivalence.py
@@ -5,6 +5,8 @@ Runs both environments with identical configs and action sequences,
 comparing ALL observable state at every step. Any divergence is a bug.
 """
 
+import numpy as np
+import pandas as pd
 import pytest
 import torch
 
@@ -438,6 +440,85 @@ class TestSLTPScalarVecEquivalenceTrending:
 # ============================================================================
 # LIQUIDATION EQUIVALENCE (FUTURES)
 # ============================================================================
+
+
+class TestSLTPScalarVecEquivalenceEntryBar:
+    """Both envs must apply the entry bar to a freshly-opened position (#268)."""
+
+    @pytest.mark.parametrize("bars_after_entry", [1, 2], ids=["next-bar", "two-bars-later"])
+    @pytest.mark.parametrize("leverage,sl_levels,tp_levels,wick_low,wick_high", [
+        (1, [-0.025], [0.50], 80.0, None),    # stop-loss
+        (10, [-0.50], [0.50], 88.0, None),    # liquidation
+        (1, [-0.50], [0.025], None, 120.0),   # take-profit: the branch the fix never ran
+    ], ids=["stop-loss", "liquidation", "take-profit"])
+    def test_entry_bar_exit_matches_scalar(
+        self, bars_after_entry, leverage, sl_levels, tp_levels, wick_low, wick_high
+    ):
+        """Both envs forked this ordering separately, so both could drift separately.
+
+        The equivalence suite passed on main because the bug was symmetric — both envs
+        skipped the entry bar identically. The value-pinning tests in
+        test_sequential_sltp.py are what catch the shared bug; this catches divergence.
+        """
+        n = 50
+        crash_bar = 20
+        prices = np.full(n, 100.0)
+        df = pd.DataFrame({
+            "timestamp": pd.date_range("2024-01-01", periods=n, freq="1min"),
+            "open": prices.copy(),
+            "high": prices.copy(),
+            "low": prices.copy(),
+            "close": prices.copy(),
+            "volume": np.ones(n) * 1000,
+        })
+        if wick_low is not None:
+            df.loc[crash_bar, "low"] = wick_low
+        else:
+            df.loc[crash_bar, "high"] = wick_high
+
+        # reset caches bar 10 (window_sizes=[10]), so step k executes at bar 10+k.
+        open_step = crash_bar - bars_after_entry - 10
+        actions = [0] * open_step + [1] + [0] * (bars_after_entry + 2)
+
+        mismatches = _run_sltp_sequence(
+            df, actions, leverage=leverage,
+            sl_levels=sl_levels, tp_levels=tp_levels,
+            label=f"sltp-entry-bar-{leverage}x-{bars_after_entry}",
+        )
+        assert not mismatches, "\n".join(mismatches)
+
+
+    def test_entry_bar_exit_after_direction_switch(self):
+        """A switch opens a position too, and each env recognises that differently.
+
+        The scalar env gates on the trade_info side, the vectorized one on
+        switch_mask | open_from_flat. Nothing else covers the switch path, so a refactor
+        could reopen #268 for switches in one env only.
+        """
+        n = 50
+        prices = np.full(n, 100.0)
+        df = pd.DataFrame({
+            "timestamp": pd.date_range("2024-01-01", periods=n, freq="1min"),
+            "open": prices.copy(),
+            "high": prices.copy(),
+            "low": prices.copy(),
+            "close": prices.copy(),
+            "volume": np.ones(n) * 1000,
+        })
+        df.loc[20, "high"] = 120.0
+
+        # Levels chosen so the incoming long survives bar 20 (SL 50, TP 150) while the
+        # short opened into it does not (SL 102.5). Otherwise the long's own trigger
+        # preempts the switch and the path under test never runs -- see #292.
+        wide_long, tight_short = 4, 5
+        actions = [0] * 5 + [wide_long] + [0] * 3 + [tight_short] + [0] * 2
+
+        mismatches = _run_sltp_sequence(
+            df, actions, leverage=2,
+            sl_levels=[-0.025, -0.50], tp_levels=[0.025, 0.50],
+            label="sltp-entry-bar-switch",
+        )
+        assert not mismatches, "\n".join(mismatches)
 
 
 class TestSLTPScalarVecEquivalenceLiquidation:

--- a/tests/envs/offline/test_vec_sltp_scalar_equivalence.py
+++ b/tests/envs/offline/test_vec_sltp_scalar_equivalence.py
@@ -478,32 +478,34 @@ def _flat_df_with_wick(bar=20, low=None, high=None, n=50):
 class TestSLTPScalarVecEquivalenceEntryBar:
     """Both envs must apply the entry bar to a freshly-opened position (#268)."""
 
-    @pytest.mark.parametrize("bars_after_entry", [1, 2], ids=["next-bar", "two-bars-later"])
     @pytest.mark.parametrize("leverage,sl_levels,tp_levels,wick_low,wick_high,expected_exit", [
         (1, [-0.025], [0.50], 80.0, None, "sltp_sl"),
         (10, [-0.50], [0.50], 88.0, None, "liquidation"),
         (1, [-0.50], [0.025], None, 120.0, "sltp_tp"),  # the branch the fix never ran
     ], ids=["stop-loss", "liquidation", "take-profit"])
     def test_entry_bar_exit_matches_scalar(
-        self, bars_after_entry, leverage, sl_levels, tp_levels, wick_low, wick_high, expected_exit
+        self, leverage, sl_levels, tp_levels, wick_low, wick_high, expected_exit
     ):
         """Both envs forked this ordering separately, so both could drift separately.
 
         The equivalence suite passed on main because the bug was symmetric — both envs
         skipped the entry bar identically. The value-pinning tests in
         test_sequential_sltp.py are what catch the shared bug; this catches divergence.
+        Only the entry-bar timing is covered here: the held-position path is already
+        exercised by the trend-based cases above.
         """
         crash_bar = 20
         df = _flat_df_with_wick(bar=crash_bar, low=wick_low, high=wick_high)
 
-        # reset caches bar 10 (window_sizes=[10]), so step k executes at bar 10+k.
-        open_step = crash_bar - bars_after_entry - 10
-        actions = [0] * open_step + [1] + [0] * (bars_after_entry + 2)
+        # reset caches bar 10 (window_sizes=[10]), so step k executes at bar 10+k, and
+        # the position opens one bar before the wick.
+        open_step = crash_bar - 1 - 10
+        actions = [0] * open_step + [1] + [0] * 3
 
         mismatches = _run_sltp_sequence(
             df, actions, leverage=leverage,
             sl_levels=sl_levels, tp_levels=tp_levels,
-            label=f"sltp-entry-bar-{leverage}x-{bars_after_entry}",
+            label=f"sltp-entry-bar-{leverage}x-{expected_exit}",
             expect_action_type=expected_exit,
         )
         assert not mismatches, "\n".join(mismatches)
@@ -527,6 +529,9 @@ class TestSLTPScalarVecEquivalenceEntryBar:
             df, actions, leverage=2,
             sl_levels=[-0.025, -0.50], tp_levels=[0.025, 0.50],
             label="sltp-entry-bar-switch",
+            # The hardcoded indices and the delicately balanced levels make this the
+            # scenario most likely to quietly stop testing anything.
+            expect_action_type="sltp_sl",
         )
         assert not mismatches, "\n".join(mismatches)
 

--- a/tests/envs/offline/test_vec_sltp_scalar_equivalence.py
+++ b/tests/envs/offline/test_vec_sltp_scalar_equivalence.py
@@ -453,7 +453,7 @@ class TestSLTPScalarVecEquivalenceTrending:
 
 
 # ============================================================================
-# LIQUIDATION EQUIVALENCE (FUTURES)
+# ENTRY-BAR EQUIVALENCE
 # ============================================================================
 
 
@@ -534,6 +534,11 @@ class TestSLTPScalarVecEquivalenceEntryBar:
             expect_action_type="sltp_sl",
         )
         assert not mismatches, "\n".join(mismatches)
+
+
+# ============================================================================
+# LIQUIDATION EQUIVALENCE (FUTURES)
+# ============================================================================
 
 
 class TestSLTPScalarVecEquivalenceLiquidation:

--- a/tests/envs/offline/test_vec_sltp_scalar_equivalence.py
+++ b/tests/envs/offline/test_vec_sltp_scalar_equivalence.py
@@ -121,8 +121,15 @@ def _run_sltp_sequence(
     label="",
     include_hold=True,
     include_close=False,
+    expect_action_type=None,
 ):
-    """Run a sequence of actions through both envs and compare at every step."""
+    """Run a sequence of actions through both envs and compare at every step.
+
+    Args:
+        expect_action_type: if given, the run must actually record this action type
+            (e.g. "sltp_sl"), so a scenario that stops reaching its bracket is reported
+            rather than passing as a pair of idle envs.
+    """
     scalar, vec = _make_sltp_pair(
         df,
         leverage=leverage,
@@ -201,6 +208,14 @@ def _run_sltp_sequence(
 
         if td_s["next"]["done"].item() or td_v["next"]["done"].item():
             break
+
+    # Without this a scenario whose action indices or wick stop reaching a bracket
+    # degrades into "both envs held cash identically" and still passes.
+    if expect_action_type is not None and expect_action_type not in scalar.history.action_types:
+        all_mismatches.append(
+            f"[{label}] path never exercised: no {expect_action_type} in "
+            f"{scalar.history.action_types}"
+        )
 
     scalar.close()
     vec.close()
@@ -442,17 +457,35 @@ class TestSLTPScalarVecEquivalenceTrending:
 # ============================================================================
 
 
+def _flat_df_with_wick(bar=20, low=None, high=None, n=50):
+    """Flat 100.0 series with one bar carrying a single excursion."""
+    prices = np.full(n, 100.0)
+    df = pd.DataFrame({
+        "timestamp": pd.date_range("2024-01-01", periods=n, freq="1min"),
+        "open": prices.copy(),
+        "high": prices.copy(),
+        "low": prices.copy(),
+        "close": prices.copy(),
+        "volume": np.ones(n) * 1000,
+    })
+    if low is not None:
+        df.loc[bar, "low"] = low
+    if high is not None:
+        df.loc[bar, "high"] = high
+    return df
+
+
 class TestSLTPScalarVecEquivalenceEntryBar:
     """Both envs must apply the entry bar to a freshly-opened position (#268)."""
 
     @pytest.mark.parametrize("bars_after_entry", [1, 2], ids=["next-bar", "two-bars-later"])
-    @pytest.mark.parametrize("leverage,sl_levels,tp_levels,wick_low,wick_high", [
-        (1, [-0.025], [0.50], 80.0, None),    # stop-loss
-        (10, [-0.50], [0.50], 88.0, None),    # liquidation
-        (1, [-0.50], [0.025], None, 120.0),   # take-profit: the branch the fix never ran
+    @pytest.mark.parametrize("leverage,sl_levels,tp_levels,wick_low,wick_high,expected_exit", [
+        (1, [-0.025], [0.50], 80.0, None, "sltp_sl"),
+        (10, [-0.50], [0.50], 88.0, None, "liquidation"),
+        (1, [-0.50], [0.025], None, 120.0, "sltp_tp"),  # the branch the fix never ran
     ], ids=["stop-loss", "liquidation", "take-profit"])
     def test_entry_bar_exit_matches_scalar(
-        self, bars_after_entry, leverage, sl_levels, tp_levels, wick_low, wick_high
+        self, bars_after_entry, leverage, sl_levels, tp_levels, wick_low, wick_high, expected_exit
     ):
         """Both envs forked this ordering separately, so both could drift separately.
 
@@ -460,21 +493,8 @@ class TestSLTPScalarVecEquivalenceEntryBar:
         skipped the entry bar identically. The value-pinning tests in
         test_sequential_sltp.py are what catch the shared bug; this catches divergence.
         """
-        n = 50
         crash_bar = 20
-        prices = np.full(n, 100.0)
-        df = pd.DataFrame({
-            "timestamp": pd.date_range("2024-01-01", periods=n, freq="1min"),
-            "open": prices.copy(),
-            "high": prices.copy(),
-            "low": prices.copy(),
-            "close": prices.copy(),
-            "volume": np.ones(n) * 1000,
-        })
-        if wick_low is not None:
-            df.loc[crash_bar, "low"] = wick_low
-        else:
-            df.loc[crash_bar, "high"] = wick_high
+        df = _flat_df_with_wick(bar=crash_bar, low=wick_low, high=wick_high)
 
         # reset caches bar 10 (window_sizes=[10]), so step k executes at bar 10+k.
         open_step = crash_bar - bars_after_entry - 10
@@ -484,28 +504,18 @@ class TestSLTPScalarVecEquivalenceEntryBar:
             df, actions, leverage=leverage,
             sl_levels=sl_levels, tp_levels=tp_levels,
             label=f"sltp-entry-bar-{leverage}x-{bars_after_entry}",
+            expect_action_type=expected_exit,
         )
         assert not mismatches, "\n".join(mismatches)
-
 
     def test_entry_bar_exit_after_direction_switch(self):
         """A switch opens a position too, and each env recognises that differently.
 
-        The scalar env gates on the trade_info side, the vectorized one on
-        switch_mask | open_from_flat. Nothing else covers the switch path, so a refactor
-        could reopen #268 for switches in one env only.
+        The scalar env gates on trade_info["executed"] plus a non-zero position size,
+        the vectorized one on switch_mask | open_from_flat. Nothing else covers the
+        switch path, so a refactor could reopen #268 for switches in one env only.
         """
-        n = 50
-        prices = np.full(n, 100.0)
-        df = pd.DataFrame({
-            "timestamp": pd.date_range("2024-01-01", periods=n, freq="1min"),
-            "open": prices.copy(),
-            "high": prices.copy(),
-            "low": prices.copy(),
-            "close": prices.copy(),
-            "volume": np.ones(n) * 1000,
-        })
-        df.loc[20, "high"] = 120.0
+        df = _flat_df_with_wick(bar=20, high=120.0)
 
         # Levels chosen so the incoming long survives bar 20 (SL 50, TP 150) while the
         # short opened into it does not (SL 102.5). Otherwise the long's own trigger

--- a/tests/envs/offline/test_vectorized_sequential_sltp.py
+++ b/tests/envs/offline/test_vectorized_sequential_sltp.py
@@ -169,6 +169,68 @@ class TestVecSLTPTriggers:
         assert (env._tp_prices == 0).all(), "TP price should be cleared"
         env.close()
 
+    @pytest.mark.parametrize("bars_after_entry", [1, 2], ids=["next-bar", "two-bars-later"])
+    @pytest.mark.parametrize("leverage,stoploss_pct,wick_low,expected_balance", [
+        (1, -0.025, 80.0, 9750.0),
+        (10, -0.50, 88.0, 400.0),
+    ], ids=["stop-loss", "liquidation"])
+    def test_exit_fires_on_the_first_bar_the_position_is_exposed_to(
+        self, bars_after_entry, leverage, stoploss_pct, wick_low, expected_balance
+    ):
+        """Same invariant as the scalar env (#268), which this env forked separately.
+
+        Trades executed at bar N's close after the trigger pass had already run against
+        bar N+1, so a position opened one bar before a crash was first checked on bar
+        N+2. The balances here are the scalar env's, so the two stay in step.
+        """
+        n = 50
+        crash_bar = 20
+        prices = np.full(n, 100.0)
+        df = pd.DataFrame({
+            "timestamp": pd.date_range("2024-01-01", periods=n, freq="1min"),
+            "open": prices.copy(),
+            "high": prices.copy(),
+            "low": prices.copy(),
+            "close": prices.copy(),
+            "volume": np.ones(n) * 1000,
+        })
+        df.loc[crash_bar, "low"] = wick_low
+
+        config = VectorizedSequentialTradingEnvSLTPConfig(
+            num_envs=2,
+            leverage=leverage,
+            stoploss_levels=[stoploss_pct],
+            takeprofit_levels=[0.50],
+            initial_cash=10000,
+            time_frames=[TF_1MIN],
+            window_sizes=[10],
+            execute_on=TF_1MIN,
+            transaction_fee=0.0,
+            slippage=0.0,
+            seed=42,
+            random_start=False,
+        )
+        env = VectorizedSequentialTradingEnvSLTP(df, config, simple_feature_fn)
+        td = env.reset()
+
+        exit_step = crash_bar - 10 - 1
+        open_step = crash_bar - bars_after_entry - 10
+        long_idx = next(i for i, v in env.action_map.items() if v[0] == "long")
+        for step in range(exit_step + 1):
+            action_td = (td if step == 0 else td["next"]).clone()
+            idx = long_idx if step == open_step else 0
+            action_td["action"] = torch.full((2,), idx, dtype=torch.long)
+            td = env.step(action_td)
+
+        assert (env._position_sizes == 0).all(), (
+            f"a wick to {wick_low} {bars_after_entry} bar(s) after entry must close the "
+            f"position, but sizes={env._position_sizes.tolist()}"
+        )
+        # rel=1e-4: these balances are float32 here and float64 in the scalar env, and a
+        # real ordering regression is off by the whole stop distance, not by 2e-3.
+        assert env._balances.tolist() == pytest.approx([expected_balance] * 2, rel=1e-4)
+        env.close()
+
     def test_sl_fires_on_a_mid_bar_wick_when_execute_on_is_coarse(self):
         """A wick inside the execution bar must close the position (issue #267).
 

--- a/tests/envs/offline/test_vectorized_sequential_sltp.py
+++ b/tests/envs/offline/test_vectorized_sequential_sltp.py
@@ -169,6 +169,43 @@ class TestVecSLTPTriggers:
         assert (env._tp_prices == 0).all(), "TP price should be cleared"
         env.close()
 
+    def test_entry_bar_check_targets_the_env_that_opened(self):
+        """The entry-bar exit mask must line up per env (#268).
+
+        Every other test of this path has all envs doing the same thing, where a per-env
+        misalignment is the identity. Aiming the check at a sibling env passes the whole
+        offline suite, so only diverging envs can catch it.
+        """
+        n = 50
+        prices = np.full(n, 100.0)
+        df = pd.DataFrame({
+            "timestamp": pd.date_range("2024-01-01", periods=n, freq="1min"),
+            "open": prices.copy(),
+            "high": prices.copy(),
+            "low": prices.copy(),
+            "close": prices.copy(),
+            "volume": np.ones(n) * 1000,
+        })
+        df.loc[20, "low"] = 80.0
+
+        env = _make_sltp_vec_env(
+            df, leverage=1, num_envs=2, sl_levels=[-0.025], tp_levels=[0.50],
+        )
+        td = env.reset()
+        long_idx = next(i for i, v in env.action_map.items() if v[0] == "long")
+
+        for step in range(10):
+            action_td = (td if step == 0 else td["next"]).clone()
+            # env 0 opens into the wick bar; env 1 stays flat throughout
+            action_td["action"] = torch.tensor(
+                [long_idx if step == 9 else 0, 0], dtype=torch.long
+            )
+            td = env.step(action_td)
+
+        assert env._position_sizes.tolist() == [0.0, 0.0]
+        assert env._balances.tolist() == pytest.approx([975.0, 1000.0])
+        env.close()
+
     def test_sl_fires_on_a_mid_bar_wick_when_execute_on_is_coarse(self):
         """A wick inside the execution bar must close the position (issue #267).
 

--- a/tests/envs/offline/test_vectorized_sequential_sltp.py
+++ b/tests/envs/offline/test_vectorized_sequential_sltp.py
@@ -26,6 +26,24 @@ from tests.conftest import simple_feature_fn
 TF_1MIN = TimeFrame(1, TimeFrameUnit.Minute)
 
 
+def _flat_df_with_wick(bar, low=None, high=None, n=50):
+    """Flat 100.0 series with one bar carrying a single excursion."""
+    prices = np.full(n, 100.0)
+    df = pd.DataFrame({
+        "timestamp": pd.date_range("2024-01-01", periods=n, freq="1min"),
+        "open": prices.copy(),
+        "high": prices.copy(),
+        "low": prices.copy(),
+        "close": prices.copy(),
+        "volume": np.ones(n) * 1000,
+    })
+    if low is not None:
+        df.loc[bar, "low"] = low
+    if high is not None:
+        df.loc[bar, "high"] = high
+    return df
+
+
 def _make_sltp_vec_env(df, leverage=1, num_envs=4, fee=0.0, sl_levels=None, tp_levels=None, max_traj=50):
     """Create a vectorized SLTP env for testing."""
     if sl_levels is None:
@@ -176,17 +194,7 @@ class TestVecSLTPTriggers:
         misalignment is the identity. Aiming the check at a sibling env passes the whole
         offline suite, so only diverging envs can catch it.
         """
-        n = 50
-        prices = np.full(n, 100.0)
-        df = pd.DataFrame({
-            "timestamp": pd.date_range("2024-01-01", periods=n, freq="1min"),
-            "open": prices.copy(),
-            "high": prices.copy(),
-            "low": prices.copy(),
-            "close": prices.copy(),
-            "volume": np.ones(n) * 1000,
-        })
-        df.loc[20, "low"] = 80.0
+        df = _flat_df_with_wick(20, low=80.0)
 
         env = _make_sltp_vec_env(
             df, leverage=1, num_envs=2, sl_levels=[-0.025], tp_levels=[0.50],
@@ -213,18 +221,8 @@ class TestVecSLTPTriggers:
         hardcoded column index and re-implements the trigger in tensor form, so it is an
         independent consumer of both the aggregation and the column order.
         """
-        n = 240
-        prices = np.full(n, 100.0)
-        df = pd.DataFrame({
-            "timestamp": pd.date_range("2024-01-01", periods=n, freq="1min"),
-            "open": prices.copy(),
-            "high": prices.copy(),
-            "low": prices.copy(),
-            "close": prices.copy(),
-            "volume": np.ones(n) * 1000,
-        })
         # Mid-bar, not the final sub-bar, of the 03:00 execution bar.
-        df.loc[183, "low"] = 95.0
+        df = _flat_df_with_wick(183, low=95.0, n=240)
 
         tf_15min = TimeFrame(15, TimeFrameUnit.Minute)
         config = VectorizedSequentialTradingEnvSLTPConfig(

--- a/tests/envs/offline/test_vectorized_sequential_sltp.py
+++ b/tests/envs/offline/test_vectorized_sequential_sltp.py
@@ -169,68 +169,6 @@ class TestVecSLTPTriggers:
         assert (env._tp_prices == 0).all(), "TP price should be cleared"
         env.close()
 
-    @pytest.mark.parametrize("bars_after_entry", [1, 2], ids=["next-bar", "two-bars-later"])
-    @pytest.mark.parametrize("leverage,stoploss_pct,wick_low,expected_balance", [
-        (1, -0.025, 80.0, 9750.0),
-        (10, -0.50, 88.0, 400.0),
-    ], ids=["stop-loss", "liquidation"])
-    def test_exit_fires_on_the_first_bar_the_position_is_exposed_to(
-        self, bars_after_entry, leverage, stoploss_pct, wick_low, expected_balance
-    ):
-        """Same invariant as the scalar env (#268), which this env forked separately.
-
-        Trades executed at bar N's close after the trigger pass had already run against
-        bar N+1, so a position opened one bar before a crash was first checked on bar
-        N+2. The balances here are the scalar env's, so the two stay in step.
-        """
-        n = 50
-        crash_bar = 20
-        prices = np.full(n, 100.0)
-        df = pd.DataFrame({
-            "timestamp": pd.date_range("2024-01-01", periods=n, freq="1min"),
-            "open": prices.copy(),
-            "high": prices.copy(),
-            "low": prices.copy(),
-            "close": prices.copy(),
-            "volume": np.ones(n) * 1000,
-        })
-        df.loc[crash_bar, "low"] = wick_low
-
-        config = VectorizedSequentialTradingEnvSLTPConfig(
-            num_envs=2,
-            leverage=leverage,
-            stoploss_levels=[stoploss_pct],
-            takeprofit_levels=[0.50],
-            initial_cash=10000,
-            time_frames=[TF_1MIN],
-            window_sizes=[10],
-            execute_on=TF_1MIN,
-            transaction_fee=0.0,
-            slippage=0.0,
-            seed=42,
-            random_start=False,
-        )
-        env = VectorizedSequentialTradingEnvSLTP(df, config, simple_feature_fn)
-        td = env.reset()
-
-        exit_step = crash_bar - 10 - 1
-        open_step = crash_bar - bars_after_entry - 10
-        long_idx = next(i for i, v in env.action_map.items() if v[0] == "long")
-        for step in range(exit_step + 1):
-            action_td = (td if step == 0 else td["next"]).clone()
-            idx = long_idx if step == open_step else 0
-            action_td["action"] = torch.full((2,), idx, dtype=torch.long)
-            td = env.step(action_td)
-
-        assert (env._position_sizes == 0).all(), (
-            f"a wick to {wick_low} {bars_after_entry} bar(s) after entry must close the "
-            f"position, but sizes={env._position_sizes.tolist()}"
-        )
-        # rel=1e-4: these balances are float32 here and float64 in the scalar env, and a
-        # real ordering regression is off by the whole stop distance, not by 2e-3.
-        assert env._balances.tolist() == pytest.approx([expected_balance] * 2, rel=1e-4)
-        env.close()
-
     def test_sl_fires_on_a_mid_bar_wick_when_execute_on_is_coarse(self):
         """A wick inside the execution bar must close the position (issue #267).
 

--- a/torchtrade/envs/offline/sequential_sltp.py
+++ b/torchtrade/envs/offline/sequential_sltp.py
@@ -345,10 +345,14 @@ class SequentialTradingEnvSLTP(SequentialTradingEnv):
         1. Liquidation check on bar N+1 (highest priority)
         2. SL/TP trigger check on bar N+1 (bracket orders)
         3. New action execution at bar N price
+        4. Liquidation and SL/TP again on bar N+1, for a position opened by step 3
 
         The sampler is advanced BEFORE checking SL/TP so that triggers are
         evaluated against the first unseen bar (bar N+1), not the stale bar
-        (bar N) that the agent already observed.
+        (bar N) that the agent already observed. Steps 1-2 see only the position
+        held coming in, so step 4 covers the one opened during this step -- bar
+        N+1 is the first bar it is exposed to, and without it that position
+        would not be checked until bar N+2.
         """
         self.step_counter += 1
 
@@ -397,12 +401,12 @@ class SequentialTradingEnvSLTP(SequentialTradingEnv):
         else:
             trade_info = self._execute_sltp_action(side, sl_pct, tp_pct, cached_price)
 
-        # A position opened at bar N's close is exposed to bar N+1 straight away, but the
-        # checks above ran against whatever was held BEFORE this step. Without this pass
-        # the new position's first check would be bar N+2, and bar N+1's range would never
-        # be applied to it. Reuses the bar already fetched above, so no lookahead: the
-        # agent committed to its action on bar N's close alone.
-        if trade_info.get("side") in ("long", "short"):
+        # The checks above ran against the position held BEFORE this step, but a position
+        # opened at bar N's close is already exposed to bar N+1. Same bar, no lookahead --
+        # the action was chosen on bar N's close alone. Must precede the portfolio value
+        # and the history record below, or both read a state that ignores this exit.
+        # executed with an open position means a successful open, direction switches too.
+        if trade_info["executed"] and self.position.position_size != 0:
             if self._check_liquidation(base_features):
                 trade_info = self._execute_liquidation()
             else:

--- a/torchtrade/envs/offline/sequential_sltp.py
+++ b/torchtrade/envs/offline/sequential_sltp.py
@@ -397,6 +397,20 @@ class SequentialTradingEnvSLTP(SequentialTradingEnv):
         else:
             trade_info = self._execute_sltp_action(side, sl_pct, tp_pct, cached_price)
 
+        # A position opened at bar N's close is exposed to bar N+1 straight away, but the
+        # checks above ran against whatever was held BEFORE this step. Without this pass
+        # the new position's first check would be bar N+2, and bar N+1's range would never
+        # be applied to it. Reuses the bar already fetched above, so no lookahead: the
+        # agent committed to its action on bar N's close alone.
+        if trade_info.get("side") in ("long", "short"):
+            if self._check_liquidation(base_features):
+                trade_info = self._execute_liquidation()
+            else:
+                entry_trigger = self._check_sltp_trigger(base_features)
+                if entry_trigger is not None:
+                    execution_price = self.stop_loss if entry_trigger == "sl" else self.take_profit
+                    trade_info = self._execute_sltp_close(execution_price, entry_trigger)
+
         # Update position flag based on actual position size
         if trade_info["executed"]:
             if self.position.position_size > 0:

--- a/torchtrade/envs/offline/vectorized_sequential_sltp.py
+++ b/torchtrade/envs/offline/vectorized_sequential_sltp.py
@@ -182,7 +182,9 @@ class VectorizedSequentialTradingEnvSLTP(VectorizedSequentialTradingEnv):
         """Execute one step for all environments with SLTP timing.
 
         SLTP timing differs from base: advance FIRST, then check triggers.
-        Priority: liquidation > SL/TP trigger > agent action.
+        Priority: liquidation > SL/TP trigger > agent action > the same liquidation and
+        SL/TP checks again for positions the agent action opened, since the first pass
+        ran before they existed and bar N+1 is the first bar they are exposed to.
         """
         N = self._num_envs
 

--- a/torchtrade/envs/offline/vectorized_sequential_sltp.py
+++ b/torchtrade/envs/offline/vectorized_sequential_sltp.py
@@ -96,9 +96,10 @@ class VectorizedSequentialTradingEnvSLTP(VectorizedSequentialTradingEnv):
     Timing (different from base vectorized env):
         1. Save bar N close as trade prices (with slippage)
         2. Advance step index to bar N+1
-        3. Check liquidation on bar N+1 (futures only)
-        4. Check SL/TP triggers on bar N+1 (SL before TP)
-        5. Execute trades at bar N price (skip triggered envs)
+        3. Check liquidation then SL/TP on bar N+1, for positions held coming in
+        4. Execute trades at bar N price (skip triggered envs)
+        5. Re-check bar N+1 for positions opened by step 4 -- it is the first bar
+           they are exposed to, and steps 3 ran before they existed
         6. Compute rewards from bar N+1 prices
 
     Args:
@@ -184,7 +185,6 @@ class VectorizedSequentialTradingEnvSLTP(VectorizedSequentialTradingEnv):
         Priority: liquidation > SL/TP trigger > agent action.
         """
         N = self._num_envs
-        leverage = float(self.config.leverage)
 
         # 1. Decode actions via tensor lookup
         action_indices = tensordict["action"]
@@ -212,25 +212,20 @@ class VectorizedSequentialTradingEnvSLTP(VectorizedSequentialTradingEnv):
         new_low = self._base_tensor[self._step_indices, 2]
         new_close = self._base_tensor[self._step_indices, 3]
 
-        # 5+6. Check liquidation, then SL/TP, on bar N+1 against positions held
-        # coming into this step.
-        triggered_mask = self._apply_exit_checks(
-            torch.ones(N, dtype=torch.bool), new_high, new_low
-        )
+        # 5. Check liquidation, then SL/TP, on bar N+1 against positions held coming in
+        triggered_mask = self._apply_exit_checks(new_high, new_low)
 
-        # 7. Execute trades at bar N price (skip triggered envs)
+        # 6. Execute trades at bar N price (skip triggered envs)
         opened_mask = self._execute_sltp_trades(
             sides, sl_pcts, tp_pcts, trade_prices, triggered_mask
         )
 
-        # 7b. A position opened at bar N's close is exposed to bar N+1 straight away,
-        # but the checks above ran against what was held BEFORE this step. Without this
-        # pass the new position's first check would be bar N+2. Reuses the bar already
-        # fetched above, so no lookahead: the action was chosen on bar N's close alone.
-        # Must run before the portfolio values below, or reward and termination read
-        # balances that ignore the exit.
+        # 7. The check above ran against what was held BEFORE this step, but a position
+        # opened at bar N's close is already exposed to bar N+1. Same bar, no lookahead --
+        # the action was chosen on bar N's close alone. Must precede the portfolio values
+        # below, or reward and termination read balances that ignore this exit.
         if opened_mask.any():
-            self._apply_exit_checks(opened_mask, new_high, new_low)
+            self._apply_exit_checks(new_high, new_low, eligible=opened_mask)
 
         # 8. Compute rewards: log(new_pv / old_pv)
         new_pvs = self._compute_portfolio_values(new_close)
@@ -260,14 +255,22 @@ class VectorizedSequentialTradingEnvSLTP(VectorizedSequentialTradingEnv):
         return obs_td
 
     def _apply_exit_checks(
-        self, eligible: torch.Tensor, new_high: torch.Tensor, new_low: torch.Tensor
+        self,
+        new_high: torch.Tensor,
+        new_low: torch.Tensor,
+        eligible: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
-        """Close eligible positions whose bar range hit liquidation or a bracket.
+        """Close positions whose bar range hit liquidation or a bracket.
 
-        Called twice per step — once for positions held coming in, once for positions
-        opened during the step — so both see the same bar. Returns the exited mask.
+        Args:
+            eligible: defaults to every open position; pass a mask to check only the
+                positions opened during this step against that same bar.
+
+        Returns the mask of envs that exited.
         """
         leverage = float(self.config.leverage)
+        if eligible is None:
+            eligible = self._position_sizes != 0
         exited = torch.zeros_like(eligible)
 
         # Liquidation takes priority over the brackets (futures only)
@@ -474,6 +477,7 @@ class VectorizedSequentialTradingEnvSLTP(VectorizedSequentialTradingEnv):
             # Float32 tolerance for can_afford check
             can_afford = (margin_new + new_fee) <= self._balances * (1 + 1e-5)
             final_open = open_mask & can_afford
+            opened = final_open
 
             if final_open.any():
                 self._balances[final_open] -= (margin_new + new_fee)[final_open]
@@ -494,6 +498,5 @@ class VectorizedSequentialTradingEnvSLTP(VectorizedSequentialTradingEnv):
                 self._tp_prices[final_open] = (
                     trade_prices * (1 + tp_pcts)
                 )[final_open]
-                opened = final_open
 
         return opened

--- a/torchtrade/envs/offline/vectorized_sequential_sltp.py
+++ b/torchtrade/envs/offline/vectorized_sequential_sltp.py
@@ -226,6 +226,8 @@ class VectorizedSequentialTradingEnvSLTP(VectorizedSequentialTradingEnv):
         # opened at bar N's close is already exposed to bar N+1. Same bar, no lookahead --
         # the action was chosen on bar N's close alone. Must precede the portfolio values
         # below, or reward and termination read balances that ignore this exit.
+        # Scoped to the newly opened: re-checking a survivor of the first pass is a no-op
+        # only while this check stays idempotent, which nothing enforces.
         if opened_mask.any():
             self._apply_exit_checks(new_high, new_low, eligible=opened_mask)
 

--- a/torchtrade/envs/offline/vectorized_sequential_sltp.py
+++ b/torchtrade/envs/offline/vectorized_sequential_sltp.py
@@ -212,14 +212,69 @@ class VectorizedSequentialTradingEnvSLTP(VectorizedSequentialTradingEnv):
         new_low = self._base_tensor[self._step_indices, 2]
         new_close = self._base_tensor[self._step_indices, 3]
 
-        # Track which envs had triggers (liquidation or SL/TP)
-        triggered_mask = torch.zeros(N, dtype=torch.bool)
+        # 5+6. Check liquidation, then SL/TP, on bar N+1 against positions held
+        # coming into this step.
+        triggered_mask = self._apply_exit_checks(
+            torch.ones(N, dtype=torch.bool), new_high, new_low
+        )
 
-        # 5. Check liquidation on bar N+1 (futures only)
+        # 7. Execute trades at bar N price (skip triggered envs)
+        opened_mask = self._execute_sltp_trades(
+            sides, sl_pcts, tp_pcts, trade_prices, triggered_mask
+        )
+
+        # 7b. A position opened at bar N's close is exposed to bar N+1 straight away,
+        # but the checks above ran against what was held BEFORE this step. Without this
+        # pass the new position's first check would be bar N+2. Reuses the bar already
+        # fetched above, so no lookahead: the action was chosen on bar N's close alone.
+        # Must run before the portfolio values below, or reward and termination read
+        # balances that ignore the exit.
+        if opened_mask.any():
+            self._apply_exit_checks(opened_mask, new_high, new_low)
+
+        # 8. Compute rewards: log(new_pv / old_pv)
+        new_pvs = self._compute_portfolio_values(new_close)
+        old_pvs = self._portfolio_values
+        safe_old = old_pvs.clamp(min=1e-10)
+        safe_new = new_pvs.clamp(min=1e-10)
+        rewards = torch.log(safe_new / safe_old)
+        rewards = torch.where(new_pvs <= 0, torch.full_like(rewards, -10.0), rewards)
+
+        self._portfolio_values = new_pvs
+
+        # 9. Compute termination signals
+        terminated = new_pvs < (self._initial_pvs * self.bankrupt_threshold)
+        truncated = (
+            ((self._step_indices + 1) >= self._end_indices)
+            | (self._step_counters >= self._max_traj_lengths)
+        )
+        done = terminated | truncated
+
+        # 10. Build observation from bar N+1
+        obs_td = self._build_observation(new_close, portfolio_values=new_pvs)
+        obs_td.set("reward", rewards.unsqueeze(-1))
+        obs_td.set("terminated", terminated.unsqueeze(-1))
+        obs_td.set("truncated", truncated.unsqueeze(-1))
+        obs_td.set("done", done.unsqueeze(-1))
+
+        return obs_td
+
+    def _apply_exit_checks(
+        self, eligible: torch.Tensor, new_high: torch.Tensor, new_low: torch.Tensor
+    ) -> torch.Tensor:
+        """Close eligible positions whose bar range hit liquidation or a bracket.
+
+        Called twice per step — once for positions held coming in, once for positions
+        opened during the step — so both see the same bar. Returns the exited mask.
+        """
+        leverage = float(self.config.leverage)
+        exited = torch.zeros_like(eligible)
+
+        # Liquidation takes priority over the brackets (futures only)
         if self.config.leverage > 1:
             liq_price = self._compute_liq_prices()
-            long_liq = (self._position_sizes > 0) & (new_low <= liq_price)
-            short_liq = (self._position_sizes < 0) & (new_high >= liq_price)
+            long_liq = eligible & (self._position_sizes > 0) & (new_low <= liq_price)
+            short_liq = eligible & (self._position_sizes < 0) & (new_high >= liq_price)
             liq_mask = long_liq | short_liq
 
             if liq_mask.any():
@@ -249,10 +304,9 @@ class VectorizedSequentialTradingEnvSLTP(VectorizedSequentialTradingEnv):
                 # Note: SL/TP are NOT cleared on liquidation, matching scalar
                 # env behavior. Stale values are harmless since position is
                 # zeroed and SL/TP checks guard on has_position.
-                triggered_mask = triggered_mask | liq_mask
+                exited = exited | liq_mask
 
-        # 6. Check SL/TP triggers on bar N+1
-        has_position = (self._position_sizes != 0) & ~triggered_mask
+        has_position = eligible & (self._position_sizes != 0) & ~exited
         has_brackets = (self._sl_prices > 0) | (self._tp_prices > 0)
         can_trigger = has_position & has_brackets
 
@@ -316,37 +370,9 @@ class VectorizedSequentialTradingEnvSLTP(VectorizedSequentialTradingEnv):
                 self._tp_prices = torch.where(
                     sltp_trigger, self._zeros, self._tp_prices
                 )
-                triggered_mask = triggered_mask | sltp_trigger
+                exited = exited | sltp_trigger
 
-        # 7. Execute trades at bar N price (skip triggered envs)
-        self._execute_sltp_trades(sides, sl_pcts, tp_pcts, trade_prices, triggered_mask)
-
-        # 8. Compute rewards: log(new_pv / old_pv)
-        new_pvs = self._compute_portfolio_values(new_close)
-        old_pvs = self._portfolio_values
-        safe_old = old_pvs.clamp(min=1e-10)
-        safe_new = new_pvs.clamp(min=1e-10)
-        rewards = torch.log(safe_new / safe_old)
-        rewards = torch.where(new_pvs <= 0, torch.full_like(rewards, -10.0), rewards)
-
-        self._portfolio_values = new_pvs
-
-        # 9. Compute termination signals
-        terminated = new_pvs < (self._initial_pvs * self.bankrupt_threshold)
-        truncated = (
-            ((self._step_indices + 1) >= self._end_indices)
-            | (self._step_counters >= self._max_traj_lengths)
-        )
-        done = terminated | truncated
-
-        # 10. Build observation from bar N+1
-        obs_td = self._build_observation(new_close, portfolio_values=new_pvs)
-        obs_td.set("reward", rewards.unsqueeze(-1))
-        obs_td.set("terminated", terminated.unsqueeze(-1))
-        obs_td.set("truncated", truncated.unsqueeze(-1))
-        obs_td.set("done", done.unsqueeze(-1))
-
-        return obs_td
+        return exited
 
     def _execute_sltp_trades(
         self,
@@ -355,7 +381,7 @@ class VectorizedSequentialTradingEnvSLTP(VectorizedSequentialTradingEnv):
         tp_pcts: torch.Tensor,
         trade_prices: torch.Tensor,
         triggered_mask: torch.Tensor,
-    ):
+    ) -> torch.Tensor:
         """Execute SLTP trades for all environments.
 
         Position sizing via trade_mode (fractional/notional/quantity). Handles:
@@ -363,6 +389,9 @@ class VectorizedSequentialTradingEnvSLTP(VectorizedSequentialTradingEnv):
         - Close: side=2 and has position
         - Direction switch: close old, open new with brackets
         - Open from flat: open new with brackets
+
+        Returns the mask of envs that opened a position, so the caller can expose it to
+        the same bar the pre-existing positions were just checked against.
         """
         leverage = float(self.config.leverage)
         active = ~triggered_mask
@@ -419,6 +448,7 @@ class VectorizedSequentialTradingEnvSLTP(VectorizedSequentialTradingEnv):
 
         # Open new positions (direction switches + open from flat)
         open_mask = switch_mask | open_from_flat
+        opened = torch.zeros_like(open_mask)
         if open_mask.any():
             # Position sizing based on trade_mode
             if self.config.trade_mode == "fractional":
@@ -464,3 +494,6 @@ class VectorizedSequentialTradingEnvSLTP(VectorizedSequentialTradingEnv):
                 self._tp_prices[final_open] = (
                     trade_prices * (1 + tp_pcts)
                 )[final_open]
+                opened = final_open
+
+        return opened


### PR DESCRIPTION
Closes #268.

## The bug

Both SLTP envs advanced the sampler and ran the liquidation and SL/TP checks against bar N+1 **before** opening the position at bar N's close. Those checks therefore only ever saw the position held *coming into* the step. A position opened at close(N) was first checked on bar N+2, and bar N+1 — the first bar it is actually exposed to — was never applied to it.

Reproduced on a flat series with one crash bar (low 80, stop at 97.5):

| Entry | Result |
|---|---|
| Two bars before the crash | Stop fires, balance **9750** |
| **One** bar before the crash | Position **rides straight through**, balance 0, still holding |

So the two paths disagreed by a full stop-loss on identical data. `OneStepTradingEnv` already handled this correctly, which is why the fix also restores the parity `lock_position_until_sltp` exists for.

The same blind spot applied to **liquidation** — a freshly opened levered position could ride through a bar that gapped past its liquidation price.

## The fix

Both envs re-run the checks against the bar **already fetched this step**, scoped to positions opened during it.

- No lookahead: the action was chosen on bar N's close alone, and the bar is not re-fetched.
- No retroactive stop: bar N's own range still cannot close a position that exists only from its close. Verified explicitly in review.
- The vectorized env had the checks inline, so extending them would have forked a second copy. They moved into `_apply_exit_checks`, called once for incoming positions and once for newly opened ones.

## Tests

Every test below was verified by mutation, with the mutation asserted to have applied.

| Test | Catches |
|---|---|
| `test_exit_fires_on_the_first_bar_the_position_is_exposed_to` (scalar, 10 cases) | the shared bug, exit-before-observation ordering, exact fills and fees |
| `TestSLTPScalarVecEquivalenceEntryBar` (+ switch case) | scalar/vectorized divergence, take-profit, direction switches |
| `test_entry_bar_check_targets_the_env_that_opened` | per-env mask misalignment |

The division of labour matters: the equivalence suite passed on `main` because the bug was **symmetric** — both envs skipped the entry bar identically. Value-pinning tests catch the shared bug; the equivalence suite catches drift; the `num_envs=2` test catches misalignment.

Three gaps found during review that the first version of this PR did not cover, each now closed and each verified to have been invisible before:

- **Exit-before-observation ordering.** Moving the new block after the observation build left the internal balance correct, so all 56 scalar tests passed — while the policy was handed a 10x-levered open long, 9.6% from liquidation, on a step the env had already liquidated. The test now asserts the returned `account_state`, `reward` and `terminated`.
- **`opened_mask` across envs.** Aiming the check at a sibling env passed all 658 offline tests, because every test touching it had all envs doing the same thing.
- **Fees and the take-profit fill.** A double-charged exit fee and a 1%-wrong take-profit fill both passed the suite; exact values now pin them.

Full suite: **2261 passed, 18 skipped.**

## Notes for the reviewer

- **A same-bar round trip records only the exit.** `HistoryTracker` has one row per step and the exit determines the ending state, matching what already happens when a previously-held position triggers — but it is now reachable one bar earlier. `action_types` is consumed only by the plot markers in `_get_action_markers`, so nothing numeric under-counts; the futures branch infers exit direction from `position_history[i-1]`, which is now `0` for these, so such an exit draws no marker. Pinned in the test so it stays a decision.
- **`eligible=opened_mask` is inert today** — dropping it passes all 658 offline tests, since re-checking a first-pass survivor on the same bar gives the same answer. Kept deliberately: that holds only while the check stays idempotent, and nothing enforces that. Noted at the call site.
- **#292 filed**, found while verifying this: when a held position triggers on bar N+1 the agent's action from close(N) is discarded outright, so a requested long→short flip can leave the account flat instead. Same ordering family, but it changes *which trades happen*, so it needs its own review.
- **#293 filed**: scalar and vectorized diverge at `leverage=10` for non-fractional trade modes, including trigger-timing disagreement. Verified byte-identical on `main`, so it predates this work; the equivalence harness never varies `trade_mode` or `lock_position_until_sltp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
