### PR TITLE
fix(envs): stop an unreachable exchange from reading as a flat account

### DIFF
--- a/tests/envs/bybit/test_futures_order_executor.py
+++ b/tests/envs/bybit/test_futures_order_executor.py
@@ -2,6 +2,7 @@
 
 import pytest
 from unittest.mock import MagicMock
+from torchtrade.envs.core.state import POSITION_UNKNOWN
 
 
 class TestBybitFuturesOrderClass:
@@ -586,11 +587,15 @@ class TestBybitFuturesOrderClass:
         assert result is expected
 
     def test_get_status_validates_retcode(self, order_executor, mock_pybit_client):
-        """get_status must return position_status=None on non-zero retCode."""
+        """A non-zero retCode is a failed call, not an empty account (#270).
+
+        Reporting None here would let the env trade as though it were flat while a
+        real position sits on the exchange.
+        """
         mock_pybit_client.get_positions = MagicMock(return_value={
             "retCode": 10001,
             "retMsg": "Invalid parameter",
             "result": {"list": []},
         })
         status = order_executor.get_status()
-        assert status["position_status"] is None
+        assert status["position_status"] is POSITION_UNKNOWN

--- a/tests/envs/okx/test_futures_order_executor.py
+++ b/tests/envs/okx/test_futures_order_executor.py
@@ -235,6 +235,19 @@ class TestOKXFuturesOrderClass:
         })
         assert order_executor.get_status()["position_status"] is POSITION_UNKNOWN
 
+    def test_multiple_open_positions_is_not_flat(self, order_executor, mock_okx_account_client):
+        """LONG_SHORT mode is unsupported here, which is not the same as holding nothing.
+
+        Reading two positions the env cannot represent as "flat" means it opens a third.
+        """
+        mock_okx_account_client.get_positions = MagicMock(return_value={
+            "code": "0", "msg": "", "data": [
+                {"instId": "BTC-USDT-SWAP", "pos": "1", "posSide": "long"},
+                {"instId": "BTC-USDT-SWAP", "pos": "-1", "posSide": "short"},
+            ],
+        })
+        assert order_executor.get_status()["position_status"] is POSITION_UNKNOWN
+
     def test_account_balance_empty_raises(self, order_executor, mock_okx_account_client):
         """get_account_balance raises when data is empty."""
         mock_okx_account_client.get_account_balance = MagicMock(return_value={

--- a/tests/envs/okx/test_futures_order_executor.py
+++ b/tests/envs/okx/test_futures_order_executor.py
@@ -2,6 +2,7 @@
 
 import pytest
 from unittest.mock import MagicMock
+from torchtrade.envs.core.state import POSITION_UNKNOWN
 
 
 class TestOKXFuturesOrderClass:
@@ -224,11 +225,15 @@ class TestOKXFuturesOrderClass:
         assert status["position_status"].liquidation_price == expected
 
     def test_get_status_validates_code(self, order_executor, mock_okx_account_client):
-        """get_status must return position_status=None on non-zero code."""
+        """A non-zero code is a failed call, not an empty account (#270).
+
+        Reporting None here would let the env trade as though it were flat while a
+        real position sits on the exchange.
+        """
         mock_okx_account_client.get_positions = MagicMock(return_value={
             "code": "51001", "msg": "Invalid parameter", "data": [],
         })
-        assert order_executor.get_status()["position_status"] is None
+        assert order_executor.get_status()["position_status"] is POSITION_UNKNOWN
 
     def test_account_balance_empty_raises(self, order_executor, mock_okx_account_client):
         """get_account_balance raises when data is empty."""

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -498,6 +498,18 @@ def _executor_with_failing_position_fetch(exchange):
             margin_mode=MarginMode.ISOLATED, position_mode=PositionMode.ONE_WAY,
             api_key="k", api_secret="s", client=client,
         )
+    if exchange == "okx":
+        from torchtrade.envs.live.okx.order_executor import (
+            OKXFuturesOrderClass, MarginMode, PositionMode,
+        )
+        return OKXFuturesOrderClass(
+            symbol="BTC-USDT-SWAP", trade_mode="quantity", demo=True, leverage=10,
+            margin_mode=MarginMode.ISOLATED, position_mode=PositionMode.NET,
+            api_key="k", api_secret="s", passphrase="p",
+            client=SimpleNamespace(),
+            account_client=SimpleNamespace(get_positions=boom, set_leverage=boom),
+            public_client=SimpleNamespace(get_instruments=boom),
+        )
     if exchange == "alpaca":
         from torchtrade.envs.live.alpaca.order_executor import AlpacaOrderClass
         client = SimpleNamespace(get_open_position=boom, get_account=boom, get_asset=boom)
@@ -505,7 +517,7 @@ def _executor_with_failing_position_fetch(exchange):
     raise AssertionError(f"unhandled exchange {exchange}")
 
 
-@pytest.mark.parametrize("exchange", ["binance", "bitget", "bybit", "alpaca"])
+@pytest.mark.parametrize("exchange", ["binance", "bitget", "bybit", "okx", "alpaca"])
 def test_a_failed_position_fetch_does_not_report_flat(exchange):
     """get_status must distinguish "the account is flat" from "the call failed".
 
@@ -552,3 +564,50 @@ def test_position_sizing_refuses_an_unknown_status(exchange):
     )
     with pytest.raises(PositionUnknownError):
         env_cls._get_current_position_quantity(env)
+
+
+@pytest.mark.parametrize("exchange", ["binance", "bitget"])
+def test_an_outage_does_not_re_enter_a_position_the_agent_already_holds(exchange):
+    """The traced failure from #270, end to end, not just its parts.
+
+    Holding a long, the exchange stops answering, and the agent asks for the level it is
+    already at. Previously: the sync read "flat", cleared current_action_level, the
+    duplicate-action guard no longer matched, the quantity re-query also read 0, and the
+    env bought the position a second time -- every bar of the outage.
+
+    The component assertions can all hold while this composite still trades, which is why
+    it is asserted here rather than inferred.
+    """
+    import importlib
+    env_mod = importlib.import_module(f"torchtrade.envs.live.{exchange}.env")
+    env_cls = next(
+        c for c in vars(env_mod).values()
+        if isinstance(c, type) and c.__module__ == env_mod.__name__
+        and "_execute_trade_if_needed" in vars(c)
+    )
+
+    orders = []
+    env = SimpleNamespace(
+        position=PositionState(),
+        trader=SimpleNamespace(
+            get_status=lambda: {"position_status": POSITION_UNKNOWN},
+            trade=lambda *a, **k: orders.append(("trade", a, k)),
+            close_position=lambda *a, **k: orders.append(("close", a, k)),
+        ),
+    )
+    env.position.current_position = 1
+    env.position.current_action_level = 1.0
+    env._create_trade_info = lambda **kw: {"executed": kw.get("executed", False)}
+    # Records rather than raises: without it a reverted guard fails this test with an
+    # AttributeError, which proves only that the guard stopped firing -- not that no
+    # order was placed, which is the claim.
+    def _sized(*a, **k):
+        orders.append(("sized", a, k))
+        return {"executed": True}
+    env._execute_fractional_action = _sized
+
+    env_cls._sync_position_from_exchange(env, env.trader.get_status()["position_status"])
+    trade_info = env_cls._execute_trade_if_needed(env, 1.0)
+
+    assert orders == [], f"an outage must not place an order, but {exchange} sent {orders}"
+    assert trade_info["executed"] is False

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -4,6 +4,10 @@ These replace the per-exchange copies of the same assertions. Testing a shared m
 once is only sound if every env actually inherits it -- so the unit test here is paired
 with a guard that asserts exactly that. If an exchange ever re-adds its own override, the
 guard fails and tells you to test that exchange separately.
+
+It also holds the tests for what an unreachable exchange must NOT look like (#270),
+which is the same invariant seen from the other side: a flat account must read flat, and
+an exchange that did not answer must not read as either.
 """
 
 import ast
@@ -526,20 +530,19 @@ def test_reading_a_field_off_an_unknown_status_says_why():
         POSITION_UNKNOWN.qty
 
 
-@pytest.mark.parametrize("exchange", ["binance", "bitget", "bybit"])
-def test_position_sizing_refuses_an_unknown_status(exchange):
+@pytest.mark.parametrize(
+    "env_cls",
+    [c for c in NON_SLTP_ENVS if "_get_current_position_quantity" in vars(c)],
+    ids=lambda c: c.__name__,
+)
+def test_position_sizing_refuses_an_unknown_status(env_cls):
     """_get_current_position_quantity must not size an order off a phantom flat account.
 
     Its `position.qty if position is not None else 0.0` reads an outage as 0 quantity,
-    which is the second half of the traced doubling: the delta is computed against a
-    position the exchange never said was gone.
+    so the delta is computed against a position the exchange never said was gone. _step
+    normally raises earlier, on its own status read -- this is the path when the outage
+    begins between the two get_status() calls inside a single step.
     """
-    import importlib
-    env_mod = importlib.import_module(f"torchtrade.envs.live.{exchange}.env")
-    env_cls = next(
-        c for c in vars(env_mod).values()
-        if isinstance(c, type) and hasattr(c, "_get_current_position_quantity")
-    )
     env = SimpleNamespace(
         trader=SimpleNamespace(get_status=lambda: {"position_status": POSITION_UNKNOWN})
     )

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -520,3 +520,35 @@ def test_a_failed_position_fetch_does_not_report_flat(exchange):
         f"{exchange} reported {status.get('position_status')!r} for a failed fetch; "
         "None here means flat and would be traded on"
     )
