### PR TITLE
fix(envs): trade only the delta on a partial resize, and age positions canonically (#274, #275)

### DIFF
--- a/tests/envs/offline/test_holding_time.py
+++ b/tests/envs/offline/test_holding_time.py
@@ -53,9 +53,6 @@ def _drive(env, actions):
     # keeps ageing. Before the fix this reported 1 forever -- the scalar env incremented
     # only in its two no-trade branches and the resize path never got one.
     (5, [-1.0, -0.5, 0.0, 0.5, 1.0], [4, 3, 4, 3, 4], [0, 1, 2, 3, 4, 5]),
-    # resize, then a direct flip OUT of the resized position, then resize the new short:
-    # the flip cell above never leaves a resized position, so it cannot catch this.
-    (5, [-1.0, -0.5, 0.0, 0.5, 1.0], [4, 3, 1, 0], [0, 1, 2, 1, 2]),
 ])
 def test_sequential_holding_time_sequence(sample_ohlcv_df, leverage, action_levels, actions, expected):
     """The opening bar reads 1, holds increment, close resets to 0, a reopen restarts at 1."""

--- a/tests/envs/offline/test_holding_time.py
+++ b/tests/envs/offline/test_holding_time.py
@@ -49,6 +49,13 @@ def _drive(env, actions):
     (10, [-1, 0, 1], [2, 2, 2, 1, 0, 0], [0, 1, 2, 3, 0, 1, 2]),
     # futures DIRECT flip: open long, hold, flip straight to short (no flat bar), hold
     (10, [-1, 0, 1], [2, 2, 0, 0], [0, 1, 2, 1, 2]),
+    # RESIZE every bar (#275): a half/full oscillation is one position all along, so it
+    # keeps ageing. Before the fix this reported 1 forever -- the scalar env incremented
+    # only in its two no-trade branches and the resize path never got one.
+    (5, [-1.0, -0.5, 0.0, 0.5, 1.0], [4, 3, 4, 3, 4], [0, 1, 2, 3, 4, 5]),
+    # resize, then a direct flip OUT of the resized position, then resize the new short:
+    # the flip cell above never leaves a resized position, so it cannot catch this.
+    (5, [-1.0, -0.5, 0.0, 0.5, 1.0], [4, 3, 1, 0], [0, 1, 2, 1, 2]),
 ])
 def test_sequential_holding_time_sequence(sample_ohlcv_df, leverage, action_levels, actions, expected):
     """The opening bar reads 1, holds increment, close resets to 0, a reopen restarts at 1."""
@@ -92,36 +99,3 @@ def test_sltp_holding_time_sequence(sample_ohlcv_df, leverage):
     seq = _drive(env, [1, 0, 0])
     assert seq == [0, 1, 2, 3]
     env.close()
-
-
-class TestHoldingTimeAcrossResize:
-    """A resized position keeps ageing -- it is the same position (#275).
-
-    account_state[3] is "steps since position opened". Both offline engines used to
-    hand-roll that: the scalar incremented it in the two no-trade branches only, so
-    _increase_position_size/_decrease_position_size never aged a position and a bar-by-bar
-    resize reported holding_time=1 forever; the vectorized env routed resizes through
-    close-then-reopen and reset it to 1 instead. Both now age once per step from the
-    post-trade direction, which is what advance_hold_counter has always specified.
-    """
-
-    LEVELS = [-1.0, -0.5, 0.0, 0.5, 1.0]
-
-    def _env(self, df, cls, cfg, **extra):
-        return cls(df, cfg(
-            action_levels=self.LEVELS, leverage=5, initial_cash=10000,
-            time_frames=[TimeFrame(1, TimeFrameUnit.Minute)], window_sizes=[10],
-            execute_on=TimeFrame(1, TimeFrameUnit.Minute),
-            transaction_fee=0.0, slippage=0.0, seed=42, max_traj_length=30,
-            random_start=False, **extra,
-        ), simple_feature_fn)
-
-    def test_resizing_every_bar_still_ages(self, sample_ohlcv_df):
-        """The exact shape #275 reports: alternate full/half and the counter must climb."""
-        env = self._env(sample_ohlcv_df, SequentialTradingEnv, SequentialTradingEnvConfig)
-        seq = _drive(env, [4, 3, 4, 3, 4])
-        assert seq == [0, 1, 2, 3, 4, 5], (
-            f"holding_time went {seq} -- a position resized every bar is still the same "
-            "position and must report cumulative age"
-        )
-        env.close()

--- a/tests/envs/offline/test_holding_time.py
+++ b/tests/envs/offline/test_holding_time.py
@@ -125,14 +125,3 @@ class TestHoldingTimeAcrossResize:
             "position and must report cumulative age"
         )
         env.close()
-
-    def test_direction_switch_restarts_but_resize_does_not(self, sample_ohlcv_df):
-        """The counterpart: a flip IS a new position, so it restarts at 1.
-
-        Without this the test above would pass on an env that simply never resets.
-        """
-        env = self._env(sample_ohlcv_df, SequentialTradingEnv, SequentialTradingEnvConfig)
-        # long full, resize to half, flip short half, resize short full
-        seq = _drive(env, [4, 3, 1, 0])
-        assert seq == [0, 1, 2, 1, 2], f"holding_time went {seq}"
-        env.close()

--- a/tests/envs/offline/test_holding_time.py
+++ b/tests/envs/offline/test_holding_time.py
@@ -92,3 +92,47 @@ def test_sltp_holding_time_sequence(sample_ohlcv_df, leverage):
     seq = _drive(env, [1, 0, 0])
     assert seq == [0, 1, 2, 3]
     env.close()
+
+
+class TestHoldingTimeAcrossResize:
+    """A resized position keeps ageing -- it is the same position (#275).
+
+    account_state[3] is "steps since position opened". Both offline engines used to
+    hand-roll that: the scalar incremented it in the two no-trade branches only, so
+    _increase_position_size/_decrease_position_size never aged a position and a bar-by-bar
+    resize reported holding_time=1 forever; the vectorized env routed resizes through
+    close-then-reopen and reset it to 1 instead. Both now age once per step from the
+    post-trade direction, which is what advance_hold_counter has always specified.
+    """
+
+    LEVELS = [-1.0, -0.5, 0.0, 0.5, 1.0]
+
+    def _env(self, df, cls, cfg, **extra):
+        return cls(df, cfg(
+            action_levels=self.LEVELS, leverage=5, initial_cash=10000,
+            time_frames=[TimeFrame(1, TimeFrameUnit.Minute)], window_sizes=[10],
+            execute_on=TimeFrame(1, TimeFrameUnit.Minute),
+            transaction_fee=0.0, slippage=0.0, seed=42, max_traj_length=30,
+            random_start=False, **extra,
+        ), simple_feature_fn)
+
+    def test_resizing_every_bar_still_ages(self, sample_ohlcv_df):
+        """The exact shape #275 reports: alternate full/half and the counter must climb."""
+        env = self._env(sample_ohlcv_df, SequentialTradingEnv, SequentialTradingEnvConfig)
+        seq = _drive(env, [4, 3, 4, 3, 4])
+        assert seq == [0, 1, 2, 3, 4, 5], (
+            f"holding_time went {seq} -- a position resized every bar is still the same "
+            "position and must report cumulative age"
+        )
+        env.close()
+
+    def test_direction_switch_restarts_but_resize_does_not(self, sample_ohlcv_df):
+        """The counterpart: a flip IS a new position, so it restarts at 1.
+
+        Without this the test above would pass on an env that simply never resets.
+        """
+        env = self._env(sample_ohlcv_df, SequentialTradingEnv, SequentialTradingEnvConfig)
+        # long full, resize to half, flip short half, resize short full
+        seq = _drive(env, [4, 3, 1, 0])
+        assert seq == [0, 1, 2, 1, 2], f"holding_time went {seq}"
+        env.close()

--- a/tests/envs/offline/test_vec_scalar_equivalence.py
+++ b/tests/envs/offline/test_vec_scalar_equivalence.py
@@ -273,13 +273,57 @@ class TestScalarVecEquivalenceResize:
         (5, [4, 3, 4, 3, 4, 3, 4, 3], "oscillate-levered"),
         (5, [4, 4, 3, 3, 4, 4, 3, 3], "gradual"),
         (5, [4, 3, 1, 0, 1, 3, 4, 0], "through-flat-and-short"),
-    ], ids=lambda v: v if isinstance(v, str) else None)
+    ], ids=["oscillate-full-half", "oscillate-levered", "gradual", "through-flat-and-short"])
     def test_resize_matches_scalar(self, sample_ohlcv_df, leverage, actions, label):
         mismatches = _run_sequence(
             sample_ohlcv_df, actions, leverage=leverage, fee=0.001,
             action_levels=self.LEVELS, max_traj=60, label=f"resize-{label}",
         )
         assert not mismatches, "\n".join(mismatches)
