### PR TITLE
fix(envs): run the agent's SLTP action before bar N+1's trigger check

### DIFF
--- a/tests/envs/offline/test_sequential_sltp.py
+++ b/tests/envs/offline/test_sequential_sltp.py
@@ -1245,7 +1245,6 @@ class TestLockPositionUntilSLTP:
         assert config.lock_position_until_sltp is False
 
 
-
 HOLD = (None, None, None)
 CLOSE = ("close", None, None)
 LONG_TIGHT = ("long", -0.025, 0.025)
@@ -1266,7 +1265,7 @@ class TestAgentActionPrecedesNextBarTrigger:
     """
 
     def _run(self, actions, *, leverage, sl_levels, tp_levels, wick_high=None,
-             wick_low=None, include_close=False, wick_bar=20):
+             wick_low=None, include_close=False):
         import numpy as np
         import pandas as pd
 
@@ -1278,9 +1277,9 @@ class TestAgentActionPrecedesNextBarTrigger:
             "close": flat.copy(), "volume": np.ones(n) * 1000,
         })
         if wick_high is not None:
-            df.loc[wick_bar, "high"] = wick_high
+            df.loc[20, "high"] = wick_high
         if wick_low is not None:
-            df.loc[wick_bar, "low"] = wick_low
+            df.loc[20, "low"] = wick_low
 
         config = SequentialTradingEnvSLTPConfig(
             leverage=leverage, initial_cash=10000,
@@ -1351,8 +1350,10 @@ class TestAgentActionPrecedesNextBarTrigger:
             leverage=2, sl_levels=[-0.025, -0.50], tp_levels=[0.025, 0.50],
             wick_high=120.0, include_close=True,
         )
-        assert "sltp_tp" not in env.history.action_types, (
-            "the bracket fired instead of the agent's close"
-        )
+        # The close must be RECORDED as a close. A stale bracket firing on the now-flat
+        # account is a financial no-op (_execute_sltp_close returns early when flat), so
+        # it moves no balance -- it just overwrites the agent's close with a phantom
+        # hold, and history feeds binarize_action_type and the reward function.
+        assert env.history.action_types[-3] == "close"
         assert env.position.position_size == 0
         assert env.balance == pytest.approx(10000.0), "a flat round trip must not move the balance"

--- a/tests/envs/offline/test_sequential_sltp.py
+++ b/tests/envs/offline/test_sequential_sltp.py
@@ -1314,10 +1314,9 @@ class TestAgentActionPrecedesNextBarTrigger:
             [HOLD] * 5 + [LONG_TIGHT] + [HOLD] * 3 + [SHORT_TIGHT] + [HOLD] * 2,
             leverage=2, sl_levels=[-0.025, -0.50], tp_levels=[0.025, 0.50], wick_high=120.0,
         )
-        assert "sltp_tp" not in env.history.action_types, (
-            "the incoming long's TP fired, so the agent's switch was discarded"
-        )
-        assert env.history.action_types[-3] == "sltp_sl", "the SHORT should have been stopped out"
+        # sltp_sl, not sltp_tp: the bar stopped out the SHORT the agent asked for,
+        # rather than taking profit on the long it had just closed.
+        assert env.history.action_types[-3] == "sltp_sl"
         assert env.position.position_size == 0
         assert env.balance == pytest.approx(9500.0)
 
@@ -1350,10 +1349,8 @@ class TestAgentActionPrecedesNextBarTrigger:
             leverage=2, sl_levels=[-0.025, -0.50], tp_levels=[0.025, 0.50],
             wick_high=120.0, include_close=True,
         )
-        # The close must be RECORDED as a close. A stale bracket firing on the now-flat
-        # account is a financial no-op (_execute_sltp_close returns early when flat), so
-        # it moves no balance -- it just overwrites the agent's close with a phantom
-        # hold, and history feeds binarize_action_type and the reward function.
+        # Recorded as a close, not sltp_tp: reverting the reorder books the bracket
+        # instead, which both changes this label and moves the balance below.
         assert env.history.action_types[-3] == "close"
         assert env.position.position_size == 0
         assert env.balance == pytest.approx(10000.0), "a flat round trip must not move the balance"

--- a/tests/envs/offline/test_sequential_sltp.py
+++ b/tests/envs/offline/test_sequential_sltp.py
@@ -1244,3 +1244,115 @@ class TestLockPositionUntilSLTP:
         config = SequentialTradingEnvSLTPConfig()
         assert config.lock_position_until_sltp is False
 
+
+
+HOLD = (None, None, None)
+CLOSE = ("close", None, None)
+LONG_TIGHT = ("long", -0.025, 0.025)
+SHORT_TIGHT = ("short", 0.025, -0.025)
+
+
+class TestAgentActionPrecedesNextBarTrigger:
+    """The agent's order fills at close(N); bar N+1 unfolds after it (#292).
+
+    _step checked the position held *coming into* the step against bar N+1 before
+    running the agent's action, so a held position whose bracket or liquidation fired
+    on N+1 discarded that action outright. The account ended the step in a position it
+    had asked to leave, at a price it never chose.
+
+    Balances are pinned, not just action types: booking the agent's close leg at the
+    bracket price rather than the market close it selected is the same class of error
+    and leaves every action_type assertion green.
+    """
+
+    def _run(self, actions, *, leverage, sl_levels, tp_levels, wick_high=None,
+             wick_low=None, include_close=False, wick_bar=20):
+        import numpy as np
+        import pandas as pd
+
+        n = 60
+        flat = np.full(n, 100.0)
+        df = pd.DataFrame({
+            "timestamp": pd.date_range("2024-01-01", periods=n, freq="1min"),
+            "open": flat.copy(), "high": flat.copy(), "low": flat.copy(),
+            "close": flat.copy(), "volume": np.ones(n) * 1000,
+        })
+        if wick_high is not None:
+            df.loc[wick_bar, "high"] = wick_high
+        if wick_low is not None:
+            df.loc[wick_bar, "low"] = wick_low
+
+        config = SequentialTradingEnvSLTPConfig(
+            leverage=leverage, initial_cash=10000,
+            execute_on=TimeFrame(1, TimeFrameUnit.Minute),
+            time_frames=[TimeFrame(1, TimeFrameUnit.Minute)],
+            window_sizes=[10], transaction_fee=0.0, slippage=0.0,
+            seed=42, random_start=False,
+            stoploss_levels=sl_levels, takeprofit_levels=tp_levels,
+            include_close_action=include_close,
+        )
+        env = SequentialTradingEnvSLTP(df, config, simple_feature_fn)
+        # Resolved from the map, not hardcoded: enabling the close action shifts every
+        # index, which would silently turn these into a run of holds.
+        index_of = {spec: idx for idx, spec in env.action_map.items()}
+        td = env.reset()
+        for step, action in enumerate(actions):
+            action_td = (td if step == 0 else td["next"]).clone()
+            action_td["action"] = torch.tensor(index_of[action])
+            td = env.step(action_td)
+        return env
+
+    def test_switch_is_not_cancelled_by_the_incoming_positions_take_profit(self):
+        """Incoming long's TP sits inside bar 20; the agent flips to short on bar 19.
+
+        The long is closed by the agent at close(19)=100, so its TP must never fire.
+        The short opens at 100 and bar 20's spike stops IT out at 102.5 instead --
+        a 2.5% adverse move at 2x on the full portfolio, so 10000 -> 9500.
+        """
+        env = self._run(
+            # reset caches bar 10, so step k executes at bar 10+k: open at step 5 (bar 15),
+            # switch at step 9 (bar 19), and bar 20 is the step-9 exposure bar.
+            [HOLD] * 5 + [LONG_TIGHT] + [HOLD] * 3 + [SHORT_TIGHT] + [HOLD] * 2,
+            leverage=2, sl_levels=[-0.025, -0.50], tp_levels=[0.025, 0.50], wick_high=120.0,
+        )
+        assert "sltp_tp" not in env.history.action_types, (
+            "the incoming long's TP fired, so the agent's switch was discarded"
+        )
+        assert env.history.action_types[-3] == "sltp_sl", "the SHORT should have been stopped out"
+        assert env.position.position_size == 0
+        assert env.balance == pytest.approx(9500.0)
+
+    def test_liquidation_does_not_cancel_the_agents_close(self):
+        """Same defect, liquidation instead of a bracket -- and here it is total.
+
+        A 10x long liquidates around 90.4 and bar 20 wicks to 88. The agent closes at
+        close(19)=100, so the position is gone before that bar and the account keeps its
+        capital; previously the pre-action liquidation check wiped it to near zero.
+        """
+        env = self._run(
+            [HOLD] * 5 + [("long", -0.50, 0.50)] + [HOLD] * 3 + [CLOSE] + [HOLD] * 2,
+            leverage=10, sl_levels=[-0.50], tp_levels=[0.50], wick_low=88.0,
+            include_close=True,
+        )
+        assert "liquidation" not in env.history.action_types, (
+            "the agent closed at close(19); bar 20 must not liquidate a position it had left"
+        )
+        assert env.position.position_size == 0
+        assert env.balance == pytest.approx(10000.0), "a flat round trip must not move the balance"
+
+    def test_agent_close_beats_a_bracket_firing_on_the_same_bar(self):
+        """The reorder applies to close actions, not only switches.
+
+        The agent closes at close(19)=100 for a flat round trip; the long's TP inside
+        bar 20 must not book a profit it did not ask for.
+        """
+        env = self._run(
+            [HOLD] * 5 + [LONG_TIGHT] + [HOLD] * 3 + [CLOSE] + [HOLD] * 2,
+            leverage=2, sl_levels=[-0.025, -0.50], tp_levels=[0.025, 0.50],
+            wick_high=120.0, include_close=True,
+        )
+        assert "sltp_tp" not in env.history.action_types, (
+            "the bracket fired instead of the agent's close"
+        )
+        assert env.position.position_size == 0
+        assert env.balance == pytest.approx(10000.0), "a flat round trip must not move the balance"

--- a/tests/envs/offline/test_vec_sltp_scalar_equivalence.py
+++ b/tests/envs/offline/test_vec_sltp_scalar_equivalence.py
@@ -520,8 +520,8 @@ class TestSLTPScalarVecEquivalenceEntryBar:
         df = _flat_df_with_wick(bar=20, high=120.0)
 
         # Levels chosen so the incoming long survives bar 20 (SL 50, TP 150) while the
-        # short opened into it does not (SL 102.5). Otherwise the long's own trigger
-        # preempts the switch and the path under test never runs -- see #292.
+        # short opened into it does not (SL 102.5), isolating the switch path from the
+        # incoming position's own bracket.
         wide_long, tight_short = 4, 5
         actions = [0] * 5 + [wide_long] + [0] * 3 + [tight_short] + [0] * 2
 
@@ -556,5 +556,38 @@ class TestSLTPScalarVecEquivalenceLiquidation:
             sl_levels=[-0.1], tp_levels=[0.2],
             max_traj=200,
             label=f"sltp-liquidation-{direction}"
+        )
+        assert not mismatches, "\n".join(mismatches)
+
+
+class TestSLTPAgentActionPrecedesNextBarTrigger:
+    """The agent's order executes at close(N); bar N+1 unfolds after it (#292).
+
+    _step advanced the sampler and checked the *pre-action* position against bar N+1
+    before running the agent's action, so a held position whose bracket fired on N+1
+    discarded the agent's order outright -- the account ended the step in a position it
+    had explicitly asked to leave, at a price it never chose, and had to re-issue.
+    """
+
+    def test_switch_is_not_cancelled_by_the_old_positions_trigger(self):
+        """Long TP's on the very bar the agent flips to short.
+
+        The long is closed at close(N)=100 by the agent, so its TP must never fire; the
+        short opens at 100 and bar N+1's range then applies to the short instead.
+        """
+        df = _flat_df_with_wick(bar=20, high=120.0)
+
+        # long: SL -2.5% / TP +2.5% -> TP 102.5, which bar 20's high of 120 would hit.
+        # The short opened at 100 has its SL at 102.5, so bar 20 stops the SHORT out --
+        # proving the bar applied to the position the agent actually asked for, and that
+        # the long was closed by the agent at close(N) rather than taking profit.
+        long_tight, short_tight = 1, 5
+        actions = [0] * 5 + [long_tight] + [0] * 3 + [short_tight] + [0] * 2
+
+        mismatches = _run_sltp_sequence(
+            df, actions, leverage=2,
+            sl_levels=[-0.025, -0.50], tp_levels=[0.025, 0.50],
+            label="sltp-292-switch-vs-trigger",
+            expect_action_type="sltp_sl",
         )
         assert not mismatches, "\n".join(mismatches)

--- a/tests/envs/offline/test_vec_sltp_scalar_equivalence.py
+++ b/tests/envs/offline/test_vec_sltp_scalar_equivalence.py
@@ -511,18 +511,20 @@ class TestSLTPScalarVecEquivalenceEntryBar:
         assert not mismatches, "\n".join(mismatches)
 
     @pytest.mark.parametrize("incoming_bracket,label", [
-        (4, "incoming-survives"),      # long SL 50 / TP 150 -- bar 20 leaves it alone
+        (4, "incoming-survives"),      # control: long SL 50 / TP 150, bar 20 leaves it alone
         (1, "incoming-would-tp"),      # long TP 102.5 -- bar 20 WOULD have fired it
     ], ids=["incoming-survives", "incoming-would-tp"])
     def test_switch_exposes_the_new_position_to_the_entry_bar(self, incoming_bracket, label):
         """A switch opens a position too, and each env recognises that differently.
 