+
+
+def test_reading_a_field_off_an_unknown_status_says_why():
+    """The trade-sizing paths read .qty/.mark_price directly, not via the direction rule.
+
+    They are fail-closed either way -- the sentinel has no such fields -- but a bare
+    AttributeError from inside order sizing does not say that the exchange was unreachable.
+    """
+    for field in ("qty", "mark_price", "notional_value", "market_value"):
+        with pytest.raises(PositionUnknownError, match="did not report the position"):
+            getattr(POSITION_UNKNOWN, field)
+
+
+@pytest.mark.parametrize("exchange", ["binance", "bitget", "bybit"])
+def test_position_sizing_refuses_an_unknown_status(exchange):
+    """_get_current_position_quantity must not size an order off a phantom flat account.
+
+    Its `position.qty if position is not None else 0.0` reads an outage as 0 quantity,
+    which is the second half of the traced doubling: the delta is computed against a
+    position the exchange never said was gone.
+    """
+    import importlib
+    env_mod = importlib.import_module(f"torchtrade.envs.live.{exchange}.env")
+    env_cls = next(
+        c for c in vars(env_mod).values()
+        if isinstance(c, type) and hasattr(c, "_get_current_position_quantity")
+    )
+    env = SimpleNamespace(
+        trader=SimpleNamespace(get_status=lambda: {"position_status": POSITION_UNKNOWN})
+    )
+    with pytest.raises(PositionUnknownError):
+        env_cls._get_current_position_quantity(env)

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -419,16 +419,18 @@ def test_unknown_status_is_not_a_direction():
 def test_unknown_status_is_truthy():
     """`if position_status:` is a live-path idiom; falsy would take the flat branch."""
     assert bool(POSITION_UNKNOWN) is True
-    assert bool(None) is False
 
 
 