+
+    def test_a_refused_resize_still_ages_the_position(self):
+        """An increase the balance cannot afford must change nothing except the age.
+
+        This is the case that forced ageing out of the trade branches and into one call
+        per step: the position is still held, so it must still age, but no branch runs to
+        age it. An earlier version of this PR incremented inside the resize branch and got
+        this wrong in the vectorized env while the scalar env got it right.
+
+        At fee=0.05 and leverage 1, going 0.95 -> 1.0 costs more than the remaining
+        balance, so the trade is refused outright rather than partially filled.
+        """
+        price, n = 100.0, 40
+        df = pd.DataFrame({
+            "timestamp": pd.date_range("2024-01-01", periods=n, freq="1min"),
+            "open": price, "high": price, "low": price, "close": price, "volume": 1000.0,
+        }, index=range(n))
+        scalar, vec = _make_pair(
+            df, leverage=1, fee=0.05, action_levels=[0.0, 0.8, 0.95, 1.0], max_traj=20
+        )
+        td_s, td_v = scalar.reset(), vec.reset()
+        td_s["action"] = torch.tensor(2)  # 0.95
+        td_v["action"] = torch.tensor([2])
+        td_s, td_v = scalar.step(td_s)["next"], vec.step(td_v)["next"]
+        size_before, balance_before = scalar.position.position_size, scalar.balance
+
+        td_s["action"] = torch.tensor(3)  # 1.0 -- unaffordable
+        td_v["action"] = torch.tensor([3])
+        scalar.step(td_s)
+        vec.step(td_v)
+
+        assert scalar.position.position_size == size_before, "the resize was not refused"
+        assert scalar.balance == balance_before, "a refused resize must cost nothing"
+        assert scalar.position.hold_counter == 2, (
+            f"hold_counter={scalar.position.hold_counter} -- a refused resize leaves the "
+            "position held, so it must still age"
+        )
+        assert float(vec._position_sizes[0]) == size_before
+        assert int(vec._hold_counters[0]) == 2, (
+            f"vec hold_counter={int(vec._hold_counters[0])} -- the vectorized env stopped "
+            "ageing a position no branch touched"
+        )
+        scalar.close()
+        vec.close()
 
     def test_resize_charges_the_delta_fee_exactly(self):
         """Halving a position must cost the fee on the half, to the cent.

--- a/tests/envs/offline/test_vec_scalar_equivalence.py
+++ b/tests/envs/offline/test_vec_scalar_equivalence.py
@@ -282,7 +282,14 @@ class TestScalarVecEquivalenceResize:
         (5, FUTURES_LEVELS, [0, 1, 0, 1]),
         # open, decrease, close to flat, open short, flip, increase, flip
         (5, FUTURES_LEVELS, [4, 3, 2, 1, 3, 4, 0]),
-    ], ids=["oscillate-spot", "oscillate-levered", "oscillate-short", "through-flat"])
+        # 0.5 -> 0.505 is a 1% target change: inside POSITION_TOLERANCE_PCT while a
+        # position is open. Both engines drop that step before classifying it, so the
+        # canonical ageing call is the only thing that ages the position -- and nothing
+        # else in the suite ever enters that branch holding anything. Re-adding either
+        # engine's removed `hold_counter += 1` there passed all 691 offline tests.
+        (5, [0.0, 0.5, 0.505, 1.0], [1, 2, 2, 1, 3]),
+    ], ids=["oscillate-spot", "oscillate-levered", "oscillate-short", "through-flat",
+            "tolerance-hold"])
     def test_resize_matches_scalar(self, sample_ohlcv_df, leverage, levels, actions):
         mismatches = _run_sequence(
             sample_ohlcv_df, actions, leverage=leverage, fee=0.001,
@@ -343,7 +350,11 @@ class TestScalarVecEquivalenceResize:
         vec.close()
 
     def test_resize_charges_the_delta_fee_exactly(self):
-        """Halving a position must cost the fee on the half, to the cent.
+        """Halving a position must cost the fee on the delta it traded, to the cent.
+
+        Precisely: fee == |change in size| * price * rate. It pins the charge against the
+        size actually reached, not that the size reached was the right target -- any target
+        error lights up dozens of tests elsewhere, so that division of labour is deliberate.
 
         The equivalence cells above compare the two engines, so they stay green if BOTH
         regress to close-and-reopen together. This pins the absolute number instead, and

--- a/tests/envs/offline/test_vec_scalar_equivalence.py
+++ b/tests/envs/offline/test_vec_scalar_equivalence.py
@@ -271,9 +271,8 @@ class TestScalarVecEquivalenceResize:
     @pytest.mark.parametrize("leverage,actions,label", [
         (1, [4, 3, 4, 3, 4, 3], "oscillate-full-half"),
         (5, [4, 3, 4, 3, 4, 3, 4, 3], "oscillate-levered"),
-        (5, [4, 4, 3, 3, 4, 4, 3, 3], "gradual"),
         (5, [4, 3, 1, 0, 1, 3, 4, 0], "through-flat-and-short"),
-    ], ids=["oscillate-full-half", "oscillate-levered", "gradual", "through-flat-and-short"])
+    ], ids=["oscillate-full-half", "oscillate-levered", "through-flat-and-short"])
     def test_resize_matches_scalar(self, sample_ohlcv_df, leverage, actions, label):
         mismatches = _run_sequence(
             sample_ohlcv_df, actions, leverage=leverage, fee=0.001,
@@ -281,47 +280,54 @@ class TestScalarVecEquivalenceResize:
         )
         assert not mismatches, "\n".join(mismatches)
 
-    def test_a_refused_resize_still_ages_the_position(self):
-        """An increase the balance cannot afford must change nothing except the age.
+    def test_an_unaffordable_increase_changes_nothing_but_the_age(self):
+        """An increase the balance cannot pay for must be refused whole, and still age.
 
-        This is the case that forced ageing out of the trade branches and into one call
-        per step: the position is still held, so it must still age, but no branch runs to
-        age it. An earlier version of this PR incremented inside the resize branch and got
-        this wrong in the vectorized env while the scalar env got it right.
+        This is the case that forced ageing out of the trade branches into one call per
+        step: the position is still held, so it must still age, but no trade branch runs
+        to age it. An earlier version of this PR incremented inside the resize branch and
+        got exactly this wrong in the vectorized env while the scalar env got it right.
 
-        At fee=0.05 and leverage 1, going 0.95 -> 1.0 costs more than the remaining
-        balance, so the trade is refused outright rather than partially filled.
+        Reaching the affordability path takes care. Scaling up under fractional sizing is
+        almost always affordable, because the target is derived from a portfolio value
+        that already contains the position; and a small increase is swallowed by the 2%
+        tolerance band before affordability is ever consulted. The drifting price here is
+        the shape TestAffordabilitySlackOnScaleUp uses: the delta is ~10 units against a
+        ~0.4 tolerance, so the refusal is genuinely about cost.
         """
-        price, n = 100.0, 40
+        drift, n = 1e-6, 40
+        prices = [100.0 * (1 + drift) ** i for i in range(n)]
         df = pd.DataFrame({
             "timestamp": pd.date_range("2024-01-01", periods=n, freq="1min"),
-            "open": price, "high": price, "low": price, "close": price, "volume": 1000.0,
+            "open": prices, "high": prices, "low": prices, "close": prices,
+            "volume": [1000.0] * n,
         }, index=range(n))
         scalar, vec = _make_pair(
-            df, leverage=1, fee=0.05, action_levels=[0.0, 0.8, 0.95, 1.0], max_traj=20
+            df, leverage=2, fee=0.0, action_levels=[0.0, 0.5, 1.0], max_traj=20
         )
         td_s, td_v = scalar.reset(), vec.reset()
-        td_s["action"] = torch.tensor(2)  # 0.95
-        td_v["action"] = torch.tensor([2])
+        td_s["action"] = torch.tensor(1)  # half
+        td_v["action"] = torch.tensor([1])
         td_s, td_v = scalar.step(td_s)["next"], vec.step(td_v)["next"]
         size_before, balance_before = scalar.position.position_size, scalar.balance
 
-        td_s["action"] = torch.tensor(3)  # 1.0 -- unaffordable
-        td_v["action"] = torch.tensor([3])
+        td_s["action"] = torch.tensor(2)  # full -- costs more than the balance
+        td_v["action"] = torch.tensor([2])
         scalar.step(td_s)
         vec.step(td_v)
 
