### PR TITLE
fix(envs): compute vectorized offline money in float64 (#293)

### DIFF
--- a/tests/envs/offline/fundamental/test_margin_accounting.py
+++ b/tests/envs/offline/fundamental/test_margin_accounting.py
@@ -11,6 +11,7 @@ Tests critical calculations that MUST be correct:
 
 import pytest
 import pandas as pd
+import torch
 from torchtrade.envs.offline.sequential import SequentialTradingEnv, SequentialTradingEnvConfig
 
 
@@ -594,6 +595,50 @@ class TestMultiTimeframeHandling:
         pv_multi = env_multi._get_portfolio_value()
         assert abs(pv_single - pv_multi) < 1, \
             f"Single TF PV {pv_single:.2f} != Multi TF {pv_multi:.2f}"
+
+
+class TestAffordabilitySlackOnScaleUp:
+    """Scaling up an existing position must respect AFFORDABILITY_REL_TOL.
+
+    An open from flat is algebraically pinned: it sizes from portfolio value and pays from
+    balance, and those are the same number while flat, so cost == pv * |action| and the
+    overshoot is ~1 ULP. Scaling up is not. It sizes the *delta* from portfolio value but
+    still pays from balance, and once a position is open those differ -- so the relative
+    shortfall is continuous in the price move since entry and sweeps straight through the
+    1e-9..1e-5 window that separated the scalar and vectorized envs before #293.
+
+    The base env's other two call sites are equivalent mutants (the vectorized env never
+    resizes in place -- it closes and reopens, so every env in open_mask is flat there).
+    This is the one that can drift, and at 1e-5 it accepts an open it cannot pay for and
+    logs "Negative balance detected" before clamping to zero.
+    """
+
+    def test_scale_up_respects_the_shared_slack(self):
+        drift = 1e-6
+        prices = [100.0 * (1 + drift) ** i for i in range(40)]
+        df = pd.DataFrame({
+            "timestamp": pd.date_range("2024-01-01", periods=40, freq="1min"),
+            "open": prices, "high": prices, "low": prices, "close": prices,
+            "volume": [1000.0] * 40,
+        }, index=range(40))
+        env = SequentialTradingEnv(df, SequentialTradingEnvConfig(
+            action_levels=[0.0, 0.5, 1.0], leverage=2, initial_cash=1000.0,
+            time_frames=["1Min"], window_sizes=[10], execute_on="1Min",
+            transaction_fee=0.0, slippage=0.0, seed=42, max_traj_length=30,
+            random_start=False,
+        ))
+        td = env.reset()
+        for action in (1, 2):  # half size, then ask for full one bar later
+            td["action"] = torch.tensor(action)
+            td = env.step(td)["next"]
+
+        # Half size is ~10 units against ~20 for full; the scale-up must be refused.
+        assert env.position.position_size < 15.0, (
+            f"the scale-up was accepted at position_size={env.position.position_size!r}, "
+            f"balance={env.balance!r} -- the base env's affordability slack has drifted "
+            "above AFFORDABILITY_REL_TOL"
+        )
+        env.close()
 
 
 if __name__ == "__main__":

--- a/tests/envs/offline/fundamental/test_slippage.py
+++ b/tests/envs/offline/fundamental/test_slippage.py
@@ -356,16 +356,12 @@ class TestSlippageOnClose:
 
 
 class TestVectorizedSlippage:
-    """The vectorized envs' slippage branch, which no test reached at all.
+    """The vectorized envs' slippage branch, which no test reached at all: raising on the
+    first line under `if self.slippage > 0:` left the whole suite green.
 
-    Verified by mutation: raising on the first line under `if self.slippage > 0:` in both
-    vectorized envs left the entire 2320-test suite green. Everything above builds the
-    scalar `SequentialTradingEnv` only.
-
-    Deliberately not an equivalence test against the scalar env: the scalar draws its noise
-    from the *global* RNG (`sequential.py:633`, bare `torch.empty(1).uniform_(...)` with no
-    generator) while the vectorized env draws from its own `self._rng`. Different streams by
-    construction, so the two can never agree on a slipped price -- only on the bounds.
+    Bounds only, not equivalence against the scalar env: the scalar draws from the global
+    RNG (`sequential.py:633`, no `generator=`) and the vectorized env from its own
+    `self._rng`, so the two can never agree on a slipped price.
     """
 
     @pytest.mark.parametrize("env_cls,config_cls,extra", [
@@ -374,17 +370,16 @@ class TestVectorizedSlippage:
         (VectorizedSequentialTradingEnvSLTP, VectorizedSequentialTradingEnvSLTPConfig,
          {"stoploss_levels": [-0.5], "takeprofit_levels": [0.5]}),
     ], ids=["base", "sltp"])
-    @pytest.mark.parametrize("slippage", [0.0, 0.01])
     def test_entry_price_respects_slippage_bounds(
-        self, constant_price_df, env_cls, config_cls, extra, slippage
+        self, constant_price_df, env_cls, config_cls, extra
     ):
-        """At slippage=0 the fill is exactly the market price; above it, inside the band.
+        """Fills land inside the band, and every env draws its own noise.
 
-        Both cases matter: the zero case pins that the branch is skipped rather than
-        applying a silent 1.0 multiplier, and the non-zero case is the only thing that
-        executes the branch at all.
+        No slippage=0 case: every cell of both equivalence files already runs the
+        vectorized env at slippage=0 against the scalar env's unslipped fill at 1e-9, so a
+        stray multiplier there fails 73 of them.
         """
-        n_envs = 16
+        n_envs, slippage, market = 16, 0.01, 100.0
         env = env_cls(
             constant_price_df,
             config_cls(
@@ -394,24 +389,17 @@ class TestVectorizedSlippage:
             ),
         )
         td = env.reset()
-        # Index 2 opens a long in both action maps: [-1,0,1] and hold/long for 1x1 SLTP.
+        # Index 2 opens a position in both action maps, though not the same side: long for
+        # [-1, 0, 1], short for the 1x1 SLTP map (0=hold, 1=long, 2=short).
         td["action"] = torch.full((n_envs,), 2, dtype=torch.long)
         env.step(td)
 
         entries = env._entry_prices[env._position_sizes != 0]
         assert entries.numel() > 0, "no env opened a position -- nothing was slipped"
-        market = 100.0
-        assert torch.all(entries >= market * (1 - slippage) - 1e-9)
-        assert torch.all(entries <= market * (1 + slippage) + 1e-9)
-
-        if slippage == 0.0:
-            assert torch.all(entries == market), "slippage=0 must fill at market"
-        else:
-            # Distinct fills across the batch: one shared draw broadcast to every env
-            # would sit inside the bounds and pass everything above.
-            assert entries.unique().numel() > 1, (
-                "every env got the same fill -- the noise is not per-env"
-            )
+        assert torch.all(entries >= market * (1 - slippage))
+        assert torch.all(entries <= market * (1 + slippage))
+        # One shared draw broadcast to every env would sit inside the bounds and pass.
+        assert entries.unique().numel() > 1, "the noise is not per-env"
 
 
 if __name__ == "__main__":

--- a/tests/envs/offline/fundamental/test_slippage.py
+++ b/tests/envs/offline/fundamental/test_slippage.py
@@ -360,7 +360,7 @@ class TestVectorizedSlippage:
     first line under `if self.slippage > 0:` left the whole suite green.
 
     Bounds only, not equivalence against the scalar env: the scalar draws from the global
-    RNG (`sequential.py:633`, no `generator=`) and the vectorized env from its own
+    RNG (`_execute_trade_if_needed`, no `generator=`) and the vectorized env from its own
     `self._rng`, so the two can never agree on a slipped price.
     """
 

--- a/tests/envs/offline/fundamental/test_slippage.py
+++ b/tests/envs/offline/fundamental/test_slippage.py
@@ -9,7 +9,14 @@ These tests verify the bounds are respected and slippage is actually applied.
 
 import pytest
 import pandas as pd
+import torch
 from torchtrade.envs.offline.sequential import SequentialTradingEnv, SequentialTradingEnvConfig
+from torchtrade.envs.offline import (
+    VectorizedSequentialTradingEnv,
+    VectorizedSequentialTradingEnvConfig,
+    VectorizedSequentialTradingEnvSLTP,
+    VectorizedSequentialTradingEnvSLTPConfig,
+)
 
 
 @pytest.fixture
@@ -346,6 +353,65 @@ class TestSlippageOnClose:
         unique_pnls = len(set([round(p, 2) for p in pnls]))
         assert unique_pnls > 5, \
             f"Only {unique_pnls} unique PnLs - close slippage not applied?"
+
+
+class TestVectorizedSlippage:
+    """The vectorized envs' slippage branch, which no test reached at all.
+
+    Verified by mutation: raising on the first line under `if self.slippage > 0:` in both
+    vectorized envs left the entire 2320-test suite green. Everything above builds the
+    scalar `SequentialTradingEnv` only.
+
+    Deliberately not an equivalence test against the scalar env: the scalar draws its noise
+    from the *global* RNG (`sequential.py:633`, bare `torch.empty(1).uniform_(...)` with no
+    generator) while the vectorized env draws from its own `self._rng`. Different streams by
+    construction, so the two can never agree on a slipped price -- only on the bounds.
+    """
+
+    @pytest.mark.parametrize("env_cls,config_cls,extra", [
+        (VectorizedSequentialTradingEnv, VectorizedSequentialTradingEnvConfig,
+         {"action_levels": [-1, 0, 1]}),
+        (VectorizedSequentialTradingEnvSLTP, VectorizedSequentialTradingEnvSLTPConfig,
+         {"stoploss_levels": [-0.5], "takeprofit_levels": [0.5]}),
+    ], ids=["base", "sltp"])
+    @pytest.mark.parametrize("slippage", [0.0, 0.01])
+    def test_entry_price_respects_slippage_bounds(
+        self, constant_price_df, env_cls, config_cls, extra, slippage
+    ):
+        """At slippage=0 the fill is exactly the market price; above it, inside the band.
+
+        Both cases matter: the zero case pins that the branch is skipped rather than
+        applying a silent 1.0 multiplier, and the non-zero case is the only thing that
+        executes the branch at all.
+        """
+        n_envs = 16
+        env = env_cls(
+            constant_price_df,
+            config_cls(
+                num_envs=n_envs, execute_on="1Hour", time_frames=["1Hour"],
+                window_sizes=[5], initial_cash=10000, transaction_fee=0.0,
+                slippage=slippage, leverage=2, random_start=False, seed=7, **extra,
+            ),
+        )
+        td = env.reset()
+        # Index 2 opens a long in both action maps: [-1,0,1] and hold/long for 1x1 SLTP.
+        td["action"] = torch.full((n_envs,), 2, dtype=torch.long)
+        env.step(td)
+
+        entries = env._entry_prices[env._position_sizes != 0]
+        assert entries.numel() > 0, "no env opened a position -- nothing was slipped"
+        market = 100.0
+        assert torch.all(entries >= market * (1 - slippage) - 1e-9)
+        assert torch.all(entries <= market * (1 + slippage) + 1e-9)
+
+        if slippage == 0.0:
+            assert torch.all(entries == market), "slippage=0 must fill at market"
+        else:
+            # Distinct fills across the batch: one shared draw broadcast to every env
+            # would sit inside the bounds and pass everything above.
+            assert entries.unique().numel() > 1, (
+                "every env got the same fill -- the noise is not per-env"
+            )
 
 
 if __name__ == "__main__":

--- a/tests/envs/offline/test_vec_scalar_equivalence.py
+++ b/tests/envs/offline/test_vec_scalar_equivalence.py
@@ -70,7 +70,7 @@ EQUIV_ATOL = 1e-9
 EQUIV_RTOL = 1e-9
 
 
-def _compare_state(scalar, vec, step, label, atol=EQUIV_ATOL, rtol=EQUIV_RTOL):
+def _compare_state(scalar, vec):
     """Compare all observable state between scalar and vectorized envs.
 
     Uses numpy-style allclose: |s - v| <= atol + rtol * max(|s|, |v|).
@@ -79,7 +79,7 @@ def _compare_state(scalar, vec, step, label, atol=EQUIV_ATOL, rtol=EQUIV_RTOL):
     """
     mismatches = []
 
-    def check(field, s_val, v_val, atol=atol, rtol=rtol):
+    def check(field, s_val, v_val, atol=EQUIV_ATOL, rtol=EQUIV_RTOL):
         diff = abs(s_val - v_val)
         tol = atol + rtol * max(abs(s_val), abs(v_val))
         if diff > tol:
@@ -117,7 +117,7 @@ def _run_sequence(df, action_indices, leverage=1, fee=0.0, action_levels=None, m
     td_v = vec.reset()
 
     # Compare initial state
-    mismatches = _compare_state(scalar, vec, 0, label)
+    mismatches = _compare_state(scalar, vec)
     for field, s_val, v_val, diff in mismatches:
         all_mismatches.append(f"[{label}] Step 0 RESET {field}: scalar={s_val:.6f} vec={v_val:.6f} diff={diff:.6f}")
 
@@ -132,13 +132,11 @@ def _run_sequence(df, action_indices, leverage=1, fee=0.0, action_levels=None, m
         action_td_v["action"] = torch.tensor([action_idx])
         td_v = vec.step(action_td_v)
 
-        atol, rtol = EQUIV_ATOL, EQUIV_RTOL
-
         # Compare rewards
         r_s = td_s["next"]["reward"].item()
         r_v = td_v["next"]["reward"].squeeze().item()
         r_diff = abs(r_s - r_v)
-        if r_diff > atol + rtol * max(abs(r_s), abs(r_v)):
+        if r_diff > EQUIV_ATOL + EQUIV_RTOL * max(abs(r_s), abs(r_v)):
             all_mismatches.append(
                 f"[{label}] Step {step+1} reward: scalar={r_s:.6f} vec={r_v:.6f} diff={r_diff:.6f}"
             )
@@ -163,7 +161,7 @@ def _run_sequence(df, action_indices, leverage=1, fee=0.0, action_levels=None, m
             s_val = as_s[i].item()
             v_val = as_v[i].item()
             diff = abs(s_val - v_val)
-            if diff > atol + rtol * max(abs(s_val), abs(v_val)):
+            if diff > EQUIV_ATOL + EQUIV_RTOL * max(abs(s_val), abs(v_val)):
                 all_mismatches.append(
                     f"[{label}] Step {step+1} account_state[{name}]: scalar={s_val:.6f} vec={v_val:.6f} diff={diff:.6f}"
                 )
@@ -174,14 +172,14 @@ def _run_sequence(df, action_indices, leverage=1, fee=0.0, action_levels=None, m
                 continue
             md_s = td_s["next"][key]
             md_v = td_v["next"][key].squeeze(0)
-            if not torch.allclose(md_s, md_v, atol=atol, rtol=rtol):
+            if not torch.allclose(md_s, md_v, atol=EQUIV_ATOL, rtol=EQUIV_RTOL):
                 max_diff = (md_s - md_v).abs().max().item()
                 all_mismatches.append(
                     f"[{label}] Step {step+1} {key}: max_diff={max_diff:.6f}"
                 )
 
         # Compare internal state
-        mismatches = _compare_state(scalar, vec, step + 1, label)
+        mismatches = _compare_state(scalar, vec)
         for field, s_val, v_val, diff in mismatches:
             all_mismatches.append(
                 f"[{label}] Step {step+1} {field}: scalar={s_val:.6f} vec={v_val:.6f} diff={diff:.6f}"

--- a/tests/envs/offline/test_vec_scalar_equivalence.py
+++ b/tests/envs/offline/test_vec_scalar_equivalence.py
@@ -63,10 +63,9 @@ def _make_pair(df, leverage=1, fee=0.0, action_levels=None, max_traj=40):
     return scalar, vec
 
 
-# Both engines compute money in float64 (MONEY_DTYPE), so the old atol=5e-4 -- sized to
-# absorb float32-vs-float64 ULP at balance=1000 -- no longer describes anything real. The
-# measured worst case across this file is under 1e-12; 1e-9 keeps ~1000x headroom. See the
-# same constants in test_vec_sltp_scalar_equivalence.py (#293).
+# Both engines compute money in float64 (MONEY_DTYPE); measured worst-case disagreement
+# across this file is under 1e-12, so 1e-9 leaves ~1000x headroom. The previous 5e-4 was
+# sized to absorb float32-vs-float64 ULP, which no longer exists.
 EQUIV_ATOL = 1e-9
 EQUIV_RTOL = 1e-9
 

--- a/tests/envs/offline/test_vec_scalar_equivalence.py
+++ b/tests/envs/offline/test_vec_scalar_equivalence.py
@@ -5,7 +5,6 @@ Runs both environments with identical configs and action sequences,
 comparing ALL observable state at every step. Any divergence is a bug.
 """
 
-import numpy as np
 import pandas as pd
 import pytest
 import torch
@@ -66,7 +65,7 @@ def _make_pair(df, leverage=1, fee=0.0, action_levels=None, max_traj=40):
 
 
 # Both engines compute money in float64 (MONEY_DTYPE); measured worst-case disagreement
-# across this file is under 1e-12, so 1e-9 leaves ~1000x headroom. The previous 5e-4 was
+# across both equivalence files is under 1e-12, so 1e-9 leaves ~1000x headroom. The previous 5e-4 was
 # sized to absorb float32-vs-float64 ULP, which no longer exists.
 EQUIV_ATOL = 1e-9
 EQUIV_RTOL = 1e-9
@@ -196,27 +195,9 @@ def _run_sequence(df, action_indices, leverage=1, fee=0.0, action_levels=None, m
     return all_mismatches
 
 
-class TestScalarVecEquivalenceRandomActions:
-    """Randomised actions on the base env.
-
-    Every other cell in this file pins a hand-picked sequence -- the pattern that let the
-    float32 divergence in #293 live in the SLTP harness for months, and that the SLTP side
-    has since moved away from. Leverage 25 is crossed in because leverage is what scales an
-    epsilon up onto a threshold.
-
-    action_levels stays in {-1, 0, 1}: intermediate levels are where the engines genuinely
-    disagree (#302), which would swamp this with a known failure.
-    """
-
-    @pytest.mark.parametrize("leverage", [1, 25], ids=["spot", "lev25"])
-    def test_random_actions_match(self, sample_ohlcv_df, leverage):
-        levels = [-1.0, 0.0, 1.0] if leverage > 1 else [0.0, 1.0]
-        actions = np.random.default_rng(0).integers(0, len(levels), size=100).tolist()
-        mismatches = _run_sequence(
-            sample_ohlcv_df, actions, leverage=leverage, fee=0.001,
-            action_levels=levels, max_traj=120, label=f"random-lev{leverage}",
-        )
-        assert not mismatches, "\n".join(mismatches)
+# ============================================================================
+# ACTION-LEVEL PRECISION
+# ============================================================================
 
 
 class TestScalarVecEquivalenceIntermediateLevel:

--- a/tests/envs/offline/test_vec_scalar_equivalence.py
+++ b/tests/envs/offline/test_vec_scalar_equivalence.py
@@ -63,12 +63,18 @@ def _make_pair(df, leverage=1, fee=0.0, action_levels=None, max_traj=40):
     return scalar, vec
 
 
-def _compare_state(scalar, vec, step, label, atol=5e-4, rtol=1e-3):
+# Both engines compute money in float64 (MONEY_DTYPE), so the old atol=5e-4 -- sized to
+# absorb float32-vs-float64 ULP at balance=1000 -- no longer describes anything real. The
+# measured worst case across this file is under 1e-12; 1e-9 keeps ~1000x headroom. See the
+# same constants in test_vec_sltp_scalar_equivalence.py (#293).
+EQUIV_ATOL = 1e-9
+EQUIV_RTOL = 1e-9
+
+
+def _compare_state(scalar, vec, step, label, atol=EQUIV_ATOL, rtol=EQUIV_RTOL):
     """Compare all observable state between scalar and vectorized envs.
 
     Uses numpy-style allclose: |s - v| <= atol + rtol * max(|s|, |v|).
-    atol=5e-4 accommodates float32 (vec) vs float64 (scalar) precision differences
-    (~1.2e-4 ULP at balance=1000).
 
     Returns list of (field, scalar_val, vec_val) mismatches.
     """
@@ -127,8 +133,7 @@ def _run_sequence(df, action_indices, leverage=1, fee=0.0, action_levels=None, m
         action_td_v["action"] = torch.tensor([action_idx])
         td_v = vec.step(action_td_v)
 
-        # Tolerances: float32 (vec) vs float64 (scalar) precision
-        atol, rtol = 5e-4, 1e-3
+        atol, rtol = EQUIV_ATOL, EQUIV_RTOL
 
         # Compare rewards
         r_s = td_s["next"]["reward"].item()

--- a/tests/envs/offline/test_vec_scalar_equivalence.py
+++ b/tests/envs/offline/test_vec_scalar_equivalence.py
@@ -5,6 +5,8 @@ Runs both environments with identical configs and action sequences,
 comparing ALL observable state at every step. Any divergence is a bug.
 """
 
+import numpy as np
+import pandas as pd
 import pytest
 import torch
 
@@ -192,6 +194,77 @@ def _run_sequence(df, action_indices, leverage=1, fee=0.0, action_levels=None, m
     scalar.close()
     vec.close()
     return all_mismatches
+
+
+class TestScalarVecEquivalenceRandomActions:
+    """Randomised actions on the base env.
+
+    Every other cell in this file pins a hand-picked sequence -- the pattern that let the
+    float32 divergence in #293 live in the SLTP harness for months, and that the SLTP side
+    has since moved away from. Leverage 25 is crossed in because leverage is what scales an
+    epsilon up onto a threshold.
+
+    action_levels stays in {-1, 0, 1}: intermediate levels are where the engines genuinely
+    disagree (#302), which would swamp this with a known failure.
+    """
+
+    @pytest.mark.parametrize("leverage", [1, 25], ids=["spot", "lev25"])
+    def test_random_actions_match(self, sample_ohlcv_df, leverage):
+        levels = [-1.0, 0.0, 1.0] if leverage > 1 else [0.0, 1.0]
+        actions = np.random.default_rng(0).integers(0, len(levels), size=100).tolist()
+        mismatches = _run_sequence(
+            sample_ohlcv_df, actions, leverage=leverage, fee=0.001,
+            action_levels=levels, max_traj=120, label=f"random-lev{leverage}",
+        )
+        assert not mismatches, "\n".join(mismatches)
+
+
+class TestScalarVecEquivalenceIntermediateLevel:
+    """An intermediate action level must reach position sizing undamaged.
+
+    Every action_levels value elsewhere in this file is in {-1, 0, 1}, exact in float32
+    and float64 alike, which leaves MONEY_DTYPE on _action_levels_tensor unfalsifiable --
+    reverting that one line to float32 keeps the whole suite green. 0.1 is not exact:
+    float32 holds it as 0.10000000149, putting a 1.5e-8 relative error into the notional.
+
+    Only the open from flat is compared. Resizing an existing position is where the two
+    engines genuinely disagree (#302), so this must not depend on that being settled.
+    """
+
+    def test_open_at_intermediate_level_matches_scalar(self):
+        # Awkward cash and price on purpose: at round numbers the level's float32 error
+        # rounds away and the test silently stops discriminating.
+        price, cash = 97.3, 1234.5678
+        n = 60
+        df = pd.DataFrame({
+            "timestamp": pd.date_range("2024-01-01", periods=n, freq="1min"),
+            "open": price, "high": price, "low": price, "close": price, "volume": 1000.0,
+        }, index=range(n))
+        common = dict(
+            action_levels=[0.0, 0.1, 1.0], leverage=3, initial_cash=cash,
+            time_frames=[TF_1MIN], window_sizes=[10], execute_on=TF_1MIN,
+            transaction_fee=0.0007, seed=42, max_traj_length=20, random_start=False,
+        )
+        scalar = SequentialTradingEnv(df, SequentialTradingEnvConfig(**common))
+        vec = VectorizedSequentialTradingEnv(
+            df, VectorizedSequentialTradingEnvConfig(num_envs=1, **common)
+        )
+        td_s, td_v = scalar.reset(), vec.reset()
+        td_s["action"] = torch.tensor(1)
+        td_v["action"] = torch.tensor([1])
+        scalar.step(td_s)
+        vec.step(td_v)
+
+        s_size = scalar.position.position_size
+        v_size = float(vec._position_sizes[0])
+        assert s_size != 0, "the level did not open a position -- nothing is being compared"
+        rel = abs(s_size - v_size) / abs(s_size)
+        assert rel < 1e-12, (
+            f"position_size scalar={s_size!r} vec={v_size!r} rel={rel:.3e} -- an "
+            "intermediate action level is being rounded before it reaches the notional"
+        )
+        scalar.close()
+        vec.close()
 
 
 # ============================================================================

--- a/tests/envs/offline/test_vec_sltp_scalar_equivalence.py
+++ b/tests/envs/offline/test_vec_sltp_scalar_equivalence.py
@@ -31,6 +31,8 @@ def _make_sltp_pair(
     max_traj=40,
     include_hold=True,
     include_close=False,
+    trade_mode="fractional",
+    lock=False,
 ):
     """Create matched scalar and N=1 vectorized SLTP envs."""
     if sl_levels is None:
@@ -38,51 +40,48 @@ def _make_sltp_pair(
     if tp_levels is None:
         tp_levels = [0.05, 0.1]
 
+    common = dict(
+        leverage=leverage,
+        stoploss_levels=sl_levels,
+        takeprofit_levels=tp_levels,
+        include_hold_action=include_hold,
+        include_close_action=include_close,
+        initial_cash=1000,
+        time_frames=[TF_1MIN],
+        window_sizes=[10],
+        execute_on=TF_1MIN,
+        transaction_fee=fee,
+        slippage=0.0,
+        seed=42,
+        max_traj_length=max_traj,
+        random_start=False,
+        trade_mode=trade_mode,
+        lock_position_until_sltp=lock,
+    )
+    # Ignored by the fractional path, which sizes off position_fraction instead.
+    if trade_mode != "fractional":
+        common["quantity_per_trade"] = 100.0
+
     scalar = SequentialTradingEnvSLTP(
-        df,
-        SequentialTradingEnvSLTPConfig(
-            leverage=leverage,
-            stoploss_levels=sl_levels,
-            takeprofit_levels=tp_levels,
-            include_hold_action=include_hold,
-            include_close_action=include_close,
-            initial_cash=1000,
-            time_frames=[TF_1MIN],
-            window_sizes=[10],
-            execute_on=TF_1MIN,
-            transaction_fee=fee,
-            slippage=0.0,
-            seed=42,
-            max_traj_length=max_traj,
-            random_start=False,
-        ),
-        simple_feature_fn,
+        df, SequentialTradingEnvSLTPConfig(**common), simple_feature_fn
     )
     vec = VectorizedSequentialTradingEnvSLTP(
-        df,
-        VectorizedSequentialTradingEnvSLTPConfig(
-            num_envs=1,
-            leverage=leverage,
-            stoploss_levels=sl_levels,
-            takeprofit_levels=tp_levels,
-            include_hold_action=include_hold,
-            include_close_action=include_close,
-            initial_cash=1000,
-            time_frames=[TF_1MIN],
-            window_sizes=[10],
-            execute_on=TF_1MIN,
-            transaction_fee=fee,
-            slippage=0.0,
-            seed=42,
-            max_traj_length=max_traj,
-            random_start=False,
-        ),
-        simple_feature_fn,
+        df, VectorizedSequentialTradingEnvSLTPConfig(num_envs=1, **common), simple_feature_fn
     )
     return scalar, vec
 
 
-def _compare_sltp_state(scalar, vec, step, label, atol=5e-4, rtol=1e-3):
+# Both engines compute money in float64 (MONEY_DTYPE), so "equivalent" can mean it.
+# Measured worst-case disagreement across this whole file is under 1e-12 -- they are not
+# bit-identical (at atol=rtol=0, 8 cases fail) but they are close to it, so 1e-9 leaves
+# ~1000x headroom. The previous 5e-4/1e-3 was loose enough to be nearly vacuous on money:
+# it swallowed a real 1.8e-4 balance divergence inside a computed tolerance of 0.24, which
+# is how the drift in #293 stayed invisible while only the binary done-flag caught anything.
+EQUIV_ATOL = 1e-9
+EQUIV_RTOL = 1e-9
+
+
+def _compare_sltp_state(scalar, vec, step, label, atol=EQUIV_ATOL, rtol=EQUIV_RTOL):
     """Compare all observable state between scalar and vectorized SLTP envs.
 
     Returns list of (field, scalar_val, vec_val) mismatches.
@@ -122,6 +121,10 @@ def _run_sltp_sequence(
     include_hold=True,
     include_close=False,
     expect_action_type=None,
+    trade_mode="fractional",
+    lock=False,
+    random_steps=None,
+    action_seed=0,
 ):
     """Run a sequence of actions through both envs and compare at every step.
 
@@ -139,13 +142,23 @@ def _run_sltp_sequence(
         max_traj=max_traj,
         include_hold=include_hold,
         include_close=include_close,
+        trade_mode=trade_mode,
+        lock=lock,
     )
+    if random_steps is not None:
+        # Drawn after construction so the draw respects the real action-space size, which
+        # changes with leverage (shorts) and include_close.
+        action_indices = (
+            np.random.default_rng(action_seed)
+            .integers(0, scalar.action_spec.n, size=random_steps)
+            .tolist()
+        )
     all_mismatches = []
 
     td_s = scalar.reset()
     td_v = vec.reset()
 
-    atol, rtol = 5e-4, 1e-3
+    atol, rtol = EQUIV_ATOL, EQUIV_RTOL
 
     # Compare initial state
     mismatches = _compare_sltp_state(scalar, vec, 0, label)
@@ -593,6 +606,39 @@ class TestSLTPScalarVecEquivalencePriority:
             sl_levels=[-0.05], tp_levels=[0.50],
             label="sltp-liquidation-over-bracket",
             expect_action_type="liquidation",
+        )
+        assert not mismatches, "\n".join(mismatches)
+
+
+class TestSLTPScalarVecEquivalenceTradeModesAndLock:
+    """The two axes this harness never varied, crossed with leverage (#293).
+
+    Every scenario above pins a hand-picked action sequence at the default
+    `trade_mode="fractional"` and `lock_position_until_sltp=False`. That left a real
+    divergence live for months: at leverage 25 with locking on, the vectorized env
+    terminated on bankruptcy a step the scalar env survived, because it accumulated money
+    in float32 and 100.0 - 2.4e-4 lands on the wrong side of a `<`.
+
+    Randomised actions rather than another hand-picked sequence: the hand-picked ones are
+    what missed it. The leverage axis is crossed in rather than fixed because leverage is
+    what scales an epsilon up onto a threshold -- at leverage 1 every combination here
+    already agreed, which is precisely why the gap was invisible.
+    """
+
+    @pytest.mark.parametrize("trade_mode", ["fractional", "notional", "quantity"])
+    @pytest.mark.parametrize("lock", [False, True], ids=["unlocked", "locked"])
+    @pytest.mark.parametrize("leverage", [1, 25], ids=["spot", "lev25"])
+    def test_random_actions_match(self, sample_ohlcv_df, trade_mode, lock, leverage):
+        mismatches = _run_sltp_sequence(
+            sample_ohlcv_df,
+            None,
+            leverage=leverage,
+            fee=0.001,
+            max_traj=120,
+            random_steps=100,
+            trade_mode=trade_mode,
+            lock=lock,
+            label=f"sltp-{trade_mode}-{'locked' if lock else 'unlocked'}-lev{leverage}",
         )
         assert not mismatches, "\n".join(mismatches)
 

--- a/tests/envs/offline/test_vec_sltp_scalar_equivalence.py
+++ b/tests/envs/offline/test_vec_sltp_scalar_equivalence.py
@@ -18,6 +18,9 @@ from torchtrade.envs.offline import (
 )
 from torchtrade.envs.utils.timeframe import TimeFrame, TimeFrameUnit
 from tests.conftest import simple_feature_fn
+# One home for the equivalence tolerance: two copies in two files is the same drift hazard
+# this PR removed from AFFORDABILITY_REL_TOL, one level up.
+from tests.envs.offline.test_vec_scalar_equivalence import EQUIV_ATOL, EQUIV_RTOL
 
 TF_1MIN = TimeFrame(1, TimeFrameUnit.Minute)
 
@@ -73,21 +76,14 @@ def _make_sltp_pair(
     return scalar, vec
 
 
-# Both engines compute money in float64 (MONEY_DTYPE); measured worst-case disagreement
-# across this file is under 1e-12, so 1e-9 leaves ~1000x headroom. They are close to
-# bit-identical but not quite: at atol=rtol=0, 8 cases fail.
-EQUIV_ATOL = 1e-9
-EQUIV_RTOL = 1e-9
-
-
-def _compare_sltp_state(scalar, vec, step, label, atol=EQUIV_ATOL, rtol=EQUIV_RTOL):
+def _compare_sltp_state(scalar, vec):
     """Compare all observable state between scalar and vectorized SLTP envs.
 
     Returns list of (field, scalar_val, vec_val) mismatches.
     """
     mismatches = []
 
-    def check(field, s_val, v_val, atol=atol, rtol=rtol):
+    def check(field, s_val, v_val, atol=EQUIV_ATOL, rtol=EQUIV_RTOL):
         diff = abs(s_val - v_val)
         tol = atol + rtol * max(abs(s_val), abs(v_val))
         if diff > tol:
@@ -111,18 +107,10 @@ def _compare_sltp_state(scalar, vec, step, label, atol=EQUIV_ATOL, rtol=EQUIV_RT
 def _run_sltp_sequence(
     df,
     action_indices,
-    leverage=1,
-    fee=0.0,
-    sl_levels=None,
-    tp_levels=None,
-    max_traj=40,
     label="",
-    include_hold=True,
-    include_close=False,
     expect_action_type=None,
-    trade_mode="fractional",
-    lock=False,
     random_steps=None,
+    **pair_kwargs,
 ):
     """Run a sequence of actions through both envs and compare at every step.
 
@@ -130,19 +118,11 @@ def _run_sltp_sequence(
         expect_action_type: if given, the run must actually record this action type
             (e.g. "sltp_sl"), so a scenario that stops reaching its bracket is reported
             rather than passing as a pair of idle envs.
+        random_steps: if given, `action_indices` is ignored and this many random actions
+            are drawn instead.
+        pair_kwargs: forwarded to `_make_sltp_pair`.
     """
-    scalar, vec = _make_sltp_pair(
-        df,
-        leverage=leverage,
-        fee=fee,
-        sl_levels=sl_levels,
-        tp_levels=tp_levels,
-        max_traj=max_traj,
-        include_hold=include_hold,
-        include_close=include_close,
-        trade_mode=trade_mode,
-        lock=lock,
-    )
+    scalar, vec = _make_sltp_pair(df, **pair_kwargs)
     if random_steps is not None:
         # Drawn after construction so the draw respects the real action-space size, which
         # changes with leverage (shorts) and include_close.
@@ -157,10 +137,8 @@ def _run_sltp_sequence(
     td_s = scalar.reset()
     td_v = vec.reset()
 
-    atol, rtol = EQUIV_ATOL, EQUIV_RTOL
-
     # Compare initial state
-    mismatches = _compare_sltp_state(scalar, vec, 0, label)
+    mismatches = _compare_sltp_state(scalar, vec)
     for field, s_val, v_val, diff in mismatches:
         all_mismatches.append(
             f"[{label}] Step 0 RESET {field}: scalar={s_val:.6f} vec={v_val:.6f} diff={diff:.6f}"
@@ -181,7 +159,7 @@ def _run_sltp_sequence(
         r_s = td_s["next"]["reward"].item()
         r_v = td_v["next"]["reward"].squeeze().item()
         r_diff = abs(r_s - r_v)
-        if r_diff > atol + rtol * max(abs(r_s), abs(r_v)):
+        if r_diff > EQUIV_ATOL + EQUIV_RTOL * max(abs(r_s), abs(r_v)):
             all_mismatches.append(
                 f"[{label}] Step {step+1} reward: scalar={r_s:.6f} vec={r_v:.6f} diff={r_diff:.6f}"
             )
@@ -206,13 +184,13 @@ def _run_sltp_sequence(
             s_val = as_s[i].item()
             v_val = as_v[i].item()
             diff = abs(s_val - v_val)
-            if diff > atol + rtol * max(abs(s_val), abs(v_val)):
+            if diff > EQUIV_ATOL + EQUIV_RTOL * max(abs(s_val), abs(v_val)):
                 all_mismatches.append(
                     f"[{label}] Step {step+1} account_state[{name}]: scalar={s_val:.6f} vec={v_val:.6f} diff={diff:.6f}"
                 )
 
         # Compare internal state
-        mismatches = _compare_sltp_state(scalar, vec, step + 1, label)
+        mismatches = _compare_sltp_state(scalar, vec)
         for field, s_val, v_val, diff in mismatches:
             all_mismatches.append(
                 f"[{label}] Step {step+1} {field}: scalar={s_val:.6f} vec={v_val:.6f} diff={diff:.6f}"
@@ -654,34 +632,26 @@ class TestSLTPScalarVecEquivalenceTradeModesAndLock:
 class TestAffordabilitySlackIsShared:
     """Both engines must make the same accept/reject call on a marginal open (#293).
 
-    `can_afford` compares cost against `balance * (1 + AFFORDABILITY_REL_TOL)`. The
-    vectorized envs carried 1e-5 there against the scalar envs' 1e-9 -- a 10,000x window
-    in which the vectorized env opened a position the scalar env refused, leaving one
-    engine in cash and the other fully deployed at a zeroed balance. Nothing caught it:
-    reverting either side to 1e-5 left all 680 offline tests green.
-
-    The prices are flat at 100 so the cost is exact arithmetic: 100 notional at leverage 1
-    is 100 margin plus 0.1 fee, and initial_cash is set to overshoot that by a chosen
-    relative amount.
+    The vectorized envs carried 1e-5 slack against the scalar envs' 1e-9 -- a 10,000x
+    window in which one engine opened a position the other refused, leaving one in cash
+    and the other fully deployed at a zeroed balance. Reverting either side to 1e-5 left
+    all 680 offline tests green.
     """
 
-    COST = 100.1  # 100.0 margin + 0.1 fee, at the flat price below
-
-    @pytest.mark.parametrize("overshoot,expect_open", [
+    @pytest.mark.parametrize("shortfall,expect_open", [
         (1e-11, True),
         (3e-6, False),
-        (1e-3, False),
-    ], ids=["inside-slack", "inside-the-old-1e-5-window", "plainly-unaffordable"])
-    def test_both_engines_make_the_same_call(self, overshoot, expect_open):
-        n = 40
+    ], ids=["inside-slack", "inside-the-old-1e-5-window"])
+    def test_both_engines_make_the_same_call(self, shortfall, expect_open):
+        # Flat at 100 so the cost is exact: 100 notional at leverage 1 is 100 margin plus
+        # 0.1 fee. Cash is set just short of that by `shortfall`.
         df = pd.DataFrame({
-            "timestamp": pd.date_range("2024-01-01", periods=n, freq="1min"),
+            "timestamp": pd.date_range("2024-01-01", periods=40, freq="1min"),
             "open": 100.0, "high": 100.0, "low": 100.0, "close": 100.0, "volume": 1000.0,
-        }, index=range(n))
+        }, index=range(40))
         scalar, vec = _make_sltp_pair(
             df, leverage=1, fee=0.001, sl_levels=[-0.05], tp_levels=[0.1],
-            max_traj=20, trade_mode="notional",
-            initial_cash=self.COST / (1 + overshoot),
+            max_traj=20, trade_mode="notional", initial_cash=100.1 / (1 + shortfall),
         )
         td_s, td_v = scalar.reset(), vec.reset()
         td_s["action"] = torch.tensor(1)
@@ -689,16 +659,10 @@ class TestAffordabilitySlackIsShared:
         scalar.step(td_s)
         vec.step(td_v)
 
-        opened_s = scalar.position.position_size != 0
-        opened_v = float(vec._position_sizes[0]) != 0
-        assert opened_s == opened_v, (
-            f"overshoot={overshoot}: scalar {'opened' if opened_s else 'refused'} but "
-            f"vec {'opened' if opened_v else 'refused'} -- the two engines disagree about "
-            "which opens are affordable"
-        )
-        assert opened_s == expect_open, (
-            f"overshoot={overshoot}: expected {'an open' if expect_open else 'a refusal'}, "
-            f"got {'an open' if opened_s else 'a refusal'}"
+        opened = (scalar.position.position_size != 0, float(vec._position_sizes[0]) != 0)
+        assert opened == (expect_open, expect_open), (
+            f"shortfall={shortfall}: (scalar, vec) opened={opened}, expected both "
+            f"{expect_open} -- the engines disagree about what is affordable"
         )
         scalar.close()
         vec.close()

--- a/tests/envs/offline/test_vec_sltp_scalar_equivalence.py
+++ b/tests/envs/offline/test_vec_sltp_scalar_equivalence.py
@@ -58,9 +58,10 @@ def _make_sltp_pair(
         trade_mode=trade_mode,
         lock_position_until_sltp=lock,
     )
-    # Ignored by the fractional path, which sizes off position_fraction instead.
-    if trade_mode != "fractional":
-        common["quantity_per_trade"] = 100.0
+    # Ignored by the fractional path. 100.0 is $100 of notional; in quantity mode it is
+    # 100 *units*, ~$10,000 at this fixture's ~$100 prices, which no leverage-1 balance can
+    # afford -- so that cell would open nothing and compare two idle envs.
+    common["quantity_per_trade"] = 100.0 if trade_mode == "notional" else 1.0
 
     scalar = SequentialTradingEnvSLTP(
         df, SequentialTradingEnvSLTPConfig(**common), simple_feature_fn
@@ -71,12 +72,9 @@ def _make_sltp_pair(
     return scalar, vec
 
 
-# Both engines compute money in float64 (MONEY_DTYPE), so "equivalent" can mean it.
-# Measured worst-case disagreement across this whole file is under 1e-12 -- they are not
-# bit-identical (at atol=rtol=0, 8 cases fail) but they are close to it, so 1e-9 leaves
-# ~1000x headroom. The previous 5e-4/1e-3 was loose enough to be nearly vacuous on money:
-# it swallowed a real 1.8e-4 balance divergence inside a computed tolerance of 0.24, which
-# is how the drift in #293 stayed invisible while only the binary done-flag caught anything.
+# Both engines compute money in float64 (MONEY_DTYPE); measured worst-case disagreement
+# across this file is under 1e-12, so 1e-9 leaves ~1000x headroom. They are close to
+# bit-identical but not quite: at atol=rtol=0, 8 cases fail.
 EQUIV_ATOL = 1e-9
 EQUIV_RTOL = 1e-9
 
@@ -153,6 +151,7 @@ def _run_sltp_sequence(
             .tolist()
         )
     all_mismatches = []
+    ever_open = False
 
     td_s = scalar.reset()
     td_v = vec.reset()
@@ -218,6 +217,8 @@ def _run_sltp_sequence(
                 f"[{label}] Step {step+1} {field}: scalar={s_val:.6f} vec={v_val:.6f} diff={diff:.6f}"
             )
 
+        ever_open = ever_open or scalar.position.position_size != 0
+
         if td_s["next"]["done"].item() or td_v["next"]["done"].item():
             break
 
@@ -227,6 +228,15 @@ def _run_sltp_sequence(
         all_mismatches.append(
             f"[{label}] path never exercised: no {expect_action_type} in "
             f"{scalar.history.action_types}"
+        )
+
+    # The random-action runs cannot name an expected action type, so this is their version
+    # of the same guard: sizing that no balance can afford opens nothing, and two envs that
+    # both sit in cash for 100 steps agree about everything. Two cells shipped that way.
+    if random_steps is not None and not ever_open:
+        all_mismatches.append(
+            f"[{label}] never opened a position in {random_steps} steps -- this cell is "
+            "comparing two idle envs, not two engines"
         )
 
     scalar.close()
@@ -610,22 +620,11 @@ class TestSLTPScalarVecEquivalencePriority:
 
 
 class TestSLTPScalarVecEquivalenceTradeModesAndLock:
-    """The two axes this harness never varied, crossed with leverage (#293).
+    """trade_mode and lock crossed with leverage -- the axes this harness never varied.
 
-    Every scenario above pins a hand-picked action sequence at the default
-    `trade_mode="fractional"` and `lock_position_until_sltp=False`. That left a real
-    divergence live for months: at leverage 25 with locking on, the vectorized env
-    terminated on bankruptcy a step the scalar env survived, because it accumulated money
-    in float32 and 100.0 - 2.4e-4 lands on the wrong side of a `<`.
-
-    Randomised actions rather than another hand-picked sequence: the hand-picked ones are
-    what missed it. Leverage is crossed in rather than fixed because it is what scales an
-    epsilon up onto a threshold -- #293 reported zero divergence at leverage 1.
-
-    That last part turns out to be a statement about the old tolerance, not about the
-    engines: with EQUIV_ATOL at 1e-9 the leverage-1 fractional and notional cells go red
-    under float32 too. Leverage decides whether the epsilon reaches a *threshold* and
-    flips an episode; it was never what decided whether the money drifted.
+    Randomised actions rather than another hand-picked sequence: hand-picked sequences are
+    what let the float32 divergence in #293 live here for months. Leverage is crossed in
+    because it is what scales an epsilon up onto a threshold and flips an episode.
     """
 
     @pytest.mark.parametrize("trade_mode", ["fractional", "notional", "quantity"])

--- a/tests/envs/offline/test_vec_sltp_scalar_equivalence.py
+++ b/tests/envs/offline/test_vec_sltp_scalar_equivalence.py
@@ -33,6 +33,7 @@ def _make_sltp_pair(
     include_close=False,
     trade_mode="fractional",
     lock=False,
+    initial_cash=1000,
 ):
     """Create matched scalar and N=1 vectorized SLTP envs."""
     if sl_levels is None:
@@ -46,7 +47,7 @@ def _make_sltp_pair(
         takeprofit_levels=tp_levels,
         include_hold_action=include_hold,
         include_close_action=include_close,
-        initial_cash=1000,
+        initial_cash=initial_cash,
         time_frames=[TF_1MIN],
         window_sizes=[10],
         execute_on=TF_1MIN,
@@ -643,6 +644,59 @@ class TestSLTPScalarVecEquivalenceTradeModesAndLock:
             label=f"sltp-{trade_mode}-{'locked' if lock else 'unlocked'}-lev{leverage}",
         )
         assert not mismatches, "\n".join(mismatches)
+
+
+class TestAffordabilitySlackIsShared:
+    """Both engines must make the same accept/reject call on a marginal open (#293).
+
+    `can_afford` compares cost against `balance * (1 + AFFORDABILITY_REL_TOL)`. The
+    vectorized envs carried 1e-5 there against the scalar envs' 1e-9 -- a 10,000x window
+    in which the vectorized env opened a position the scalar env refused, leaving one
+    engine in cash and the other fully deployed at a zeroed balance. Nothing caught it:
+    reverting either side to 1e-5 left all 680 offline tests green.
+
+    The prices are flat at 100 so the cost is exact arithmetic: 100 notional at leverage 1
+    is 100 margin plus 0.1 fee, and initial_cash is set to overshoot that by a chosen
+    relative amount.
+    """
+
+    COST = 100.1  # 100.0 margin + 0.1 fee, at the flat price below
+
+    @pytest.mark.parametrize("overshoot,expect_open", [
+        (1e-11, True),
+        (3e-6, False),
+        (1e-3, False),
+    ], ids=["inside-slack", "inside-the-old-1e-5-window", "plainly-unaffordable"])
+    def test_both_engines_make_the_same_call(self, overshoot, expect_open):
+        n = 40
+        df = pd.DataFrame({
+            "timestamp": pd.date_range("2024-01-01", periods=n, freq="1min"),
+            "open": 100.0, "high": 100.0, "low": 100.0, "close": 100.0, "volume": 1000.0,
+        }, index=range(n))
+        scalar, vec = _make_sltp_pair(
+            df, leverage=1, fee=0.001, sl_levels=[-0.05], tp_levels=[0.1],
+            max_traj=20, trade_mode="notional",
+            initial_cash=self.COST / (1 + overshoot),
+        )
+        td_s, td_v = scalar.reset(), vec.reset()
+        td_s["action"] = torch.tensor(1)
+        td_v["action"] = torch.tensor([1])
+        scalar.step(td_s)
+        vec.step(td_v)
+
+        opened_s = scalar.position.position_size != 0
+        opened_v = float(vec._position_sizes[0]) != 0
+        assert opened_s == opened_v, (
+            f"overshoot={overshoot}: scalar {'opened' if opened_s else 'refused'} but "
+            f"vec {'opened' if opened_v else 'refused'} -- the two engines disagree about "
+            "which opens are affordable"
+        )
+        assert opened_s == expect_open, (
+            f"overshoot={overshoot}: expected {'an open' if expect_open else 'a refusal'}, "
+            f"got {'an open' if opened_s else 'a refusal'}"
+        )
+        scalar.close()
+        vec.close()
 
 
 class TestSLTPScalarVecEquivalenceLiquidation:

--- a/tests/envs/offline/test_vec_sltp_scalar_equivalence.py
+++ b/tests/envs/offline/test_vec_sltp_scalar_equivalence.py
@@ -124,7 +124,6 @@ def _run_sltp_sequence(
     trade_mode="fractional",
     lock=False,
     random_steps=None,
-    action_seed=0,
 ):
     """Run a sequence of actions through both envs and compare at every step.
 
@@ -149,7 +148,7 @@ def _run_sltp_sequence(
         # Drawn after construction so the draw respects the real action-space size, which
         # changes with leverage (shorts) and include_close.
         action_indices = (
-            np.random.default_rng(action_seed)
+            np.random.default_rng(0)
             .integers(0, scalar.action_spec.n, size=random_steps)
             .tolist()
         )
@@ -620,9 +619,13 @@ class TestSLTPScalarVecEquivalenceTradeModesAndLock:
     in float32 and 100.0 - 2.4e-4 lands on the wrong side of a `<`.
 
     Randomised actions rather than another hand-picked sequence: the hand-picked ones are
-    what missed it. The leverage axis is crossed in rather than fixed because leverage is
-    what scales an epsilon up onto a threshold -- at leverage 1 every combination here
-    already agreed, which is precisely why the gap was invisible.
+    what missed it. Leverage is crossed in rather than fixed because it is what scales an
+    epsilon up onto a threshold -- #293 reported zero divergence at leverage 1.
+
+    That last part turns out to be a statement about the old tolerance, not about the
+    engines: with EQUIV_ATOL at 1e-9 the leverage-1 fractional and notional cells go red
+    under float32 too. Leverage decides whether the epsilon reaches a *threshold* and
+    flips an episode; it was never what decided whether the money drifted.
     """
 
     @pytest.mark.parametrize("trade_mode", ["fractional", "notional", "quantity"])

--- a/tests/envs/offline/test_vec_sltp_scalar_equivalence.py
+++ b/tests/envs/offline/test_vec_sltp_scalar_equivalence.py
@@ -5,6 +5,8 @@ Runs both environments with identical configs and action sequences,
 comparing ALL observable state at every step. Any divergence is a bug.
 """
 
+import collections
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -132,7 +134,6 @@ def _run_sltp_sequence(
             .tolist()
         )
     all_mismatches = []
-    steps_held = 0
 
     td_s = scalar.reset()
     td_v = vec.reset()
@@ -196,12 +197,8 @@ def _run_sltp_sequence(
                 f"[{label}] Step {step+1} {field}: scalar={s_val:.6f} vec={v_val:.6f} diff={diff:.6f}"
             )
 
-        steps_held += scalar.position.position_size != 0
-
         if td_s["next"]["done"].item() or td_v["next"]["done"].item():
             break
-
-    step_count = step + 1 if action_indices else 0
 
     # Without this a scenario whose action indices or wick stop reaching a bracket
     # degrades into "both envs held cash identically" and still passes.
@@ -211,17 +208,21 @@ def _run_sltp_sequence(
             f"{scalar.history.action_types}"
         )
 
-    # The random-action runs cannot name an expected action type, so this is their version
-    # of the same guard: sizing that no balance can afford opens nothing, and two envs that
-    # both sit in cash agree about everything. Two cells shipped that way, holding a
-    # position 0 steps out of 100. The floor is 25% rather than "at least once" because
-    # every healthy cell measures 91-100%, so a cell that falls near the floor has already
-    # stopped exercising the engines even though it still trades.
-    if random_steps is not None and steps_held < 0.25 * step_count:
-        all_mismatches.append(
-            f"[{label}] held a position on only {steps_held}/{step_count} steps -- this "
-            "cell is mostly comparing two idle envs, not two engines"
-        )
+    # The random runs cannot name one expected action type, so this is their version of the
+    # same guard, and it counts what the run exercised rather than how long a position sat
+    # open. Both weaker forms shipped: first cells that opened nothing at all, then cells
+    # that opened once and held for 99 steps with no bracket ever firing -- which a
+    # "position was open" check reads as maximally healthy. Healthy cells measure 8-38
+    # opens and 4-13 bracket exits, so these floors have room.
+    if random_steps is not None:
+        kinds = collections.Counter(scalar.history.action_types)
+        opens = kinds["long"] + kinds["short"]
+        brackets = kinds["sltp_sl"] + kinds["sltp_tp"]
+        if opens < 2 or brackets < 1:
+            all_mismatches.append(
+                f"[{label}] exercised {opens} opens and {brackets} bracket exits "
+                f"({dict(kinds)}) -- this cell is not reaching the SLTP machinery"
+            )
 
     scalar.close()
     vec.close()
@@ -624,6 +625,10 @@ class TestSLTPScalarVecEquivalenceTradeModesAndLock:
             random_steps=100,
             trade_mode=trade_mode,
             lock=lock,
+            # The fixture only spans +5.9%/-1.7%, so the default +/-5% brackets can never
+            # trigger: as shipped this grid fired zero stops across all twelve cells.
+            sl_levels=[-0.005],
+            tp_levels=[0.005],
             label=f"sltp-{trade_mode}-{'locked' if lock else 'unlocked'}-lev{leverage}",
         )
         assert not mismatches, "\n".join(mismatches)

--- a/tests/envs/offline/test_vec_sltp_scalar_equivalence.py
+++ b/tests/envs/offline/test_vec_sltp_scalar_equivalence.py
@@ -65,7 +65,7 @@ def _make_sltp_pair(
         lock_position_until_sltp=lock,
     )
     # Ignored by the fractional path. 100.0 is $100 of notional; in quantity mode it is
-    # 100 *units*, ~$10,000 at this fixture's ~$100 prices, which no leverage-1 balance can
+    # 100 *units*, ~$10,000 at these fixtures' ~$100 prices, which no leverage-1 balance can
     # afford -- so that cell would open nothing and compare two idle envs.
     common["quantity_per_trade"] = 100.0 if trade_mode == "notional" else 1.0
 
@@ -108,7 +108,7 @@ def _compare_sltp_state(scalar, vec):
 
 def _run_sltp_sequence(
     df,
-    action_indices,
+    action_indices=None,
     label="",
     expect_action_type=None,
     random_steps=None,
@@ -464,8 +464,8 @@ class TestSLTPScalarVecEquivalenceTrending:
 # ============================================================================
 
 
-def _flat_df_with_wick(bar=20, low=None, high=None, n=50):
-    """Flat 100.0 series with one bar carrying a single excursion."""
+def _flat_df(bar=20, low=None, high=None, n=50):
+    """Flat 100.0 series, optionally with one bar carrying a single excursion."""
     prices = np.full(n, 100.0)
     df = pd.DataFrame({
         "timestamp": pd.date_range("2024-01-01", periods=n, freq="1min"),
@@ -502,7 +502,7 @@ class TestSLTPScalarVecEquivalenceEntryBar:
         exercised by the trend-based cases above.
         """
         crash_bar = 20
-        df = _flat_df_with_wick(bar=crash_bar, low=wick_low, high=wick_high)
+        df = _flat_df(bar=crash_bar, low=wick_low, high=wick_high)
 
         # reset caches bar 10 (window_sizes=[10]), so step k executes at bar 10+k, and
         # the position opens one bar before the wick.
@@ -526,7 +526,7 @@ class TestSLTPScalarVecEquivalenceEntryBar:
         must NOT pre-empt the switch (#292): the agent closed that long at close(N),
         so bar 20 belongs to the short, which its own SL at 102.5 then stops out.
         """
-        df = _flat_df_with_wick(bar=20, high=120.0)
+        df = _flat_df(bar=20, high=120.0)
         long_tight, short_tight = 1, 5
         actions = [0] * 5 + [long_tight] + [0] * 3 + [short_tight] + [0] * 2
 
@@ -560,7 +560,7 @@ class TestSLTPScalarVecEquivalenceCloseVsTrigger:
     def test_close_action_beats_an_exit_on_the_same_bar(
         self, leverage, sl_levels, tp_levels, wick_high, wick_low
     ):
-        df = _flat_df_with_wick(bar=20, high=wick_high, low=wick_low)
+        df = _flat_df(bar=20, high=wick_high, low=wick_low)
         # With the close action enabled every index shifts by one: 2 is the first long.
         long_action, close_action = 2, 1
         actions = [0] * 5 + [long_action] + [0] * 3 + [close_action] + [0] * 2
@@ -590,7 +590,7 @@ class TestSLTPScalarVecEquivalencePriority:
     """
 
     def test_liquidation_wins_over_the_bracket_in_both_envs(self):
-        df = _flat_df_with_wick(bar=20, low=88.0)
+        df = _flat_df(bar=20, low=88.0)
         # 10x long at 100: SL 95, liquidation 90.4, bar low 88 breaches both.
         long_action = 1
         actions = [0] * 5 + [long_action] + [0] * 4
@@ -618,7 +618,6 @@ class TestSLTPScalarVecEquivalenceTradeModesAndLock:
     def test_random_actions_match(self, sample_ohlcv_df, trade_mode, lock, leverage):
         mismatches = _run_sltp_sequence(
             sample_ohlcv_df,
-            None,
             leverage=leverage,
             fee=0.001,
             max_traj=120,
@@ -640,7 +639,7 @@ class TestAffordabilitySlackIsShared:
     The vectorized envs carried 1e-5 slack against the scalar envs' 1e-9 -- a 10,000x
     window in which one engine opened a position the other refused, leaving one in cash
     and the other fully deployed at a zeroed balance. Reverting either side to 1e-5 left
-    all 680 offline tests green.
+    the whole offline suite green.
     """
 
     @pytest.mark.parametrize("shortfall,expect_open", [
@@ -648,12 +647,10 @@ class TestAffordabilitySlackIsShared:
         (3e-6, False),
     ], ids=["inside-slack", "inside-the-old-1e-5-window"])
     def test_both_engines_make_the_same_call(self, shortfall, expect_open):
-        # Flat at 100 so the cost is exact: 100 notional at leverage 1 is 100 margin plus
-        # 0.1 fee. Cash is set just short of that by `shortfall`.
-        df = pd.DataFrame({
-            "timestamp": pd.date_range("2024-01-01", periods=40, freq="1min"),
-            "open": 100.0, "high": 100.0, "low": 100.0, "close": 100.0, "volume": 1000.0,
-        }, index=range(40))
+        # Flat at 100, and _make_sltp_pair sizes notional mode at quantity_per_trade=100,
+        # so the cost is exact: 100 margin at leverage 1 plus 0.1 fee. Cash is set just
+        # short of that 100.1 by `shortfall`.
+        df = _flat_df(n=40)
         scalar, vec = _make_sltp_pair(
             df, leverage=1, fee=0.001, sl_levels=[-0.05], tp_levels=[0.1],
             max_traj=20, trade_mode="notional", initial_cash=100.1 / (1 + shortfall),

--- a/tests/envs/offline/test_vec_sltp_scalar_equivalence.py
+++ b/tests/envs/offline/test_vec_sltp_scalar_equivalence.py
@@ -152,7 +152,7 @@ def _run_sltp_sequence(
             .tolist()
         )
     all_mismatches = []
-    ever_open = False
+    steps_held = 0
 
     td_s = scalar.reset()
     td_v = vec.reset()
@@ -218,10 +218,12 @@ def _run_sltp_sequence(
                 f"[{label}] Step {step+1} {field}: scalar={s_val:.6f} vec={v_val:.6f} diff={diff:.6f}"
             )
 
-        ever_open = ever_open or scalar.position.position_size != 0
+        steps_held += scalar.position.position_size != 0
 
         if td_s["next"]["done"].item() or td_v["next"]["done"].item():
             break
+
+    step_count = step + 1 if action_indices else 0
 
     # Without this a scenario whose action indices or wick stop reaching a bracket
     # degrades into "both envs held cash identically" and still passes.
@@ -233,11 +235,14 @@ def _run_sltp_sequence(
 
     # The random-action runs cannot name an expected action type, so this is their version
     # of the same guard: sizing that no balance can afford opens nothing, and two envs that
-    # both sit in cash for 100 steps agree about everything. Two cells shipped that way.
-    if random_steps is not None and not ever_open:
+    # both sit in cash agree about everything. Two cells shipped that way, holding a
+    # position 0 steps out of 100. The floor is 25% rather than "at least once" because
+    # every healthy cell measures 91-100%, so a cell that falls near the floor has already
+    # stopped exercising the engines even though it still trades.
+    if random_steps is not None and steps_held < 0.25 * step_count:
         all_mismatches.append(
-            f"[{label}] never opened a position in {random_steps} steps -- this cell is "
-            "comparing two idle envs, not two engines"
+            f"[{label}] held a position on only {steps_held}/{step_count} steps -- this "
+            "cell is mostly comparing two idle envs, not two engines"
         )
 
     scalar.close()

--- a/tests/envs/offline/test_vec_sltp_scalar_equivalence.py
+++ b/tests/envs/offline/test_vec_sltp_scalar_equivalence.py
@@ -616,6 +616,13 @@ class TestSLTPScalarVecEquivalenceTradeModesAndLock:
     @pytest.mark.parametrize("lock", [False, True], ids=["unlocked", "locked"])
     @pytest.mark.parametrize("leverage", [1, 25], ids=["spot", "lev25"])
     def test_random_actions_match(self, sample_ohlcv_df, trade_mode, lock, leverage):
+        if lock and leverage == 1:
+            pytest.skip(
+                "lock is inert in spot: with no shorts and no close action the agent can "
+                "only ask for long or hold, and re-asking for long is already a no-op via "
+                "the duplicate-action guard. Measured byte-identical to the unlocked twin "
+                "(same action histogram, balance and position), so this cell is a copy."
+            )
         mismatches = _run_sltp_sequence(
             sample_ohlcv_df,
             leverage=leverage,

--- a/tests/envs/offline/test_vectorized_sequential.py
+++ b/tests/envs/offline/test_vectorized_sequential.py
@@ -328,6 +328,39 @@ class TestVecEnvEdgeCases:
 
         env.close()
 
+    def test_seeded_draws_stay_on_the_float32_stream(self, sample_ohlcv_df):
+        """MONEY_DTYPE widened the money state; the RNG draws must not widen with it.
+
+        torch's uniform_ consumes more generator bits at float64, so drawing initial cash
+        (or slippage noise) straight into MONEY_DTYPE shifts every subsequent draw and
+        silently changes the trajectory a saved seed reproduces -- seed 42 moved from
+        [1382.27, 1415.00, 882.86, 1459.31] to [558.15, 562.91, 623.59, 552.58] while
+        every test stayed green, because they only assert the values land inside the range.
+
+        Pinned against a reconstructed float32 stream rather than hardcoded numbers, so it
+        keeps its meaning if the range or env count changes.
+        """
+        n, lo, hi, seed = 4, 500.0, 1500.0, 42
+        env = VectorizedSequentialTradingEnv(
+            sample_ohlcv_df,
+            VectorizedSequentialTradingEnvConfig(
+                num_envs=n, initial_cash=(lo, hi), time_frames=[TF_1MIN],
+                window_sizes=[10], execute_on=TF_1MIN, max_traj_length=20,
+                random_start=False, seed=seed,
+            ),
+            simple_feature_fn,
+        )
+        env.reset()
+
+        generator = torch.Generator().manual_seed(seed)
+        expected = torch.empty(n).uniform_(lo, hi, generator=generator)
+        assert torch.equal(env._balances.float(), expected), (
+            f"initial cash {env._balances.tolist()} != the float32 stream's "
+            f"{expected.tolist()} -- the draw widened to MONEY_DTYPE and every saved seed "
+            "now reproduces a different trajectory"
+        )
+        env.close()
+
 
 # ============================================================================
 # FEE TESTS

--- a/tests/envs/offline/test_vectorized_sequential_sltp.py
+++ b/tests/envs/offline/test_vectorized_sequential_sltp.py
@@ -254,7 +254,8 @@ class TestVecSLTPTriggers:
 
         # Column 2 is low: pinning it here separates a mislanded step from a bar that
         # did not aggregate, and checks the hardcoded index this env reads by.
-        assert torch.allclose(env._base_tensor[env._step_indices, 2], torch.tensor(95.0)), (
+        lows = env._base_tensor[env._step_indices, 2]
+        assert torch.allclose(lows, torch.full_like(lows, 95.0)), (
             "the bar the position is checked against must report the wick: either the "
             "step landed on a different bar, or the bar did not aggregate its sub-bars"
         )
@@ -546,5 +547,7 @@ class TestSLTPCanAfford:
         env.step(td)
 
         assert (env._position_sizes == 0).all(), "an unaffordable open must be refused"
-        assert env._balances.allclose(torch.full((1,), 100.0)), "a refused open must cost nothing"
+        assert env._balances.allclose(
+            torch.full_like(env._balances, 100.0)
+        ), "a refused open must cost nothing"
         env.close()

--- a/torchtrade/envs/offline/sequential.py
+++ b/torchtrade/envs/offline/sequential.py
@@ -32,6 +32,7 @@ from torchtrade.envs.utils.fractional_sizing import (
     calculate_fractional_position,
     PositionCalculationParams,
     validate_action_levels,
+    AFFORDABILITY_REL_TOL,
     POSITION_TOLERANCE_PCT,
     POSITION_TOLERANCE_ABS,
 )
@@ -728,10 +729,7 @@ class SequentialTradingEnv(TorchTradeOfflineEnv):
         margin_required = notional_value / self.leverage
         fee = abs(notional_value) * self.transaction_fee
 
-        # Check if sufficient balance (relative tolerance for float round-trip errors:
-        # notional = PV / fee_multiplier * leverage, then margin = notional / leverage,
-        # fee = notional * fee_rate; round-trip can overshoot PV by ~1 ULP)
-        if margin_required + fee > self.balance * (1 + 1e-9):
+        if margin_required + fee > self.balance * (1 + AFFORDABILITY_REL_TOL):
             return {"executed": False, "side": None, "fee_paid": 0.0, "liquidated": False}
 
         # Deduct fee and margin
@@ -792,8 +790,7 @@ class SequentialTradingEnv(TorchTradeOfflineEnv):
         fee = delta_notional * self.transaction_fee
         margin_required = delta_notional / self.leverage
 
-        # Check sufficient balance (relative tolerance for float round-trip errors)
-        if margin_required + fee > self.balance * (1 + 1e-9):
+        if margin_required + fee > self.balance * (1 + AFFORDABILITY_REL_TOL):
             return {"executed": False, "side": None, "fee_paid": 0.0, "liquidated": False}
 
         # Execute trade - deduct fee and additional margin

--- a/torchtrade/envs/offline/sequential_sltp.py
+++ b/torchtrade/envs/offline/sequential_sltp.py
@@ -32,6 +32,7 @@ from torchtrade.envs.utils.sltp_helpers import (
     calculate_short_bracket_prices,
 )
 from torchtrade.envs.utils.action_maps import create_sltp_action_map
+from torchtrade.envs.utils.fractional_sizing import AFFORDABILITY_REL_TOL
 
 
 @dataclass
@@ -551,8 +552,7 @@ class SequentialTradingEnvSLTP(SequentialTradingEnv):
         margin_required = notional_value / self.leverage
         fee = abs(notional_value) * self.transaction_fee
 
-        # Check sufficient balance (relative tolerance for float round-trip errors)
-        if margin_required + fee > self.balance * (1 + 1e-9):
+        if margin_required + fee > self.balance * (1 + AFFORDABILITY_REL_TOL):
             return {"executed": False, "side": None, "fee_paid": 0.0, "liquidated": False}
 
         # Deduct fee and margin

--- a/torchtrade/envs/offline/vectorized_sequential.py
+++ b/torchtrade/envs/offline/vectorized_sequential.py
@@ -536,10 +536,11 @@ class VectorizedSequentialTradingEnv(EnvBase):
 
         # 4. Apply slippage
         if self.slippage > 0:
-            # float32 draw (see _sample_initial_cash), widened for the product below.
+            # float32 draw, for the generator-stream reason in _sample_initial_cash. No
+            # cast: torch promotes the float64 price times this, bit-identically.
             noise = torch.empty(self._num_envs).uniform_(
                 1 - self.slippage, 1 + self.slippage, generator=self._rng
-            ).to(MONEY_DTYPE)
+            )
             trade_prices = trade_prices * noise
 
         # 5. Execute trades (skip liquidated envs — scalar env skips trade after liquidation)

--- a/torchtrade/envs/offline/vectorized_sequential.py
+++ b/torchtrade/envs/offline/vectorized_sequential.py
@@ -24,11 +24,20 @@ from torchtrade.envs.offline.infrastructure.sampler import MarketDataObservation
 from torchtrade.envs.utils.timeframe import TimeFrame, normalize_timeframe_config
 from torchtrade.envs.utils.fractional_sizing import (
     validate_action_levels,
+    AFFORDABILITY_REL_TOL,
     POSITION_TOLERANCE_PCT,
     POSITION_TOLERANCE_ABS,
 )
 
 from torchtrade.envs.core.common_types import MarginType
+
+# Money is tracked in float64 to match the scalar envs, which compute in Python floats.
+# float32 has ~7 significant digits; leverage multiplies the absolute magnitudes, so the
+# accumulated relative epsilon lands on a bracket/bankruptcy boundary and flips a `<`.
+# That is not drift you can round away -- it is the two engines disagreeing about whether
+# a stop fired (#293). Every tensor holding money, a price, or a position size shares this
+# dtype; observations are cast back to float32 at the emission boundary for the network.
+MONEY_DTYPE = torch.float64
 
 
 @dataclass
@@ -103,10 +112,13 @@ class VectorizedSequentialTradingEnv(EnvBase):
     """Vectorized sequential trading environment.
 
     .. warning::
-        **EXPERIMENTAL**: This environment passes extensive equivalence tests
-        against SequentialTradingEnv, but has not been battle-tested in
-        production training runs. Use with caution and verify results against
-        the scalar implementation.
+        **EXPERIMENTAL**: Not battle-tested in production training runs.
+
+        Equivalence against SequentialTradingEnv is verified by
+        tests/envs/offline/test_vec_scalar_equivalence.py, which agrees on every
+        binary outcome (exit timing, done flags) and on money to within 1e-9. That
+        is a claim about the axes the harness varies -- leverage, fee, action
+        levels -- not a general guarantee; an untested axis is untested.
 
     Processes N environments in a single _step() call using tensor operations.
     All state (balances, positions, step indices) is stored as (num_envs,) tensors
@@ -141,7 +153,7 @@ class VectorizedSequentialTradingEnv(EnvBase):
 
         # Action levels as tensor
         self._action_levels_tensor = torch.tensor(
-            config.action_levels, dtype=torch.float32
+            config.action_levels, dtype=MONEY_DTYPE
         )
         # Clamp negative actions for spot mode (no shorts)
         if config.leverage == 1:
@@ -162,7 +174,9 @@ class VectorizedSequentialTradingEnv(EnvBase):
         # Extract pre-computed data from sampler
         self._market_tensors = self._sampler.torch_tensors  # {key: (N, F)}
         self._obs_indices = self._sampler._obs_indices  # {key: ndarray}
-        self._base_tensor = self._sampler.execute_base_tensor  # (M, F)
+        # OHLCV the trades price off: float64 so a bracket price computed from it does not
+        # round before it is compared against a wick.
+        self._base_tensor = self._sampler.execute_base_tensor.to(MONEY_DTYPE)  # (M, F)
         self._total_exec_times = len(self._sampler._exec_times_arr)
         if self._total_exec_times == 0:
             raise ValueError("Dataset has no execution times - cannot create environment")
@@ -235,21 +249,21 @@ class VectorizedSequentialTradingEnv(EnvBase):
             self._rng.manual_seed(config.seed)
 
         # Allocate state tensors
-        self._balances = torch.zeros(N)
-        self._position_sizes = torch.zeros(N)
-        self._entry_prices = torch.zeros(N)
+        self._balances = torch.zeros(N, dtype=MONEY_DTYPE)
+        self._position_sizes = torch.zeros(N, dtype=MONEY_DTYPE)
+        self._entry_prices = torch.zeros(N, dtype=MONEY_DTYPE)
         self._hold_counters = torch.zeros(N, dtype=torch.long)
-        self._prev_action_values = torch.full((N,), float("nan"))
+        self._prev_action_values = torch.full((N,), float("nan"), dtype=MONEY_DTYPE)
         self._step_indices = torch.zeros(N, dtype=torch.long)
         self._end_indices = torch.zeros(N, dtype=torch.long)
         self._step_counters = torch.zeros(N, dtype=torch.long)
         self._max_traj_lengths = torch.zeros(N, dtype=torch.long)
-        self._initial_pvs = torch.zeros(N)
-        self._portfolio_values = torch.zeros(N)
+        self._initial_pvs = torch.zeros(N, dtype=MONEY_DTYPE)
+        self._portfolio_values = torch.zeros(N, dtype=MONEY_DTYPE)
 
         # Constants
-        self._ones = torch.ones(N)
-        self._zeros = torch.zeros(N)
+        self._ones = torch.ones(N, dtype=MONEY_DTYPE)
+        self._zeros = torch.zeros(N, dtype=MONEY_DTYPE)
 
     def _set_seed(self, seed: Optional[int] = None):
         if seed is not None:
@@ -260,8 +274,10 @@ class VectorizedSequentialTradingEnv(EnvBase):
         """Sample initial cash for n environments."""
         if isinstance(self.config.initial_cash, (tuple, list)):
             lo, hi = self.config.initial_cash
-            return torch.empty(n).uniform_(float(lo), float(hi), generator=self._rng)
-        return torch.full((n,), float(self.config.initial_cash))
+            return torch.empty(n, dtype=MONEY_DTYPE).uniform_(
+                float(lo), float(hi), generator=self._rng
+            )
+        return torch.full((n,), float(self.config.initial_cash), dtype=MONEY_DTYPE)
 
     def _sample_start_indices(self, n: int) -> Tuple[torch.Tensor, torch.Tensor]:
         """Sample random start indices and compute end indices.
@@ -418,17 +434,20 @@ class VectorizedSequentialTradingEnv(EnvBase):
         else:
             distance_to_liq = self._ones
 
+        # Money is float64 internally (see MONEY_DTYPE); the observation is the boundary
+        # where it becomes float32 again, because that is what the spec and the network
+        # expect. Cast the stack, not the parts, so a new element cannot miss it.
         account_state = torch.stack(
             [
                 exposure_pct,
                 position_direction,
                 unrealized_pnl_pct,
-                self._hold_counters.float(),
+                self._hold_counters.to(MONEY_DTYPE),
                 leverage_tensor,
                 distance_to_liq,
             ],
             dim=-1,
-        )  # (N, 6)
+        ).float()  # (N, 6)
 
         obs_data = {"account_state": account_state}
 
@@ -518,7 +537,7 @@ class VectorizedSequentialTradingEnv(EnvBase):
 
         # 4. Apply slippage
         if self.slippage > 0:
-            noise = torch.empty(self._num_envs).uniform_(
+            noise = torch.empty(self._num_envs, dtype=MONEY_DTYPE).uniform_(
                 1 - self.slippage, 1 + self.slippage, generator=self._rng
             )
             trade_prices = trade_prices * noise
@@ -564,7 +583,8 @@ class VectorizedSequentialTradingEnv(EnvBase):
 
         # 10. Build next observation (reuse already-computed PVs)
         obs_td = self._build_observation(new_prices, portfolio_values=new_pvs)
-        obs_td.set("reward", rewards.unsqueeze(-1))
+        # .float(): reward is derived from float64 money but declared float32 (MONEY_DTYPE).
+        obs_td.set("reward", rewards.unsqueeze(-1).float())
         obs_td.set("terminated", terminated.unsqueeze(-1))
         obs_td.set("truncated", truncated.unsqueeze(-1))
         obs_td.set("done", done.unsqueeze(-1))
@@ -661,10 +681,9 @@ class VectorizedSequentialTradingEnv(EnvBase):
             )
             new_fee = notional_new * self.transaction_fee
 
-            # Check sufficient balance (float32 needs larger tolerance than float64:
-            # scalar env uses 1e-9 with float64, but float32 division+multiplication
-            # round-trip can overshoot by up to ~1e-4 at balance=1000, so we use 1e-5)
-            can_afford = (margin_new + new_fee) <= self._balances * (1 + 1e-5)
+            can_afford = (margin_new + new_fee) <= self._balances * (
+                1 + AFFORDABILITY_REL_TOL
+            )
             final_open = open_mask & can_afford
 
             if final_open.any():

--- a/torchtrade/envs/offline/vectorized_sequential.py
+++ b/torchtrade/envs/offline/vectorized_sequential.py
@@ -31,12 +31,10 @@ from torchtrade.envs.utils.fractional_sizing import (
 
 from torchtrade.envs.core.common_types import MarginType
 
-# Money is tracked in float64 to match the scalar envs, which compute in Python floats.
-# float32 has ~7 significant digits; leverage multiplies the absolute magnitudes, so the
-# accumulated relative epsilon lands on a bracket/bankruptcy boundary and flips a `<`.
-# That is not drift you can round away -- it is the two engines disagreeing about whether
-# a stop fired (#293). Every tensor holding money, a price, or a position size shares this
-# dtype; observations are cast back to float32 at the emission boundary for the network.
+# Money, prices and position sizes are tracked in float64 to match the scalar envs' Python
+# floats. In float32 the accumulated relative epsilon, scaled up by leverage, lands on a
+# bracket/bankruptcy boundary and flips it -- the two engines then disagree about whether a
+# stop fired (#293). Observations and rewards are cast back to float32 at emission.
 MONEY_DTYPE = torch.float64
 
 
@@ -116,8 +114,8 @@ class VectorizedSequentialTradingEnv(EnvBase):
 
         Equivalence against SequentialTradingEnv is verified by
         tests/envs/offline/test_vec_scalar_equivalence.py: every binary outcome, and
-        money to within 1e-9. That is a claim about the axes the harness varies --
-        leverage and fee. It does NOT cover intermediate action_levels, where the two
+        money to within 1e-9 -- a claim about the axes it varies, leverage and fee.
+        It does NOT cover intermediate action_levels, where the two
         engines are known to disagree (see #302): the scalar env resizes a position in
         place with a weighted-average entry, the vectorized env always closes and
         reopens.
@@ -275,9 +273,9 @@ class VectorizedSequentialTradingEnv(EnvBase):
         """Sample initial cash for n environments."""
         if isinstance(self.config.initial_cash, (tuple, list)):
             lo, hi = self.config.initial_cash
-            # Drawn float32 then widened: uniform_ consumes different generator bits at
-            # float64, which would change what every saved seed reproduces. This is an
-            # input, not accumulated state.
+            # Drawn in float32 then widened: at float64 uniform_ consumes different
+            # generator bits, changing what every saved seed reproduces. An input, not
+            # accumulated state.
             return torch.empty(n).uniform_(
                 float(lo), float(hi), generator=self._rng
             ).to(MONEY_DTYPE)
@@ -438,8 +436,6 @@ class VectorizedSequentialTradingEnv(EnvBase):
         else:
             distance_to_liq = self._ones
 
-        # float32 boundary for the spec. Cast the stack, not the parts, so a new element
-        # cannot miss it.
         account_state = torch.stack(
             [
                 exposure_pct,
@@ -450,7 +446,7 @@ class VectorizedSequentialTradingEnv(EnvBase):
                 distance_to_liq,
             ],
             dim=-1,
-        ).float()  # (N, 6)
+        ).float()  # (N, 6); spec is float32 -- cast the stack so a new element cannot miss it
 
         obs_data = {"account_state": account_state}
 

--- a/torchtrade/envs/offline/vectorized_sequential.py
+++ b/torchtrade/envs/offline/vectorized_sequential.py
@@ -115,10 +115,10 @@ class VectorizedSequentialTradingEnv(EnvBase):
         Equivalence against SequentialTradingEnv is verified by
         tests/envs/offline/test_vec_scalar_equivalence.py: every binary outcome, and
         money to within 1e-9 -- a claim about the axes it varies, leverage and fee.
-        It does NOT cover intermediate action_levels, where the two
-        engines are known to disagree (see #302): the scalar env resizes a position in
-        place with a weighted-average entry, the vectorized env always closes and
-        reopens.
+        It does NOT cover *resizing* a position through an intermediate action_level,
+        where the two engines are known to disagree (see #302): the scalar env resizes
+        in place with a weighted-average entry, the vectorized env always closes and
+        reopens. The open from flat at an intermediate level is covered.
 
     Processes N environments in a single _step() call using tensor operations.
     All state (balances, positions, step indices) is stored as (num_envs,) tensors
@@ -174,7 +174,8 @@ class VectorizedSequentialTradingEnv(EnvBase):
         # Extract pre-computed data from sampler
         self._market_tensors = self._sampler.torch_tensors  # {key: (N, F)}
         self._obs_indices = self._sampler._obs_indices  # {key: ndarray}
-        # float64: bracket prices are computed against these wicks.
+        # float64: the wicks feed liquidation checks here and bracket triggers in the
+        # SLTP subclass, and the close column feeds every money computation.
         self._base_tensor = self._sampler.execute_base_tensor.to(MONEY_DTYPE)  # (M, F)
         self._total_exec_times = len(self._sampler._exec_times_arr)
         if self._total_exec_times == 0:
@@ -441,7 +442,7 @@ class VectorizedSequentialTradingEnv(EnvBase):
                 exposure_pct,
                 position_direction,
                 unrealized_pnl_pct,
-                self._hold_counters.to(MONEY_DTYPE),
+                self._hold_counters.to(MONEY_DTYPE),  # not money; the stack needs one dtype
                 leverage_tensor,
                 distance_to_liq,
             ],

--- a/torchtrade/envs/offline/vectorized_sequential.py
+++ b/torchtrade/envs/offline/vectorized_sequential.py
@@ -115,10 +115,12 @@ class VectorizedSequentialTradingEnv(EnvBase):
         **EXPERIMENTAL**: Not battle-tested in production training runs.
 
         Equivalence against SequentialTradingEnv is verified by
-        tests/envs/offline/test_vec_scalar_equivalence.py, which agrees on every
-        binary outcome (exit timing, done flags) and on money to within 1e-9. That
-        is a claim about the axes the harness varies -- leverage, fee, action
-        levels -- not a general guarantee; an untested axis is untested.
+        tests/envs/offline/test_vec_scalar_equivalence.py: every binary outcome, and
+        money to within 1e-9. That is a claim about the axes the harness varies --
+        leverage and fee. It does NOT cover intermediate action_levels, where the two
+        engines are known to disagree (see #302): the scalar env resizes a position in
+        place with a weighted-average entry, the vectorized env always closes and
+        reopens.
 
     Processes N environments in a single _step() call using tensor operations.
     All state (balances, positions, step indices) is stored as (num_envs,) tensors
@@ -174,8 +176,7 @@ class VectorizedSequentialTradingEnv(EnvBase):
         # Extract pre-computed data from sampler
         self._market_tensors = self._sampler.torch_tensors  # {key: (N, F)}
         self._obs_indices = self._sampler._obs_indices  # {key: ndarray}
-        # OHLCV the trades price off: float64 so a bracket price computed from it does not
-        # round before it is compared against a wick.
+        # float64: bracket prices are computed against these wicks.
         self._base_tensor = self._sampler.execute_base_tensor.to(MONEY_DTYPE)  # (M, F)
         self._total_exec_times = len(self._sampler._exec_times_arr)
         if self._total_exec_times == 0:
@@ -437,9 +438,8 @@ class VectorizedSequentialTradingEnv(EnvBase):
         else:
             distance_to_liq = self._ones
 
-        # Money is float64 internally (see MONEY_DTYPE); the observation is the boundary
-        # where it becomes float32 again, because that is what the spec and the network
-        # expect. Cast the stack, not the parts, so a new element cannot miss it.
+        # float32 boundary for the spec. Cast the stack, not the parts, so a new element
+        # cannot miss it.
         account_state = torch.stack(
             [
                 exposure_pct,
@@ -587,7 +587,7 @@ class VectorizedSequentialTradingEnv(EnvBase):
 
         # 10. Build next observation (reuse already-computed PVs)
         obs_td = self._build_observation(new_prices, portfolio_values=new_pvs)
-        # .float(): reward is derived from float64 money but declared float32 (MONEY_DTYPE).
+        # reward_spec is float32.
         obs_td.set("reward", rewards.unsqueeze(-1).float())
         obs_td.set("terminated", terminated.unsqueeze(-1))
         obs_td.set("truncated", truncated.unsqueeze(-1))
@@ -685,9 +685,7 @@ class VectorizedSequentialTradingEnv(EnvBase):
             )
             new_fee = notional_new * self.transaction_fee
 
-            can_afford = (margin_new + new_fee) <= self._balances * (
-                1 + AFFORDABILITY_REL_TOL
-            )
+            can_afford = (margin_new + new_fee) <= self._balances * (1 + AFFORDABILITY_REL_TOL)
             final_open = open_mask & can_afford
 
             if final_open.any():

--- a/torchtrade/envs/offline/vectorized_sequential.py
+++ b/torchtrade/envs/offline/vectorized_sequential.py
@@ -274,9 +274,12 @@ class VectorizedSequentialTradingEnv(EnvBase):
         """Sample initial cash for n environments."""
         if isinstance(self.config.initial_cash, (tuple, list)):
             lo, hi = self.config.initial_cash
-            return torch.empty(n, dtype=MONEY_DTYPE).uniform_(
+            # Drawn float32 then widened: uniform_ consumes different generator bits at
+            # float64, which would change what every saved seed reproduces. This is an
+            # input, not accumulated state.
+            return torch.empty(n).uniform_(
                 float(lo), float(hi), generator=self._rng
-            )
+            ).to(MONEY_DTYPE)
         return torch.full((n,), float(self.config.initial_cash), dtype=MONEY_DTYPE)
 
     def _sample_start_indices(self, n: int) -> Tuple[torch.Tensor, torch.Tensor]:
@@ -537,9 +540,10 @@ class VectorizedSequentialTradingEnv(EnvBase):
 
         # 4. Apply slippage
         if self.slippage > 0:
-            noise = torch.empty(self._num_envs, dtype=MONEY_DTYPE).uniform_(
+            # float32 draw (see _sample_initial_cash), widened for the product below.
+            noise = torch.empty(self._num_envs).uniform_(
                 1 - self.slippage, 1 + self.slippage, generator=self._rng
-            )
+            ).to(MONEY_DTYPE)
             trade_prices = trade_prices * noise
 
         # 5. Execute trades (skip liquidated envs — scalar env skips trade after liquidation)

--- a/torchtrade/envs/offline/vectorized_sequential_sltp.py
+++ b/torchtrade/envs/offline/vectorized_sequential_sltp.py
@@ -163,10 +163,8 @@ class VectorizedSequentialTradingEnvSLTP(VectorizedSequentialTradingEnv):
             tp_list.append(tp if tp is not None else 0.0)
 
         self._action_sides = torch.tensor(sides_list, dtype=torch.long)
-        # float64 because of what is STORED, not what is computed: torch promotes, so a
-        # float32 level times a float64 price is already a float64 product. But float32
-        # holds 0.05 as 0.050000000745, putting the bracket at 104.999995 instead of
-        # 105.0 -- an error in the level itself, carried into every price it sizes.
+        # float64 for the level itself, not the product (torch already promotes that):
+        # float32 holds 0.05 as 0.050000000745, putting the bracket at 104.999995.
         self._action_sl_pcts = torch.tensor(sl_list, dtype=MONEY_DTYPE)
         self._action_tp_pcts = torch.tensor(tp_list, dtype=MONEY_DTYPE)
 

--- a/torchtrade/envs/offline/vectorized_sequential_sltp.py
+++ b/torchtrade/envs/offline/vectorized_sequential_sltp.py
@@ -206,10 +206,11 @@ class VectorizedSequentialTradingEnvSLTP(VectorizedSequentialTradingEnv):
         # 2. Save bar N close as trade prices (with slippage)
         trade_prices = self._base_tensor[self._step_indices, 3].clone()
         if self.slippage > 0:
-            # float32 draw (see _sample_initial_cash), widened for the product below.
+            # float32 draw, for the generator-stream reason in _sample_initial_cash. No
+            # cast: torch promotes the float64 price times this, bit-identically.
             noise = torch.empty(N).uniform_(
                 1 - self.slippage, 1 + self.slippage, generator=self._rng
-            ).to(MONEY_DTYPE)
+            )
             trade_prices = trade_prices * noise
 
         # 3. Advance step indices to bar N+1

--- a/torchtrade/envs/offline/vectorized_sequential_sltp.py
+++ b/torchtrade/envs/offline/vectorized_sequential_sltp.py
@@ -209,9 +209,10 @@ class VectorizedSequentialTradingEnvSLTP(VectorizedSequentialTradingEnv):
         # 2. Save bar N close as trade prices (with slippage)
         trade_prices = self._base_tensor[self._step_indices, 3].clone()
         if self.slippage > 0:
-            noise = torch.empty(N, dtype=MONEY_DTYPE).uniform_(
+            # float32 draw (see _sample_initial_cash), widened for the product below.
+            noise = torch.empty(N).uniform_(
                 1 - self.slippage, 1 + self.slippage, generator=self._rng
-            )
+            ).to(MONEY_DTYPE)
             trade_prices = trade_prices * noise
 
         # 3. Advance step indices to bar N+1

--- a/torchtrade/envs/offline/vectorized_sequential_sltp.py
+++ b/torchtrade/envs/offline/vectorized_sequential_sltp.py
@@ -90,11 +90,8 @@ class VectorizedSequentialTradingEnvSLTP(VectorizedSequentialTradingEnv):
 
         Equivalence against SequentialTradingEnvSLTP is verified by
         tests/envs/offline/test_vec_sltp_scalar_equivalence.py across leverage,
-        trade_mode and lock_position_until_sltp, agreeing on every binary outcome
-        and on money to within 1e-9. The trade_mode and lock axes were added in
-        #293, where their absence had hidden a real divergence: this env computed
-        money in float32, and at leverage 25 the accumulated epsilon flipped a
-        bankruptcy comparison the scalar env did not trip.
+        trade_mode and lock_position_until_sltp: every binary outcome, and money
+        to within 1e-9.
 
     Processes N SLTP environments in a single _step() call using tensor
     operations. All state (balances, positions, SL/TP prices) is stored as
@@ -166,8 +163,10 @@ class VectorizedSequentialTradingEnvSLTP(VectorizedSequentialTradingEnv):
             tp_list.append(tp if tp is not None else 0.0)
 
         self._action_sides = torch.tensor(sides_list, dtype=torch.long)
-        # MONEY_DTYPE, not float32: these multiply into bracket prices, and float32 here
-        # would round the product before it is ever assigned into a float64 tensor.
+        # float64 because of what is STORED, not what is computed: torch promotes, so a
+        # float32 level times a float64 price is already a float64 product. But float32
+        # holds 0.05 as 0.050000000745, putting the bracket at 104.999995 instead of
+        # 105.0 -- an error in the level itself, carried into every price it sizes.
         self._action_sl_pcts = torch.tensor(sl_list, dtype=MONEY_DTYPE)
         self._action_tp_pcts = torch.tensor(tp_list, dtype=MONEY_DTYPE)
 
@@ -252,7 +251,7 @@ class VectorizedSequentialTradingEnvSLTP(VectorizedSequentialTradingEnv):
 
         # 9. Build observation from bar N+1
         obs_td = self._build_observation(new_close, portfolio_values=new_pvs)
-        # .float(): reward is derived from float64 money but declared float32 (MONEY_DTYPE).
+        # reward_spec is float32.
         obs_td.set("reward", rewards.unsqueeze(-1).float())
         obs_td.set("terminated", terminated.unsqueeze(-1))
         obs_td.set("truncated", truncated.unsqueeze(-1))
@@ -459,9 +458,7 @@ class VectorizedSequentialTradingEnvSLTP(VectorizedSequentialTradingEnv):
             margin_new = notional / leverage
             new_fee = notional * self.transaction_fee
 
-            can_afford = (margin_new + new_fee) <= self._balances * (
-                1 + AFFORDABILITY_REL_TOL
-            )
+            can_afford = (margin_new + new_fee) <= self._balances * (1 + AFFORDABILITY_REL_TOL)
             final_open = open_mask & can_afford
 
             if final_open.any():

--- a/torchtrade/envs/offline/vectorized_sequential_sltp.py
+++ b/torchtrade/envs/offline/vectorized_sequential_sltp.py
@@ -22,10 +22,12 @@ from torchrl.data import Categorical
 
 from torchtrade.envs.core.common import TradeMode, validate_trade_mode
 from torchtrade.envs.offline.vectorized_sequential import (
+    MONEY_DTYPE,
     VectorizedSequentialTradingEnv,
     VectorizedSequentialTradingEnvConfig,
 )
 from torchtrade.envs.utils.action_maps import create_sltp_action_map
+from torchtrade.envs.utils.fractional_sizing import AFFORDABILITY_REL_TOL
 
 _SIDE_MAP = {"long": 1, "short": -1, "close": 2}
 
@@ -84,10 +86,15 @@ class VectorizedSequentialTradingEnvSLTP(VectorizedSequentialTradingEnv):
     """Vectorized sequential trading environment with stop-loss/take-profit support.
 
     .. warning::
-        **EXPERIMENTAL**: This environment passes extensive equivalence tests
-        against SequentialTradingEnvSLTP, but has not been battle-tested in
-        production training runs. Use with caution and verify results against
-        the scalar implementation.
+        **EXPERIMENTAL**: Not battle-tested in production training runs.
+
+        Equivalence against SequentialTradingEnvSLTP is verified by
+        tests/envs/offline/test_vec_sltp_scalar_equivalence.py across leverage,
+        trade_mode and lock_position_until_sltp, agreeing on every binary outcome
+        and on money to within 1e-9. The trade_mode and lock axes were added in
+        #293, where their absence had hidden a real divergence: this env computed
+        money in float32, and at leverage 25 the accumulated epsilon flipped a
+        bankruptcy comparison the scalar env did not trip.
 
     Processes N SLTP environments in a single _step() call using tensor
     operations. All state (balances, positions, SL/TP prices) is stored as
@@ -159,12 +166,14 @@ class VectorizedSequentialTradingEnvSLTP(VectorizedSequentialTradingEnv):
             tp_list.append(tp if tp is not None else 0.0)
 
         self._action_sides = torch.tensor(sides_list, dtype=torch.long)
-        self._action_sl_pcts = torch.tensor(sl_list, dtype=torch.float32)
-        self._action_tp_pcts = torch.tensor(tp_list, dtype=torch.float32)
+        # MONEY_DTYPE, not float32: these multiply into bracket prices, and float32 here
+        # would round the product before it is ever assigned into a float64 tensor.
+        self._action_sl_pcts = torch.tensor(sl_list, dtype=MONEY_DTYPE)
+        self._action_tp_pcts = torch.tensor(tp_list, dtype=MONEY_DTYPE)
 
         # SL/TP state tensors
-        self._sl_prices = torch.zeros(N)
-        self._tp_prices = torch.zeros(N)
+        self._sl_prices = torch.zeros(N, dtype=MONEY_DTYPE)
+        self._tp_prices = torch.zeros(N, dtype=MONEY_DTYPE)
 
     def _reset(self, tensordict: TensorDictBase, **kwargs) -> TensorDictBase:
         """Reset environments, including SL/TP state."""
@@ -200,7 +209,7 @@ class VectorizedSequentialTradingEnvSLTP(VectorizedSequentialTradingEnv):
         # 2. Save bar N close as trade prices (with slippage)
         trade_prices = self._base_tensor[self._step_indices, 3].clone()
         if self.slippage > 0:
-            noise = torch.empty(N).uniform_(
+            noise = torch.empty(N, dtype=MONEY_DTYPE).uniform_(
                 1 - self.slippage, 1 + self.slippage, generator=self._rng
             )
             trade_prices = trade_prices * noise
@@ -242,7 +251,8 @@ class VectorizedSequentialTradingEnvSLTP(VectorizedSequentialTradingEnv):
 
         # 9. Build observation from bar N+1
         obs_td = self._build_observation(new_close, portfolio_values=new_pvs)
-        obs_td.set("reward", rewards.unsqueeze(-1))
+        # .float(): reward is derived from float64 money but declared float32 (MONEY_DTYPE).
+        obs_td.set("reward", rewards.unsqueeze(-1).float())
         obs_td.set("terminated", terminated.unsqueeze(-1))
         obs_td.set("truncated", truncated.unsqueeze(-1))
         obs_td.set("done", done.unsqueeze(-1))
@@ -448,8 +458,9 @@ class VectorizedSequentialTradingEnvSLTP(VectorizedSequentialTradingEnv):
             margin_new = notional / leverage
             new_fee = notional * self.transaction_fee
 
-            # Float32 tolerance for can_afford check
-            can_afford = (margin_new + new_fee) <= self._balances * (1 + 1e-5)
+            can_afford = (margin_new + new_fee) <= self._balances * (
+                1 + AFFORDABILITY_REL_TOL
+            )
             final_open = open_mask & can_afford
 
             if final_open.any():

--- a/torchtrade/envs/utils/fractional_sizing.py
+++ b/torchtrade/envs/utils/fractional_sizing.py
@@ -21,6 +21,14 @@ class PositionCalculationParams:
 POSITION_TOLERANCE_PCT = 0.02  # 2% - relative tolerance as fraction of target position
 POSITION_TOLERANCE_ABS = 0.001  # Absolute minimum tolerance for very small positions
 
+# Affordability slack for "can I open this position?".
+# notional = PV / fee_multiplier * leverage, then margin = notional / leverage and
+# fee = notional * fee_rate; that round-trip can overshoot PV by ~1 ULP, and without slack
+# a position sized from the full balance refuses itself. Scalar and vectorized envs MUST
+# share this number: while the vectorized env ran on float32 it carried 1e-5 instead, so it
+# accepted opens the scalar env refused -- the same class of scalar/vec divergence as #293.
+AFFORDABILITY_REL_TOL = 1e-9
+
 
 def calculate_fractional_position(params: PositionCalculationParams) -> Tuple[float, float, str]:
     """Calculate position size from fractional action value.

--- a/torchtrade/envs/utils/fractional_sizing.py
+++ b/torchtrade/envs/utils/fractional_sizing.py
@@ -21,12 +21,11 @@ class PositionCalculationParams:
 POSITION_TOLERANCE_PCT = 0.02  # 2% - relative tolerance as fraction of target position
 POSITION_TOLERANCE_ABS = 0.001  # Absolute minimum tolerance for very small positions
 
-# Affordability slack for "can I open this position?".
-# notional = PV / fee_multiplier * leverage, then margin = notional / leverage and
-# fee = notional * fee_rate; that round-trip can overshoot PV by ~1 ULP, and without slack
-# a position sized from the full balance refuses itself. Scalar and vectorized envs MUST
-# share this number: while the vectorized env ran on float32 it carried 1e-5 instead, so it
-# accepted opens the scalar env refused -- the same class of scalar/vec divergence as #293.
+# Affordability slack for "can I open this position?": notional = PV / fee_multiplier *
+# leverage, then margin = notional / leverage and fee = notional * fee_rate -- a round-trip
+# that can overshoot PV by ~1 ULP, so without slack a position sized from the full balance
+# refuses itself. Scalar and vectorized envs MUST share this number or they disagree about
+# which opens are affordable.
 AFFORDABILITY_REL_TOL = 1e-9
 
 


### PR DESCRIPTION
Fixes #293.

## The bug

`VectorizedSequentialTradingEnvSLTP` tracked balances, positions and bracket prices in **float32** while `SequentialTradingEnvSLTP` used Python floats (float64). float32 carries ~7 significant digits; leverage scales the absolute magnitudes, so the accumulated relative epsilon lands on a threshold and flips a comparison.

Reproduced deterministically at `leverage=25`, `trade_mode="fractional"`, `lock_position_until_sltp=True`:

```
step 39: scalar balance 100.00000000   vec balance 99.99975586
         bankruptcy threshold = 1000 * 0.1 = 100.0, compared with strict `<`
scalar:  100.00000000 < 100.0  ->  False  ->  episode continues
vec:      99.99975586 < 100.0  ->  True   ->  TERMINATED
```

The two engines disagree about whether the episode ended, so a policy evaluated on one and deployed against the other's assumptions sees different exits.

## Why float64 and not a tolerance

The obvious alternative is a relative tolerance on the threshold comparisons. Measured, it does not hold up: the reproduced gap is `2.441e-06` relative, so the natural `1e-6` constant **still terminates** — the tolerance must exceed the accumulated error, which grows with leverage and episode length, making any fixed constant a guess.

I also tested the hypothesis that the divergence came from the two engines computing position size by differently-ordered but algebraically identical formulas. Aligning them changes the reproduced balance **not at all** — same value to the last bit. The cause is plain accumulated float32 rounding.

After the change the two engines agree to better than **1e-12** across the entire equivalence suite.

## Cost

Pinned `.venv`, CPU, `OMP_NUM_THREADS=1`, best of 5:

| num_envs | float32 | float64 | delta |
|---|---|---|---|
| 64 | 154,006 steps/s | 155,058 steps/s | +0.7% (noise) |
| 256 | 547,732 steps/s | 534,276 steps/s | −2.5% |
| 1024 | 1,575,547 steps/s | 1,501,097 steps/s | −4.7% |

Up to ~5% at the largest batch, still 1.5M steps/s. Observations and reward are cast back to float32 at emission, so specs and networks are unchanged.

## Seeded reproducibility is preserved (a near-miss)

`uniform_` consumes more generator bits at float64, so drawing initial cash and slippage noise straight into `MONEY_DTYPE` shifted every subsequent draw. Seed 42 went from cash `[1382.27, 1415.00, 882.86, 1459.31]` / starts `[231, 233, 238, 41]` to `[558.15, 562.91, 623.59, 552.58]` / `[229, 77, 253, 181]` — silently different trajectories for anyone with a pinned seed.

The draws now stay float32 and are widened afterwards, so the RNG stream is **bit-identical to main**. The sampled value is an input; it was the accumulation that needed the wider type.

## Two further bugs found by getting the dtype right

- **`can_afford` tolerance.** The vectorized envs used `1e-5` with a comment justifying it as a float32 workaround; the scalar envs used `1e-9`. The vectorized env was *accepting opens the scalar env refused*. All five sites now share `AFFORDABILITY_REL_TOL`. Genuinely coupled to the dtype: under float32, `1e-9` fails.
- **Slippage noise** was drawn in float32 and multiplied into a float64 price. Every equivalence test runs `slippage=0.0`, which is why nothing caught it — that branch had **zero** coverage suite-wide.

## Tests

The harness now varies `trade_mode` × `lock_position_until_sltp` × leverage (12 cells) with randomised fixed-seed actions, and the equivalence tolerance is tightened from `atol=5e-4, rtol=1e-3` to `1e-9`. The old value was close to vacuous on money: it swallowed a real 1.8e-4 balance divergence inside a computed tolerance of 0.24, so only the binary done-flag comparison caught anything. Measured worst case is under 1e-12.

New coverage for previously-unguarded lines: the float32 RNG stream, the vectorized slippage branch, `_action_levels_tensor`'s dtype (unfalsifiable before, since every level in the suite was in `{-1,0,1}` — exact in both dtypes), and the affordability slack on both the SLTP and scale-up paths.

Mutation matrix at the tip:

| Mutation | Tests red |
|---|---|
| `MONEY_DTYPE` → float32 | 75 |
| `account_state` `.float()` removed | 63 |
| `_action_sl/tp_pcts` → float32 | 43 |
| `_base_tensor` cast removed | 42 |
| `_sl/_tp_prices` → float32 | 36 |
| SLTP grid brackets widened back | 12 |
| `AFFORDABILITY_REL_TOL` → 0.0 | 8 |
| `AFFORDABILITY_REL_TOL` → 1e-5 | 2 |
| slippage branch skipped | 2 |
| `_action_levels_tensor` → float32 | 1 |
| initial-cash draw widened to float64 | 1 |
| clean baseline | 0 |

Full suite: 2324 passed, 18 skipped.

## Review

Three rounds, four reviewers each. Each round found real defects in the previous round's fixes:

- **Round 1** — the RNG-stream break above; two of the twelve new grid cells were vacuous (sizing no leverage-1 balance could afford, so they compared two idle envs); a comment named the wrong mechanism for the SL/TP level dtype.
- **Round 2** — the grid fired **zero brackets** in all twelve cells (the fixture spans +5.9%/−1.7% against ±5% levels), and nine cells opened once then held for 99 steps, which the round-1 guard read as maximally healthy. Guard now counts opens and bracket exits.
- **Round 3** — a docstring claiming the base harness does not cover intermediate `action_levels`, made false by a test added later in round 2; and a refutation of my own dismissal of an affordability finding: I checked `_open_position`, found `cost == pv * |action|` algebraically, and generalised to all three base sites without checking `_increase_position_size`, which sizes the delta from portfolio value but pays from balance and *does* reach the 1e-9..1e-5 window (position 9.9999/balance 500 vs position 19.9998/balance 0.0, with a "Negative balance detected" log). Now pinned.

## Follow-up

**#302** — the scalar and vectorized envs disagree by 1.5% of portfolio in 8 steps on intermediate `action_levels`: the scalar resizes in place with a weighted-average entry, the vectorized always closes and reopens. Pre-existing, roughly five orders of magnitude larger than the divergence this PR fixes, and deliberately out of scope. The class docstring now scopes the equivalence claim to exclude it rather than asserting coverage it lacks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