-@pytest.mark.parametrize("env_cls", FUTURES_ENVS, ids=lambda c: c.__name__)
-def test_unknown_status_refuses_to_build_account_state(env_cls):
+def test_unknown_status_refuses_to_build_account_state():
     """An outage must not produce an account_state at all, rather than a flat-looking one.
 
     account_state has no way to say "unknown", and the flat branch would report a held
     position as flat -- invariant #3. Fails closed like get_account_balance() beside it.
+
+    One case, not one per env: all 12 futures envs resolve _get_observation to this same
+    implementation, and test_no_futures_env_reforks_the_shared_observation is what proves
+    they still do. Parametrizing would run one function twelve times.
     """
     env = SimpleNamespace(
         observer=SimpleNamespace(
@@ -437,12 +439,17 @@ def test_unknown_status_refuses_to_build_account_state(env_cls):
         trader=SimpleNamespace(
             get_status=lambda: {"position_status": POSITION_UNKNOWN},
             get_account_balance=lambda: {"total_margin_balance": 1000.0},
+            # Present so a regression fails on "DID NOT RAISE" rather than on a gap in
+            # the fake, which would say nothing about what the env reported.
+            get_mark_price=lambda: 100.0,
         ),
         config=SimpleNamespace(include_base_features=False, leverage=10),
         position=PositionState(),
+        account_state_key="account_state",
+        market_data_keys=[],
     )
     with pytest.raises(PositionUnknownError):
-        env_cls._get_observation(env)
+        TorchTradeFuturesLiveEnv._get_observation(env)
 
 
 def _executor_with_failing_position_fetch(exchange):
@@ -514,9 +521,9 @@ def test_reading_a_field_off_an_unknown_status_says_why():
     They are fail-closed either way -- the sentinel has no such fields -- but a bare
     AttributeError from inside order sizing does not say that the exchange was unreachable.
     """
-    for field in ("qty", "mark_price", "notional_value", "market_value"):
-        with pytest.raises(PositionUnknownError, match="did not report the position"):
-            getattr(POSITION_UNKNOWN, field)
+    # One field is the whole contract: __getattr__ does not branch on the name.
+    with pytest.raises(PositionUnknownError, match="did not report the position"):
+        POSITION_UNKNOWN.qty
 
 
 @pytest.mark.parametrize("exchange", ["binance", "bitget", "bybit"])

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -540,8 +540,9 @@ def test_position_sizing_refuses_an_unknown_status(exchange):
         env_cls._get_current_position_quantity(env)
 
 
-@pytest.mark.parametrize("exchange", ["binance", "bitget", "bybit", "okx"])
-def test_an_outage_stops_the_step_before_it_can_trade(exchange):
+@pytest.mark.parametrize("module", ["env", "env_sltp"])
+@pytest.mark.parametrize("exchange", ["binance", "bitget", "bybit", "okx", "alpaca"])
+def test_an_outage_stops_the_step_before_it_can_trade(exchange, module):
     """The traced failure from #270, driven through _step rather than reassembled.
 
     Holding a long, the exchange stops answering. Previously _step read that as an empty
@@ -554,13 +555,15 @@ def test_an_outage_stops_the_step_before_it_can_trade(exchange):
     about production -- _step raises on the status read before it ever reaches the sync.
     """
     import importlib
-    env_mod = importlib.import_module(f"torchtrade.envs.live.{exchange}.env")
+    env_mod = importlib.import_module(f"torchtrade.envs.live.{exchange}.{module}")
     env_cls = next(
         c for c in vars(env_mod).values()
         if isinstance(c, type) and c.__module__ == env_mod.__name__ and "_step" in vars(c)
     )
 
     orders = []
+    unexpected = None
+
     def _sized(*a, **k):
         orders.append("sized")
         return {"executed": True}
@@ -574,6 +577,8 @@ def test_an_outage_stops_the_step_before_it_can_trade(exchange):
             close_position=lambda *a, **k: orders.append("close"),
         ),
         action_levels=[-1.0, 0.0, 1.0],
+        active_stop_loss=0.0,
+        active_take_profit=0.0,
         _create_trade_info=lambda **kw: {"executed": kw.get("executed", False)},
         _execute_fractional_action=_sized,
         _execute_trade_if_needed=_sized,
@@ -583,8 +588,12 @@ def test_an_outage_stops_the_step_before_it_can_trade(exchange):
     # The real shared sync, so that if the status ever stops raising the step proceeds the
     # way production would -- otherwise a regression surfaces as a missing-attribute error
     # on the fake instead of as the order it placed.
+    if hasattr(env_cls, "_get_current_price"):
+        env._get_current_price = lambda ps=None: env_cls._get_current_price(env, ps)
+        env.observer = SimpleNamespace(get_current_price=lambda: 100.0)
+    sync_owner = SLTPMixin if module == "env_sltp" else TorchTradeLiveEnv
     env._sync_position_from_exchange = (
-        lambda ps: TorchTradeLiveEnv._sync_position_from_exchange(env, ps)
+        lambda ps: sync_owner._sync_position_from_exchange(env, ps)
     )
 
     try:
@@ -592,16 +601,20 @@ def test_an_outage_stops_the_step_before_it_can_trade(exchange):
         failed_closed = False
     except PositionUnknownError:
         failed_closed = True
-    except Exception:
-        # The fake is deliberately too thin to finish a whole step. Getting far enough to
-        # fail on something else already means the status read did not stop it; whether
-        # that mattered is what `orders` below answers.
+    except Exception as exc:
+        # The fake is deliberately too thin to finish a whole step. Whether getting this
+        # far mattered is what `orders` below answers -- but name the exception, or a gap
+        # in the fake reads as "the env did not fail closed", which it is not.
         failed_closed = False
+        unexpected = exc
 
     # Order matters: the money claim is "no order", and asserting it first means a
     # regression reports that rather than "DID NOT RAISE".
     assert orders == [], f"an outage must not place an order, but {exchange} sent {orders}"
-    assert failed_closed, "an outage must fail closed rather than stepping on stale state"
+    assert failed_closed, (
+        "an outage must fail closed rather than stepping on stale state"
+        + (f"; stopped on {unexpected!r} instead" if unexpected else "")
+    )
 
 
 @pytest.mark.parametrize("body,expect_flat", [
@@ -635,3 +648,67 @@ def test_alpaca_only_treats_its_not_found_error_as_flat(body, expect_flat):
         assert position_status is POSITION_UNKNOWN, (
             f"{body[:40]!r} is an answer we cannot read as an empty account"
         )
+
+
+def test_alpaca_refuses_to_build_account_state_on_an_unknown_status():
+    """Alpaca has its own _get_observation, so the futures test above does not reach it.
+
+    Its flat branch would report a held position as flat -- invariant #3 for the spot env.
+    """
+    from torchtrade.envs.live.alpaca.base import AlpacaBaseTorchTradingEnv
+
+    env = SimpleNamespace(
+        observer=SimpleNamespace(get_observations=lambda **k: {}, get_keys=lambda: []),
+        trader=SimpleNamespace(
+            get_status=lambda: {"position_status": POSITION_UNKNOWN},
+            client=SimpleNamespace(get_account=lambda: SimpleNamespace(cash="1000")),
+        ),
+        config=SimpleNamespace(include_base_features=False),
+        position=PositionState(),
+        # Present so a regression fails on the assertion below rather than on a gap in
+        # the fake, which would say nothing about what the env reported.
+        account_state_key="account_state",
+        market_data_keys=[],
+    )
+    with pytest.raises(PositionUnknownError):
+        AlpacaBaseTorchTradingEnv._get_observation(env)
+
+
+def test_alpaca_refuses_to_value_the_portfolio_on_an_unknown_status():
+    """Cash alone feeds _check_termination, so an outage would read as a near-total loss.
+
+    The flat branch returns the balance without the position's market value, which for a
+    held position is most of the portfolio -- enough to terminate the episode as bankrupt.
+    """
+    from torchtrade.envs.live.alpaca.base import AlpacaBaseTorchTradingEnv
+
+    env = SimpleNamespace(
+        trader=SimpleNamespace(
+            get_status=lambda: {"position_status": POSITION_UNKNOWN},
+            client=SimpleNamespace(get_account=lambda: SimpleNamespace(cash="1000")),
+        ),
+        balance=0.0,
+    )
+    with pytest.raises(PositionUnknownError):
+        AlpacaBaseTorchTradingEnv._get_portfolio_value(env)
+
+
+def test_alpaca_outer_failure_does_not_report_flat():
+    """get_status wraps everything in a second try, and it used to return {}.
+
+    An absent key reads as flat downstream exactly like an explicit None does, so the
+    outer handler needs the sentinel too. Reached by failing the order lookup, which runs
+    before the position fetch.
+    """
+    from torchtrade.envs.live.alpaca.order_executor import AlpacaOrderClass
+
+    def boom(*a, **k):
+        raise ConnectionError("simulated outage")
+
+    executor = AlpacaOrderClass(
+        symbol="BTCUSD", trade_mode="quantity",
+        client=SimpleNamespace(get_order_by_id=boom, get_open_position=boom),
+    )
+    executor.last_order_id = "some-order-id"   # forces the outer try to run and fail
+
+    assert executor.get_status().get("position_status") is POSITION_UNKNOWN

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -563,7 +563,7 @@ def test_position_sizing_refuses_an_unknown_status(env_cls):
 
 
 @pytest.mark.parametrize("module", ["env", "env_sltp"])
-@pytest.mark.parametrize("exchange", ["binance", "bitget", "bybit", "okx", "alpaca"])
+@pytest.mark.parametrize("exchange", _FAILING_FETCH_EXCHANGES)
 def test_an_outage_stops_the_step_before_it_can_trade(exchange, module):
     """The traced failure from #270, driven through _step rather than reassembled.
 
@@ -757,11 +757,11 @@ def test_neither_sync_fork_treats_an_outage_as_flat(sync):
 
 
 def test_the_hand_listed_exchanges_match_the_discovered_ones():
-    """Two parametrize lists in this file are hand-written, against its own rule.
+    """The hand-written exchange list, against this file's "discovered, not hand-listed".
 
-    They cannot be derived -- each exchange's executor takes different constructor kwargs
-    -- so this asserts the lists instead, and names exchange #6 rather than letting it
-    quietly skip two of the three #270 parametrizations.
+    It cannot be derived -- each exchange's executor takes different constructor kwargs --
+    so the list is asserted instead. Both #270 parametrizations that cannot be derived now
+    read from it, so exchange #6 fails here rather than quietly skipping them.
     """
     # NON_SLTP_ENVS is one concrete env per exchange; LIVE_ENVS also carries the
     # intermediate futures base, whose module is "shared" rather than an exchange.

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -427,7 +427,6 @@ def test_unknown_status_is_truthy():
     assert bool(POSITION_UNKNOWN) is True
 
 
-
 def test_unknown_status_refuses_to_build_account_state():
     """An outage must not produce an account_state at all, rather than a flat-looking one.
 
@@ -535,7 +534,7 @@ def test_reading_a_field_off_an_unknown_status_says_why():
     They are fail-closed either way -- the sentinel has no such fields -- but a bare
     AttributeError from inside order sizing does not say that the exchange was unreachable.
     """
-    # One field is the whole contract: __getattr__ does not branch on the name.
+    # __getattr__ branches only on dunders, so one real field is the whole contract.
     with pytest.raises(PositionUnknownError, match="did not report the position"):
         POSITION_UNKNOWN.qty
 
@@ -552,6 +551,9 @@ def test_position_sizing_refuses_an_unknown_status(env_cls):
     so the delta is computed against a position the exchange never said was gone. _step
     normally raises earlier, on its own status read -- this is the path when the outage
     begins between the two get_status() calls inside a single step.
+
+    3 of 5: okx takes current_qty from _step, and alpaca spells the same second query
+    inline, so both are covered through _step by the composite test instead.
     """
     env = SimpleNamespace(
         trader=SimpleNamespace(get_status=lambda: {"position_status": POSITION_UNKNOWN})
@@ -779,3 +781,7 @@ def test_position_unknown_identity_survives_a_round_trip():
 
     assert pickle.loads(pickle.dumps(POSITION_UNKNOWN)) is POSITION_UNKNOWN
     assert copy.copy(POSITION_UNKNOWN) is POSITION_UNKNOWN
+    # deepcopy probes the instance for __deepcopy__; without the dunder escape hatch in
+    # __getattr__ that probe raises a trading error from inside a copy.
+    assert copy.deepcopy(POSITION_UNKNOWN) is POSITION_UNKNOWN
+    assert copy.deepcopy({"position_status": POSITION_UNKNOWN})["position_status"] is POSITION_UNKNOWN

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -416,7 +416,9 @@ def test_unknown_status_is_not_a_direction():
     and 0 means "flat" -- which is how a held position gets re-bought every bar.
     """
     assert position_direction_from_status(None) == 0            # confirmed flat
-    with pytest.raises(PositionUnknownError):
+    # match=: without it the explicit branch is dead weight, since reading .qty off the
+    # sentinel raises anyway. The message is the branch's only observable effect.
+    with pytest.raises(PositionUnknownError, match="must handle this"):
         position_direction_from_status(POSITION_UNKNOWN)
 
 
@@ -454,6 +456,14 @@ def test_unknown_status_refuses_to_build_account_state():
     )
     with pytest.raises(PositionUnknownError):
         TorchTradeFuturesLiveEnv._get_observation(env)
+
+
+# A rename would empty this and pytest would SKIP rather than fail -- the hazard this
+# file guards against elsewhere with its own len() assertions.
+_SIZING_ENVS = [c for c in NON_SLTP_ENVS if "_get_current_position_quantity" in vars(c)]
+assert len(_SIZING_ENVS) == 3, f"expected 3 envs that size from a live query, got {_SIZING_ENVS}"
+
+_FAILING_FETCH_EXCHANGES = ["binance", "bitget", "bybit", "okx", "alpaca"]
 
 
 def _executor_with_failing_position_fetch(exchange):
@@ -502,7 +512,7 @@ def _executor_with_failing_position_fetch(exchange):
     raise AssertionError(f"unhandled exchange {exchange}")
 
 
-@pytest.mark.parametrize("exchange", ["binance", "bitget", "bybit", "okx", "alpaca"])
+@pytest.mark.parametrize("exchange", _FAILING_FETCH_EXCHANGES)
 def test_a_failed_position_fetch_does_not_report_flat(exchange):
     """get_status must distinguish "the account is flat" from "the call failed".
 
@@ -532,7 +542,7 @@ def test_reading_a_field_off_an_unknown_status_says_why():
 
 @pytest.mark.parametrize(
     "env_cls",
-    [c for c in NON_SLTP_ENVS if "_get_current_position_quantity" in vars(c)],
+    _SIZING_ENVS,
     ids=lambda c: c.__name__,
 )
 def test_position_sizing_refuses_an_unknown_status(env_cls):
@@ -722,3 +732,50 @@ def test_alpaca_outer_failure_does_not_report_flat():
     executor.last_order_id = "some-order-id"   # forces the outer try to run and fail
 
     assert executor.get_status().get("position_status") is POSITION_UNKNOWN
+
+
+@pytest.mark.parametrize("sync", [
+    TorchTradeLiveEnv._sync_position_from_exchange,
+    SLTPMixin._sync_position_from_exchange,
+], ids=["base", "sltp"])
+def test_neither_sync_fork_treats_an_outage_as_flat(sync):
+    """Pins the contract #295 will edit.
+
+    Today _step raises on its own status read before either fork is reached, so making
+    these sync an outage to 0 changes nothing observable -- which is exactly why it needs
+    saying. #295 sets out to make an outage survivable, and will start here; without this
+    it could reintroduce the flat reading with the whole suite still green.
+    """
+    env = SimpleNamespace(position=PositionState(), active_stop_loss=0.0, active_take_profit=0.0)
+    env.position.current_position = 1
+    env.position.current_action_level = 1.0
+
+    with pytest.raises(PositionUnknownError):
+        sync(env, POSITION_UNKNOWN)
+
+
+def test_the_hand_listed_exchanges_match_the_discovered_ones():
+    """Two parametrize lists in this file are hand-written, against its own rule.
+
+    They cannot be derived -- each exchange's executor takes different constructor kwargs
+    -- so this asserts the lists instead, and names exchange #6 rather than letting it
+    quietly skip two of the three #270 parametrizations.
+    """
+    # NON_SLTP_ENVS is one concrete env per exchange; LIVE_ENVS also carries the
+    # intermediate futures base, whose module is "shared" rather than an exchange.
+    discovered = {c.__module__.split(".")[-2] for c in NON_SLTP_ENVS}
+    assert discovered == set(_FAILING_FETCH_EXCHANGES), (
+        f"hand-listed {sorted(_FAILING_FETCH_EXCHANGES)} but discovered {sorted(discovered)}"
+    )
+
+
+def test_position_unknown_identity_survives_a_round_trip():
+    """`is POSITION_UNKNOWN` is the check at every call site, so identity has to hold.
+
+    __new__ exists for this; without pinning it the docstring is an unverified claim.
+    """
+    import copy
+    import pickle
+
+    assert pickle.loads(pickle.dumps(POSITION_UNKNOWN)) is POSITION_UNKNOWN
+    assert copy.copy(POSITION_UNKNOWN) is POSITION_UNKNOWN

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -422,32 +422,6 @@ def test_unknown_status_is_truthy():
     assert bool(None) is False
 
 
-@pytest.mark.parametrize("sync", [
-    TorchTradeLiveEnv._sync_position_from_exchange,
-    SLTPMixin._sync_position_from_exchange,
-], ids=["base", "sltp"])
-def test_unknown_status_leaves_the_cached_position_alone(sync):
-    """Both sync forks must keep the last confirmed position on an outage.
-
-    Preserving current_action_level is what lets the duplicate-action guard suppress the
-    agent's repeat; syncing to flat resets it and the repeat becomes a second entry.
-    """
-    env = SimpleNamespace(position=PositionState(), active_stop_loss=97.5, active_take_profit=110.0)
-    env.position.current_position = 1
-    env.position.current_action_level = 1.0
-    env.position.hold_counter = 7
-
-    result = sync(env, POSITION_UNKNOWN)
-
-    assert env.position.current_position == 1
-    assert env.position.current_action_level == 1.0
-    assert env.position.hold_counter == 7
-    # The SLTP fork returns "was the position closed?" -- an outage is not a close, and
-    # reporting one would clear brackets the exchange still holds.
-    assert result in (None, False)
-    assert env.active_stop_loss == 97.5
-    assert env.active_take_profit == 110.0
-
 
 @pytest.mark.parametrize("env_cls", FUTURES_ENVS, ids=lambda c: c.__name__)
 def test_unknown_status_refuses_to_build_account_state(env_cls):
@@ -566,48 +540,98 @@ def test_position_sizing_refuses_an_unknown_status(exchange):
         env_cls._get_current_position_quantity(env)
 
 
-@pytest.mark.parametrize("exchange", ["binance", "bitget"])
-def test_an_outage_does_not_re_enter_a_position_the_agent_already_holds(exchange):
-    """The traced failure from #270, end to end, not just its parts.
+@pytest.mark.parametrize("exchange", ["binance", "bitget", "bybit", "okx"])
+def test_an_outage_stops_the_step_before_it_can_trade(exchange):
+    """The traced failure from #270, driven through _step rather than reassembled.
 
-    Holding a long, the exchange stops answering, and the agent asks for the level it is
-    already at. Previously: the sync read "flat", cleared current_action_level, the
-    duplicate-action guard no longer matched, the quantity re-query also read 0, and the
-    env bought the position a second time -- every bar of the outage.
+    Holding a long, the exchange stops answering. Previously _step read that as an empty
+    account, the duplicate-action guard no longer matched, and the env bought the position
+    a second time -- every bar of the outage. _step must now fail closed, and above all
+    must place no order.
 
-    The component assertions can all hold while this composite still trades, which is why
-    it is asserted here rather than inferred.
+    Asserting through _step is the point. An earlier version of this test called the sync
+    and the trade path by hand, in an order _step cannot produce, and so proved nothing
+    about production -- _step raises on the status read before it ever reaches the sync.
     """
     import importlib
     env_mod = importlib.import_module(f"torchtrade.envs.live.{exchange}.env")
     env_cls = next(
         c for c in vars(env_mod).values()
-        if isinstance(c, type) and c.__module__ == env_mod.__name__
-        and "_execute_trade_if_needed" in vars(c)
+        if isinstance(c, type) and c.__module__ == env_mod.__name__ and "_step" in vars(c)
     )
 
     orders = []
+    def _sized(*a, **k):
+        orders.append("sized")
+        return {"executed": True}
+
     env = SimpleNamespace(
         position=PositionState(),
         trader=SimpleNamespace(
             get_status=lambda: {"position_status": POSITION_UNKNOWN},
-            trade=lambda *a, **k: orders.append(("trade", a, k)),
-            close_position=lambda *a, **k: orders.append(("close", a, k)),
+            get_mark_price=lambda: 100.0,
+            trade=lambda *a, **k: orders.append("trade"),
+            close_position=lambda *a, **k: orders.append("close"),
         ),
+        action_levels=[-1.0, 0.0, 1.0],
+        _create_trade_info=lambda **kw: {"executed": kw.get("executed", False)},
+        _execute_fractional_action=_sized,
+        _execute_trade_if_needed=_sized,
     )
     env.position.current_position = 1
     env.position.current_action_level = 1.0
-    env._create_trade_info = lambda **kw: {"executed": kw.get("executed", False)}
-    # Records rather than raises: without it a reverted guard fails this test with an
-    # AttributeError, which proves only that the guard stopped firing -- not that no
-    # order was placed, which is the claim.
-    def _sized(*a, **k):
-        orders.append(("sized", a, k))
-        return {"executed": True}
-    env._execute_fractional_action = _sized
+    # The real shared sync, so that if the status ever stops raising the step proceeds the
+    # way production would -- otherwise a regression surfaces as a missing-attribute error
+    # on the fake instead of as the order it placed.
+    env._sync_position_from_exchange = (
+        lambda ps: TorchTradeLiveEnv._sync_position_from_exchange(env, ps)
+    )
 
-    env_cls._sync_position_from_exchange(env, env.trader.get_status()["position_status"])
-    trade_info = env_cls._execute_trade_if_needed(env, 1.0)
+    try:
+        env_cls._step(env, {"action": 2})
+        failed_closed = False
+    except PositionUnknownError:
+        failed_closed = True
+    except Exception:
+        # The fake is deliberately too thin to finish a whole step. Getting far enough to
+        # fail on something else already means the status read did not stop it; whether
+        # that mattered is what `orders` below answers.
+        failed_closed = False
 
+    # Order matters: the money claim is "no order", and asserting it first means a
+    # regression reports that rather than "DID NOT RAISE".
     assert orders == [], f"an outage must not place an order, but {exchange} sent {orders}"
-    assert trade_info["executed"] is False
+    assert failed_closed, "an outage must fail closed rather than stepping on stale state"
+
+
+@pytest.mark.parametrize("body,expect_flat", [
+    ('{"code":40410000,"message":"position does not exist"}', True),
+    ('{"code":42910000,"message":"rate limit exceeded"}', False),
+    ('{"code":50010000,"message":"internal server error"}', False),
+    ("not the documented json", False),
+], ids=["no-position", "rate-limited", "server-error", "unparseable-body"])
+def test_alpaca_only_treats_its_not_found_error_as_flat(body, expect_flat):
+    """Alpaca raises for a flat account, so the error itself has to be read.
+
+    Every APIError meaning flat would put #270 back inside its own fix: a 429 during a
+    volatile minute, or a 5xx, would report a held position as gone.
+    """
+    from alpaca.common.exceptions import APIError
+    from torchtrade.envs.live.alpaca.order_executor import AlpacaOrderClass
+
+    def raise_api_error(*a, **k):
+        raise APIError(body)
+
+    executor = AlpacaOrderClass(
+        symbol="BTCUSD", trade_mode="quantity",
+        client=SimpleNamespace(get_open_position=raise_api_error),
+    )
+
+    position_status = executor.get_status()["position_status"]
+
+    if expect_flat:
+        assert position_status is None
+    else:
+        assert position_status is POSITION_UNKNOWN, (
+            f"{body[:40]!r} is an answer we cannot read as an empty account"
+        )

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -18,7 +18,13 @@ import torchtrade.envs  # noqa: F401  -- registers every live env as a subclass
 from torchtrade.envs.core.live import TorchTradeLiveEnv
 from torchtrade.envs.live.shared.futures_live_base import TorchTradeFuturesLiveEnv
 from torchtrade.envs.utils.sltp_mixin import SLTPMixin
-from torchtrade.envs.core.state import PositionState, advance_hold_counter
+from torchtrade.envs.core.state import (
+    POSITION_UNKNOWN,
+    PositionState,
+    PositionUnknownError,
+    advance_hold_counter,
+    position_direction_from_status,
+)
 
 
 def _subclasses(cls):
@@ -391,4 +397,126 @@ def test_hold_counter_is_only_advanced_inside_get_observation(path):
     assert not offenders, (
         f"{path} calls advance_hold_counter() outside _get_observation():\n  "
         + "\n  ".join(offenders)
+    )
+
+
+# ============================================================================
+# UNKNOWN EXCHANGE STATUS (#270)
+# ============================================================================
+
+
+def test_unknown_status_is_not_a_direction():
+    """The whole bug in one assertion: an unreachable exchange must not read as flat.
+
+    Every caller that has not been taught about an outage falls through to 0 otherwise,
+    and 0 means "flat" -- which is how a held position gets re-bought every bar.
+    """
+    assert position_direction_from_status(None) == 0            # confirmed flat
+    with pytest.raises(PositionUnknownError):
+        position_direction_from_status(POSITION_UNKNOWN)
+
+
+def test_unknown_status_is_truthy():
+    """`if position_status:` is a live-path idiom; falsy would take the flat branch."""
+    assert bool(POSITION_UNKNOWN) is True
+    assert bool(None) is False
+
+
+@pytest.mark.parametrize("sync", [
+    TorchTradeLiveEnv._sync_position_from_exchange,
+    SLTPMixin._sync_position_from_exchange,
+], ids=["base", "sltp"])
+def test_unknown_status_leaves_the_cached_position_alone(sync):
+    """Both sync forks must keep the last confirmed position on an outage.
+
+    Preserving current_action_level is what lets the duplicate-action guard suppress the
+    agent's repeat; syncing to flat resets it and the repeat becomes a second entry.
+    """
+    env = SimpleNamespace(position=PositionState(), active_stop_loss=97.5, active_take_profit=110.0)
+    env.position.current_position = 1
+    env.position.current_action_level = 1.0
+    env.position.hold_counter = 7
+
+    result = sync(env, POSITION_UNKNOWN)
+
+    assert env.position.current_position == 1
+    assert env.position.current_action_level == 1.0
+    assert env.position.hold_counter == 7
+    # The SLTP fork returns "was the position closed?" -- an outage is not a close, and
+    # reporting one would clear brackets the exchange still holds.
+    assert result in (None, False)
+    assert env.active_stop_loss == 97.5
+    assert env.active_take_profit == 110.0
+
+
+@pytest.mark.parametrize("env_cls", FUTURES_ENVS, ids=lambda c: c.__name__)
+def test_unknown_status_refuses_to_build_account_state(env_cls):
+    """An outage must not produce an account_state at all, rather than a flat-looking one.
+
+    account_state has no way to say "unknown", and the flat branch would report a held
+    position as flat -- invariant #3. Fails closed like get_account_balance() beside it.
+    """
+    env = SimpleNamespace(
+        observer=SimpleNamespace(
+            get_observations=lambda **k: {}, get_keys=lambda: []
+        ),
+        trader=SimpleNamespace(
+            get_status=lambda: {"position_status": POSITION_UNKNOWN},
+            get_account_balance=lambda: {"total_margin_balance": 1000.0},
+        ),
+        config=SimpleNamespace(include_base_features=False, leverage=10),
+        position=PositionState(),
+    )
+    with pytest.raises(PositionUnknownError):
+        env_cls._get_observation(env)
+
+
+def _executor_with_failing_position_fetch(exchange):
+    """Build a real order executor whose position fetch raises, as in an outage."""
+    def boom(*a, **k):
+        raise ConnectionError("simulated outage")
+
+    if exchange == "binance":
+        from torchtrade.envs.live.binance.order_executor import BinanceFuturesOrderClass
+        client = SimpleNamespace(futures_position_information=boom, futures_exchange_info=boom)
+        return BinanceFuturesOrderClass(
+            symbol="BTCUSDT", trade_mode="quantity", demo=True, leverage=10, client=client
+        )
+    if exchange == "bitget":
+        from torchtrade.envs.live.bitget.order_executor import BitgetFuturesOrderClass
+        client = SimpleNamespace(fetch_positions=boom, load_markets=boom, markets={})
+        return BitgetFuturesOrderClass(
+            symbol="BTCUSDT", trade_mode="quantity", demo=True, leverage=10, client=client
+        )
+    if exchange == "bybit":
+        from torchtrade.envs.live.bybit.order_executor import (
+            BybitFuturesOrderClass, MarginMode, PositionMode,
+        )
+        client = SimpleNamespace(get_positions=boom, get_instruments_info=boom)
+        return BybitFuturesOrderClass(
+            symbol="BTCUSDT", trade_mode="quantity", demo=True, leverage=10,
+            margin_mode=MarginMode.ISOLATED, position_mode=PositionMode.ONE_WAY,
+            api_key="k", api_secret="s", client=client,
+        )
+    if exchange == "alpaca":
+        from torchtrade.envs.live.alpaca.order_executor import AlpacaOrderClass
+        client = SimpleNamespace(get_open_position=boom, get_account=boom, get_asset=boom)
+        return AlpacaOrderClass(symbol="BTCUSD", trade_mode="quantity", client=client)
+    raise AssertionError(f"unhandled exchange {exchange}")
+
+
+@pytest.mark.parametrize("exchange", ["binance", "bitget", "bybit", "alpaca"])
+def test_a_failed_position_fetch_does_not_report_flat(exchange):
+    """get_status must distinguish "the account is flat" from "the call failed".
+
+    Collapsing both to None is the root cause of #270: every consumer downstream then
+    reads an outage as an empty account, and a held position gets re-bought.
+    """
+    executor = _executor_with_failing_position_fetch(exchange)
+
+    status = executor.get_status()
+
+    assert status.get("position_status") is POSITION_UNKNOWN, (
+        f"{exchange} reported {status.get('position_status')!r} for a failed fetch; "
+        "None here means flat and would be traded on"
     )

--- a/tests/mocks/alpaca.py
+++ b/tests/mocks/alpaca.py
@@ -9,6 +9,7 @@ from datetime import datetime, timedelta
 from enum import Enum
 from typing import Any, Dict, List, Optional
 from zoneinfo import ZoneInfo
+from alpaca.common.exceptions import APIError
 import uuid
 
 import numpy as np
@@ -207,10 +208,16 @@ class MockTradingClient:
         raise Exception(f"Order not found: {order_id}")
 
     def get_open_position(self, symbol_or_asset_id: str) -> MockPosition:
-        """Get open position for symbol."""
+        """Get open position for symbol.
+
+        Raises APIError, not a bare Exception: Alpaca signals a flat account by returning
+        an error, so the exception TYPE is the only thing separating "flat" from "the
+        request never reached Alpaca". A bare Exception here made the mock unable to
+        express that difference.
+        """
         if symbol_or_asset_id in self.positions:
             return self.positions[symbol_or_asset_id]
-        raise Exception(f"No position found for {symbol_or_asset_id}")
+        raise APIError('{"code":40410000,"message":"position does not exist"}')
 
     def get_all_positions(self) -> List[MockPosition]:
         """Get all open positions."""

--- a/torchtrade/envs/core/live.py
+++ b/torchtrade/envs/core/live.py
@@ -1,6 +1,5 @@
 """Base class for live trading environments."""
 
-import logging
 import time
 from abc import abstractmethod
 from datetime import datetime, timedelta
@@ -12,13 +11,10 @@ from torchrl.data import Unbounded
 
 from torchtrade.envs.core.base import TorchTradeBaseEnv
 from torchtrade.envs.core.state import (
-    POSITION_UNKNOWN,
     PositionState,
     position_direction_from_status,
 )
 from torchtrade.envs.utils.termination import is_bankrupt
-
-logger = logging.getLogger(__name__)
 
 
 class TorchTradeLiveEnv(TorchTradeBaseEnv):
@@ -218,19 +214,12 @@ class TorchTradeLiveEnv(TorchTradeBaseEnv):
         Only the direction is reconciled, not the size: a PARTIAL external close leaves the
         direction intact and is still invisible to the guard. Pre-existing, not fixed here.
 
-        An unknown status leaves the cache ALONE rather than syncing. The cache is the last
-        thing the exchange actually confirmed; overwriting it with the 0 that an unreachable
-        exchange would otherwise produce is what let a held position read as flat and get
-        re-bought every bar of an outage. Keeping it also leaves current_action_level intact,
-        so the duplicate-action guard still suppresses the agent's repeat.
+        An unknown status raises via position_direction_from_status rather than syncing to
+        the 0 an unreachable exchange would otherwise produce -- which is what let a held
+        position read as flat and get re-bought every bar of an outage. Riding an outage out
+        on the cached position instead is #295; it needs every _step and _get_observation to
+        stop raising first, so half of it here would be a tolerance the env does not have.
         """
-        if position_status is POSITION_UNKNOWN:
-            logger.warning(
-                "Exchange status unavailable; keeping the last confirmed position "
-                "(%s) rather than syncing to flat.", self.position.current_position
-            )
-            return
-
         observed = position_direction_from_status(position_status)
 
         if observed != self.position.current_position:

--- a/torchtrade/envs/core/live.py
+++ b/torchtrade/envs/core/live.py
@@ -10,10 +10,7 @@ from tensordict import TensorDictBase
 from torchrl.data import Unbounded
 
 from torchtrade.envs.core.base import TorchTradeBaseEnv
-from torchtrade.envs.core.state import (
-    PositionState,
-    position_direction_from_status,
-)
+from torchtrade.envs.core.state import PositionState, position_direction_from_status
 from torchtrade.envs.utils.termination import is_bankrupt
 
 
@@ -214,11 +211,8 @@ class TorchTradeLiveEnv(TorchTradeBaseEnv):
         Only the direction is reconciled, not the size: a PARTIAL external close leaves the
         direction intact and is still invisible to the guard. Pre-existing, not fixed here.
 
-        An unknown status raises via position_direction_from_status rather than syncing to
-        the 0 an unreachable exchange would otherwise produce -- which is what let a held
-        position read as flat and get re-bought every bar of an outage. Riding an outage out
-        on the cached position instead is #295; it needs every _step and _get_observation to
-        stop raising first, so half of it here would be a tolerance the env does not have.
+        An unknown status raises rather than syncing to the 0 an unreachable exchange
+        would produce. In practice _step raises earlier, on its own status read.
         """
         observed = position_direction_from_status(position_status)
 

--- a/torchtrade/envs/core/live.py
+++ b/torchtrade/envs/core/live.py
@@ -1,5 +1,6 @@
 """Base class for live trading environments."""
 
+import logging
 import time
 from abc import abstractmethod
 from datetime import datetime, timedelta
@@ -10,8 +11,14 @@ from tensordict import TensorDictBase
 from torchrl.data import Unbounded
 
 from torchtrade.envs.core.base import TorchTradeBaseEnv
-from torchtrade.envs.core.state import PositionState, position_direction_from_status
+from torchtrade.envs.core.state import (
+    POSITION_UNKNOWN,
+    PositionState,
+    position_direction_from_status,
+)
 from torchtrade.envs.utils.termination import is_bankrupt
+
+logger = logging.getLogger(__name__)
 
 
 class TorchTradeLiveEnv(TorchTradeBaseEnv):
@@ -210,7 +217,20 @@ class TorchTradeLiveEnv(TorchTradeBaseEnv):
 
         Only the direction is reconciled, not the size: a PARTIAL external close leaves the
         direction intact and is still invisible to the guard. Pre-existing, not fixed here.
+
+        An unknown status leaves the cache ALONE rather than syncing. The cache is the last
+        thing the exchange actually confirmed; overwriting it with the 0 that an unreachable
+        exchange would otherwise produce is what let a held position read as flat and get
+        re-bought every bar of an outage. Keeping it also leaves current_action_level intact,
+        so the duplicate-action guard still suppresses the agent's repeat.
         """
+        if position_status is POSITION_UNKNOWN:
+            logger.warning(
+                "Exchange status unavailable; keeping the last confirmed position "
+                "(%s) rather than syncing to flat.", self.position.current_position
+            )
+            return
+
         observed = position_direction_from_status(position_status)
 
         if observed != self.position.current_position:

--- a/torchtrade/envs/core/state.py
+++ b/torchtrade/envs/core/state.py
@@ -10,13 +10,51 @@ from typing import Dict, List, Union
 POSITION_DUST_EPS = 1e-9
 
 
+class _PositionUnknown:
+    """The exchange did not answer, which is not the same as answering "flat"."""
+
+    _instance = None
+
+    def __new__(cls):
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+        return cls._instance
+
+    def __bool__(self):
+        # `if position_status:` is a live-path idiom, and returning True there stops an
+        # outage from silently taking the flat branch.
+        return True
+
+    def __repr__(self):
+        return "POSITION_UNKNOWN"
+
+
+# Returned by get_status() when the exchange call failed or reported an error. Distinct
+# from None, which is a confirmed-flat account: reading a failed call as flat is how a
+# held position gets re-bought every bar of an outage.
+POSITION_UNKNOWN = _PositionUnknown()
+
+
+class PositionUnknownError(RuntimeError):
+    """Raised when an unknown exchange status reaches code that needs a real direction."""
+
+
 def position_direction_from_status(position_status) -> int:
     """The direction the exchange holds: -1 short, 0 flat, +1 long. None means flat.
 
     The single rule for the LIVE envs: their position syncs, their resets, and the
     account_state they show the agent all go through here. The offline envs still derive
     direction their own way -- out of scope here, and not covered by this.
+
+    POSITION_UNKNOWN raises rather than returning a direction. A caller that has not been
+    taught to handle an unreachable exchange must fail loudly, because the alternative it
+    would otherwise fall into is 0, and reading an outage as flat is the whole bug.
     """
+    if position_status is POSITION_UNKNOWN:
+        raise PositionUnknownError(
+            "exchange status is unknown; the caller must handle this rather than "
+            "treating it as a direction"
+        )
     qty = 0.0 if position_status is None else float(position_status.qty)
     if abs(qty) <= POSITION_DUST_EPS:
         return 0

--- a/torchtrade/envs/core/state.py
+++ b/torchtrade/envs/core/state.py
@@ -36,10 +36,14 @@ class _PositionUnknown:
         return cls._instance
 
     def __getattr__(self, name):
+        if name.startswith("__") and name.endswith("__"):
+            # copy/pickle probe the instance for __deepcopy__ and friends. Answering
+            # those with a trading error breaks copying for a question that was never
+            # about the position.
+            raise AttributeError(name)
         # This is the guard every live _step actually hits: all ten read a field off the
-        # status before anything else looks at it -- directly in the futures envs, via a
-        # price helper in alpaca. A bare AttributeError would also fail closed; raising
-        # here says why.
+        # status (mark_price/current_price) before anything else looks at it. A bare
+        # AttributeError would also fail closed; raising here says why.
         raise PositionUnknownError(
             f"cannot read {name!r}: the exchange did not report the position"
         )

--- a/torchtrade/envs/core/state.py
+++ b/torchtrade/envs/core/state.py
@@ -15,24 +15,29 @@ class PositionUnknownError(RuntimeError):
 
 
 class _PositionUnknown:
-    """The exchange did not answer, which is not the same as answering "flat"."""
+    """The exchange did not report a position we can trust, which is not "flat".
+
+    Covers both a call that failed and one the exchange answered with an error code.
+
+    Truthy, by leaving __bool__ alone: alpaca reads the status as
+    ``position_status.current_price if position_status else 0.0``
+    (env.py:195,239,270,345 and env_sltp.py:140), so a falsy sentinel would quietly
+    substitute a fallback price instead of stopping.
+    """
 
     _instance = None
 
     def __new__(cls):
+        # Identity survives pickling and copying, which is what makes `is
+        # POSITION_UNKNOWN` safe as the check at every call site.
         if cls._instance is None:
             cls._instance = super().__new__(cls)
         return cls._instance
 
-    def __bool__(self):
-        # `if position_status:` is a live-path idiom, and returning True there stops an
-        # outage from silently taking the flat branch.
-        return True
-
     def __getattr__(self, name):
-        # Reading qty/mark_price/notional_value off this would otherwise be a bare
-        # AttributeError from deep inside a sizing path. Every reader is fail-closed
-        # either way; this only makes the reason legible.
+        # This is the guard every live _step actually hits: all ten read a field off the
+        # status (mark_price/current_price) before anything else looks at it. A bare
+        # AttributeError would also fail closed; raising here says why.
         raise PositionUnknownError(
             f"cannot read {name!r}: the exchange did not report the position"
         )

--- a/torchtrade/envs/core/state.py
+++ b/torchtrade/envs/core/state.py
@@ -19,10 +19,11 @@ class _PositionUnknown:
 
     Covers both a call that failed and one the exchange answered with an error code.
 
-    Truthy, by leaving __bool__ alone: alpaca reads the status as
-    ``position_status.current_price if position_status else 0.0``
-    (env.py:195,239,270,345 and env_sltp.py:140), so a falsy sentinel would quietly
-    substitute a fallback price instead of stopping.
+    Truthy, by leaving __bool__ alone. Every live env reads the status behind a
+    truthiness check -- ``if position_status:`` in the futures envs, and
+    ``position_status.<field> if position_status else <fallback>`` throughout alpaca --
+    so a falsy sentinel would quietly take the flat branch and substitute a fallback
+    price instead of stopping.
     """
 
     _instance = None
@@ -36,8 +37,9 @@ class _PositionUnknown:
 
     def __getattr__(self, name):
         # This is the guard every live _step actually hits: all ten read a field off the
-        # status (mark_price/current_price) before anything else looks at it. A bare
-        # AttributeError would also fail closed; raising here says why.
+        # status before anything else looks at it -- directly in the futures envs, via a
+        # price helper in alpaca. A bare AttributeError would also fail closed; raising
+        # here says why.
         raise PositionUnknownError(
             f"cannot read {name!r}: the exchange did not report the position"
         )

--- a/torchtrade/envs/core/state.py
+++ b/torchtrade/envs/core/state.py
@@ -10,6 +10,10 @@ from typing import Dict, List, Union
 POSITION_DUST_EPS = 1e-9
 
 
+class PositionUnknownError(RuntimeError):
+    """Raised when an unknown exchange status reaches code that needs a real direction."""
+
+
 class _PositionUnknown:
     """The exchange did not answer, which is not the same as answering "flat"."""
 
@@ -25,6 +29,14 @@ class _PositionUnknown:
         # outage from silently taking the flat branch.
         return True
 
+    def __getattr__(self, name):
+        # Reading qty/mark_price/notional_value off this would otherwise be a bare
+        # AttributeError from deep inside a sizing path. Every reader is fail-closed
+        # either way; this only makes the reason legible.
+        raise PositionUnknownError(
+            f"cannot read {name!r}: the exchange did not report the position"
+        )
+
     def __repr__(self):
         return "POSITION_UNKNOWN"
 
@@ -33,10 +45,6 @@ class _PositionUnknown:
 # from None, which is a confirmed-flat account: reading a failed call as flat is how a
 # held position gets re-bought every bar of an outage.
 POSITION_UNKNOWN = _PositionUnknown()
-
-
-class PositionUnknownError(RuntimeError):
-    """Raised when an unknown exchange status reaches code that needs a real direction."""
 
 
 def position_direction_from_status(position_status) -> int:

--- a/torchtrade/envs/live/alpaca/base.py
+++ b/torchtrade/envs/live/alpaca/base.py
@@ -262,6 +262,9 @@ class AlpacaBaseTorchTradingEnv(TorchTradeLiveEnv):
         Calculate total portfolio value for Alpaca.
 
         Returns cash + position_market_value.
+
+        Raises PositionUnknownError on an unknown status: cash alone feeds
+        _check_termination, and for a held position that reads as a near-total loss.
         """
         status = self.trader.get_status()
         position_status = status.get("position_status", None)

--- a/torchtrade/envs/live/alpaca/base.py
+++ b/torchtrade/envs/live/alpaca/base.py
@@ -263,8 +263,7 @@ class AlpacaBaseTorchTradingEnv(TorchTradeLiveEnv):
 
         Returns cash + position_market_value.
 
-        Raises PositionUnknownError on an unknown status: cash alone feeds
-        _check_termination, and for a held position that reads as a near-total loss.
+        Raises PositionUnknownError on an unknown status -- see the comment on the return.
         """
         status = self.trader.get_status()
         position_status = status.get("position_status", None)

--- a/torchtrade/envs/live/alpaca/base.py
+++ b/torchtrade/envs/live/alpaca/base.py
@@ -11,8 +11,10 @@ from torchtrade.envs.live.alpaca.observation import AlpacaObservationClass
 from torchtrade.envs.live.alpaca.order_executor import AlpacaOrderClass
 from torchtrade.envs.core.live import TorchTradeLiveEnv
 from torchtrade.envs.core.state import (
+    POSITION_UNKNOWN,
     HistoryTracker,
     PositionState,
+    PositionUnknownError,
     advance_hold_counter,
     position_direction_from_status,
 )
@@ -267,6 +269,14 @@ class AlpacaBaseTorchTradingEnv(TorchTradeLiveEnv):
 
         account = self.trader.client.get_account()
         self.balance = float(account.cash)
+
+        if position_status is POSITION_UNKNOWN:
+            # Falling through to the flat branch would drop a held position's market value
+            # and feed cash alone to _check_termination -- an outage would read as a
+            # near-total loss and could terminate the episode as bankrupt.
+            raise PositionUnknownError(
+                "cannot value the portfolio: the exchange did not report the position"
+            )
 
         if position_status is None:
             return self.balance

--- a/torchtrade/envs/live/alpaca/base.py
+++ b/torchtrade/envs/live/alpaca/base.py
@@ -14,7 +14,6 @@ from torchtrade.envs.core.state import (
     POSITION_UNKNOWN,
     HistoryTracker,
     PositionState,
-    PositionUnknownError,
     advance_hold_counter,
     position_direction_from_status,
 )
@@ -270,16 +269,11 @@ class AlpacaBaseTorchTradingEnv(TorchTradeLiveEnv):
         account = self.trader.client.get_account()
         self.balance = float(account.cash)
 
-        if position_status is POSITION_UNKNOWN:
-            # Falling through to the flat branch would drop a held position's market value
-            # and feed cash alone to _check_termination -- an outage would read as a
-            # near-total loss and could terminate the episode as bankrupt.
-            raise PositionUnknownError(
-                "cannot value the portfolio: the exchange did not report the position"
-            )
-
         if position_status is None:
             return self.balance
+        # An unknown status raises on the .market_value read rather than taking the flat
+        # branch above: cash alone feeds _check_termination, and for a held position that
+        # is most of the portfolio missing -- an outage would read as a near-total loss.
         return self.balance + position_status.market_value
 
     def _reset(self, tensordict: TensorDictBase, **kwargs) -> TensorDictBase:

--- a/torchtrade/envs/live/alpaca/env.py
+++ b/torchtrade/envs/live/alpaca/env.py
@@ -187,6 +187,10 @@ class AlpacaTorchTradingEnv(AlpacaBaseTorchTradingEnv):
 
         Returns:
             Current price, or 0.0 if unavailable
+
+        Raises:
+            PositionUnknownError: the exchange did not report the position. This is where
+                both alpaca _step paths stop on an outage, before any trade is sized.
         """
         # Try position status first
         if position_status is None:

--- a/torchtrade/envs/live/alpaca/env.py
+++ b/torchtrade/envs/live/alpaca/env.py
@@ -190,7 +190,8 @@ class AlpacaTorchTradingEnv(AlpacaBaseTorchTradingEnv):
 
         Raises:
             PositionUnknownError: the exchange did not report the position. This is where
-                both alpaca _step paths stop on an outage, before any trade is sized.
+                AlpacaTorchTradingEnv._step stops on an outage, before any trade is
+                sized; the SLTP env stops on its own inline read instead.
         """
         # Try position status first
         if position_status is None:

--- a/torchtrade/envs/live/alpaca/order_executor.py
+++ b/torchtrade/envs/live/alpaca/order_executor.py
@@ -4,7 +4,9 @@ from dataclasses import dataclass
 from decimal import ROUND_DOWN, Decimal
 from typing import Dict, List, Optional, Union
 
+from alpaca.common.exceptions import APIError
 from alpaca.trading.client import TradingClient
+
 from alpaca.trading.enums import OrderSide, OrderType, QueryOrderStatus, TimeInForce, OrderClass
 from alpaca.trading.requests import (
     ClosePositionRequest,
@@ -19,6 +21,7 @@ from dotenv import load_dotenv
 
 from torchtrade.envs.core.common import TradeMode
 from torchtrade.envs.core.common_types import OrderStatus
+from torchtrade.envs.core.state import POSITION_UNKNOWN
 
 logger = logging.getLogger(__name__)
 
@@ -303,15 +306,24 @@ class AlpacaOrderClass:
                     unrealized_plpc=float(position.unrealized_plpc),
                     current_price=float(position.current_price),
                 )
+            except APIError as e:
+                # Alpaca reports a flat account by raising, so flat and failure share one
+                # channel here. An APIError means the request reached Alpaca and it
+                # answered -- that is the flat case.
+                logger.debug(f"No open position for {self.symbol}: {e}")
+                status["position_status"] = None
             except Exception as e:
-                logger.warning(f"Error getting position status: {str(e)}")
-                status["position_status"] = None  # No open position
+                # Never got an answer (timeout, connection reset). Not the same as flat:
+                # reading it as flat is how a held position gets re-bought every bar.
+                logger.error(f"Position status unavailable: {str(e)}")
+                status["position_status"] = POSITION_UNKNOWN
 
             return status
 
         except Exception as e:
             logger.error(f"Error getting status: {str(e)}", exc_info=True)
-            return {}
+            # An empty dict reads as flat downstream, same bug one level up.
+            return {"position_status": POSITION_UNKNOWN}
 
     def get_open_orders(self) -> List[Dict]:
         """

--- a/torchtrade/envs/live/alpaca/order_executor.py
+++ b/torchtrade/envs/live/alpaca/order_executor.py
@@ -25,6 +25,20 @@ from torchtrade.envs.core.state import POSITION_UNKNOWN
 
 logger = logging.getLogger(__name__)
 
+# Alpaca's error code for "position does not exist" -- the one APIError that means the
+# account is genuinely flat rather than unreachable.
+_POSITION_NOT_FOUND_CODE = 40410000
+
+
+def _is_position_not_found(exc: APIError) -> bool:
+    """True only for Alpaca's flat-account error, not for 429/5xx/auth failures."""
+    try:
+        return int(exc.code) == _POSITION_NOT_FOUND_CODE
+    except Exception:
+        # Body was not the documented JSON, so we cannot tell -- treat as unreachable.
+        return getattr(exc, "status_code", None) == 404
+
+
 
 # Common Time in Force Options:
 # GTC (Good Till Canceled) – The order remains open until it is executed or manually canceled by the trader. It does not expire at the end of the trading day.
@@ -308,10 +322,15 @@ class AlpacaOrderClass:
                 )
             except APIError as e:
                 # Alpaca reports a flat account by raising, so flat and failure share one
-                # channel here. An APIError means the request reached Alpaca and it
-                # answered -- that is the flat case.
-                logger.debug(f"No open position for {self.symbol}: {e}")
-                status["position_status"] = None
+                # channel. 40410000 ("position does not exist") is the only APIError that
+                # means flat -- a 429, a 5xx or an auth failure is an answer we cannot read
+                # as an empty account, which would be this same bug one layer in.
+                if _is_position_not_found(e):
+                    logger.debug(f"No open position for {self.symbol}: {e}")
+                    status["position_status"] = None
+                else:
+                    logger.error(f"Position status unavailable: {e}")
+                    status["position_status"] = POSITION_UNKNOWN
             except Exception as e:
                 # Never got an answer (timeout, connection reset). Not the same as flat:
                 # reading it as flat is how a held position gets re-bought every bar.
@@ -323,7 +342,8 @@ class AlpacaOrderClass:
         except Exception as e:
             logger.error(f"Error getting status: {str(e)}", exc_info=True)
             # An empty dict reads as flat downstream, same bug one level up.
-            return {"position_status": POSITION_UNKNOWN}
+            status["position_status"] = POSITION_UNKNOWN
+            return status
 
     def get_open_orders(self) -> List[Dict]:
         """

--- a/torchtrade/envs/live/alpaca/order_executor.py
+++ b/torchtrade/envs/live/alpaca/order_executor.py
@@ -6,7 +6,6 @@ from typing import Dict, List, Optional, Union
 
 from alpaca.common.exceptions import APIError
 from alpaca.trading.client import TradingClient
-
 from alpaca.trading.enums import OrderSide, OrderType, QueryOrderStatus, TimeInForce, OrderClass
 from alpaca.trading.requests import (
     ClosePositionRequest,
@@ -41,7 +40,6 @@ def _is_position_not_found(exc: APIError) -> bool:
         return int(exc.code) == _POSITION_NOT_FOUND_CODE
     except (ValueError, KeyError, TypeError):
         return False
-
 
 
 # Common Time in Force Options:

--- a/torchtrade/envs/live/alpaca/order_executor.py
+++ b/torchtrade/envs/live/alpaca/order_executor.py
@@ -31,12 +31,16 @@ _POSITION_NOT_FOUND_CODE = 40410000
 
 
 def _is_position_not_found(exc: APIError) -> bool:
-    """True only for Alpaca's flat-account error, not for 429/5xx/auth failures."""
+    """True only for Alpaca's flat-account error, not for 429/5xx/auth failures.
+
+    A real flat account always parses: Alpaca returns the documented JSON body. So an
+    unparseable body means something other than Alpaca answered -- a proxy, a gateway, a
+    maintenance page -- and its 404 says nothing about whether a position exists.
+    """
     try:
         return int(exc.code) == _POSITION_NOT_FOUND_CODE
-    except Exception:
-        # Body was not the documented JSON, so we cannot tell -- treat as unreachable.
-        return getattr(exc, "status_code", None) == 404
+    except (ValueError, KeyError, TypeError):
+        return False
 
 
 

--- a/torchtrade/envs/live/binance/order_executor.py
+++ b/torchtrade/envs/live/binance/order_executor.py
@@ -1,5 +1,4 @@
 import logging
-from torchtrade.envs.core.state import POSITION_UNKNOWN
 from dataclasses import dataclass
 from enum import Enum
 from typing import Dict, List, Optional, Union
@@ -9,6 +8,7 @@ from dotenv import load_dotenv
 
 from torchtrade.envs.core.common import TradeMode
 from torchtrade.envs.core.common_types import MarginType, OrderStatus
+from torchtrade.envs.core.state import POSITION_UNKNOWN
 
 load_dotenv()
 

--- a/torchtrade/envs/live/binance/order_executor.py
+++ b/torchtrade/envs/live/binance/order_executor.py
@@ -1,4 +1,5 @@
 import logging
+from torchtrade.envs.core.state import POSITION_UNKNOWN
 from dataclasses import dataclass
 from enum import Enum
 from typing import Dict, List, Optional, Union
@@ -347,7 +348,7 @@ class BinanceFuturesOrderClass:
 
         except Exception as e:
             logger.error(f"Error getting status: {str(e)}")
-            status["position_status"] = None
+            status["position_status"] = POSITION_UNKNOWN
 
         return status
 

--- a/torchtrade/envs/live/bitget/order_executor.py
+++ b/torchtrade/envs/live/bitget/order_executor.py
@@ -1,5 +1,4 @@
 import logging
-from torchtrade.envs.core.state import POSITION_UNKNOWN
 from dataclasses import dataclass
 from enum import Enum
 from typing import Dict, List, Optional, Union
@@ -9,6 +8,7 @@ import ccxt
 from torchtrade.envs.live.bitget.utils import normalize_symbol
 from torchtrade.envs.core.common import TradeMode
 from torchtrade.envs.core.common_types import OrderStatus
+from torchtrade.envs.core.state import POSITION_UNKNOWN
 
 logger = logging.getLogger(__name__)
 

--- a/torchtrade/envs/live/bitget/order_executor.py
+++ b/torchtrade/envs/live/bitget/order_executor.py
@@ -1,4 +1,5 @@
 import logging
+from torchtrade.envs.core.state import POSITION_UNKNOWN
 from dataclasses import dataclass
 from enum import Enum
 from typing import Dict, List, Optional, Union
@@ -585,7 +586,7 @@ class BitgetFuturesOrderClass:
 
         except Exception as e:
             logger.error(f"Error getting status: {str(e)}")
-            status["position_status"] = None
+            status["position_status"] = POSITION_UNKNOWN
 
         return status
 

--- a/torchtrade/envs/live/bybit/order_executor.py
+++ b/torchtrade/envs/live/bybit/order_executor.py
@@ -1,5 +1,6 @@
 """Order executor for Bybit Futures trading using pybit."""
 import logging
+from torchtrade.envs.core.state import POSITION_UNKNOWN
 from dataclasses import dataclass
 from enum import Enum
 from typing import Dict, List, Optional
@@ -318,7 +319,7 @@ class BybitFuturesOrderClass:
             if ret_code is not None and int(ret_code) != 0:
                 ret_msg = response.get("retMsg", "unknown error")
                 logger.error(f"get_positions failed (retCode={ret_code}): {ret_msg}")
-                status["position_status"] = None
+                status["position_status"] = POSITION_UNKNOWN
                 return status
 
             positions = response.get("result", {}).get("list", [])
@@ -357,7 +358,7 @@ class BybitFuturesOrderClass:
 
         except Exception as e:
             logger.error(f"Error getting status: {str(e)}")
-            status["position_status"] = None
+            status["position_status"] = POSITION_UNKNOWN
 
         return status
 

--- a/torchtrade/envs/live/bybit/order_executor.py
+++ b/torchtrade/envs/live/bybit/order_executor.py
@@ -1,12 +1,12 @@
 """Order executor for Bybit Futures trading using pybit."""
 import logging
-from torchtrade.envs.core.state import POSITION_UNKNOWN
 from dataclasses import dataclass
 from enum import Enum
 from typing import Dict, List, Optional
 
 from torchtrade.envs.live.bybit.utils import normalize_symbol
 from torchtrade.envs.core.common import TradeMode
+from torchtrade.envs.core.state import POSITION_UNKNOWN
 
 logger = logging.getLogger(__name__)
 

--- a/torchtrade/envs/live/okx/order_executor.py
+++ b/torchtrade/envs/live/okx/order_executor.py
@@ -1,6 +1,5 @@
 """Order executor for OKX Futures trading using python-okx."""
 import logging
-from torchtrade.envs.core.state import POSITION_UNKNOWN
 import math
 from dataclasses import dataclass
 from enum import Enum
@@ -8,6 +7,7 @@ from typing import Dict, List, Optional
 
 from torchtrade.envs.live.okx.utils import normalize_symbol
 from torchtrade.envs.core.common import TradeMode
+from torchtrade.envs.core.state import POSITION_UNKNOWN
 
 logger = logging.getLogger(__name__)
 

--- a/torchtrade/envs/live/okx/order_executor.py
+++ b/torchtrade/envs/live/okx/order_executor.py
@@ -1,5 +1,6 @@
 """Order executor for OKX Futures trading using python-okx."""
 import logging
+from torchtrade.envs.core.state import POSITION_UNKNOWN
 import math
 from dataclasses import dataclass
 from enum import Enum
@@ -328,7 +329,7 @@ class OKXFuturesOrderClass:
             if str(code) != "0":
                 msg = response.get("msg", "unknown error")
                 logger.error(f"get_positions failed (code={code}): {msg}")
-                status["position_status"] = None
+                status["position_status"] = POSITION_UNKNOWN
                 return status
 
             positions = response.get("data", [])
@@ -337,7 +338,7 @@ class OKXFuturesOrderClass:
             non_zero = [p for p in positions if float(p.get("pos", 0)) != 0]
             if len(non_zero) > 1:
                 logger.error("Multiple open positions in LONG_SHORT mode are not supported by this env")
-                status["position_status"] = None
+                status["position_status"] = POSITION_UNKNOWN
                 return status
             pos = non_zero[0] if non_zero else None
 
@@ -377,7 +378,7 @@ class OKXFuturesOrderClass:
 
         except Exception as e:
             logger.error(f"Error getting status: {str(e)}")
-            status["position_status"] = None
+            status["position_status"] = POSITION_UNKNOWN
 
         return status
 

--- a/torchtrade/envs/live/shared/futures_live_base.py
+++ b/torchtrade/envs/live/shared/futures_live_base.py
@@ -13,10 +13,7 @@ import torch
 from tensordict import TensorDict, TensorDictBase
 
 from torchtrade.envs.core.live import TorchTradeLiveEnv
-from torchtrade.envs.core.state import (
-    advance_hold_counter,
-    position_direction_from_status,
-)
+from torchtrade.envs.core.state import advance_hold_counter, position_direction_from_status
 
 
 class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):