-        assert scalar.position.position_size == size_before, "the resize was not refused"
-        assert scalar.balance == balance_before, "a refused resize must cost nothing"
-        assert scalar.position.hold_counter == 2, (
-            f"hold_counter={scalar.position.hold_counter} -- a refused resize leaves the "
-            "position held, so it must still age"
-        )
-        assert float(vec._position_sizes[0]) == size_before
-        assert int(vec._hold_counters[0]) == 2, (
-            f"vec hold_counter={int(vec._hold_counters[0])} -- the vectorized env stopped "
-            "ageing a position no branch touched"
-        )
+        for name, size, balance, held in (
+            ("scalar", scalar.position.position_size, scalar.balance,
+             scalar.position.hold_counter),
+            ("vec", float(vec._position_sizes[0]), float(vec._balances[0]),
+             int(vec._hold_counters[0])),
+        ):
+            assert size == size_before, f"{name} filled an unaffordable increase"
+            assert balance == balance_before, f"{name} paid for a refused increase"
+            assert held == 2, (
+                f"{name} hold_counter={held} -- a refused increase leaves the position "
+                "held, so it must still age"
+            )
         scalar.close()
         vec.close()
 

--- a/tests/envs/offline/test_vec_scalar_equivalence.py
+++ b/tests/envs/offline/test_vec_scalar_equivalence.py
@@ -281,33 +281,45 @@ class TestScalarVecEquivalenceResize:
         )
         assert not mismatches, "\n".join(mismatches)
 
-    def test_resize_pays_only_the_delta_fee(self, sample_ohlcv_df):
-        """Halving a position must cost the fee on the half, not on a full round trip.
+    def test_resize_charges_the_delta_fee_exactly(self):
+        """Halving a position must cost the fee on the half, to the cent.
 
-        The equivalence cells above would also fail if BOTH engines started closing and
-        reopening, so this pins the absolute cost rather than just agreement.
+        The equivalence cells above compare the two engines, so they stay green if BOTH
+        regress to close-and-reopen together. This pins the absolute number instead, and
+        pins it tightly: an earlier version of this test asserted only "cost < 1.1% of
+        base", which a doubled fee on the closed half slipped straight through.
+
+        Flat prices so the expectation is exact arithmetic with no PnL term.
         """
+        price, cash, fee = 100.0, 10000.0, 0.01
+        n = 40
+        df = pd.DataFrame({
+            "timestamp": pd.date_range("2024-01-01", periods=n, freq="1min"),
+            "open": price, "high": price, "low": price, "close": price, "volume": 1000.0,
+        }, index=range(n))
         scalar, vec = _make_pair(
-            sample_ohlcv_df, leverage=1, fee=0.01, action_levels=self.LEVELS, max_traj=20
+            df, leverage=1, fee=fee, action_levels=self.LEVELS, max_traj=20
         )
         td_s, td_v = scalar.reset(), vec.reset()
         td_s["action"] = torch.tensor(4)  # full
         td_v["action"] = torch.tensor([4])
         td_s, td_v = scalar.step(td_s)["next"], vec.step(td_v)["next"]
-        before = scalar.balance + abs(scalar.position.position_size) * scalar.position.entry_price
+
+        opened_qty = scalar.position.position_size
+        equity_before = scalar.balance + abs(opened_qty) * price
 
         td_s["action"] = torch.tensor(3)  # half
         td_v["action"] = torch.tensor([3])
         scalar.step(td_s)
         vec.step(td_v)
 
-        # A close-and-reopen at 1% would cost ~1.5% of notional here; a delta trade
-        # touches only the half being closed.
-        held = abs(scalar.position.position_size) * scalar.position.entry_price
-        cost = before - (scalar.balance + held)
-        assert cost < 0.011 * before, (
-            f"resize cost {cost:.4f} on a base of {before:.4f} -- that is a round trip, "
-            "not a delta trade"
+        # At a flat price the only cost of halving is the fee on the half being closed.
+        expected_fee = abs(opened_qty - scalar.position.position_size) * price * fee
+        equity_after = scalar.balance + abs(scalar.position.position_size) * price
+        charged = equity_before - equity_after
+        assert abs(charged - expected_fee) < 1e-6, (
+            f"halving charged {charged:.6f}, expected {expected_fee:.6f} -- that is not "
+            "a delta trade"
         )
         assert abs(float(vec._position_sizes[0]) - scalar.position.position_size) < 1e-9
         scalar.close()

--- a/tests/envs/offline/test_vec_scalar_equivalence.py
+++ b/tests/envs/offline/test_vec_scalar_equivalence.py
@@ -208,8 +208,8 @@ class TestScalarVecEquivalenceIntermediateLevel:
     reverting that one line to float32 keeps the whole suite green. 0.1 is not exact:
     float32 holds it as 0.10000000149, putting a 1.5e-8 relative error into the notional.
 
-    Only the open from flat is compared. Resizing an existing position is where the two
-    engines genuinely disagree (#302), so this must not depend on that being settled.
+    Only the open from flat is compared here; resizing is covered by
+    TestScalarVecEquivalenceResize below.
     """
 
     def test_open_at_intermediate_level_matches_scalar(self):
@@ -244,6 +244,72 @@ class TestScalarVecEquivalenceIntermediateLevel:
             f"position_size scalar={s_size!r} vec={v_size!r} rel={rel:.3e} -- an "
             "intermediate action level is being rounded before it reaches the notional"
         )
+        scalar.close()
+        vec.close()
+
+
+# ============================================================================
+# PARTIAL RESIZE
+# ============================================================================
+
+
+class TestScalarVecEquivalenceResize:
+    """Changing an open position's size must trade only the delta in both engines (#274).
+
+    The vectorized env used to route every target change through close-then-reopen, so a
+    same-direction resize paid a full round trip of fees and threw away the entry price --
+    which also moves the liquidation price and unrealized_pnl_pct. Measured 3.46% of
+    portfolio over 8 steps at leverage 5.
+
+    This is the axis `action_levels` exists for and no cell ever used: with the default
+    {-1, 0, 1} every action is flat-or-full, so the resize branch is unreachable and the
+    two implementations coincide.
+    """
+
+    LEVELS = [-1.0, -0.5, 0.0, 0.5, 1.0]
+
+    @pytest.mark.parametrize("leverage,actions,label", [
+        (1, [4, 3, 4, 3, 4, 3], "oscillate-full-half"),
+        (5, [4, 3, 4, 3, 4, 3, 4, 3], "oscillate-levered"),
+        (5, [4, 4, 3, 3, 4, 4, 3, 3], "gradual"),
+        (5, [4, 3, 1, 0, 1, 3, 4, 0], "through-flat-and-short"),
+    ], ids=lambda v: v if isinstance(v, str) else None)
+    def test_resize_matches_scalar(self, sample_ohlcv_df, leverage, actions, label):
+        mismatches = _run_sequence(
+            sample_ohlcv_df, actions, leverage=leverage, fee=0.001,
+            action_levels=self.LEVELS, max_traj=60, label=f"resize-{label}",
+        )
+        assert not mismatches, "\n".join(mismatches)
+
+    def test_resize_pays_only_the_delta_fee(self, sample_ohlcv_df):
+        """Halving a position must cost the fee on the half, not on a full round trip.
+
+        The equivalence cells above would also fail if BOTH engines started closing and
+        reopening, so this pins the absolute cost rather than just agreement.
+        """
+        scalar, vec = _make_pair(
+            sample_ohlcv_df, leverage=1, fee=0.01, action_levels=self.LEVELS, max_traj=20
+        )
+        td_s, td_v = scalar.reset(), vec.reset()
+        td_s["action"] = torch.tensor(4)  # full
+        td_v["action"] = torch.tensor([4])
+        td_s, td_v = scalar.step(td_s)["next"], vec.step(td_v)["next"]
+        before = scalar.balance + abs(scalar.position.position_size) * scalar.position.entry_price
+
+        td_s["action"] = torch.tensor(3)  # half
+        td_v["action"] = torch.tensor([3])
+        scalar.step(td_s)
+        vec.step(td_v)
+
+        # A close-and-reopen at 1% would cost ~1.5% of notional here; a delta trade
+        # touches only the half being closed.
+        held = abs(scalar.position.position_size) * scalar.position.entry_price
+        cost = before - (scalar.balance + held)
+        assert cost < 0.011 * before, (
+            f"resize cost {cost:.4f} on a base of {before:.4f} -- that is a round trip, "
+            "not a delta trade"
+        )
+        assert abs(float(vec._position_sizes[0]) - scalar.position.position_size) < 1e-9
         scalar.close()
         vec.close()
 

--- a/tests/envs/offline/test_vec_scalar_equivalence.py
+++ b/tests/envs/offline/test_vec_scalar_equivalence.py
@@ -302,9 +302,9 @@ class TestScalarVecEquivalenceResize:
         almost always affordable, because the target is derived from a portfolio value
         that already contains the position; and a small increase is swallowed by the 2%
         tolerance band before affordability is ever consulted. The drifting price here is