-        The scalar env gates on a non-zero position size post-action, the vectorized one
-        on switch_mask | open_from_flat, so a refactor could reopen #268 for switches in
-        one env only. The `incoming-would-tp` case additionally pins #292: the incoming
+        Both envs open a switch through their own code path -- _execute_sltp_action
+        against switch_mask | open_from_flat -- so a refactor could reopen #268 for
+        switches in one env only. The `incoming-would-tp` case additionally pins #292: the incoming
         long's own TP sits inside bar 20, and it must NOT pre-empt the switch -- the
         agent closed that long at close(N), so bar 20 belongs to the short instead.
-        Both cases must record sltp_sl, from the short's SL at 102.5.
+        Both cases must record sltp_sl, from the short's SL at 102.5; `incoming-survives`
+        is the control that proves the sltp_sl comes from the short's entry bar rather
+        than the incoming long, and catches no regression the other case does not.
         """
         df = _flat_df_with_wick(bar=20, high=120.0)
         tight_short = 5
@@ -542,22 +544,31 @@ class TestSLTPScalarVecEquivalenceEntryBar:
 class TestSLTPScalarVecEquivalenceCloseVsTrigger:
     """A close action and a firing bracket on the same bar (#292).
 
-    The reorder applies to closes as well as switches, and each env gates the close
-    differently -- scalar on the post-action position size, vectorized on
-    close_action_mask -- so a vec-only regression here is invisible to any test that
-    never puts a close and a trigger on the same bar.
+    The reorder applies to closes as well as switches, and each env recognises a close
+    through its own path -- _execute_sltp_action against close_action_mask -- so a
+    vec-only regression here is invisible to any test that never puts a close and a
+    trigger on the same bar.
     """
 
-    def test_close_action_beats_a_bracket_on_the_same_bar(self):
-        df = _flat_df_with_wick(bar=20, high=120.0)
-        # With the close action enabled every index shifts by one: 2 is the tight long.
-        long_tight, close_action = 2, 1
-        actions = [0] * 5 + [long_tight] + [0] * 3 + [close_action] + [0] * 2
+    @pytest.mark.parametrize("leverage,sl_levels,tp_levels,wick_high,wick_low", [
+        (2, [-0.025, -0.50], [0.025, 0.50], 120.0, None),
+        # Liquidation flavour: a 10x long liquidates near 90.4 and bar 20 wicks to 88.
+        # The held-and-hold version of this scenario passes under BOTH orderings, which
+        # is what made the scalar liquidation test dead before it sent a close.
+        (10, [-0.50], [0.50], None, 88.0),
+    ], ids=["bracket", "liquidation"])
+    def test_close_action_beats_an_exit_on_the_same_bar(
+        self, leverage, sl_levels, tp_levels, wick_high, wick_low
+    ):
+        df = _flat_df_with_wick(bar=20, high=wick_high, low=wick_low)
+        # With the close action enabled every index shifts by one: 2 is the first long.
+        long_action, close_action = 2, 1
+        actions = [0] * 5 + [long_action] + [0] * 3 + [close_action] + [0] * 2
 
         mismatches = _run_sltp_sequence(
-            df, actions, leverage=2,
-            sl_levels=[-0.025, -0.50], tp_levels=[0.025, 0.50],
-            label="sltp-close-vs-trigger",
+            df, actions, leverage=leverage,
+            sl_levels=sl_levels, tp_levels=tp_levels,
+            label="sltp-close-vs-exit",
             include_close=True,
             expect_action_type="close",
         )

--- a/tests/envs/offline/test_vec_sltp_scalar_equivalence.py
+++ b/tests/envs/offline/test_vec_sltp_scalar_equivalence.py
@@ -510,25 +510,28 @@ class TestSLTPScalarVecEquivalenceEntryBar:
         )
         assert not mismatches, "\n".join(mismatches)
 
-    def test_entry_bar_exit_after_direction_switch(self):
+    @pytest.mark.parametrize("incoming_bracket,label", [
+        (4, "incoming-survives"),      # long SL 50 / TP 150 -- bar 20 leaves it alone
+        (1, "incoming-would-tp"),      # long TP 102.5 -- bar 20 WOULD have fired it
+    ], ids=["incoming-survives", "incoming-would-tp"])
+    def test_switch_exposes_the_new_position_to_the_entry_bar(self, incoming_bracket, label):
         """A switch opens a position too, and each env recognises that differently.
 
-        The scalar env gates on trade_info["executed"] plus a non-zero position size,
-        the vectorized one on switch_mask | open_from_flat. Nothing else covers the
-        switch path, so a refactor could reopen #268 for switches in one env only.
+        The scalar env gates on a non-zero position size post-action, the vectorized one
+        on switch_mask | open_from_flat, so a refactor could reopen #268 for switches in
+        one env only. The `incoming-would-tp` case additionally pins #292: the incoming
+        long's own TP sits inside bar 20, and it must NOT pre-empt the switch -- the
+        agent closed that long at close(N), so bar 20 belongs to the short instead.
+        Both cases must record sltp_sl, from the short's SL at 102.5.
         """
         df = _flat_df_with_wick(bar=20, high=120.0)
-
-        # Levels chosen so the incoming long survives bar 20 (SL 50, TP 150) while the
-        # short opened into it does not (SL 102.5), isolating the switch path from the
-        # incoming position's own bracket.
-        wide_long, tight_short = 4, 5
-        actions = [0] * 5 + [wide_long] + [0] * 3 + [tight_short] + [0] * 2
+        tight_short = 5
+        actions = [0] * 5 + [incoming_bracket] + [0] * 3 + [tight_short] + [0] * 2
 
         mismatches = _run_sltp_sequence(
             df, actions, leverage=2,
             sl_levels=[-0.025, -0.50], tp_levels=[0.025, 0.50],
-            label="sltp-entry-bar-switch",
+            label=f"sltp-entry-bar-switch-{label}",
             # The hardcoded indices and the delicately balanced levels make this the
             # scenario most likely to quietly stop testing anything.
             expect_action_type="sltp_sl",
@@ -536,9 +539,29 @@ class TestSLTPScalarVecEquivalenceEntryBar:
         assert not mismatches, "\n".join(mismatches)
 
 
-# ============================================================================
-# LIQUIDATION EQUIVALENCE (FUTURES)
-# ============================================================================
+class TestSLTPScalarVecEquivalenceCloseVsTrigger:
+    """A close action and a firing bracket on the same bar (#292).
+
+    The reorder applies to closes as well as switches, and each env gates the close
+    differently -- scalar on the post-action position size, vectorized on
+    close_action_mask -- so a vec-only regression here is invisible to any test that
+    never puts a close and a trigger on the same bar.
+    """
+
+    def test_close_action_beats_a_bracket_on_the_same_bar(self):
+        df = _flat_df_with_wick(bar=20, high=120.0)
+        # With the close action enabled every index shifts by one: 2 is the tight long.
+        long_tight, close_action = 2, 1
+        actions = [0] * 5 + [long_tight] + [0] * 3 + [close_action] + [0] * 2
+
+        mismatches = _run_sltp_sequence(
+            df, actions, leverage=2,
+            sl_levels=[-0.025, -0.50], tp_levels=[0.025, 0.50],
+            label="sltp-close-vs-trigger",
+            include_close=True,
+            expect_action_type="close",
+        )
+        assert not mismatches, "\n".join(mismatches)
 
 
 class TestSLTPScalarVecEquivalenceLiquidation:
@@ -556,38 +579,5 @@ class TestSLTPScalarVecEquivalenceLiquidation:
             sl_levels=[-0.1], tp_levels=[0.2],
             max_traj=200,
             label=f"sltp-liquidation-{direction}"
-        )
-        assert not mismatches, "\n".join(mismatches)
-
-
-class TestSLTPAgentActionPrecedesNextBarTrigger:
-    """The agent's order executes at close(N); bar N+1 unfolds after it (#292).
-
-    _step advanced the sampler and checked the *pre-action* position against bar N+1
-    before running the agent's action, so a held position whose bracket fired on N+1
-    discarded the agent's order outright -- the account ended the step in a position it
-    had explicitly asked to leave, at a price it never chose, and had to re-issue.
-    """
-
-    def test_switch_is_not_cancelled_by_the_old_positions_trigger(self):
-        """Long TP's on the very bar the agent flips to short.
-
-        The long is closed at close(N)=100 by the agent, so its TP must never fire; the
-        short opens at 100 and bar N+1's range then applies to the short instead.
-        """
-        df = _flat_df_with_wick(bar=20, high=120.0)
-
-        # long: SL -2.5% / TP +2.5% -> TP 102.5, which bar 20's high of 120 would hit.
-        # The short opened at 100 has its SL at 102.5, so bar 20 stops the SHORT out --
-        # proving the bar applied to the position the agent actually asked for, and that
-        # the long was closed by the agent at close(N) rather than taking profit.
-        long_tight, short_tight = 1, 5
-        actions = [0] * 5 + [long_tight] + [0] * 3 + [short_tight] + [0] * 2
-
-        mismatches = _run_sltp_sequence(
-            df, actions, leverage=2,
-            sl_levels=[-0.025, -0.50], tp_levels=[0.025, 0.50],
-            label="sltp-292-switch-vs-trigger",
-            expect_action_type="sltp_sl",
         )
         assert not mismatches, "\n".join(mismatches)

--- a/tests/envs/offline/test_vec_sltp_scalar_equivalence.py
+++ b/tests/envs/offline/test_vec_sltp_scalar_equivalence.py
@@ -510,30 +510,23 @@ class TestSLTPScalarVecEquivalenceEntryBar:
         )
         assert not mismatches, "\n".join(mismatches)
 
-    @pytest.mark.parametrize("incoming_bracket,label", [
-        (4, "incoming-survives"),      # control: long SL 50 / TP 150, bar 20 leaves it alone
-        (1, "incoming-would-tp"),      # long TP 102.5 -- bar 20 WOULD have fired it
-    ], ids=["incoming-survives", "incoming-would-tp"])
-    def test_switch_exposes_the_new_position_to_the_entry_bar(self, incoming_bracket, label):
+    def test_switch_exposes_the_new_position_to_the_entry_bar(self):
         """A switch opens a position too, and each env recognises that differently.
 
         Both envs open a switch through their own code path -- _execute_sltp_action
         against switch_mask | open_from_flat -- so a refactor could reopen #268 for
-        switches in one env only. The `incoming-would-tp` case additionally pins #292: the incoming
-        long's own TP sits inside bar 20, and it must NOT pre-empt the switch -- the
-        agent closed that long at close(N), so bar 20 belongs to the short instead.
-        Both cases must record sltp_sl, from the short's SL at 102.5; `incoming-survives`
-        is the control that proves the sltp_sl comes from the short's entry bar rather
-        than the incoming long, and catches no regression the other case does not.
+        switches in one env only. The incoming long's own TP sits inside bar 20 and
+        must NOT pre-empt the switch (#292): the agent closed that long at close(N),
+        so bar 20 belongs to the short, which its own SL at 102.5 then stops out.
         """
         df = _flat_df_with_wick(bar=20, high=120.0)
-        tight_short = 5
-        actions = [0] * 5 + [incoming_bracket] + [0] * 3 + [tight_short] + [0] * 2
+        long_tight, short_tight = 1, 5
+        actions = [0] * 5 + [long_tight] + [0] * 3 + [short_tight] + [0] * 2
 
         mismatches = _run_sltp_sequence(
             df, actions, leverage=2,
             sl_levels=[-0.025, -0.50], tp_levels=[0.025, 0.50],
-            label=f"sltp-entry-bar-switch-{label}",
+            label="sltp-entry-bar-switch",
             # The hardcoded indices and the delicately balanced levels make this the
             # scenario most likely to quietly stop testing anything.
             expect_action_type="sltp_sl",
@@ -568,7 +561,7 @@ class TestSLTPScalarVecEquivalenceCloseVsTrigger:
         mismatches = _run_sltp_sequence(
             df, actions, leverage=leverage,
             sl_levels=sl_levels, tp_levels=tp_levels,
-            label="sltp-close-vs-exit",
+            label=f"sltp-close-vs-exit-{leverage}x",
             include_close=True,
             expect_action_type="close",
         )

--- a/tests/envs/offline/test_vectorized_sequential_sltp.py
+++ b/tests/envs/offline/test_vectorized_sequential_sltp.py
@@ -514,10 +514,11 @@ class TestVecSLTPLockPosition:
 class TestSLTPCanAfford:
     """An SLTP open must be refused when the balance cannot fund it.
 
-    `final_open = open_mask & can_afford` is the only thing stopping _balances going
-    negative before the clamp; nothing exercised it, so deleting the gate outright left
-    the suite green. The switch path makes it reachable in a way the base env's does
-    not: the close leg lands first, so what the reopen can afford depends on it.
+    `final_open = open_mask & can_afford` is what stops the env funding a position it
+    cannot afford; nothing exercised it, so deleting the gate outright left the suite
+    green. Covers the open_from_flat path only -- the switch path, where a refused
+    reopen leaves the account flat rather than in its old position, is pre-existing
+    behaviour this PR does not change and is still uncovered in both envs.
 
     Deliberately asserts only that the gate holds. The scalar and vectorized envs use
     different tolerances here (1e-9 vs 1e-5) and pinning that divergence would cement
@@ -527,31 +528,23 @@ class TestSLTPCanAfford:
     def test_unaffordable_open_is_refused_and_balance_never_goes_negative(
         self, sample_ohlcv_df
     ):
-        import torch
-        from torchtrade.envs.offline import (
-            VectorizedSequentialTradingEnvSLTP,
-            VectorizedSequentialTradingEnvSLTPConfig,
-        )
-        from torchtrade.envs.utils.timeframe import TimeFrame, TimeFrameUnit
-
         config = VectorizedSequentialTradingEnvSLTPConfig(
-            num_envs=2, initial_cash=100.0, leverage=1,
+            num_envs=1, initial_cash=100.0, leverage=1,
             execute_on=TimeFrame(1, TimeFrameUnit.Minute),
             time_frames=[TimeFrame(1, TimeFrameUnit.Minute)],
             window_sizes=[10], transaction_fee=0.0, slippage=0.0,
             seed=42, random_start=False,
             stoploss_levels=[-0.05], takeprofit_levels=[0.10],
-            # Fixed notional an order of magnitude above the funded balance.
+            # Fixed notional two orders of magnitude above the funded balance.
             trade_mode="notional", quantity_per_trade=10_000.0,
         )
         env = VectorizedSequentialTradingEnvSLTP(sample_ohlcv_df, config)
         td = env.reset()
 
         long_idx = next(i for i, v in env.action_map.items() if v[0] == "long")
-        td["action"] = torch.full((2,), long_idx, dtype=torch.long)
+        td["action"] = torch.full((1,), long_idx, dtype=torch.long)
         env.step(td)
 
         assert (env._position_sizes == 0).all(), "an unaffordable open must be refused"
-        assert (env._balances >= 0).all(), "balance went negative before the clamp"
-        assert env._balances.allclose(torch.full((2,), 100.0)), "a refused open must cost nothing"
+        assert env._balances.allclose(torch.full((1,), 100.0)), "a refused open must cost nothing"
         env.close()

--- a/tests/envs/offline/test_vectorized_sequential_sltp.py
+++ b/tests/envs/offline/test_vectorized_sequential_sltp.py
@@ -509,3 +509,49 @@ class TestVecSLTPLockPosition:
 
         assert env._position_sizes[0].item() == pytest.approx(initial_size, rel=1e-6)
         env.close()
+
+
+class TestSLTPCanAfford:
+    """An SLTP open must be refused when the balance cannot fund it.
+
+    `final_open = open_mask & can_afford` is the only thing stopping _balances going
+    negative before the clamp; nothing exercised it, so deleting the gate outright left
+    the suite green. The switch path makes it reachable in a way the base env's does
+    not: the close leg lands first, so what the reopen can afford depends on it.
+
+    Deliberately asserts only that the gate holds. The scalar and vectorized envs use
+    different tolerances here (1e-9 vs 1e-5) and pinning that divergence would cement
+    it -- it belongs with the leverage-dependent equivalence work in #293.
+    """
+
+    def test_unaffordable_open_is_refused_and_balance_never_goes_negative(
+        self, sample_ohlcv_df
+    ):
+        import torch
+        from torchtrade.envs.offline import (
+            VectorizedSequentialTradingEnvSLTP,
+            VectorizedSequentialTradingEnvSLTPConfig,
+        )
+        from torchtrade.envs.utils.timeframe import TimeFrame, TimeFrameUnit
+
+        config = VectorizedSequentialTradingEnvSLTPConfig(
+            num_envs=2, initial_cash=100.0, leverage=1,
+            execute_on=TimeFrame(1, TimeFrameUnit.Minute),
+            time_frames=[TimeFrame(1, TimeFrameUnit.Minute)],
+            window_sizes=[10], transaction_fee=0.0, slippage=0.0,
+            seed=42, random_start=False,
+            stoploss_levels=[-0.05], takeprofit_levels=[0.10],
+            # Fixed notional an order of magnitude above the funded balance.
+            trade_mode="notional", quantity_per_trade=10_000.0,
+        )
+        env = VectorizedSequentialTradingEnvSLTP(sample_ohlcv_df, config)
+        td = env.reset()
+
+        long_idx = next(i for i, v in env.action_map.items() if v[0] == "long")
+        td["action"] = torch.full((2,), long_idx, dtype=torch.long)
+        env.step(td)
+
+        assert (env._position_sizes == 0).all(), "an unaffordable open must be refused"
+        assert (env._balances >= 0).all(), "balance went negative before the clamp"
+        assert env._balances.allclose(torch.full((2,), 100.0)), "a refused open must cost nothing"
+        env.close()

--- a/torchtrade/envs/offline/sequential_sltp.py
+++ b/torchtrade/envs/offline/sequential_sltp.py
@@ -382,20 +382,17 @@ class SequentialTradingEnvSLTP(SequentialTradingEnv):
         if self.config.lock_position_until_sltp and self.position.position_size != 0:
             side, sl_pct, tp_pct = None, None, None
 
-        # 1. The agent's action, at bar N's close.
         trade_info = self._execute_sltp_action(side, sl_pct, tp_pct, cached_price)
 
-        # 2. Bar N+1, against whatever is held after the action. Must precede the
-        # portfolio value and the history record below, or both read a state that
-        # ignores this exit.
-        if self.position.position_size != 0:
-            if self._check_liquidation(base_features):
-                trade_info = self._execute_liquidation()
-            else:
-                trigger = self._check_sltp_trigger(base_features)
-                if trigger is not None:
-                    execution_price = self.stop_loss if trigger == "sl" else self.take_profit
-                    trade_info = self._execute_sltp_close(execution_price, trigger)
+        # Bar N+1, against whatever is held after the action. Must precede the portfolio
+        # value and the history record below, or both read a state that ignores this exit.
+        if self._check_liquidation(base_features):
+            trade_info = self._execute_liquidation()
+        else:
+            trigger = self._check_sltp_trigger(base_features)
+            if trigger is not None:
+                execution_price = self.stop_loss if trigger == "sl" else self.take_profit
+                trade_info = self._execute_sltp_close(execution_price, trigger)
 
         # Update position flag based on actual position size
         if trade_info["executed"]:

--- a/torchtrade/envs/offline/sequential_sltp.py
+++ b/torchtrade/envs/offline/sequential_sltp.py
@@ -341,18 +341,19 @@ class SequentialTradingEnvSLTP(SequentialTradingEnv):
     def _step(self, tensordict: TensorDictBase) -> TensorDictBase:
         """Execute one environment step with SLTP logic.
 
-        Priority order:
-        1. Liquidation check on bar N+1 (highest priority)
-        2. SL/TP trigger check on bar N+1 (bracket orders)
-        3. New action execution at bar N price
-        4. Liquidation and SL/TP again on bar N+1, for a position opened by step 3
+        Order:
+        1. Execute the agent's action at bar N's close
+        2. Liquidation, then SL/TP, on bar N+1 against whatever position results
 
-        The sampler is advanced BEFORE checking SL/TP so that triggers are
-        evaluated against the first unseen bar (bar N+1), not the stale bar
-        (bar N) that the agent already observed. Steps 1-2 see only the position
-        held coming in, so step 4 covers the one opened during this step -- bar
-        N+1 is the first bar it is exposed to, and without it that position
-        would not be checked until bar N+2.
+        The agent observes bar N and its order fills at close(N); bar N+1 unfolds
+        afterwards. So the action goes first and the bar is then applied to the
+        position actually held during it -- held-and-untouched, freshly opened, or
+        flipped alike. Checking the incoming position first instead discarded the
+        agent's order whenever the old bracket fired on N+1 (#292), leaving the
+        account in a position it had asked to leave, at a price it never chose.
+
+        The sampler is advanced before the check so triggers are evaluated against
+        the first unseen bar, never the bar the agent already acted on.
         """
         self.step_counter += 1
 
@@ -376,44 +377,25 @@ class SequentialTradingEnvSLTP(SequentialTradingEnv):
         self._cached_base_features = base_features
         new_price = base_features["close"]
 
-        # Priority 1: Check for liquidation on bar N+1 (futures only)
-        if self._check_liquidation(base_features):
-            trade_info = self._execute_liquidation()
+        # Locking discards the agent's action by config, so the position it is holding
+        # is what bar N+1 gets applied to below.
+        if self.config.lock_position_until_sltp and self.position.position_size != 0:
+            side, sl_pct, tp_pct = None, None, None
 
-        # Priority 2: Check for SL/TP trigger on bar N+1 (if in position)
-        elif self.position.position_size != 0:
-            sltp_trigger = self._check_sltp_trigger(base_features)
-            if sltp_trigger is not None:
-                # Determine execution price based on trigger type
-                if sltp_trigger == "sl":
-                    execution_price = self.stop_loss
-                else:  # "tp"
-                    execution_price = self.take_profit
-                trade_info = self._execute_sltp_close(execution_price, sltp_trigger)
-            elif self.config.lock_position_until_sltp:
-                # Position locked — ignore agent action, treat as HOLD
-                trade_info = self._execute_sltp_action(None, None, None, cached_price)
-            else:
-                # No trigger, execute new action at bar N price
-                trade_info = self._execute_sltp_action(side, sl_pct, tp_pct, cached_price)
+        # 1. The agent's action, at bar N's close.
+        trade_info = self._execute_sltp_action(side, sl_pct, tp_pct, cached_price)
 
-        # Priority 3: Execute new action at bar N price (if flat)
-        else:
-            trade_info = self._execute_sltp_action(side, sl_pct, tp_pct, cached_price)
-
-        # The checks above ran against the position held BEFORE this step, but a position
-        # opened at bar N's close is already exposed to bar N+1. Same bar, no lookahead --
-        # the action was chosen on bar N's close alone. Must precede the portfolio value
-        # and the history record below, or both read a state that ignores this exit.
-        # executed with an open position means a successful open, direction switches too.
-        if trade_info["executed"] and self.position.position_size != 0:
+        # 2. Bar N+1, against whatever is held after the action. Must precede the
+        # portfolio value and the history record below, or both read a state that
+        # ignores this exit.
+        if self.position.position_size != 0:
             if self._check_liquidation(base_features):
                 trade_info = self._execute_liquidation()
             else:
-                entry_trigger = self._check_sltp_trigger(base_features)
-                if entry_trigger is not None:
-                    execution_price = self.stop_loss if entry_trigger == "sl" else self.take_profit
-                    trade_info = self._execute_sltp_close(execution_price, entry_trigger)
+                trigger = self._check_sltp_trigger(base_features)
+                if trigger is not None:
+                    execution_price = self.stop_loss if trigger == "sl" else self.take_profit
+                    trade_info = self._execute_sltp_close(execution_price, trigger)
 
         # Update position flag based on actual position size
         if trade_info["executed"]:

--- a/torchtrade/envs/offline/vectorized_sequential_sltp.py
+++ b/torchtrade/envs/offline/vectorized_sequential_sltp.py
@@ -96,11 +96,10 @@ class VectorizedSequentialTradingEnvSLTP(VectorizedSequentialTradingEnv):
     Timing (different from base vectorized env):
         1. Save bar N close as trade prices (with slippage)
         2. Advance step index to bar N+1
-        3. Check liquidation then SL/TP on bar N+1, for positions held coming in
-        4. Execute trades at bar N price (skip triggered envs)
-        5. Re-check bar N+1 for positions opened by step 4 -- it is the first bar
-           they are exposed to, and steps 3 ran before they existed
-        6. Compute rewards from bar N+1 prices
+        3. Execute trades at bar N price
+        4. Check liquidation then SL/TP on bar N+1, against whatever each env holds
+           after step 3
+        5. Compute rewards from bar N+1 prices
 
     Args:
         df: OHLCV DataFrame for backtesting
@@ -182,9 +181,11 @@ class VectorizedSequentialTradingEnvSLTP(VectorizedSequentialTradingEnv):
         """Execute one step for all environments with SLTP timing.
 
         SLTP timing differs from base: advance FIRST, then check triggers.
-        Priority: liquidation > SL/TP trigger > agent action > the same liquidation and
-        SL/TP checks again for positions the agent action opened, since the first pass
-        ran before they existed and bar N+1 is the first bar they are exposed to.
+
+        The agent's action fills at close(N) and bar N+1 unfolds afterwards, so the
+        action runs first and the bar is applied to the resulting position. Checking
+        the incoming position first instead discarded the action wherever the old
+        bracket fired on N+1 (#292).
         """
         N = self._num_envs
 
@@ -214,22 +215,14 @@ class VectorizedSequentialTradingEnvSLTP(VectorizedSequentialTradingEnv):
         new_low = self._base_tensor[self._step_indices, 2]
         new_close = self._base_tensor[self._step_indices, 3]
 
-        # 5. Check liquidation, then SL/TP, on bar N+1 against positions held coming in
-        triggered_mask = self._apply_exit_checks(new_high, new_low)
+        # 5. The agent's action, at bar N's price.
+        self._execute_sltp_trades(sides, sl_pcts, tp_pcts, trade_prices)
 
-        # 6. Execute trades at bar N price (skip triggered envs)
-        opened_mask = self._execute_sltp_trades(
-            sides, sl_pcts, tp_pcts, trade_prices, triggered_mask
-        )
-
-        # 7. The check above ran against what was held BEFORE this step, but a position
-        # opened at bar N's close is already exposed to bar N+1. Same bar, no lookahead --
-        # the action was chosen on bar N's close alone. Must precede the portfolio values
-        # below, or reward and termination read balances that ignore this exit.
-        # Scoped to the newly opened: re-checking a survivor of the first pass is a no-op
-        # only while this check stays idempotent, which nothing enforces.
-        if opened_mask.any():
-            self._apply_exit_checks(new_high, new_low, eligible=opened_mask)
+        # 6. Bar N+1, against whatever each env holds after the action. Must precede the
+        # portfolio values below, or reward and termination read balances that ignore
+        # this exit. Checking the incoming position first instead discarded the agent's
+        # action wherever the old bracket fired on N+1 (#292).
+        self._apply_exit_checks(new_high, new_low)
 
         # 8. Compute rewards: log(new_pv / old_pv)
         new_pvs = self._compute_portfolio_values(new_close)
@@ -267,8 +260,7 @@ class VectorizedSequentialTradingEnvSLTP(VectorizedSequentialTradingEnv):
         """Close positions whose bar range hit liquidation or a bracket.
 
         Args:
-            eligible: defaults to every open position; pass a mask to check only the
-                positions opened during this step against that same bar.
+            eligible: defaults to every open position.
 
         Returns the mask of envs that exited.
         """
@@ -387,8 +379,7 @@ class VectorizedSequentialTradingEnvSLTP(VectorizedSequentialTradingEnv):
         sl_pcts: torch.Tensor,
         tp_pcts: torch.Tensor,
         trade_prices: torch.Tensor,
-        triggered_mask: torch.Tensor,
-    ) -> torch.Tensor:
+    ) -> None:
         """Execute SLTP trades for all environments.
 
         Position sizing via trade_mode (fractional/notional/quantity). Handles:
@@ -397,11 +388,8 @@ class VectorizedSequentialTradingEnvSLTP(VectorizedSequentialTradingEnv):
         - Direction switch: close old, open new with brackets
         - Open from flat: open new with brackets
 
-        Returns the mask of envs that opened a position, so the caller can expose it to
-        the same bar the pre-existing positions were just checked against.
         """
         leverage = float(self.config.leverage)
-        active = ~triggered_mask
 
         is_long = self._position_sizes > 0
         is_short = self._position_sizes < 0
@@ -409,13 +397,13 @@ class VectorizedSequentialTradingEnvSLTP(VectorizedSequentialTradingEnv):
 
         # Position locking: force HOLD for envs with open positions
         if self.config.lock_position_until_sltp:
-            has_position = (~is_flat) & active
+            has_position = ~is_flat
             if has_position.any():
                 sides = sides.clone()
                 sides[has_position] = 0  # Force HOLD
 
         # Hold: explicit hold or already in same direction
-        hold_mask = active & (
+        hold_mask = (
             (sides == 0)
             | ((sides == 1) & is_long)
             | ((sides == -1) & is_short)
@@ -424,15 +412,13 @@ class VectorizedSequentialTradingEnvSLTP(VectorizedSequentialTradingEnv):
         self._hold_counters[hold_with_pos] += 1
 
         # Close action (side=2) with existing position
-        close_action_mask = active & (sides == 2) & ~is_flat
+        close_action_mask = (sides == 2) & ~is_flat
 
         # Direction switch: want opposite direction
-        switch_mask = active & (
-            ((sides == 1) & is_short) | ((sides == -1) & is_long)
-        )
+        switch_mask = ((sides == 1) & is_short) | ((sides == -1) & is_long)
 
         # Open from flat: want position, currently flat
-        open_from_flat = active & ((sides == 1) | (sides == -1)) & is_flat
+        open_from_flat = ((sides == 1) | (sides == -1)) & is_flat
 
         # Close existing positions (direction switches + close actions)
         close_mask = switch_mask | close_action_mask
@@ -455,7 +441,6 @@ class VectorizedSequentialTradingEnvSLTP(VectorizedSequentialTradingEnv):
 
         # Open new positions (direction switches + open from flat)
         open_mask = switch_mask | open_from_flat
-        opened = torch.zeros_like(open_mask)
         if open_mask.any():
             # Position sizing based on trade_mode
             if self.config.trade_mode == "fractional":
@@ -481,7 +466,6 @@ class VectorizedSequentialTradingEnvSLTP(VectorizedSequentialTradingEnv):
             # Float32 tolerance for can_afford check
             can_afford = (margin_new + new_fee) <= self._balances * (1 + 1e-5)
             final_open = open_mask & can_afford
-            opened = final_open
 
             if final_open.any():
                 self._balances[final_open] -= (margin_new + new_fee)[final_open]
@@ -503,4 +487,3 @@ class VectorizedSequentialTradingEnvSLTP(VectorizedSequentialTradingEnv):
                     trade_prices * (1 + tp_pcts)
                 )[final_open]
 
-        return opened

--- a/torchtrade/envs/offline/vectorized_sequential_sltp.py
+++ b/torchtrade/envs/offline/vectorized_sequential_sltp.py
@@ -358,8 +358,6 @@ class VectorizedSequentialTradingEnvSLTP(VectorizedSequentialTradingEnv):
                 self._tp_prices = torch.where(
                     sltp_trigger, self._zeros, self._tp_prices
                 )
-                exited = exited | sltp_trigger
-
 
     def _execute_sltp_trades(
         self,
@@ -375,7 +373,6 @@ class VectorizedSequentialTradingEnvSLTP(VectorizedSequentialTradingEnv):
         - Close: side=2 and has position
         - Direction switch: close old, open new with brackets
         - Open from flat: open new with brackets
-
         """
         leverage = float(self.config.leverage)
 

--- a/torchtrade/envs/offline/vectorized_sequential_sltp.py
+++ b/torchtrade/envs/offline/vectorized_sequential_sltp.py
@@ -256,7 +256,6 @@ class VectorizedSequentialTradingEnvSLTP(VectorizedSequentialTradingEnv):
     ) -> None:
         """Close positions whose bar range hit liquidation or a bracket."""
         leverage = float(self.config.leverage)
-        exited = torch.zeros_like(self._position_sizes, dtype=torch.bool)
 
         # Liquidation takes priority over the brackets (futures only)
         if self.config.leverage > 1:
@@ -292,9 +291,8 @@ class VectorizedSequentialTradingEnvSLTP(VectorizedSequentialTradingEnv):
                 # Note: SL/TP are NOT cleared on liquidation, matching scalar
                 # env behavior. Stale values are harmless since position is
                 # zeroed and SL/TP checks guard on has_position.
-                exited = exited | liq_mask
 
-        has_position = (self._position_sizes != 0) & ~exited
+        has_position = self._position_sizes != 0
         has_brackets = (self._sl_prices > 0) | (self._tp_prices > 0)
         can_trigger = has_position & has_brackets
 

--- a/torchtrade/envs/offline/vectorized_sequential_sltp.py
+++ b/torchtrade/envs/offline/vectorized_sequential_sltp.py
@@ -5,7 +5,7 @@ in a single _step() call using pure tensor operations. Extends
 VectorizedSequentialTradingEnv with bracket order support.
 
 Key differences from base vectorized env:
-    - SLTP timing: advance FIRST, then check triggers, then execute trades
+    - SLTP timing: advance, execute the agent's trade, then check triggers
     - trade_mode-aware position sizing (fractional, notional, quantity)
     - SL/TP bracket orders with intrabar trigger detection
     - SL checked before TP (pessimistic bias)
@@ -180,7 +180,7 @@ class VectorizedSequentialTradingEnvSLTP(VectorizedSequentialTradingEnv):
     def _step(self, tensordict: TensorDictBase) -> TensorDictBase:
         """Execute one step for all environments with SLTP timing.
 
-        SLTP timing differs from base: advance FIRST, then check triggers.
+        SLTP timing differs from base: the sampler advances before the checks.
 
         The agent's action fills at close(N) and bar N+1 unfolds afterwards, so the
         action runs first and the bar is applied to the resulting position. Checking
@@ -215,16 +215,14 @@ class VectorizedSequentialTradingEnvSLTP(VectorizedSequentialTradingEnv):
         new_low = self._base_tensor[self._step_indices, 2]
         new_close = self._base_tensor[self._step_indices, 3]
 
-        # 5. The agent's action, at bar N's price.
+        # 5. The agent's action, at bar N's price
         self._execute_sltp_trades(sides, sl_pcts, tp_pcts, trade_prices)
 
         # 6. Bar N+1, against whatever each env holds after the action. Must precede the
-        # portfolio values below, or reward and termination read balances that ignore
-        # this exit. Checking the incoming position first instead discarded the agent's
-        # action wherever the old bracket fired on N+1 (#292).
+        # portfolio values below, or reward and termination read balances that ignore it.
         self._apply_exit_checks(new_high, new_low)
 
-        # 8. Compute rewards: log(new_pv / old_pv)
+        # 7. Compute rewards: log(new_pv / old_pv)
         new_pvs = self._compute_portfolio_values(new_close)
         old_pvs = self._portfolio_values
         safe_old = old_pvs.clamp(min=1e-10)
@@ -234,7 +232,7 @@ class VectorizedSequentialTradingEnvSLTP(VectorizedSequentialTradingEnv):
 
         self._portfolio_values = new_pvs
 
-        # 9. Compute termination signals
+        # 8. Compute termination signals
         terminated = new_pvs < (self._initial_pvs * self.bankrupt_threshold)
         truncated = (
             ((self._step_indices + 1) >= self._end_indices)
@@ -242,7 +240,7 @@ class VectorizedSequentialTradingEnvSLTP(VectorizedSequentialTradingEnv):
         )
         done = terminated | truncated
 
-        # 10. Build observation from bar N+1
+        # 9. Build observation from bar N+1
         obs_td = self._build_observation(new_close, portfolio_values=new_pvs)
         obs_td.set("reward", rewards.unsqueeze(-1))
         obs_td.set("terminated", terminated.unsqueeze(-1))
@@ -255,25 +253,16 @@ class VectorizedSequentialTradingEnvSLTP(VectorizedSequentialTradingEnv):
         self,
         new_high: torch.Tensor,
         new_low: torch.Tensor,
-        eligible: Optional[torch.Tensor] = None,
-    ) -> torch.Tensor:
-        """Close positions whose bar range hit liquidation or a bracket.
-
-        Args:
-            eligible: defaults to every open position.
-
-        Returns the mask of envs that exited.
-        """
+    ) -> None:
+        """Close positions whose bar range hit liquidation or a bracket."""
         leverage = float(self.config.leverage)
-        if eligible is None:
-            eligible = self._position_sizes != 0
-        exited = torch.zeros_like(eligible)
+        exited = torch.zeros_like(self._position_sizes, dtype=torch.bool)
 
         # Liquidation takes priority over the brackets (futures only)
         if self.config.leverage > 1:
             liq_price = self._compute_liq_prices()
-            long_liq = eligible & (self._position_sizes > 0) & (new_low <= liq_price)
-            short_liq = eligible & (self._position_sizes < 0) & (new_high >= liq_price)
+            long_liq = (self._position_sizes > 0) & (new_low <= liq_price)
+            short_liq = (self._position_sizes < 0) & (new_high >= liq_price)
             liq_mask = long_liq | short_liq
 
             if liq_mask.any():
@@ -305,7 +294,7 @@ class VectorizedSequentialTradingEnvSLTP(VectorizedSequentialTradingEnv):
                 # zeroed and SL/TP checks guard on has_position.
                 exited = exited | liq_mask
 
-        has_position = eligible & (self._position_sizes != 0) & ~exited
+        has_position = (self._position_sizes != 0) & ~exited
         has_brackets = (self._sl_prices > 0) | (self._tp_prices > 0)
         can_trigger = has_position & has_brackets
 
@@ -371,7 +360,6 @@ class VectorizedSequentialTradingEnvSLTP(VectorizedSequentialTradingEnv):
                 )
                 exited = exited | sltp_trigger
 