--- a/torchtrade/envs/live/shared/futures_live_base.py
+++ b/torchtrade/envs/live/shared/futures_live_base.py
@@ -13,7 +13,10 @@ import torch
 from tensordict import TensorDict, TensorDictBase
 
 from torchtrade.envs.core.live import TorchTradeLiveEnv
-from torchtrade.envs.core.state import advance_hold_counter, position_direction_from_status
+from torchtrade.envs.core.state import (
+    advance_hold_counter,
+    position_direction_from_status,
+)
 
 
 class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
@@ -68,7 +71,11 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
         position_status = status.get("position_status", None)
 
         # Dust is not a position: gating on `is None` let a 1e-12 residual left behind a
-        # close take the position branch and read stale fields off it.
+        # close take the position branch and read stale fields off it. An unknown status
+        # raises here rather than taking the flat branch below, which would report a held
+        # position as flat (invariant #3) -- fail-closed like get_account_balance() above,
+        # which already raises rather than inventing a balance. #295 adds a stale-but-marked
+        # observation so a blip need not end the episode.
         position_direction = float(position_direction_from_status(position_status))
         if advance_hold:
             advance_hold_counter(self.position, position_direction)

--- a/torchtrade/envs/utils/sltp_mixin.py
+++ b/torchtrade/envs/utils/sltp_mixin.py
@@ -2,10 +2,7 @@
 
 import logging
 
