### PR TITLE
feat(actor): add optional Adanos sentiment tool

### DIFF
--- a/docs/components/actors.md
+++ b/docs/components/actors.md
@@ -147,7 +147,7 @@ only when configured (live path); without them the actor is single-shot as befor
 
 ```python
 from torchtrade.actor import LocalLLMActor
-from torchtrade.actor.tools import GoogleNewsTool
+from torchtrade.actor.tools import AdanosSentimentTool, GoogleNewsTool
 
 actor = LocalLLMActor(
     model="Qwen/Qwen2.5-0.5B-Instruct", backend="vllm",
@@ -155,7 +155,10 @@ actor = LocalLLMActor(
     account_state_labels=env.account_state,
     action_levels=env.action_levels,
     symbol="BTC/USD",
-    tools=[GoogleNewsTool(symbol="BTC/USD")],
+    tools=[
+        GoogleNewsTool(symbol="BTC/USD"),
+        AdanosSentimentTool(symbol="BTC/USD", asset_type="crypto"),
+    ],
     max_tool_iters=3,
 )
 ```
@@ -166,6 +169,15 @@ block, then continues until it emits `<answer>N</answer>`. Only conversations th
 call a tool are re-generated, so batched multi-symbol inference stays efficient.
 Tool use requires `backend="vllm"` (the transformers backend can't halt at
 `</tool>`) and the `[llm]` extra (adds `feedparser`).