-        the shape TestAffordabilitySlackOnScaleUp uses: the delta is ~10 units against a
-        ~0.4 tolerance, so the refusal is genuinely about cost. (Same shape as
-        TestAffordabilitySlackOnScaleUp in fundamental/test_margin_accounting.py.)
+        the shape TestAffordabilitySlackOnScaleUp (fundamental/test_margin_accounting.py)
+        uses: the delta is ~10 units against a ~0.4 tolerance, so the refusal is
+        genuinely about cost.
         """
         drift, n = 1e-6, 40
         prices = [100.0 * (1 + drift) ** i for i in range(n)]

--- a/tests/envs/offline/test_vec_scalar_equivalence.py
+++ b/tests/envs/offline/test_vec_scalar_equivalence.py
@@ -266,17 +266,27 @@ class TestScalarVecEquivalenceResize:
     two implementations coincide.
     """
 
-    LEVELS = [-1.0, -0.5, 0.0, 0.5, 1.0]
+    # Signed levels only where shorts exist: at leverage 1 the env clips negatives and
+    # warns, so a spot cell declaring them reads as an oversight.
+    SPOT_LEVELS = [0.0, 0.5, 1.0]
+    FUTURES_LEVELS = [-1.0, -0.5, 0.0, 0.5, 1.0]
 
-    @pytest.mark.parametrize("leverage,actions,label", [
-        (1, [4, 3, 4, 3, 4, 3], "oscillate-full-half"),
-        (5, [4, 3, 4, 3, 4, 3, 4, 3], "oscillate-levered"),
-        (5, [4, 3, 1, 0, 1, 3, 4, 0], "through-flat-and-short"),
-    ], ids=["oscillate-full-half", "oscillate-levered", "through-flat-and-short"])
-    def test_resize_matches_scalar(self, sample_ohlcv_df, leverage, actions, label):
+    @pytest.mark.parametrize("leverage,levels,actions", [
+        # same sequence spot and levered, so the cell pair isolates leverage
+        (1, SPOT_LEVELS, [2, 1, 2, 1, 2, 1]),
+        (5, FUTURES_LEVELS, [4, 3, 4, 3, 4, 3]),
+        # shorts resize through the same branches with every sign flipped: closed_qty,
+        # pnl and freed_margin all carry it. Nothing exercised that until this cell --
+        # the sequence it replaced refused one short resize for affordability and held
+        # the other inside the tolerance band, so both compared two idle engines.
+        (5, FUTURES_LEVELS, [0, 1, 0, 1]),
+        # open, decrease, close to flat, open short, flip, increase, flip
+        (5, FUTURES_LEVELS, [4, 3, 2, 1, 3, 4, 0]),
+    ], ids=["oscillate-spot", "oscillate-levered", "oscillate-short", "through-flat"])
+    def test_resize_matches_scalar(self, sample_ohlcv_df, leverage, levels, actions):
         mismatches = _run_sequence(
             sample_ohlcv_df, actions, leverage=leverage, fee=0.001,
-            action_levels=self.LEVELS, max_traj=60, label=f"resize-{label}",
+            action_levels=levels, max_traj=60, label=f"resize-lev{leverage}",
         )
         assert not mismatches, "\n".join(mismatches)
 
@@ -293,7 +303,8 @@ class TestScalarVecEquivalenceResize:
         that already contains the position; and a small increase is swallowed by the 2%
         tolerance band before affordability is ever consulted. The drifting price here is
         the shape TestAffordabilitySlackOnScaleUp uses: the delta is ~10 units against a
-        ~0.4 tolerance, so the refusal is genuinely about cost.
+        ~0.4 tolerance, so the refusal is genuinely about cost. (Same shape as
+        TestAffordabilitySlackOnScaleUp in fundamental/test_margin_accounting.py.)
         """
         drift, n = 1e-6, 40
         prices = [100.0 * (1 + drift) ** i for i in range(n)]
@@ -348,30 +359,34 @@ class TestScalarVecEquivalenceResize:
             "open": price, "high": price, "low": price, "close": price, "volume": 1000.0,
         }, index=range(n))
         scalar, vec = _make_pair(
-            df, leverage=1, fee=fee, action_levels=self.LEVELS, max_traj=20
+            df, leverage=1, fee=fee, action_levels=self.SPOT_LEVELS, max_traj=20
         )
         td_s, td_v = scalar.reset(), vec.reset()
-        td_s["action"] = torch.tensor(4)  # full
-        td_v["action"] = torch.tensor([4])
+        td_s["action"] = torch.tensor(2)  # full
+        td_v["action"] = torch.tensor([2])
         td_s, td_v = scalar.step(td_s)["next"], vec.step(td_v)["next"]
 
         opened_qty = scalar.position.position_size
         equity_before = scalar.balance + abs(opened_qty) * price
+        vec_equity_before = float(vec._balances[0]) + abs(float(vec._position_sizes[0])) * price
 
-        td_s["action"] = torch.tensor(3)  # half
-        td_v["action"] = torch.tensor([3])
+        td_s["action"] = torch.tensor(1)  # half
+        td_v["action"] = torch.tensor([1])
         scalar.step(td_s)
         vec.step(td_v)
 
         # At a flat price the only cost of halving is the fee on the half being closed.
         expected_fee = abs(opened_qty - scalar.position.position_size) * price * fee
-        equity_after = scalar.balance + abs(scalar.position.position_size) * price
-        charged = equity_before - equity_after
-        assert abs(charged - expected_fee) < 1e-6, (
-            f"halving charged {charged:.6f}, expected {expected_fee:.6f} -- that is not "
-            "a delta trade"
-        )
-        assert abs(float(vec._position_sizes[0]) - scalar.position.position_size) < 1e-9
+        for name, equity_before_, balance, size in (
+            ("scalar", equity_before, scalar.balance, scalar.position.position_size),
+            ("vec", vec_equity_before, float(vec._balances[0]),
+             float(vec._position_sizes[0])),
+        ):
+            charged = equity_before_ - (balance + abs(size) * price)
+            assert abs(charged - expected_fee) < 1e-6, (
+                f"{name} halving charged {charged:.6f}, expected {expected_fee:.6f} -- "
+                "that is not a delta trade"
+            )
         scalar.close()
         vec.close()
 

--- a/torchtrade/envs/core/state.py
+++ b/torchtrade/envs/core/state.py
@@ -1,5 +1,6 @@
 """State management dataclasses for TorchTrade environments."""
 
+import math
 from dataclasses import asdict, dataclass, field, fields
 from typing import Dict, List, Union
 
@@ -221,6 +222,17 @@ class HistoryTracker:
             Number of steps in the history
         """
         return len(self.base_prices)
+
+
+def advance_hold_counter_from_size(position: PositionState) -> None:
+    """advance_hold_counter for the offline envs, which own the signed size directly.
+
+    The live envs pass a direction read off the exchange (position_direction_from_status).
+    Offline, position.position_size IS the truth, so the conversion belongs here rather
+    than hand-rolled once per engine -- which is the drift this rule exists to stop.
+    """
+    size = position.position_size
+    advance_hold_counter(position, math.copysign(1.0, size) if size else 0.0)
 
 
 def advance_hold_counter(position: PositionState, direction: float) -> None:

--- a/torchtrade/envs/offline/sequential.py
+++ b/torchtrade/envs/offline/sequential.py
@@ -25,7 +25,11 @@ from tensordict import TensorDict, TensorDictBase
 from torchrl.data import Categorical
 
 from torchtrade.envs.core.offline_base import TorchTradeOfflineEnv