-from torchtrade.envs.core.state import (
-    POSITION_UNKNOWN,
-    position_direction_from_status,
-)
+from torchtrade.envs.core.state import position_direction_from_status
 
 logger = logging.getLogger(__name__)
 
@@ -31,27 +28,20 @@ class SLTPMixin:
         the exchange's actual state, preventing position stacking when bracket
         orders fail but the main order succeeds.
 
-        Args:
-            position_status: Position status from trader.get_status(), or None
-                if no position exists on the exchange.
+        An unknown status raises via position_direction_from_status. Syncing it would read
+        the outage as the position having vanished -- indistinguishable here from an SL/TP
+        fill -- and clear active_stop_loss/active_take_profit while the real position still
+        carries its brackets on the exchange. Riding an outage out instead is #295.
 
-        An unknown status leaves everything alone and reports no closure. Syncing it would
-        read the outage as the position having vanished -- indistinguishable here from an
-        SL/TP fill -- and clear active_stop_loss/active_take_profit while the real position
-        still carries its brackets on the exchange.
+        Args:
+            position_status: Position status from trader.get_status(), None if the
+                exchange confirmed no position, or POSITION_UNKNOWN if it did not
+                answer -- which raises rather than syncing.
 
         Returns:
             True if a position was closed since the last step (SL/TP trigger
             or external closure), False otherwise.
         """
-        if position_status is POSITION_UNKNOWN:
-            logger.warning(
-                "Exchange status unavailable; keeping the last confirmed position (%s) "
-                "and its brackets rather than reading this as a close.",
-                self.position.current_position,
-            )
-            return False
-
         prev_position = self.position.current_position
         self.position.current_position = position_direction_from_status(position_status)
 

--- a/torchtrade/envs/utils/sltp_mixin.py
+++ b/torchtrade/envs/utils/sltp_mixin.py
@@ -28,10 +28,9 @@ class SLTPMixin:
         the exchange's actual state, preventing position stacking when bracket
         orders fail but the main order succeeds.
 
-        An unknown status raises via position_direction_from_status. Syncing it would read
-        the outage as the position having vanished -- indistinguishable here from an SL/TP
-        fill -- and clear active_stop_loss/active_take_profit while the real position still
-        carries its brackets on the exchange. Riding an outage out instead is #295.
+        An unknown status raises rather than syncing: it is indistinguishable here from an
+        SL/TP fill, and would clear brackets the exchange still holds. In practice _step
+        raises earlier, on its own status read.
 
         Args:
             position_status: Position status from trader.get_status(), None if the

--- a/torchtrade/envs/utils/sltp_mixin.py
+++ b/torchtrade/envs/utils/sltp_mixin.py
@@ -2,7 +2,10 @@
 
 import logging
 
-from torchtrade.envs.core.state import position_direction_from_status
+from torchtrade.envs.core.state import (
+    POSITION_UNKNOWN,
+    position_direction_from_status,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -32,10 +35,23 @@ class SLTPMixin:
             position_status: Position status from trader.get_status(), or None
                 if no position exists on the exchange.
 
+        An unknown status leaves everything alone and reports no closure. Syncing it would
+        read the outage as the position having vanished -- indistinguishable here from an
+        SL/TP fill -- and clear active_stop_loss/active_take_profit while the real position
+        still carries its brackets on the exchange.
+
         Returns:
             True if a position was closed since the last step (SL/TP trigger
             or external closure), False otherwise.
         """