+
+`AdanosSentimentTool` uses the official Adanos SDK and reads
+`ADANOS_API_KEY`. For stocks, choose `source="reddit"`, `"x"`, `"news"`, or
+`"polymarket"`; crypto sentiment currently uses Reddit. The tool accepts
+explicit inclusive UTC `from_date` and `to_date` arguments and returns a compact
+summary as additional evidence, not as a buy or sell signal. See the
+[Adanos API documentation](https://api.adanos.org/docs) for plan limits and
+field definitions. Install both optional extras with
+`pip install "torchtrade[llm,sentiment]"`.
 
 ---
 

--- a/examples/llm/tools/adanos_sentiment_decision.py
+++ b/examples/llm/tools/adanos_sentiment_decision.py
@@ -1,0 +1,46 @@
+"""LocalLLMActor using Adanos sentiment as optional decision context.
+
+Requires: pip install -e ".[llm,sentiment]" and ADANOS_API_KEY.
+Run:      python examples/llm/tools/adanos_sentiment_decision.py
+"""
+import os
+
+os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
+
+import torch
+from tensordict import TensorDict
+
+from torchtrade.actor import LocalLLMActor
+from torchtrade.actor.tools import AdanosSentimentTool
+
+SYMBOL = "BTC/USD"
+
+
+def main():
+    actor = LocalLLMActor(
+        model="Qwen/Qwen2.5-0.5B-Instruct",
+        backend="vllm",
+        device="cuda" if torch.cuda.is_available() else "cpu",
+        debug=True,
+        market_data_keys=["market_data_1Hour_48"],
+        account_state_labels=[
+            "exposure_pct", "position_direction", "unrealized_pnl_pct",
+            "holding_time", "leverage", "distance_to_liquidation",
+        ],
+        action_levels=[-1, 0, 1],
+        symbol=SYMBOL,
+        execute_on="1Hour",
+        tools=[AdanosSentimentTool(symbol=SYMBOL, asset_type="crypto")],
+        max_tool_iters=3,
+    )
+    td = TensorDict({
+        "market_data_1Hour_48": torch.randn(1, 48, 5),
+        "account_state": torch.tensor([[0.0, 0.0, 0.0, 0.0, 1.0, 1.0]]),
+    }, batch_size=[])
+    out = actor(td)
+    print(f"\nDecision: action={out['action'].item()} "
+          f"(target {actor.action_levels[out['action'].item()] * 100:+.0f}%)")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,9 @@ llm = [
     "feedparser>=6.0.0",
     "peft>=0.10.0",
 ]
+sentiment = [
+    "adanos>=2.7.0,<3",
+]
 chronos = [
     "chronos-forecasting",
 ]

--- a/tests/actor/test_tools.py
+++ b/tests/actor/test_tools.py
@@ -173,6 +173,31 @@ def test_adanos_crypto_uses_token_endpoint(monkeypatch):
     assert '"asset_type": "crypto"' in out
 
 
+def test_adanos_preserves_hyphenated_stock_ticker(monkeypatch):
+    calls = _fake_adanos(monkeypatch, _SentimentResult({"ticker": "BRK-B", "found": True}))
+    tool = AdanosSentimentTool(
+        symbol="BRK-B",
+        asset_type="stock",
+        api_key="test-key",
+    )
+
+    tool.run()
+
+    assert calls["stock"] == ("reddit", "BRK-B", {})
+
+
+def test_adanos_typed_error_response_is_not_sent_as_sentiment(monkeypatch):
+    result = _SentimentResult({"detail": {"message": "invalid period"}})
+    _fake_adanos(monkeypatch, result)
+    tool = AdanosSentimentTool(symbol="AAPL", asset_type="stock", api_key="test-key")
+
+    out = tool.run()
+
+    assert out.startswith("error: adanos_sentiment unavailable")
+    assert "invalid period" in out
+    assert "Adanos market sentiment:" not in out
+
+
 def test_adanos_missing_key_returns_error_without_fetch(monkeypatch):
     monkeypatch.delenv("ADANOS_API_KEY", raising=False)
     tool = AdanosSentimentTool(symbol="AAPL", asset_type="stock")

--- a/tests/actor/test_tools.py
+++ b/tests/actor/test_tools.py
@@ -1,7 +1,7 @@
 """Tests for LLM actor tools."""
 import pytest
 
-from torchtrade.actor.tools import GoogleNewsTool, symbol_to_query
+from torchtrade.actor.tools import AdanosSentimentTool, GoogleNewsTool, symbol_to_query
 
 
 @pytest.mark.parametrize("symbol,expected", [
@@ -87,3 +87,108 @@ def test_google_news_timeout_returns_error_string(monkeypatch):
     monkeypatch.setattr("urllib.request.urlopen", stall)
     out = GoogleNewsTool(symbol="BTC/USD", timeout=0.01).run()
     assert "error" in out.lower()
+
+
+class _SentimentResult:
+    def __init__(self, data):
+        self.data = data
+
+    def to_dict(self):
+        return self.data
+
+
+def _fake_adanos(monkeypatch, result):
+    import sys
+    import types
+
+    calls = {}
+
+    class _Namespace:
+        def __init__(self, source):
+            self.source = source
+
+        def stock(self, symbol, **period):
+            calls["stock"] = (self.source, symbol, period)
+            if isinstance(result, Exception):
+                raise result
+            return result
+
+        def token(self, symbol, **period):
+            calls["token"] = (self.source, symbol, period)
+            if isinstance(result, Exception):
+                raise result
+            return result
+
+    class _Client:
+        def __init__(self, **kwargs):
+            calls["client"] = kwargs
+            self.reddit = _Namespace("reddit")
+            self.x = _Namespace("x")
+            self.news = _Namespace("news")
+            self.polymarket = _Namespace("polymarket")
+            self.crypto = _Namespace("crypto")
+
+        def close(self):
+            calls["closed"] = True
+
+    module = types.ModuleType("adanos")
+    module.AdanosClient = _Client
+    monkeypatch.setitem(sys.modules, "adanos", module)
+    return calls
+
+
+def test_adanos_stock_uses_source_dates_and_closes_client(monkeypatch):
+    result = _SentimentResult({"ticker": "AAPL", "sentiment_score": 0.4, "top_mentions": ["omit"]})
+    calls = _fake_adanos(monkeypatch, result)
+    tool = AdanosSentimentTool(
+        symbol="AAPL/USD",
+        asset_type="stock",
+        source="news",
+        api_key="test-key",
+        timeout=2.5,
+    )
+
+    out = tool.run(from_date="2026-08-01", to_date="2026-08-08")
+
+    assert calls["client"] == {"api_key": "test-key", "timeout": 2.5}
+    assert calls["stock"] == (
+        "news", "AAPL", {"from_": "2026-08-01", "to": "2026-08-08"}
+    )
+    assert calls["closed"] is True
+    assert '"sentiment_score": 0.4' in out
+    assert "top_mentions" not in out
+
+
+def test_adanos_crypto_uses_token_endpoint(monkeypatch):
+    calls = _fake_adanos(monkeypatch, _SentimentResult({"symbol": "BTC", "buzz_score": 72.0}))
+    tool = AdanosSentimentTool(
+        symbol="BTC/USD",
+        asset_type="crypto",
+        api_key="test-key",
+    )
+
+    out = tool.run()
+
+    assert calls["token"] == ("crypto", "BTC", {})
+    assert '"asset_type": "crypto"' in out
+
+
+def test_adanos_missing_key_returns_error_without_fetch(monkeypatch):
+    monkeypatch.delenv("ADANOS_API_KEY", raising=False)
+    tool = AdanosSentimentTool(symbol="AAPL", asset_type="stock")
+    monkeypatch.setattr(tool, "_fetch", lambda *args: pytest.fail("must not fetch"))
+
+    assert "requires ADANOS_API_KEY" in tool.run()
+
+
+def test_adanos_failure_returns_error_string(monkeypatch):
+    calls = _fake_adanos(monkeypatch, TimeoutError("timed out"))
+    tool = AdanosSentimentTool(symbol="AAPL", asset_type="stock", api_key="test-key")
+
+    assert "error" in tool.run().lower()
+    assert calls["closed"] is True
+
+
+def test_adanos_rejects_non_reddit_crypto_source():
+    with pytest.raises(ValueError, match="Reddit"):
+        AdanosSentimentTool(symbol="BTC/USD", asset_type="crypto", source="news")

--- a/torchtrade/actor/tools.py
+++ b/torchtrade/actor/tools.py
@@ -1,5 +1,7 @@
 """External information tools the LLM trading actor can call mid-reasoning."""
-from typing import Optional
+import json
+import os
+from typing import Literal, Optional
 from urllib.parse import quote_plus
 
 SYMBOL_QUERY_MAP = {
@@ -76,3 +78,88 @@ class GoogleNewsTool(Tool):
             published = e.get("published", "")
             lines.append(f"{i}. {title} — {source} · {published}".rstrip(" ·"))
         return "\n".join(lines)
+
+
+class AdanosSentimentTool(Tool):
+    """Structured Adanos sentiment context for the traded stock or crypto asset."""
+
+    name = "adanos_sentiment"
+    description = (
+        "adanos_sentiment(from_date?: YYYY-MM-DD, to_date?: YYYY-MM-DD): "
+        "market sentiment evidence for the traded asset; not a trade signal"
+    )
+    _STOCK_SOURCES = {"reddit", "x", "news", "polymarket"}
+    _OUTPUT_FIELDS = (
+        "ticker",
+        "symbol",
+        "company_name",
+        "name",
+        "found",
+        "sentiment_score",
+        "bullish_pct",
+        "bearish_pct",
+        "buzz_score",
+        "mentions",
+        "trend",
+        "period_days",
+    )
+
+    def __init__(
+        self,
+        symbol: str,
+        *,
+        asset_type: Literal["stock", "crypto"],
+        source: Literal["reddit", "x", "news", "polymarket"] = "reddit",
+        api_key: Optional[str] = None,
+        timeout: float = 5.0,
+    ):
+        if asset_type not in {"stock", "crypto"}:
+            raise ValueError("asset_type must be 'stock' or 'crypto'")
+        if source not in self._STOCK_SOURCES:
+            raise ValueError(f"unsupported Adanos source: {source}")
+        if asset_type == "crypto" and source != "reddit":
+            raise ValueError("Adanos crypto sentiment currently uses the Reddit source")
+
+        self.symbol = symbol.split("/")[0].split("-")[0].upper()
+        self.asset_type = asset_type
+        self.source = source
+        self.api_key = api_key
+        self.timeout = timeout
+
+    def _fetch(self, api_key: str, from_date: Optional[str], to_date: Optional[str]):
+        """Fetch one asset summary through the official SDK."""
+        from adanos import AdanosClient
+
+        period = {key: value for key, value in {"from_": from_date, "to": to_date}.items() if value}
+        client = AdanosClient(api_key=api_key, timeout=self.timeout)
+        try:
+            if self.asset_type == "crypto":
+                return client.crypto.token(self.symbol, **period)
+            return getattr(client, self.source).stock(self.symbol, **period)
+        finally:
+            client.close()
+
+    def run(
+        self,
+        from_date: Optional[str] = None,
+        to_date: Optional[str] = None,
+    ) -> str:
+        api_key = self.api_key or os.getenv("ADANOS_API_KEY")
+        if not api_key:
+            return "error: adanos_sentiment requires ADANOS_API_KEY"
+
+        try:
+            result = self._fetch(api_key, from_date, to_date)
+        except Exception as exc:  # never raise into a live trading step
+            return f"error: adanos_sentiment unavailable ({exc})"
+
+        if result is None:
+            return f"No Adanos sentiment data for '{self.symbol}'."
+        data = result.to_dict() if hasattr(result, "to_dict") else result
+        if not isinstance(data, dict):
+            return "error: adanos_sentiment returned an unexpected response"
+
+        summary = {field: data[field] for field in self._OUTPUT_FIELDS if field in data}
+        summary["asset_type"] = self.asset_type
+        summary["source"] = self.source
+        return "Adanos market sentiment: " + json.dumps(summary, ensure_ascii=True)

--- a/torchtrade/actor/tools.py
+++ b/torchtrade/actor/tools.py
@@ -120,7 +120,10 @@ class AdanosSentimentTool(Tool):
         if asset_type == "crypto" and source != "reddit":
             raise ValueError("Adanos crypto sentiment currently uses the Reddit source")
 
-        self.symbol = symbol.split("/")[0].split("-")[0].upper()
+        base_symbol = symbol.split("/", 1)[0]
+        if asset_type == "crypto":
+            base_symbol = base_symbol.split("-", 1)[0]
+        self.symbol = base_symbol.upper()
         self.asset_type = asset_type
         self.source = source
         self.api_key = api_key
@@ -158,6 +161,9 @@ class AdanosSentimentTool(Tool):
         data = result.to_dict() if hasattr(result, "to_dict") else result
         if not isinstance(data, dict):
             return "error: adanos_sentiment returned an unexpected response"
+        if "detail" in data or "error" in data:
+            detail = data.get("detail", data.get("error"))
+            return "error: adanos_sentiment unavailable (" + json.dumps(detail, ensure_ascii=True) + ")"
 
         summary = {field: data[field] for field in self._OUTPUT_FIELDS if field in data}
         summary["asset_type"] = self.asset_type


### PR DESCRIPTION
## Summary

Adds an optional `AdanosSentimentTool` to the LLM actor tool loop introduced in #234.

The tool gives a configured actor compact stock or crypto sentiment context from the Adanos Market Sentiment API. It uses the official `adanos` Python SDK, supports Reddit, X, News, and Polymarket for stocks plus Reddit for crypto, and accepts explicit inclusive UTC date windows. The result is presented as additional evidence rather than a trading signal.

## Design

- Reuses the existing `Tool` interface and fail-open live-step behavior.
- Keeps Adanos outside TorchTrade's core dependencies through a dedicated `[sentiment]` extra.
- Reads `ADANOS_API_KEY` only when the tool runs; no credential is stored in the repository.
- Bounds SDK requests with the configured timeout and closes the client in a `finally` block.
- Returns only compact aggregate fields, avoiding raw mention payloads in the model context.
- Includes a runnable `LocalLLMActor` example and updates the actor documentation.

## Verification

- `.venv/bin/python -m pytest tests/actor/test_tools.py tests/actor/test_local_llm_actor.py -q` (46 passed)
- `.venv/bin/python -m py_compile torchtrade/actor/tools.py examples/llm/tools/adanos_sentiment_decision.py`
- `uv pip compile pyproject.toml --extra sentiment` (resolved `adanos==2.7.0`)
- `git diff --check`

The tests cover stock source routing, crypto token routing, explicit date forwarding, timeout configuration, response minimization, missing credentials, API failures, client teardown, and unsupported crypto sources without live network calls.