-        return exited
 
     def _execute_sltp_trades(
         self,


### PR DESCRIPTION
Closes #292.

## The bug

The agent observes bar N and its order fills at `close(N)`; bar N+1 unfolds afterwards. But `_step` advanced the sampler and checked the position held *coming into* the step against bar N+1 **before** running the agent's action — so a held position whose bracket fired on N+1 discarded that action outright. Not deferred, discarded.

The account ended the step in a position it had explicitly asked to leave, at a price it never chose, and had to re-issue next step.

The premise is verifiable in the code rather than inferred: `cached_price` is captured before the sampler advances, commented *"Bar N price — where the agent's action would execute"*. The obvious counter-argument — a resting bracket order fills intrabar before a new decision round-trips — is real in live trading but does not transfer here, because the agent's own close also executes at `close(N)`, strictly earlier. There is no latency model in the offline env to appeal to.

## Reproduced

Long open at 100 with TP 102.5; agent requests a flip to short on the bar before a spike to 120.

| | `action_type` | direction | portfolio |
|---|---|---|---|
| before | `sltp_tp` | flat | 10500 |
| after | `sltp_sl` | flat | 9500 |

After the fix the long closes flat at `close(N)=100`, the short opens at 100, and the spike stops the **short** out at its own SL. Worth noting the old behaviour was **not** conservative — here it handed the account a win it never asked for, so this is not a one-directional safety margin.

## The fix

Both offline SLTP envs shared the shape — scalar via the `if/elif` priority chain, vectorized via `active = ~triggered_mask` masking triggered envs out of every action mask. Both now:

1. execute the agent's action at `close(N)`
2. apply bar N+1 once, to whatever is held after it

That second step is exactly what the #268 entry-trigger block already did for freshly opened positions; it becomes the *only* check rather than a bolt-on, so a step now makes strictly fewer trigger calls than before.

`lock_position_until_sltp` is applied up front by forcing the action to `None`, so a locked position is still what bar N+1 gets checked against.

## Scope note

**Liquidation had the identical defect for the identical reason** and is folded into the same post-action check. The issue names only the SL/TP chain, so this is deliberately broader than the text — but splitting liquidation back out would reintroduce the redundant double-check the merge removes.

## Live envs are unaffected

`env_sltp.py::_step` calls `_sync_position_from_exchange` **before** decoding the agent's action, so the exchange is the source of truth for whether a bracket already filled. There is no synthetic future-bar check to get backwards — the "exchange truth beats the cache" invariant this codebase already documents. No change to `sltp_mixin.py` or any `env_sltp.py`.

## Tests

No existing test encoded the bug — verified rather than assumed. One test (`test_entry_bar_exit_after_direction_switch`) had been written to *dodge* it, with a comment citing #292; that workaround note is now stale and updated.

Added a regression test through the existing scalar/vectorized equivalence harness, so it pins the behaviour in both envs and their parity at once. It was confirmed to fail for the right reason before the fix (`sltp_tp` recorded where `sltp_sl` is expected).

## Verification

```
Full suite (CUDA_VISIBLE_DEVICES=""):  2296 passed, 18 skipped, 0 failed
Offline env suite:                     659 passed
```

Run against `.venv/bin/python` (torchrl 0.13.2, matching the pin).

## Review

The mandated `torchrl-engineer` design pass ran before implementation, and three full rounds of code-simplifier / pr-test-analyzer / torchrl-engineer / test-justification ran after it, with findings fixed between each.

The rounds earned their keep — every round found a defect in the previous round's fix:

- **Round 1**: the two broadenings beyond the issue text (liquidation, and the money the exit is booked at) had *no* coverage — reverting either left the suite fully green. The one regression test pinned which action type fired, never a balance.
- **Round 2**: removing the outer position guard made the callee guard in `_check_sltp_trigger` load-bearing with nothing holding it — deleting it silently rewrote the agent's close to `hold` in history. The dead-test shape fixed in the scalar env was still present in the vectorized one. The affordability gate had no test at all.
- **Round 3**: the affordability test added in Round 2 was itself passing for the wrong reason — `assert (_balances >= 0).all()` cannot fail, because `clamp_` runs inside the call.

Final differential fuzz against `main`: 6,000 scalar and 3,500 vectorized scenarios, 1,464 and 1,859 divergences, **100% explained by the intended reorder, zero unexplained**.

## Not included

`#298` — the documented "liquidation takes priority over the bracket" rule is unenforced in both envs: swapping the two checks leaves the suite green, because no test builds a bar where both would fire. Pre-existing on `main`, filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