+        if position_status is POSITION_UNKNOWN:
+            logger.warning(
+                "Exchange status unavailable; keeping the last confirmed position (%s) "
+                "and its brackets rather than reading this as a close.",
+                self.position.current_position,
+            )
+            return False
+
         prev_position = self.position.current_position
         self.position.current_position = position_direction_from_status(position_status)
 


### PR DESCRIPTION
Closes #270.

## The bug

All five live exchanges collapsed a failed position fetch to `position_status = None` — which is also how a **confirmed-flat account** is encoded. An API timeout was therefore indistinguishable from an empty account.

Traced on binance at 20x holding 0.5 BTC long:

1. `futures_position_information` times out → `position_status = None`
2. the sync sees "flat", so it resets `current_action_level`
3. the agent repeats its action → the duplicate-action guard no longer matches
4. the quantity re-query also reads 0 mid-outage
5. delta = 0.5 → **buys another 0.5 BTC** — and repeats every bar until the outage ends

The strongest evidence this was an oversight rather than a design choice: `get_account_balance()` and `get_mark_price()` in those same classes already **raise** on failure. Only the position path was fail-open.

## What the blast-radius map found beyond the issue

- **It isn't only the `except` blocks.** Bybit and OKX also mapped a non-zero API return code to `None` without raising at all, and OKX did the same for an account holding positions it cannot represent. Two existing tests asserted that as correct.
- **There are two `_sync_position_from_exchange` forks.** The SLTP one returns "was the position closed?", so an outage looked like an SL/TP fill and would clear brackets the exchange still holds.
- **Alpaca's `_get_portfolio_value`** dropped a held position's market value on the flat branch, feeding cash alone to the bankruptcy check — an outage could terminate the episode as bankrupt.