-from torchtrade.envs.core.state import HistoryTracker, binarize_action_type
+from torchtrade.envs.core.state import (
+    HistoryTracker,
+    advance_hold_counter,
+    binarize_action_type,
+)
 from torchtrade.envs.core.default_rewards import log_return_reward
 from torchtrade.envs.utils.timeframe import TimeFrame, normalize_timeframe_config
 from torchtrade.envs.utils.fractional_sizing import (
@@ -530,6 +534,15 @@ class SequentialTradingEnv(TorchTradeOfflineEnv):
         else:
             trade_info = self._execute_trade_if_needed(desired_action, cached_price)
 
+        # Age the position once per step through the canonical rule, whatever happened
+        # above (#275). Five hand-rolled sites used to do this -- hold, tolerance-hold,
+        # open, close, liquidation -- and the resize path was simply never given one, so
+        # a position that was resized every bar reported holding_time=1 forever. Deriving
+        # the direction from the post-trade size means every path is covered by
+        # construction, including paths added later.
+        size = self.position.position_size
+        advance_hold_counter(self.position, 0.0 if size == 0 else (1.0 if size > 0 else -1.0))
+
         # Update position flag based on actual position size
         if trade_info["executed"]:
             if self.position.position_size > 0:
@@ -655,7 +668,6 @@ class SequentialTradingEnv(TorchTradeOfflineEnv):
         """
         # If action hasn't changed and we already have a position, just hold
         if action_value == self._prev_action_value and self.position.position_size != 0:
-            self.position.hold_counter += 1
             return {"executed": False, "side": None, "fee_paid": 0.0, "liquidated": False}
         self._prev_action_value = action_value
 
@@ -669,8 +681,6 @@ class SequentialTradingEnv(TorchTradeOfflineEnv):
 
         # Check if already at target position (implicit hold)
         if abs(target_position_size - self.position.position_size) < tolerance:
-            if self.position.position_size != 0:
-                self.position.hold_counter += 1
             return {"executed": False, "side": None, "fee_paid": 0.0, "liquidated": False}
 
         # Execute appropriate position change
@@ -742,9 +752,6 @@ class SequentialTradingEnv(TorchTradeOfflineEnv):
         self.position.position_size = position_size
         self.position.position_value = abs(notional_value)
         self.position.entry_price = execution_price
-        # The bar a position OPENS on is holding_time=1, not 0 (see advance_hold_counter
-        # docstring in core/state.py for the canonical rule this must match).
-        self.position.hold_counter = 1
 
         # Set position direction
         if not self.allows_short:
@@ -878,7 +885,6 @@ class SequentialTradingEnv(TorchTradeOfflineEnv):
         self.position.entry_price = 0.0
         self.liquidation_price = 0.0
         self.position.current_position = 0
-        self.position.hold_counter = 0
 
         return {"executed": True, "side": "close", "fee_paid": fee, "liquidated": False}
 
@@ -914,7 +920,6 @@ class SequentialTradingEnv(TorchTradeOfflineEnv):
         self.position.entry_price = 0.0
         self.liquidation_price = 0.0
         self.position.current_position = 0
-        self.position.hold_counter = 0
 
         return trade_info
 

--- a/torchtrade/envs/offline/sequential.py
+++ b/torchtrade/envs/offline/sequential.py
@@ -12,6 +12,7 @@ Key Features:
     - Fractional position sizing with configurable action levels
 """
 
+import math
 import warnings
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Tuple, Union, Callable
@@ -541,7 +542,7 @@ class SequentialTradingEnv(TorchTradeOfflineEnv):
         # the direction from the post-trade size means every path is covered by
         # construction, including paths added later.
         size = self.position.position_size
-        advance_hold_counter(self.position, 0.0 if size == 0 else (1.0 if size > 0 else -1.0))
+        advance_hold_counter(self.position, math.copysign(1.0, size) if size else 0.0)
 
         # Update position flag based on actual position size
         if trade_info["executed"]:

--- a/torchtrade/envs/offline/sequential.py
+++ b/torchtrade/envs/offline/sequential.py
@@ -12,7 +12,6 @@ Key Features:
     - Fractional position sizing with configurable action levels
 """
 
-import math
 import warnings
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Tuple, Union, Callable
@@ -28,7 +27,7 @@ from torchrl.data import Categorical
 from torchtrade.envs.core.offline_base import TorchTradeOfflineEnv
 from torchtrade.envs.core.state import (
     HistoryTracker,
-    advance_hold_counter,
+    advance_hold_counter_from_size,
     binarize_action_type,
 )
 from torchtrade.envs.core.default_rewards import log_return_reward
@@ -541,8 +540,7 @@ class SequentialTradingEnv(TorchTradeOfflineEnv):
         # a position that was resized every bar reported holding_time=1 forever. Deriving
         # the direction from the post-trade size means every path is covered by
         # construction, including paths added later.
-        size = self.position.position_size
-        advance_hold_counter(self.position, math.copysign(1.0, size) if size else 0.0)
+        advance_hold_counter_from_size(self.position)
 
         # Update position flag based on actual position size
         if trade_info["executed"]:

--- a/torchtrade/envs/offline/sequential_sltp.py
+++ b/torchtrade/envs/offline/sequential_sltp.py
@@ -26,7 +26,7 @@ from torchtrade.envs.offline.sequential import (
     SequentialTradingEnvConfig,
 )
 from torchtrade.envs.core.common import TradeMode, validate_trade_mode
-from torchtrade.envs.core.state import binarize_action_type
+from torchtrade.envs.core.state import advance_hold_counter, binarize_action_type
 from torchtrade.envs.utils.sltp_helpers import (
     calculate_long_bracket_prices,
     calculate_short_bracket_prices,
@@ -327,7 +327,6 @@ class SequentialTradingEnvSLTP(SequentialTradingEnv):
         self.position.position_value = 0.0
         self.position.entry_price = 0.0
         self.position.current_position = 0
-        self.position.hold_counter = 0
         self.liquidation_price = 0.0
         self.stop_loss = 0.0
         self.take_profit = 0.0
@@ -395,6 +394,11 @@ class SequentialTradingEnvSLTP(SequentialTradingEnv):
                 execution_price = self.stop_loss if trigger == "sl" else self.take_profit
                 trade_info = self._execute_sltp_close(execution_price, trigger)
 
+        # Same canonical aging as SequentialTradingEnv (#275): one call per step off the
+        # post-trade size, so no exit path can be added later without ageing correctly.
+        size = self.position.position_size
+        advance_hold_counter(self.position, 0.0 if size == 0 else (1.0 if size > 0 else -1.0))
+
         # Update position flag based on actual position size
         if trade_info["executed"]:
             if self.position.position_size > 0:
@@ -461,8 +465,6 @@ class SequentialTradingEnvSLTP(SequentialTradingEnv):
         """
         # HOLD action
         if side is None:
-            if self.position.position_size != 0:
-                self.position.hold_counter += 1
             return {"executed": False, "side": None, "fee_paid": 0.0, "liquidated": False}
 
         # CLOSE action
@@ -481,10 +483,8 @@ class SequentialTradingEnvSLTP(SequentialTradingEnv):
 
         # Check if already in same direction - if so, hold (ignore duplicate action)
         if side == "long" and self.position.position_size > 0:
-            self.position.hold_counter += 1
             return {"executed": False, "side": None, "fee_paid": 0.0, "liquidated": False}
         if side == "short" and self.position.position_size < 0:
-            self.position.hold_counter += 1
             return {"executed": False, "side": None, "fee_paid": 0.0, "liquidated": False}
 
         # If switching direction, close existing position first
@@ -565,9 +565,6 @@ class SequentialTradingEnvSLTP(SequentialTradingEnv):
         self.position.position_size = position_size if side == "long" else -abs(position_size)
         self.position.position_value = abs(notional_value)
         self.position.entry_price = execution_price
-        # The bar a position OPENS on is holding_time=1, not 0 (see advance_hold_counter
-        # docstring in core/state.py for the canonical rule this must match).
-        self.position.hold_counter = 1
 
         # Set position direction
         if self.leverage == 1:

--- a/torchtrade/envs/offline/sequential_sltp.py
+++ b/torchtrade/envs/offline/sequential_sltp.py
@@ -16,6 +16,8 @@ Key Features:
 from dataclasses import dataclass
 from typing import Dict, List, Optional, Tuple, Union, Callable
 
+import math
+
 import pandas as pd
 import torch
 from tensordict import TensorDictBase
@@ -397,7 +399,7 @@ class SequentialTradingEnvSLTP(SequentialTradingEnv):
         # Same canonical aging as SequentialTradingEnv (#275): one call per step off the
         # post-trade size, so no exit path can be added later without ageing correctly.
         size = self.position.position_size
-        advance_hold_counter(self.position, 0.0 if size == 0 else (1.0 if size > 0 else -1.0))
+        advance_hold_counter(self.position, math.copysign(1.0, size) if size else 0.0)
 
         # Update position flag based on actual position size
         if trade_info["executed"]:

--- a/torchtrade/envs/offline/sequential_sltp.py
+++ b/torchtrade/envs/offline/sequential_sltp.py
@@ -16,8 +16,6 @@ Key Features:
 from dataclasses import dataclass
 from typing import Dict, List, Optional, Tuple, Union, Callable
 
-import math
-
 import pandas as pd
 import torch
 from tensordict import TensorDictBase
@@ -28,7 +26,10 @@ from torchtrade.envs.offline.sequential import (
     SequentialTradingEnvConfig,
 )
 from torchtrade.envs.core.common import TradeMode, validate_trade_mode
-from torchtrade.envs.core.state import advance_hold_counter, binarize_action_type
+from torchtrade.envs.core.state import (
+    advance_hold_counter_from_size,
+    binarize_action_type,
+)
 from torchtrade.envs.utils.sltp_helpers import (
     calculate_long_bracket_prices,
     calculate_short_bracket_prices,
@@ -398,8 +399,7 @@ class SequentialTradingEnvSLTP(SequentialTradingEnv):
 
         # Same canonical aging as SequentialTradingEnv (#275): one call per step off the
         # post-trade size, so no exit path can be added later without ageing correctly.
-        size = self.position.position_size
-        advance_hold_counter(self.position, math.copysign(1.0, size) if size else 0.0)
+        advance_hold_counter_from_size(self.position)
 
         # Update position flag based on actual position size
         if trade_info["executed"]:

--- a/torchtrade/envs/offline/vectorized_sequential.py
+++ b/torchtrade/envs/offline/vectorized_sequential.py
@@ -594,9 +594,10 @@ class VectorizedSequentialTradingEnv(EnvBase):
 
         Called once per step from the post-trade state rather than inside the trade
         branches, for the reason core/state.py gives: a branch that forgets to age is
-        invisible, and every branch and early return in _execute_trades would need one. A refused
-        resize is the case that proved it -- the position is still held, so it must still
-        age, and the scalar env ages it because its call sits in _step (#274, #275).
+        invisible, and every branch and early return in _execute_trades would need one.
+        A refused resize is the case that proved it: the position is still held, so it
+        must still age, and the scalar env ages it because its call sits in _step
+        (#274, #275).
         """
         direction = self._position_sizes.sign()
         self._hold_counters = torch.where(
@@ -620,12 +621,14 @@ class VectorizedSequentialTradingEnv(EnvBase):
         - Tolerance-based holding (avoid churn from small price drift)
         - Long and short positions
         - Direction switches (long→short, short→long): close then reopen
+        - Same-direction resizes: trade only the delta (weighted-average entry on an
+          increase, entry untouched on a decrease)
         - Leverage-aware margin and fee calculations
         """
+        has_position = self._position_sizes != 0
+
         # Same action optimization (#187): if action unchanged and has position, hold
-        same_action = (action_values == self._prev_action_values) & (
-            self._position_sizes != 0
-        )
+        same_action = (action_values == self._prev_action_values) & has_position
 
         # Update prev action values
         self._prev_action_values.copy_(action_values)
@@ -658,7 +661,7 @@ class VectorizedSequentialTradingEnv(EnvBase):
             min=POSITION_TOLERANCE_ABS
         )
         within_tol = (target_sizes - self._position_sizes).abs() < tolerance
-        hold_tol = need_trade & within_tol & (self._position_sizes != 0)
+        hold_tol = need_trade & within_tol & has_position
         need_trade = need_trade & ~hold_tol
 
         if not need_trade.any():
@@ -672,14 +675,13 @@ class VectorizedSequentialTradingEnv(EnvBase):
         # need_trade that has anything to do -- an env that is flat and asked to stay flat
         # matches none of them, which is the correct no-op. Disjointness is what stops an
         # env being charged by two branches.
-        has_pos = self._position_sizes != 0
-        wants_pos = action_values != 0
+        wants_position = action_values != 0
         same_sign = self._position_sizes.sign() == target_sizes.sign()
 
-        is_resize = need_trade & has_pos & wants_pos & same_sign
-        is_switch = need_trade & has_pos & wants_pos & ~same_sign
-        is_close_to_flat = need_trade & has_pos & ~wants_pos
-        is_open_from_flat = need_trade & ~has_pos & wants_pos
+        is_resize = need_trade & has_position & wants_position & same_sign
+        is_switch = need_trade & has_position & wants_position & ~same_sign
+        is_close_to_flat = need_trade & has_position & ~wants_position
+        is_open_from_flat = need_trade & ~has_position & wants_position
 
         if is_resize.any():
             # Target is sized off the PRE-trade portfolio value, as in the scalar env.

--- a/torchtrade/envs/offline/vectorized_sequential.py
+++ b/torchtrade/envs/offline/vectorized_sequential.py
@@ -526,11 +526,6 @@ class VectorizedSequentialTradingEnv(EnvBase):
                 self._entry_prices = torch.where(
                     liq_mask, self._zeros, self._entry_prices
                 )
-                self._hold_counters = torch.where(
-                    liq_mask,
-                    torch.zeros_like(self._hold_counters),
-                    self._hold_counters,
-                )
 
         # 3. Get current prices (trade execution prices)
         trade_prices = self._base_tensor[self._step_indices, 3].clone()
@@ -673,8 +668,10 @@ class VectorizedSequentialTradingEnv(EnvBase):
         # this (_adjust_position_size -> _increase/_decrease vs close-then-open); the
         # vectorized env used to send everything down close-then-open, which pays a full
         # round trip of fees on a same-direction resize and throws the entry price away
-        # (#274). These four masks are disjoint and cover need_trade exactly, so no env
-        # can be charged by two branches.
+        # (#274). These four masks are disjoint, and together they cover every env in
+        # need_trade that has anything to do -- an env that is flat and asked to stay flat
+        # matches none of them, which is the correct no-op. Disjointness is what stops an
+        # env being charged by two branches.
         has_pos = self._position_sizes != 0
         wants_pos = action_values != 0
         same_sign = self._position_sizes.sign() == target_sizes.sign()
@@ -682,6 +679,7 @@ class VectorizedSequentialTradingEnv(EnvBase):
         is_resize = need_trade & has_pos & wants_pos & same_sign
         is_switch = need_trade & has_pos & wants_pos & ~same_sign
         is_close_to_flat = need_trade & has_pos & ~wants_pos
+        is_open_from_flat = need_trade & ~has_pos & wants_pos
 
         if is_resize.any():
             # Target is sized off the PRE-trade portfolio value, as in the scalar env.
@@ -704,6 +702,7 @@ class VectorizedSequentialTradingEnv(EnvBase):
                     new_qty = delta.abs()
                     total_qty = old_qty + new_qty
                     # Quantity-weighted, matching _increase_position_size.
+                    # clamp: flat lanes would divide by zero here and are masked out below
                     weighted_entry = (
                         self._entry_prices * old_qty + execution_prices * new_qty
                     ) / total_qty.clamp(min=1e-12)
@@ -714,6 +713,7 @@ class VectorizedSequentialTradingEnv(EnvBase):
                     self._position_sizes[final_inc] = target_sizes[final_inc]
 
             if is_decrease.any():
+                # clamp: same reason as above -- flat lanes are discarded by is_decrease
                 frac_close = 1.0 - (
                     target_sizes.abs() / self._position_sizes.abs().clamp(min=1e-12)
                 )
@@ -749,7 +749,7 @@ class VectorizedSequentialTradingEnv(EnvBase):
             self._entry_prices[close_mask] = 0.0
 
         # Open new positions: from flat, or the second half of a direction switch.
-        open_mask = is_switch | (need_trade & ~has_pos & wants_pos)
+        open_mask = is_switch | is_open_from_flat
         if open_mask.any():
             # Recalculate target with updated balance (after closing)
             pvs_new = self._compute_portfolio_values(execution_prices)

--- a/torchtrade/envs/offline/vectorized_sequential.py
+++ b/torchtrade/envs/offline/vectorized_sequential.py
@@ -114,11 +114,8 @@ class VectorizedSequentialTradingEnv(EnvBase):
 
         Equivalence against SequentialTradingEnv is verified by
         tests/envs/offline/test_vec_scalar_equivalence.py: every binary outcome, and
-        money to within 1e-9 -- a claim about the axes it varies, leverage and fee.
-        It does NOT cover *resizing* a position through an intermediate action_level,
-        where the two engines are known to disagree (see #302): the scalar env resizes
-        in place with a weighted-average entry, the vectorized env always closes and
-        reopens. The open from flat at an intermediate level is covered.
+        money to within 1e-9, across leverage, fee, and intermediate action_levels
+        (opens, partial resizes and direction switches).
 
     Processes N environments in a single _step() call using tensor operations.
     All state (balances, positions, step indices) is stored as (num_envs,) tensors
@@ -253,6 +250,8 @@ class VectorizedSequentialTradingEnv(EnvBase):
         self._position_sizes = torch.zeros(N, dtype=MONEY_DTYPE)
         self._entry_prices = torch.zeros(N, dtype=MONEY_DTYPE)
         self._hold_counters = torch.zeros(N, dtype=torch.long)
+        # The direction hold_counters is counting, so a direct flip restarts it.
+        self._hold_directions = torch.zeros(N, dtype=MONEY_DTYPE)
         self._prev_action_values = torch.full((N,), float("nan"), dtype=MONEY_DTYPE)
         self._step_indices = torch.zeros(N, dtype=torch.long)
         self._end_indices = torch.zeros(N, dtype=torch.long)
@@ -366,6 +365,7 @@ class VectorizedSequentialTradingEnv(EnvBase):
         self._position_sizes[reset_mask] = 0.0
         self._entry_prices[reset_mask] = 0.0
         self._hold_counters[reset_mask] = 0
+        self._hold_directions[reset_mask] = 0.0
         self._prev_action_values[reset_mask] = float("nan")
         self._step_counters[reset_mask] = 0
 
@@ -548,6 +548,7 @@ class VectorizedSequentialTradingEnv(EnvBase):
         if liq_mask is not None and liq_mask.any():
             action_values = torch.where(liq_mask, self._zeros, action_values)
         self._execute_trades(action_values, trade_prices)
+        self._advance_hold_counters()
 
         # 6. Advance step indices and counters
         self._step_indices += 1
@@ -593,6 +594,27 @@ class VectorizedSequentialTradingEnv(EnvBase):
 
         return obs_td
 
+    def _advance_hold_counters(self):
+        """Age every position by one step -- the tensor form of advance_hold_counter.
+
+        Called once per step from the post-trade state rather than inside the trade
+        branches, for the reason core/state.py gives: a branch that forgets to age is
+        invisible, and _execute_trades has six of them plus three early returns. A refused
+        resize is the case that proved it -- the position is still held, so it must still
+        age, and the scalar env ages it because its call sits in _step (#274, #275).
+        """
+        direction = self._position_sizes.sign()
+        self._hold_counters = torch.where(
+            direction == 0,
+            torch.zeros_like(self._hold_counters),
+            torch.where(
+                direction != self._hold_directions,
+                torch.ones_like(self._hold_counters),
+                self._hold_counters + 1,
+            ),
+        )
+        self._hold_directions = direction
+
     def _execute_trades(
         self, action_values: torch.Tensor, execution_prices: torch.Tensor
     ):
@@ -609,7 +631,6 @@ class VectorizedSequentialTradingEnv(EnvBase):
         same_action = (action_values == self._prev_action_values) & (
             self._position_sizes != 0
         )
-        self._hold_counters[same_action] += 1
 
         # Update prev action values
         self._prev_action_values.copy_(action_values)
@@ -643,14 +664,74 @@ class VectorizedSequentialTradingEnv(EnvBase):
         )
         within_tol = (target_sizes - self._position_sizes).abs() < tolerance
         hold_tol = need_trade & within_tol & (self._position_sizes != 0)
-        self._hold_counters[hold_tol] += 1
         need_trade = need_trade & ~hold_tol
 
         if not need_trade.any():
             return
 
-        # Close existing positions that need to change
-        close_mask = need_trade & (self._position_sizes != 0)
+        # Classify what each trading env is actually doing. The scalar env branches on
+        # this (_adjust_position_size -> _increase/_decrease vs close-then-open); the
+        # vectorized env used to send everything down close-then-open, which pays a full
+        # round trip of fees on a same-direction resize and throws the entry price away
+        # (#274). These four masks are disjoint and cover need_trade exactly, so no env
+        # can be charged by two branches.
+        has_pos = self._position_sizes != 0
+        wants_pos = action_values != 0
+        same_sign = self._position_sizes.sign() == target_sizes.sign()
+
+        is_resize = need_trade & has_pos & wants_pos & same_sign
+        is_switch = need_trade & has_pos & wants_pos & ~same_sign
+        is_close_to_flat = need_trade & has_pos & ~wants_pos
+
+        if is_resize.any():
+            # Target is sized off the PRE-trade portfolio value, as in the scalar env.
+            delta = target_sizes - self._position_sizes
+            delta_notional = (delta * execution_prices).abs()
+            is_increase = is_resize & (target_sizes.abs() > self._position_sizes.abs())
+            is_decrease = is_resize & ~is_increase
+
+            if is_increase.any():
+                fee = delta_notional * self.transaction_fee
+                margin_required = delta_notional / leverage
+                can_afford = (margin_required + fee) <= self._balances * (
+                    1 + AFFORDABILITY_REL_TOL
+                )
+                # An unaffordable increase must leave the env completely untouched, the
+                # way the scalar env early-returns executed=False -- not fall through.
+                final_inc = is_increase & can_afford
+                if final_inc.any():
+                    old_qty = self._position_sizes.abs()
+                    new_qty = delta.abs()
+                    total_qty = old_qty + new_qty
+                    # Quantity-weighted, matching _increase_position_size.
+                    weighted_entry = (
+                        self._entry_prices * old_qty + execution_prices * new_qty
+                    ) / total_qty.clamp(min=1e-12)
+
+                    self._balances[final_inc] -= (fee + margin_required)[final_inc]
+                    self._balances.clamp_(min=0.0)
+                    self._entry_prices[final_inc] = weighted_entry[final_inc]
+                    self._position_sizes[final_inc] = target_sizes[final_inc]
+
+            if is_decrease.any():
+                frac_close = 1.0 - (
+                    target_sizes.abs() / self._position_sizes.abs().clamp(min=1e-12)
+                )
+                closed_qty = self._position_sizes * frac_close
+                pnl = (execution_prices - self._entry_prices) * closed_qty
+                fee = (closed_qty * execution_prices).abs() * self.transaction_fee
+                # Freed margin is priced at entry, not at the current price.
+                freed_margin = (closed_qty * self._entry_prices).abs() / leverage
+
+                self._balances[is_decrease] += (pnl - fee + freed_margin)[is_decrease]
+                self._balances.clamp_(min=0.0)
+                self._position_sizes[is_decrease] = target_sizes[is_decrease]
+                # Entry price is deliberately untouched: partially closing does not
+                # re-price the remainder, so the liquidation price is unchanged.
+
+        # Close existing positions that need to change. Narrowed from "every env with a
+        # position that is trading" to switches and closes -- a resize is handled above.
+        close_mask = is_switch | is_close_to_flat
         if close_mask.any():
             # PnL works for both long and short via signed position_sizes:
             # Long:  (current - entry) * (+qty) = positive if price went up
@@ -666,10 +747,9 @@ class VectorizedSequentialTradingEnv(EnvBase):
             self._balances.clamp_(min=0.0)
             self._position_sizes[close_mask] = 0.0
             self._entry_prices[close_mask] = 0.0
-            self._hold_counters[close_mask] = 0
 
-        # Open new positions where action != 0 (both long and short)
-        open_mask = need_trade & (action_values != 0)
+        # Open new positions: from flat, or the second half of a direction switch.
+        open_mask = is_switch | (need_trade & ~has_pos & wants_pos)
         if open_mask.any():
             # Recalculate target with updated balance (after closing)
             pvs_new = self._compute_portfolio_values(execution_prices)
@@ -691,9 +771,6 @@ class VectorizedSequentialTradingEnv(EnvBase):
                 self._balances.clamp_(min=0.0)
                 self._position_sizes[final_open] = new_sizes[final_open]
                 self._entry_prices[final_open] = execution_prices[final_open]
-                # The bar a position OPENS on is holding_time=1, not 0 (matches the
-                # scalar SequentialTradingEnv / advance_hold_counter canonical rule).
-                self._hold_counters[final_open] = 1
 
     def close(self):
         """Clean up resources."""

--- a/torchtrade/envs/offline/vectorized_sequential.py
+++ b/torchtrade/envs/offline/vectorized_sequential.py
@@ -594,7 +594,7 @@ class VectorizedSequentialTradingEnv(EnvBase):
 
         Called once per step from the post-trade state rather than inside the trade
         branches, for the reason core/state.py gives: a branch that forgets to age is
-        invisible, and _execute_trades has six of them plus three early returns. A refused
+        invisible, and every branch and early return in _execute_trades would need one. A refused
         resize is the case that proved it -- the position is still held, so it must still
         age, and the scalar env ages it because its call sits in _step (#274, #275).
         """
@@ -702,7 +702,8 @@ class VectorizedSequentialTradingEnv(EnvBase):
                     new_qty = delta.abs()
                     total_qty = old_qty + new_qty
                     # Quantity-weighted, matching _increase_position_size.
-                    # clamp: flat lanes would divide by zero here and are masked out below
+                    # clamp: a lane that is flat AND has a zero target divides by zero here;
+                    # every such lane is outside final_inc and discarded below
                     weighted_entry = (
                         self._entry_prices * old_qty + execution_prices * new_qty
                     ) / total_qty.clamp(min=1e-12)

--- a/torchtrade/envs/offline/vectorized_sequential_sltp.py
+++ b/torchtrade/envs/offline/vectorized_sequential_sltp.py
@@ -240,6 +240,11 @@ class VectorizedSequentialTradingEnvSLTP(VectorizedSequentialTradingEnv):
 
         self._portfolio_values = new_pvs
 
+        # Same canonical ageing as the base env (#275). This subclass inherits
+        # _hold_directions but overrides _step, so without this call the tensor is
+        # allocated and never read and the four offline engines count holds two ways.
+        self._advance_hold_counters()
+
         # 8. Compute termination signals
         terminated = new_pvs < (self._initial_pvs * self.bankrupt_threshold)
         truncated = (
@@ -291,11 +296,6 @@ class VectorizedSequentialTradingEnvSLTP(VectorizedSequentialTradingEnv):
                 )
                 self._entry_prices = torch.where(
                     liq_mask, self._zeros, self._entry_prices
-                )
-                self._hold_counters = torch.where(
-                    liq_mask,
-                    torch.zeros_like(self._hold_counters),
-                    self._hold_counters,
                 )
                 # Note: SL/TP are NOT cleared on liquidation, matching scalar
                 # env behavior. Stale values are harmless: the trigger masks
@@ -356,11 +356,6 @@ class VectorizedSequentialTradingEnvSLTP(VectorizedSequentialTradingEnv):
                 self._entry_prices = torch.where(
                     sltp_trigger, self._zeros, self._entry_prices
                 )
-                self._hold_counters = torch.where(
-                    sltp_trigger,
-                    torch.zeros_like(self._hold_counters),
-                    self._hold_counters,
-                )
                 self._sl_prices = torch.where(
                     sltp_trigger, self._zeros, self._sl_prices
                 )
@@ -403,7 +398,6 @@ class VectorizedSequentialTradingEnvSLTP(VectorizedSequentialTradingEnv):
             | ((sides == -1) & is_short)
         )
         hold_with_pos = hold_mask & ~is_flat
-        self._hold_counters[hold_with_pos] += 1
 
         # Close action (side=2) with existing position
         close_action_mask = (sides == 2) & ~is_flat
@@ -428,7 +422,6 @@ class VectorizedSequentialTradingEnvSLTP(VectorizedSequentialTradingEnv):
             self._balances.clamp_(min=0.0)
             self._position_sizes[close_mask] = 0.0
             self._entry_prices[close_mask] = 0.0
-            self._hold_counters[close_mask] = 0
             # Note: SL/TP NOT cleared here, matching scalar env behavior.
             # Stale values are harmless (guarded by has_position).
             # For switches, new brackets are set in the open section below.
@@ -465,9 +458,6 @@ class VectorizedSequentialTradingEnvSLTP(VectorizedSequentialTradingEnv):
                 self._balances.clamp_(min=0.0)
                 self._position_sizes[final_open] = new_sizes[final_open]
                 self._entry_prices[final_open] = trade_prices[final_open]
-                # The bar a position OPENS on is holding_time=1, not 0 (matches the
-                # scalar SequentialTradingEnvSLTP / advance_hold_counter canonical rule).
-                self._hold_counters[final_open] = 1
 
                 # Set bracket prices: entry * (1 + pct)
                 # E.g. Long entry=100, sl_pct=-0.05 → sl_price=95

--- a/torchtrade/envs/offline/vectorized_sequential_sltp.py
+++ b/torchtrade/envs/offline/vectorized_sequential_sltp.py
@@ -230,6 +230,12 @@ class VectorizedSequentialTradingEnvSLTP(VectorizedSequentialTradingEnv):
         # portfolio values below, or reward and termination read balances that ignore it.
         self._apply_exit_checks(new_high, new_low)
 
+        # Age straight after the last thing that can move _position_sizes -- the same
+        # invariant the base env keeps by calling this right after _execute_trades. This
+        # subclass overrides _step, so without the call nothing ages the counters here and
+        # holding_time reads 0 forever (#275).
+        self._advance_hold_counters()
+
         # 7. Compute rewards: log(new_pv / old_pv)
         new_pvs = self._compute_portfolio_values(new_close)
         old_pvs = self._portfolio_values
@@ -239,11 +245,6 @@ class VectorizedSequentialTradingEnvSLTP(VectorizedSequentialTradingEnv):
         rewards = torch.where(new_pvs <= 0, torch.full_like(rewards, -10.0), rewards)
 
         self._portfolio_values = new_pvs
-
-        # Same canonical ageing as the base env (#275). This subclass inherits
-        # _hold_directions but overrides _step, so without this call the tensor is
-        # allocated and never read and the four offline engines count holds two ways.
-        self._advance_hold_counters()
 
         # 8. Compute termination signals
         terminated = new_pvs < (self._initial_pvs * self.bankrupt_threshold)
@@ -390,14 +391,6 @@ class VectorizedSequentialTradingEnvSLTP(VectorizedSequentialTradingEnv):
             if has_position.any():
                 sides = sides.clone()
                 sides[has_position] = 0  # Force HOLD
-
-        # Hold: explicit hold or already in same direction
-        hold_mask = (
-            (sides == 0)
-            | ((sides == 1) & is_long)
-            | ((sides == -1) & is_short)
-        )
-        hold_with_pos = hold_mask & ~is_flat
 
         # Close action (side=2) with existing position
         close_action_mask = (sides == 2) & ~is_flat


### PR DESCRIPTION
Fixes #274 and #275. Both were invisible to the suite: 2321 tests passed before this change and 2321 after, unchanged.

## 1. Partial resize traded as a full round trip (#274)

`VectorizedSequentialTradingEnv._execute_trades` sent **every** target change through close-then-reopen, including a same-direction resize. That pays a full round trip of fees and throws the entry price away — which also moves the liquidation price and `unrealized_pnl_pct`.

Measured against `SequentialTradingEnv`, `action_levels=[-1,-0.5,0,0.5,1]`, fee 0.001:

| scenario | before | after |
|---|---|---|
| lev 1, oscillate full↔half, 6 steps | 0.4982% of portfolio | **0.0000%** |
| lev 5, oscillate full↔half, 8 steps | 3.4566% | **0.0000%** |
| lev 5, gradual resize, 8 steps | 1.4983% | **0.0000%** |

Entry prices are now bit-equal too.

The fix classifies each trading env into four disjoint masks — resize / switch / close-to-flat / open-from-flat — and narrows the close and open masks to the last three. The resize branch uses the scalar engine's exact formulas: fee and margin on the delta only, a quantity-weighted entry on an increase, and an **untouched** entry on a decrease (partially closing does not re-price the remainder, so the liquidation price is unchanged).

## 2. holding_time did not survive a resize (#275)

`account_state[3]` is documented as "steps since position opened". Both engines got it wrong, in opposite directions:

- **scalar** hand-rolled the counter at five sites and never gave the resize path one, so a position resized every bar reported `holding_time=1` forever
- **vectorized** reset it to 1 through the reopen, discarding the age

`advance_hold_counter` in `core/state.py` has specified this rule since the live envs were fixed to share it — and no offline env ever called it. They only cited it in comments. All **four** offline engines now age once per step from the post-trade direction: the two scalar engines through `advance_hold_counter_from_size` (extracted to `core/state.py` in review, so the size→direction conversion is not itself duplicated), the two vectorized engines through `_advance_hold_counters`, its tensor form. Seventeen hand-rolled sites were removed.

**That part was not optional, and a test proved it.** My first attempt incremented inside the resize branch instead. A new equivalence cell caught it immediately: on a *refused* resize (unaffordable at leverage 5) the vectorized position stayed un-aged while the scalar aged it — because the scalar's call sits in `_step` and runs whether or not the trade executed. Six branches and three early returns is exactly the shape `core/state.py` warns about.

## Cost

~20% throughput on the vectorized env at worst-case churn (uniform random over five levels, so nearly every step is a resize):

| num_envs | main | this PR |
|---|---|---|
| 256 | 579,558 steps/s | 457,880 |
| 1024 | 1,659,959 | 1,332,503 |
| 4096 | 3,308,434 | 2,686,819 |

A trained policy holds far more often than uniform-random, so this is an upper bound. Still ~2.7M steps/s, orders of magnitude above the collector ceiling.

## Tests

`action_levels` was already threaded through `_make_pair` and `_run_sequence` and **no caller ever passed it** — every cell ran the default `{-1,0,1}` where every action is flat-or-full and the resize branch is unreachable. That is the axis this bug lived behind. Now covered by `TestScalarVecEquivalenceResize`: four equivalence cells (`oscillate-spot`, `oscillate-levered`, `oscillate-short`, `through-flat`), plus `test_an_unaffordable_increase_changes_nothing_but_the_age` and `test_resize_charges_the_delta_fee_exactly` — the latter pinning the absolute fee on *both* engines, so a joint regression to close-and-reopen still fails. One new cell in `test_sequential_holding_time_sequence` pins that a resized position keeps ageing.

Mutation-verified across 23 mutations of the changed production lines — resize arithmetic, mask classification, and the ageing rule — with **no survivors**. Per-cell, `oscillate-short` is the sole killer of dropping the sign in the decrease branch (which carries through `closed_qty`, `pnl` and `freed_margin`), and `through-flat` is the sole killer of both switch-classified-as-resize and close-to-flat. `oscillate-spot` is not the sole killer of anything; it is kept as cheap coverage of a supported mode, not claimed as load-bearing.

## On #302

I filed #302 while reviewing #301, not having found #274 first — same mechanism, same file, same lines. It is closed as a duplicate, and the class docstring it was cited in (`vectorized_sequential.py`) now points at the coverage this PR adds rather than at a closed issue. Two things #302 contributed that #274 did not name are carried here: the `hold_counter` divergence (fixed as #275), and `margin_type` being dead config on both engines (left for #285, the dead-code sweep).

## Not fixed, deliberately

#274 also names a start-of-data padding divergence (scalar zero-pads, vectorized repeats the first bar). **Both branches are unreachable.** `sampler.py`'s `min_start_time` guarantees every window has full lookback — verified across five multi-timeframe configs, every `first_idx >= window_size - 1` — and `TestUndersizedWindowPadding` has to monkeypatch `_obs_indices` to reach the branch at all. It is a code inconsistency, not a live bug, and aligning it is defence-in-depth rather than a fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