## The fix

`get_status()` returns `POSITION_UNKNOWN` on failure, distinct from `None`. It is truthy (so `if position_status:` cannot take the flat branch), `position_direction_from_status` raises on it instead of returning 0, and reading any field off it raises with the reason — which is what makes the trade-sizing paths fail closed without editing four call sites.

Alpaca is the awkward one: **its API signals a flat account by raising**, so flat and failure share one channel. Only error code `40410000` means flat; a 429, a 5xx or an unparseable body counts as unreachable. Its mock raised a bare `Exception` and so could not express that distinction — it now raises `APIError` like the real client.

## Behaviour change

An outage now **raises out of `_step`/`_reset`** rather than trading on a phantom flat account. Verified: nothing in `examples/` or TorchRL's collector catches it, so it stops the driver rather than being swallowed. Riding an outage out instead — a stale-but-marked observation, truncating on a prolonged outage — is **#295**, which has to stop `_get_observation` raising before any of it works.

## Tests

Mutation-driven across three review rounds: the final sweep ran 46 mutants with 43 killed, and every remaining survivor is provably equivalent.

| Test | Covers |
|---|---|
| `test_an_outage_stops_the_step_before_it_can_trade` | the traced scenario end to end, 5 exchanges × `env`/`env_sltp`, asserting **no order placed** before asserting it failed closed |
| `test_a_failed_position_fetch_does_not_report_flat` | all five real executors with a failing client |
| `test_alpaca_only_treats_its_not_found_error_as_flat` | 40410000 vs 429 / 5xx / unparseable |
| `test_neither_sync_fork_treats_an_outage_as_flat` | the contract #295 will edit |
| plus alpaca's own observation, portfolio value and outer-handler paths, okx's multi-position branch, and the sentinel's identity/truthiness contracts |

## Notes for the reviewer

- **Polymarket is out of scope by construction**, not oversight: it subclasses `EnvBase` directly rather than `TorchTradeLiveEnv`, and its executor has no `position_status` concept. It is invisible to the discovery guard for that reason.
- **`check_env_specs` fails on these envs** with a `('next','truncated')` mismatch — pre-existing on `main` and tracked as **#272**, unrelated to this branch.
- After **#295** softens the sync forks, alpaca's non-SLTP `_step` will be stopped solely by its price read, which nothing currently pins. Worth carrying a test there when #295 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
