### PR TITLE
fix(envs): align every observation timeframe to the fill instant, and compare timeframes by duration (#282)

### DIFF
--- a/docs/guides/sampler.md
+++ b/docs/guides/sampler.md
@@ -107,10 +107,16 @@ Execute at:              ↑         ↑         ↑
                         t=5      t=10      t=15
 ```
 
-At t=10 (executing on 5-minute bar B):
-- **1-minute data**: Last 12 bars (from recent history)
-- **5-minute data**: Bar A (completed at t=5)
-- **15-minute data**: Bar X (completed at t=0)
+Each execution step is labelled by its bin's **start**, but the trade fills at that
+bin's **close**. So the step labelled t=10 spans [10, 15) and executes at minute 14 —
+verified by intercepting the executed price, and pinned by
+`tests/envs/offline/test_sequential.py::TestExecutionPriceConvention`.
+
+Every observation window is therefore as-of minute 14, the instant money changes hands:
+
+- **1-minute data**: last 12 bars, ending at minute 14
+- **5-minute data**: bar C [10, 15), whose close *is* the execution price
+- **15-minute data**: bar X [0, 15) only once it has closed; until then, the previous one
 
 ### Lookahead Bias Prevention
 
@@ -128,26 +134,36 @@ At t=10 (executing on 5-minute bar B):
 # At t=10, agent can only see bars that closed BEFORE t=10 ✅
 ```
 
-**Detailed Example at t=10**:
-
-When your agent executes at minute 10, here's what data is available:
+**Detailed Example at the step labelled t=10** (`execute_on=5Minute`, so it fills at
+minute 14):
 
 ```
-✅ CAN use (completed bars only):
-  - 1-min bars: [1, 2, 3, ..., 9] (bar 10 is still forming)
-  - 5-min bar A [0-5]: Closed at t=5, fully complete
-  - 15-min bar covering previous period: Only if it ended before t=10
+✅ CAN use (everything known by minute 14):
+  - 1-min bars: [..., 12, 13, 14] — up to the fill instant
+  - 5-min bar C [10-15]: its close IS the execution price
+  - 15-min bar covering a period that ended at or before t=10
 
-❌ CANNOT use (incomplete bars):
-  - 5-min bar B [5-10]: Still forming, closes at t=10
-  - 15-min bar X [0-15]: Still forming, closes at t=15
+❌ CANNOT use:
+  - any 1-min bar from minute 15 onwards — that is the next step
+  - 5-min bar D [15-20]: has not started
+  - 15-min bar X [0-15]: not yet closed at t=10
 ```
 
-**Why This Matters**: Without this protection, your agent would train on future information (looking into bars that haven't closed yet), leading to unrealistic backtest results that won't work in live trading.
+**Why This Matters**: the boundary is the instant the trade fills, not the bar's label.
+Bounding on the label looks safer but is not — it withholds data the agent demonstrably
+already has, because the `execute_on` window's own close is the execution price. Before
+#282, timeframes finer than `execute_on` were bounded on the label and so lagged the rest
+of the observation by up to a full execution bar.
 
-**Implementation Detail** (from `sampler.py:71-77`):
+**Implementation Detail**:
 
-Higher timeframes (coarser than `execute_on`) are shifted forward by their period during resampling. This ensures bars are indexed by their END time. When the agent queries data at execution time, `searchsorted` automatically excludes any bars that haven't closed yet.
+- Timeframes **coarser** than `execute_on` are shifted forward by their period during
+  resampling, so they are indexed by their END time and only completed bars are visible.
+- Timeframes **finer** than `execute_on` keep their own labels but are looked up with the
+  last instant inside the current execution bin, so they end where the fill happens.
+- A coarse bar that completes *inside* the current bin is not shown until the next step.
+  That only arises when the coarse grid does not align with `execute_on` (e.g. 90-minute
+  bars under hourly execution); it is conservative, never leaky.
 
 ---
 

--- a/docs/guides/sampler.md
+++ b/docs/guides/sampler.md
@@ -160,7 +160,10 @@ of the observation by up to a full execution bar.
 - Timeframes **coarser** than `execute_on` are shifted forward by their period during
   resampling, so they are indexed by their END time and only completed bars are visible.
 - Timeframes **finer** than `execute_on` keep their own labels but are looked up with the
-  last instant inside the current execution bin, so they end where the fill happens.
+  last bar that *closes* at or before the execution bin ends, so they end where the fill
+  happens. Note "closes", not "starts": a bar is aggregated across its whole span, so one
+  that merely starts inside the bin can carry a close from after it — a 7-minute bar
+  beginning at minute 70 closes at 76, past a bin ending at 75.
 - A coarse bar that completes *inside* the current bin is not shown until the next step.
   That only arises when the coarse grid does not align with `execute_on` (e.g. 90-minute
   bars under hourly execution); it is conservative, never leaky.

--- a/tests/envs/offline/test_sampler.py
+++ b/tests/envs/offline/test_sampler.py
@@ -2054,6 +2054,48 @@ class TestObservationTimeframesShareOneInstant:
                     f"{minute:.0f}, which is {minute - decision_instant:.0f} past the "
                     f"decision instant {decision_instant:.0f}"
                 )
+
+            # Safety alone is satisfiable by any stale bound, and staleness is what
+            # #282 was about. The window must end on the FRESHEST legal bar: if the
+            # last legal one is [L, L+f) then the next closes at L+2f, past the bin,
+            # so the lag can never reach a full fine period.
+            newest = obs[fine.obs_key_freq()][-1, 3].item() - 1000.0
+            assert decision_instant - newest < fine.to_minutes(), (
+                f"at {timestamp}: {fine.obs_key_freq()} ends at {newest:.0f}, "
+                f"{decision_instant - newest:.0f} min behind the decision instant "
+                f"{decision_instant:.0f} -- a whole {fine.to_minutes():.0f}-min bar "
+                f"was available and withheld"
+            )
+            if truncated:
+                break
+
+    def test_both_lookup_paths_agree_for_a_finer_frame(self):
+        """get_observation(ts) must return what get_sequential_observation() returned.
+
+        They are separate implementations -- one precomputes indices at init, the other
+        searches at call time -- and the fine-frame rule was originally applied to only
+        the first, so they disagreed by up to a full execution bar.
+
+        Reachable, not theoretical: sequential.py and onestep.py both fall back to
+        get_observation() for the terminal observation of a truncated episode, which is
+        exactly what a value estimate bootstraps from.
+        """
+        fine = TimeFrame(1, TimeFrameUnit.Minute)
+        exec_tf = TimeFrame(15, TimeFrameUnit.Minute)
+        sampler = MarketDataObservationSampler(
+            df=self._counter_df(), time_frames=[fine, exec_tf], window_sizes=[4, 4],
+            execute_on=exec_tf, max_traj_length=10, seed=0,
+        )
+        sampler.reset(random_start=False)
+
+        for _ in range(5):
+            sequential, timestamp, truncated = sampler.get_sequential_observation()
+            direct = sampler.get_observation(timestamp)
+            for key in (fine.obs_key_freq(), exec_tf.obs_key_freq()):
+                assert torch.equal(sequential[key], direct[key]), (
+                    f"at {timestamp}: {key} differs between the sequential and the "
+                    f"timestamp-lookup paths"
+                )
             if truncated:
                 break
 
@@ -2098,3 +2140,45 @@ class TestObservationTimeframesShareOneInstant:
             )
             if truncated:
                 break
+
+
+    @pytest.mark.parametrize("exec_tf,should_raise", [
+        (TimeFrame(1, TimeFrameUnit.Day), True),
+        (TimeFrame(2, TimeFrameUnit.Day), True),
+        (TimeFrame(1, TimeFrameUnit.Hour), False),   # Tick offsets are DST-immune
+        (TimeFrame(1, TimeFrameUnit.Minute), False),
+    ], ids=["1day", "2day", "1hour_ok", "1min_ok"])
+    def test_tz_aware_index_refused_only_for_day_or_longer(self, exec_tf, should_raise):
+        """Day-or-longer bins follow LOCAL midnight, so a DST day is 23h or 25h wide
+        while the search bound uses a fixed 24h period. On a spring-forward day that
+        reaches an hour past the bin's real close -- lookahead, not staleness.
+
+        Minute and Hour resample as fixed-width Tick offsets and are immune, so the
+        guard must not reject them; rejecting every tz-aware config would needlessly
+        break intraday users who are not exposed to this at all.
+
+        The guard is deliberately broader than the hazard: it rejects ANY tz-aware
+        index at Day or longer, including fixed-offset zones like UTC that have no DST
+        and are therefore safe. Deciding whether a given zone actually transitions
+        inside the data's span is more machinery than the case is worth, and the error
+        tells the caller exactly what to do instead.
+        """
+        n = 60 * 24 * 4
+        ts = pd.date_range("2024-03-08", periods=n, freq="1min", tz="UTC")
+        close = np.arange(n, dtype=float) + 1000.0
+        df = pd.DataFrame({
+            "timestamp": ts, "open": close, "high": close + 0.5,
+            "low": close - 0.5, "close": close, "volume": 1000.0,
+        })
+
+        def build():
+            return MarketDataObservationSampler(
+                df=df, time_frames=[exec_tf], window_sizes=[3],
+                execute_on=exec_tf, max_traj_length=5, seed=0,
+            )
+
+        if should_raise:
+            with pytest.raises(ValueError, match="tz-naive"):
+                build()
+        else:
+            build()  # must not raise

--- a/tests/envs/offline/test_sampler.py
+++ b/tests/envs/offline/test_sampler.py
@@ -940,8 +940,16 @@ class TestSamplerNoFutureLeakage:
 
         Tests: 1min, 5min, 15min, 30min, 1hour, 4hour execution intervals.
 
-        For each execution timeframe, the observation at time T must not
-        contain any data from time > T.
+        The boundary is the DECISION INSTANT, not the bar's label. `timestamp` is the
+        execution bin's start label, but the env hands money over at that bin's close --
+        pinned by TestExecutionPriceConvention, verified by intercepting the executed
+        price. So an observation labelled T may legitimately contain anything up to the
+        end of bin T, and nothing beyond it.
+
+        This previously bounded on the label, which made the finer window stop a full
+        execution bar short of the price it was about to trade at (#282). That was not
+        preventing lookahead -- the coarse window already carried that close -- it was
+        withholding data the observation already contained one row up.
         """
         execute_on = TimeFrame(exec_value, exec_unit)
         window_size = 10
@@ -956,19 +964,23 @@ class TestSamplerNoFutureLeakage:
 
         start_time = pd.Timestamp("2024-01-01 00:00:00")
         prev_last_close = None
+        # Last minute bar inside the bin labelled `timestamp`; the next bin is the future.
+        last_minute_in_bin = int(execute_on.to_minutes()) - 1
 
         # Test at least 20 steps
         for step in range(20):
             obs, timestamp, truncated = sampler.get_sequential_observation()
             current_minute_idx = int((timestamp - start_time).total_seconds() / 60)
+            decision_instant = current_minute_idx + last_minute_in_bin
 
-            # All close prices must be <= current_minute_idx (no future data)
+            # No close may come from after the instant the trade fills at
             close_values = obs["1Minute"][:, 3].numpy()
 
             for close_val in close_values:
-                assert close_val <= current_minute_idx, (
+                assert close_val <= decision_instant, (
                     f"Future leakage detected with {exec_value}{exec_unit.name} execution! "
-                    f"At minute {current_minute_idx}, observation contains close={close_val}"
+                    f"Bin labelled minute {current_minute_idx} closes at minute "
+                    f"{decision_instant}, but observation contains close={close_val}"
                 )
 
             # Verify execution advances by expected amount
@@ -997,9 +1009,14 @@ class TestSamplerNoFutureLeakage:
         self, large_sequential_ohlcv_df, exec_value, exec_unit
     ):
         """
-        The last bar in observation should be at or before query timestamp.
+        The last bar in the observation should be the one the trade fills at.
 
         Tests across: 1min, 5min, 15min, 30min, 1hour, 4hour execution.
+
+        "Current time" is the execution bin's CLOSE, not its label. `timestamp` is the
+        label; the env executes at the bin's close (TestExecutionPriceConvention). For
+        execute_on=1Minute the two coincide, which is why this read as correct for years
+        while every coarser execute_on left the minute window a full bar behind (#282).
         """
         execute_on = TimeFrame(exec_value, exec_unit)
         window_size = 10
@@ -1013,17 +1030,19 @@ class TestSamplerNoFutureLeakage:
         sampler.reset(random_start=False)
 
         start_time = pd.Timestamp("2024-01-01 00:00:00")
+        last_minute_in_bin = int(execute_on.to_minutes()) - 1
 
         for step in range(15):
             obs, timestamp, truncated = sampler.get_sequential_observation()
             current_minute_idx = int((timestamp - start_time).total_seconds() / 60)
+            decision_instant = current_minute_idx + last_minute_in_bin
 
-            # Last close should equal current minute (since close = minute_index)
+            # Last close should be the bin's closing minute (since close = minute_index)
             last_close = obs["1Minute"][-1, 3].item()
-            assert last_close == current_minute_idx, (
-                f"With {exec_value}{exec_unit.name} execution: "
-                f"Last observation should be at current time. "
-                f"Expected close={current_minute_idx}, got {last_close}"
+            assert last_close == decision_instant, (
+                f"With {exec_value}{exec_unit.name} execution: last observation should be "
+                f"the bar the trade fills at. Expected close={decision_instant}, "
+                f"got {last_close}"
             )
 
             if truncated:
@@ -1047,8 +1066,17 @@ class TestSamplerNoFutureLeakage:
         timeframe itself must not contain future information.
 
         Tests across: 1min, 5min, 15min, 30min, 1hour, 4hour execution.
+
+        Bounded on the execution bin's CLOSE, which is where the trade fills, not on its
+        label (TestExecutionPriceConvention, #282).
+
+        This also asserts the execute_on-keyed column, which it never did -- it checked
+        only obs["1Minute"] and passed trivially, so the column the agent actually trades
+        off was unguarded. Asserting both is what pins the real invariant: every
+        timeframe up to execute_on ends at the same instant.
         """
         execute_on = TimeFrame(exec_value, exec_unit)
+        exec_key = execute_on.obs_key_freq()
 
         # Use execution timeframe as one of the observation timeframes
         sampler = MarketDataObservationSampler(
@@ -1063,18 +1091,27 @@ class TestSamplerNoFutureLeakage:
         sampler.reset(random_start=False)
 
         start_time = pd.Timestamp("2024-01-01 00:00:00")
+        last_minute_in_bin = int(execute_on.to_minutes()) - 1
 
         for step in range(15):
             obs, timestamp, truncated = sampler.get_sequential_observation()
             current_minute_idx = int((timestamp - start_time).total_seconds() / 60)
+            decision_instant = current_minute_idx + last_minute_in_bin
 
-            # 1-minute timeframe must have no leakage
-            close_1min = obs["1Minute"][:, 3].numpy()
-            for close_val in close_1min:
-                assert close_val <= current_minute_idx, (
-                    f"1Minute leakage with {exec_value}{exec_unit.name} execution! "
-                    f"Close={close_val} > current_minute={current_minute_idx}"
-                )
+            # Neither timeframe may reach past the instant the trade fills at
+            for key in ("1Minute", exec_key):
+                for close_val in obs[key][:, 3].numpy():
+                    assert close_val <= decision_instant, (
+                        f"{key} leakage with {exec_value}{exec_unit.name} execution! "
+                        f"Close={close_val} > decision instant {decision_instant}"
+                    )
+
+            # ...and they must agree about where "now" is
+            assert obs["1Minute"][-1, 3].item() == obs[exec_key][-1, 3].item(), (
+                f"With {exec_value}{exec_unit.name} execution the 1Minute window ends at "
+                f"{obs['1Minute'][-1, 3].item()} but {exec_key} ends at "
+                f"{obs[exec_key][-1, 3].item()} -- one observation, two 'now's"
+            )
 
             if truncated:
                 break
@@ -1920,3 +1957,81 @@ class TestTimeframeSpellingIsNotObservable:
             f"1Hour saw {as_hours}, 60Minute saw {as_minutes} -- same duration, "
             "same execute_on, so the spelling must not change the data"
         )
+
+
+class TestObservationTimeframesShareOneInstant:
+    """Every timeframe up to execute_on must end at the same instant (#282 defect 1).
+
+    The env executes at the last close in obs[execute_on] -- pinned by
+    tests/envs/offline/test_sequential.py::TestExecutionPriceConvention, verified by
+    intercepting the executed price. So that instant is what the whole observation
+    should be as-of.
+
+    Timeframes FINER than execute_on were not: the resample loop shifts only
+    tf > execute_on to END labels, and _obs_indices searches every timeframe with the
+    same key -- the exec bin's START label. For the execute_on frame that lands right by
+    accident, because its bin is already aggregated through the bin's end. For a finer
+    frame the index has real per-bar granularity, so the same key returns the bar
+    STARTING at the label: a 1Minute window sat 59 minutes behind the 1Hour window it
+    was sampled beside, and behind the price the trade filled at.
+    """
+
+    @staticmethod
+    def _counter_df(n=60 * 40):
+        ts = pd.date_range("2024-01-01", periods=n, freq="1min")
+        close = np.arange(n, dtype=float) + 1000.0  # close identifies its own minute
+        return pd.DataFrame({
+            "timestamp": ts, "open": close, "high": close + 0.5,
+            "low": close - 0.5, "close": close, "volume": 1000.0,
+        })
+
+    @pytest.mark.parametrize("fine,exec_tf", [
+        (TimeFrame(1, TimeFrameUnit.Minute), TimeFrame(1, TimeFrameUnit.Hour)),
+        (TimeFrame(5, TimeFrameUnit.Minute), TimeFrame(1, TimeFrameUnit.Hour)),
+        (TimeFrame(1, TimeFrameUnit.Minute), TimeFrame(15, TimeFrameUnit.Minute)),
+    ], ids=["1min_under_1h", "5min_under_1h", "1min_under_15min"])
+    def test_finer_window_ends_where_the_execute_on_window_ends(self, fine, exec_tf):
+        sampler = MarketDataObservationSampler(
+            df=self._counter_df(), time_frames=[fine, exec_tf], window_sizes=[4, 4],
+            execute_on=exec_tf, max_traj_length=8, seed=0,
+        )
+        sampler.reset(random_start=False)
+
+        for _ in range(5):
+            obs, timestamp, truncated = sampler.get_sequential_observation()
+            fine_close = obs[fine.obs_key_freq()][-1, 3].item()
+            exec_close = obs[exec_tf.obs_key_freq()][-1, 3].item()
+            assert fine_close == exec_close, (
+                f"at {timestamp}: {fine.obs_key_freq()} ends at close {fine_close} while "
+                f"{exec_tf.obs_key_freq()} ends at {exec_close} -- the same observation "
+                f"disagrees with itself about now by {exec_close - fine_close:.0f} minutes"
+            )
+            if truncated:
+                break
+
+    def test_finer_window_never_reaches_into_the_next_bin(self):
+        """The bound must stay strictly inside the current execute_on bin.
+
+        Extending the fine window to the decision instant recovers granularity the agent
+        already has via obs[execute_on]. Overshooting by one tick would hand it the next
+        bin, which has not happened yet.
+        """
+        exec_tf = TimeFrame(1, TimeFrameUnit.Hour)
+        fine = TimeFrame(1, TimeFrameUnit.Minute)
+        sampler = MarketDataObservationSampler(
+            df=self._counter_df(), time_frames=[fine, exec_tf], window_sizes=[4, 4],
+            execute_on=exec_tf, max_traj_length=8, seed=0,
+        )
+        sampler.reset(random_start=False)
+        start = pd.Timestamp("2024-01-01 00:00:00")
+
+        for _ in range(5):
+            obs, timestamp, truncated = sampler.get_sequential_observation()
+            bin_end_minute = (timestamp - start).total_seconds() / 60 + 60  # exclusive
+            for value in obs[fine.obs_key_freq()][:, 3].tolist():
+                assert value - 1000.0 < bin_end_minute, (
+                    f"at {timestamp}: fine window contains minute {value - 1000.0:.0f}, "
+                    f"which is in the NEXT bin (starts {bin_end_minute:.0f})"
+                )
+            if truncated:
+                break

--- a/tests/envs/offline/test_sampler.py
+++ b/tests/envs/offline/test_sampler.py
@@ -2099,7 +2099,6 @@ class TestObservationTimeframesShareOneInstant:
             if truncated:
                 break
 
-
     def test_three_timeframes_spanning_both_sides_of_execute_on(self):
         """The realistic shape from docs/guides/sampler.md, and the only config where
         the fine search key and the coarse END-shift both apply at once.
@@ -2107,6 +2106,11 @@ class TestObservationTimeframesShareOneInstant:
         Each side has a different correct answer, which is the point: fine and exec end
         at the decision instant, while coarse holds the last bar that has CLOSED -- it
         is still mid-bar at that instant, so showing it would be lookahead.
+
+        The coarse side is bounded, not pinned: an exact expectation would be brittle to
+        grid alignment, so a coarse frame that went several bars stale would pass here.
+        Its freshness is not what this test is for -- the interaction between the two
+        mechanisms is.
         """
         fine = TimeFrame(1, TimeFrameUnit.Minute)
         exec_tf = TimeFrame(15, TimeFrameUnit.Minute)

--- a/tests/envs/offline/test_sampler.py
+++ b/tests/envs/offline/test_sampler.py
@@ -2009,29 +2009,42 @@ class TestObservationTimeframesShareOneInstant:
             if truncated:
                 break
 
-    def test_finer_window_never_reaches_into_the_next_bin(self):
-        """The bound must stay strictly inside the current execute_on bin.
+    @pytest.mark.parametrize("exec_tf,fine", [
+        (TimeFrame(15, TimeFrameUnit.Minute), TimeFrame(5, TimeFrameUnit.Minute)),
+        (TimeFrame(15, TimeFrameUnit.Minute), TimeFrame(7, TimeFrameUnit.Minute)),
+        (TimeFrame(1, TimeFrameUnit.Hour), TimeFrame(45, TimeFrameUnit.Minute)),
+        (TimeFrame(1, TimeFrameUnit.Hour), TimeFrame(25, TimeFrameUnit.Minute)),
+    ], ids=["5_divides_15", "7_does_not", "45_does_not", "25_does_not"])
+    def test_fine_bar_straddling_the_bin_end_is_not_served(self, exec_tf, fine):
+        """A fine bar may only be served once it has CLOSED at or before the bin end.
 
-        Extending the fine window to the decision instant recovers granularity the agent
-        already has via obs[execute_on]. Overshooting by one tick would hand it the next
-        bin, which has not happened yet.
+        pandas aggregates a bar across its whole span, so a bar that merely STARTS
+        inside the execution bin can carry a close from after the bin. With
+        execute_on=15Minute and a 7Minute frame, the bar labelled minute 70 spans
+        [70, 77) and closes at 76 -- past a bin whose decision instant is 74.
+
+        The first version of this fix bounded on "the last bar starting inside the bin"
+        and leaked exactly that: 6 minutes here, 30 with 45Minute under 1Hour. Divisor
+        pairs are immune because their boundaries line up and nothing straddles, which
+        is why every other test in this file missed it -- they are all divisors.
         """
-        exec_tf = TimeFrame(1, TimeFrameUnit.Hour)
-        fine = TimeFrame(1, TimeFrameUnit.Minute)
         sampler = MarketDataObservationSampler(
-            df=self._counter_df(), time_frames=[fine, exec_tf], window_sizes=[4, 4],
-            execute_on=exec_tf, max_traj_length=8, seed=0,
+            df=self._counter_df(), time_frames=[fine, exec_tf], window_sizes=[3, 3],
+            execute_on=exec_tf, max_traj_length=12, seed=0,
         )
         sampler.reset(random_start=False)
         start = pd.Timestamp("2024-01-01 00:00:00")
 
-        for _ in range(5):
+        for _ in range(8):
             obs, timestamp, truncated = sampler.get_sequential_observation()
-            bin_end_minute = (timestamp - start).total_seconds() / 60 + 60  # exclusive
+            bin_start = (timestamp - start).total_seconds() / 60
+            decision_instant = bin_start + exec_tf.to_minutes() - 1
             for value in obs[fine.obs_key_freq()][:, 3].tolist():
-                assert value - 1000.0 < bin_end_minute, (
-                    f"at {timestamp}: fine window contains minute {value - 1000.0:.0f}, "
-                    f"which is in the NEXT bin (starts {bin_end_minute:.0f})"
+                minute = value - 1000.0
+                assert minute <= decision_instant, (
+                    f"at {timestamp}: {fine.obs_key_freq()} window carries minute "
+                    f"{minute:.0f}, which is {minute - decision_instant:.0f} past the "
+                    f"decision instant {decision_instant:.0f}"
                 )
             if truncated:
                 break

--- a/tests/envs/offline/test_sampler.py
+++ b/tests/envs/offline/test_sampler.py
@@ -1881,3 +1881,42 @@ class TestPerTimeframeFeatureProcessing:
         num_features = sampler.get_num_features_per_timeframe()
         assert num_features["1Minute"] == expected_1min
         assert num_features["5Minute"] == expected_5min
+
+
+class TestTimeframeSpellingIsNotObservable:
+    """Two spellings of the same duration must sample the same data (#282).
+
+    They stay distinct objects on purpose -- the observation key differs, and the parser
+    warns that models trained on one will not transfer. But the DATA behind that key must
+    not depend on the spelling, and it did: `if tf > execute_on` in the resample loop was
+    true in both directions for equal durations, so a 60Minute frame against
+    execute_on=1Hour took the anti-lookahead shift meant for coarser bars and went a
+    full bar stale.
+    """
+
+    def test_same_duration_different_spelling_samples_identically(self):
+        n = 60 * 40
+        ts = pd.date_range("2024-01-01", periods=n, freq="1min")
+        close = np.arange(n, dtype=float) + 1000.0  # close identifies its own minute
+        df = pd.DataFrame({
+            "timestamp": ts, "open": close, "high": close + 0.5,
+            "low": close - 0.5, "close": close, "volume": 1000.0,
+        })
+        execute_on = TimeFrame(1, TimeFrameUnit.Hour)
+
+        def sample_last_close(tf):
+            sampler = MarketDataObservationSampler(
+                df=df.copy(), time_frames=[tf], window_sizes=[4],
+                execute_on=execute_on, max_traj_length=5, seed=0,
+            )
+            sampler.reset()
+            obs, timestamp, _ = sampler.get_sequential_observation()
+            return obs[tf.obs_key_freq()][-1, 3].item(), timestamp  # col 3 == close
+
+        as_hours = sample_last_close(TimeFrame(1, TimeFrameUnit.Hour))
+        as_minutes = sample_last_close(TimeFrame(60, TimeFrameUnit.Minute))
+
+        assert as_hours == as_minutes, (
+            f"1Hour saw {as_hours}, 60Minute saw {as_minutes} -- same duration, "
+            "same execute_on, so the spelling must not change the data"
+        )

--- a/tests/envs/offline/test_sampler.py
+++ b/tests/envs/offline/test_sampler.py
@@ -1358,9 +1358,15 @@ class TestLookaheadBiasFix:
         """
         CRITICAL: The execution timeframe itself should NOT be shifted.
 
-        Only higher timeframes (tf != execute_on) should be shifted.
-        The execution timeframe represents when we're making decisions,
-        so it must remain at its natural timing.
+        Only strictly coarser timeframes (tf > execute_on) are shifted. The predicate
+        used to be `!= execute_on`, which compared (value, unit) and so shifted a
+        60Minute frame against execute_on=1Hour -- the same duration -- leaving it a bar
+        stale (#282). This test still passes under that bug, since it never constructs
+        an equal-duration pair, so the predicate is spelled out here rather than left to
+        the test name.
+
+        The execution timeframe represents when we're making decisions, so it must
+        remain at its natural timing.
         """
         sampler = MarketDataObservationSampler(
             df=lookahead_test_df,
@@ -1519,9 +1525,11 @@ class TestSamplerMultiTimeframeAlignment:
         """
         Higher timeframe bars should be properly structured.
 
-        Note: Pandas resampling indexes bars by START time. A 5-min bar at 00:05:00
-        contains data from 00:05:00-00:09:59. When queried at 00:07:00, we see this
-        bar which includes "future" close from 00:09:59.
+        Note: pandas resampling labels bars by START time, and this class runs with
+        execute_on=1Minute, so a coarser 5-min bar IS shifted to its END label before it
+        can be seen -- the "future close" this note used to describe is not reachable
+        here. What remains true is the narrower point: a bar aggregates its whole span,
+        which is why a bar must be bounded by when it CLOSES, not when it starts.
 
         This test verifies the structure is correct, not that there's no lookahead.
         See TestSamplerNoFutureLeakage for lookahead discussion.
@@ -2046,5 +2054,47 @@ class TestObservationTimeframesShareOneInstant:
                     f"{minute:.0f}, which is {minute - decision_instant:.0f} past the "
                     f"decision instant {decision_instant:.0f}"
                 )
+            if truncated:
+                break
+
+
+    def test_three_timeframes_spanning_both_sides_of_execute_on(self):
+        """The realistic shape from docs/guides/sampler.md, and the only config where
+        the fine search key and the coarse END-shift both apply at once.
+
+        Each side has a different correct answer, which is the point: fine and exec end
+        at the decision instant, while coarse holds the last bar that has CLOSED -- it
+        is still mid-bar at that instant, so showing it would be lookahead.
+        """
+        fine = TimeFrame(1, TimeFrameUnit.Minute)
+        exec_tf = TimeFrame(15, TimeFrameUnit.Minute)
+        coarse = TimeFrame(1, TimeFrameUnit.Hour)
+
+        sampler = MarketDataObservationSampler(
+            df=self._counter_df(), time_frames=[fine, exec_tf, coarse],
+            window_sizes=[4, 4, 4], execute_on=exec_tf, max_traj_length=10, seed=0,
+        )
+        sampler.reset(random_start=False)
+        start = pd.Timestamp("2024-01-01 00:00:00")
+
+        for _ in range(6):
+            obs, timestamp, truncated = sampler.get_sequential_observation()
+            bin_start = (timestamp - start).total_seconds() / 60
+            decision_instant = bin_start + exec_tf.to_minutes() - 1
+
+            fine_last = obs[fine.obs_key_freq()][-1, 3].item() - 1000.0
+            exec_last = obs[exec_tf.obs_key_freq()][-1, 3].item() - 1000.0
+            coarse_last = obs[coarse.obs_key_freq()][-1, 3].item() - 1000.0
+
+            assert fine_last == decision_instant == exec_last, (
+                f"at {timestamp}: fine={fine_last:.0f} exec={exec_last:.0f}, both should "
+                f"be the decision instant {decision_instant:.0f}"
+            )
+            # The coarse bar is END-labelled, so it is only shown once closed. It may
+            # therefore trail, but must never reach past the decision instant.
+            assert coarse_last <= decision_instant, (
+                f"at {timestamp}: coarse={coarse_last:.0f} is past the decision instant "
+                f"{decision_instant:.0f}"
+            )
             if truncated:
                 break

--- a/tests/envs/offline/test_sampler.py
+++ b/tests/envs/offline/test_sampler.py
@@ -1993,12 +1993,23 @@ class TestObservationTimeframesShareOneInstant:
             "low": close - 0.5, "close": close, "volume": 1000.0,
         })
 
-    @pytest.mark.parametrize("fine,exec_tf", [
-        (TimeFrame(1, TimeFrameUnit.Minute), TimeFrame(1, TimeFrameUnit.Hour)),
-        (TimeFrame(5, TimeFrameUnit.Minute), TimeFrame(1, TimeFrameUnit.Hour)),
-        (TimeFrame(1, TimeFrameUnit.Minute), TimeFrame(15, TimeFrameUnit.Minute)),
-    ], ids=["1min_under_1h", "5min_under_1h", "1min_under_15min"])
-    def test_finer_window_ends_where_the_execute_on_window_ends(self, fine, exec_tf):
+    def test_finer_window_ends_where_the_execute_on_window_ends(self):
+        """Kept for one dimension only: a fine frame that is NOT 1-minute.
+
+        Review showed the 1Minute params here never fired without
+        TestSamplerNoFutureLeakage::test_multi_timeframe_no_leakage_in_execution_tf
+        also firing -- it asserts the identical relation over six execute_on values
+        instead of three. What does not exist elsewhere is a fine frame whose `value`
+        exceeds execute_on's, which is the only place a `.value`-vs-duration comparison
+        slip in TimeFrame.__gt__ shows up.
+
+        Folding this into that test is not free: it parametrizes execute_on over six
+        values including 5Minute, and a duplicate timeframe silently collapses in
+        resampled_dfs (3 requested, 2 returned), so the 5Minute case would quietly
+        degrade.
+        """
+        fine = TimeFrame(5, TimeFrameUnit.Minute)
+        exec_tf = TimeFrame(1, TimeFrameUnit.Hour)
         sampler = MarketDataObservationSampler(
             df=self._counter_df(), time_frames=[fine, exec_tf], window_sizes=[4, 4],
             execute_on=exec_tf, max_traj_length=8, seed=0,
@@ -2141,6 +2152,18 @@ class TestObservationTimeframesShareOneInstant:
             assert coarse_last <= decision_instant, (
                 f"at {timestamp}: coarse={coarse_last:.0f} is past the decision instant "
                 f"{decision_instant:.0f}"
+            )
+            # ...nor trail further than one coarse bar plus the exec bin it is read in.
+            # Derivable, not tuned: the visible coarse bar closes at floor(B/c)*c - 1, so
+            # with B a multiple of exec the lag is (B mod c) + exec < c + exec. Without
+            # this, `tf < execute_on` in _fine_period_ns can be weakened to `!=` -- the
+            # same spelling-vs-duration slip this branch exists to remove -- and coarse
+            # frames silently go an extra bar stale with the whole suite green.
+            coarse_limit = coarse.to_minutes() + exec_tf.to_minutes()
+            assert decision_instant - coarse_last < coarse_limit, (
+                f"at {timestamp}: coarse={coarse_last:.0f} is "
+                f"{decision_instant - coarse_last:.0f} min behind the decision instant "
+                f"{decision_instant:.0f}, past the {coarse_limit:.0f} min bound"
             )
             if truncated:
                 break

--- a/tests/envs/offline/test_sequential.py
+++ b/tests/envs/offline/test_sequential.py
@@ -1068,3 +1068,61 @@ class TestSamplerExhaustion:
         assert not result["next"]["terminated"].item()
 
         env.close()
+
+
+class TestExecutionPriceConvention:
+    """Pins WHEN a decision is made relative to the observation it is made on.
+
+    This convention is load-bearing and was previously implicit: nothing asserted
+    it, and `TestSamplerNoFutureLeakage::test_multi_timeframe_no_leakage_in_
+    execution_tf` only checks `obs["1Minute"]`, never the execute_on-keyed column.
+
+    Getting it backwards is expensive in both directions. Read it as "the bar's
+    label is the decision instant" and the aux/OHLCV aggregation looks like it
+    leaks a whole bar when it does not; "fixing" that makes every auxiliary
+    column stale by a bar relative to the price beside it. Read it as one bar
+    later than it is and real lookahead goes unnoticed.
+    """
+
+    @pytest.mark.parametrize("exec_tf", [
+        TimeFrame(1, TimeFrameUnit.Minute),
+        TimeFrame(1, TimeFrameUnit.Hour),
+    ], ids=["1Minute", "1Hour"])
+    def test_env_executes_at_the_last_close_the_agent_observed(self, exec_tf):
+        """The decision instant is the observed bar's CLOSE, not its label.
+
+        close is set to a running counter so every price identifies its own bar.
+        """
+        n = 60 * 30
+        counter = pd.Series(range(n), dtype=float) + 1000.0
+        df = pd.DataFrame({
+            "timestamp": pd.date_range("2024-01-01", periods=n, freq="1min"),
+            "open": counter, "high": counter + 0.5, "low": counter - 0.5,
+            "close": counter, "volume": 1000.0,
+        })
+        env = SequentialTradingEnv(df, SequentialTradingEnvConfig(
+            action_levels=[0, 1], initial_cash=100_000,
+            time_frames=[exec_tf], window_sizes=[4], execute_on=exec_tf,
+            random_start=False, seed=0,
+        ), simple_feature_fn)
+
+        executed = []
+        original = env._execute_trade_if_needed
+        env._execute_trade_if_needed = lambda action, price, *a, **k: (
+            executed.append(price), original(action, price, *a, **k))[1]
+
+        obs_key = f"market_data_{exec_tf.obs_key_freq()}_4"
+        close_col = env.sampler.resampled_dfs[exec_tf.obs_key_freq()].columns.get_loc(
+            "features_close"
+        )
+        td = env.reset()
+        for _ in range(3):
+            observed_close = td[obs_key][-1, close_col].item()
+            td["action"] = torch.tensor(1)
+            td = env.step(td)["next"]
+            assert executed[-1] == pytest.approx(observed_close), (
+                "the env must trade at the last close the agent saw; a mismatch "
+                "means the observation window and the execution price disagree "
+                "about which bar the decision belongs to"
+            )
+        env.close()

--- a/tests/envs/offline/test_utils.py
+++ b/tests/envs/offline/test_utils.py
@@ -481,6 +481,34 @@ class TestTimeFrameComparison:
         assert not (tf_1day < tf_24hours)
         assert not (tf_24hours < tf_1day)
 
+    def test_greater_than_equal_durations(self):
+        """The mirror of test_less_than_equal_durations, which nobody wrote (#282).
+
+        @total_ordering derives __gt__ as `not (self < other or self == other)`. __lt__
+        compares duration while __eq__ compares (value, unit) -- deliberately, since the
+        two spellings produce different observation keys and the parser warns that models
+        trained on one will not work with the other. So for equal durations neither
+        branch is true and BOTH directions returned True: 1Hour > 60Minute *and*
+        60Minute > 1Hour.
+
+        sampler.py reads `tf > execute_on` to pick which timeframes get the
+        anti-lookahead shift, so a 60Minute frame against execute_on=1Hour was shifted
+        forward by its own period and went a full bar stale.
+        """
+        pairs = [
+            (TimeFrame(1, TimeFrameUnit.Hour), TimeFrame(60, TimeFrameUnit.Minute)),
+            (TimeFrame(1, TimeFrameUnit.Day), TimeFrame(24, TimeFrameUnit.Hour)),
+            (TimeFrame(1, TimeFrameUnit.Day), TimeFrame(1440, TimeFrameUnit.Minute)),
+        ]
+        for a, b in pairs:
+            assert not (a > b), f"{a!r} > {b!r} despite equal duration"
+            assert not (b > a), f"{b!r} > {a!r} despite equal duration"
+            # Still distinct objects -- equality is intentionally structural.
+            assert a != b
+            # and the inclusive operators must agree with that
+            assert a >= b and b >= a
+            assert a <= b and b <= a
+
     def test_greater_than_same_unit(self):
         """Greater-than should work correctly for same unit."""
         tf_5min = TimeFrame(5, TimeFrameUnit.Minute)

--- a/tests/envs/offline/test_utils.py
+++ b/tests/envs/offline/test_utils.py
@@ -481,7 +481,12 @@ class TestTimeFrameComparison:
         assert not (tf_1day < tf_24hours)
         assert not (tf_24hours < tf_1day)
 
-    def test_greater_than_equal_durations(self):
+    @pytest.mark.parametrize("a,b", [
+        (TimeFrame(1, TimeFrameUnit.Hour), TimeFrame(60, TimeFrameUnit.Minute)),
+        (TimeFrame(1, TimeFrameUnit.Day), TimeFrame(24, TimeFrameUnit.Hour)),
+        (TimeFrame(1, TimeFrameUnit.Day), TimeFrame(1440, TimeFrameUnit.Minute)),
+    ], ids=["1h_vs_60min", "1d_vs_24h", "1d_vs_1440min"])
+    def test_greater_than_equal_durations(self, a, b):
         """The mirror of test_less_than_equal_durations, which nobody wrote (#282).
 
         @total_ordering derives __gt__ as `not (self < other or self == other)`. __lt__
@@ -495,19 +500,14 @@ class TestTimeFrameComparison:
         anti-lookahead shift, so a 60Minute frame against execute_on=1Hour was shifted
         forward by its own period and went a full bar stale.
         """
-        pairs = [
-            (TimeFrame(1, TimeFrameUnit.Hour), TimeFrame(60, TimeFrameUnit.Minute)),
-            (TimeFrame(1, TimeFrameUnit.Day), TimeFrame(24, TimeFrameUnit.Hour)),
-            (TimeFrame(1, TimeFrameUnit.Day), TimeFrame(1440, TimeFrameUnit.Minute)),
-        ]
-        for a, b in pairs:
-            assert not (a > b), f"{a!r} > {b!r} despite equal duration"
-            assert not (b > a), f"{b!r} > {a!r} despite equal duration"
-            # Still distinct objects -- equality is intentionally structural.
-            assert a != b
-            # and the inclusive operators must agree with that
-            assert a >= b and b >= a
-            assert a <= b and b <= a
+        assert not (a > b), f"{a!r} > {b!r} despite equal duration"
+        assert not (b > a), f"{b!r} > {a!r} despite equal duration"
+        # Still distinct objects -- equality is intentionally structural.
+        assert a != b
+        # <= and >= are public API that @total_ordering used to provide; library
+        # consumers may rely on them, so they are kept and must agree with the above.
+        assert a >= b and b >= a
+        assert a <= b and b <= a
 
     def test_greater_than_same_unit(self):
         """Greater-than should work correctly for same unit."""

--- a/torchtrade/envs/offline/infrastructure/sampler.py
+++ b/torchtrade/envs/offline/infrastructure/sampler.py
@@ -78,6 +78,19 @@ class MarketDataObservationSampler:
         df = df.set_index("timestamp").sort_index()
         self.df = df
 
+        # A tz-aware index anchors Day bins to LOCAL midnight, so a DST spring-forward
+        # day is 23h wide while the fixed period below stays 24h -- and the bound would
+        # then reach an hour past the bin's real close. That is lookahead, not
+        # staleness. Nothing in this repo produces a tz-aware index, so refuse it at the
+        # boundary rather than carry a silent wrong number (#282).
+        if df.index.tz is not None and execute_on >= TimeFrame(1, TimeFrameUnit.Day):
+            raise ValueError(
+                f"execute_on={execute_on.obs_key_freq()} needs a tz-naive index: "
+                "day-or-longer bins follow local midnight, so DST transitions make them "
+                "23h or 25h wide and the observation window would run past the bin's "
+                "close. Convert to UTC and drop the timezone."
+            )
+
         self.time_frames = time_frames
         self.window_sizes = window_sizes
         self.max_traj_length = max_traj_length

--- a/torchtrade/envs/offline/infrastructure/sampler.py
+++ b/torchtrade/envs/offline/infrastructure/sampler.py
@@ -235,20 +235,14 @@ class MarketDataObservationSampler:
         # Using .as_unit('ns') ensures searchsorted comparisons are consistent.
         exec_ts_int64 = self.exec_times.as_unit('ns').asi8  # int64 nanoseconds
 
-        # Timeframes FINER than execute_on need a later search key. The resample loop
-        # shifts only coarser ones to END labels, so a finer frame is still labelled by
-        # its bar's START -- and searching it with the exec bin's start label returns the
-        # bar that starts there, leaving the fine window up to a full exec bar behind the
-        # close the trade actually fills at (#282). The execute_on frame lands right with
-        # the plain label only because its bin is already aggregated through the bin's
-        # end; a finer index has real per-bar granularity and does not.
-        #
-        # Exclusive upper bound, by one nanosecond: the window must reach the last bar
-        # inside the current bin and never the first bar of the next one, which has not
-        # happened at decision time.
-        exec_period_ns = tf_to_timedelta(execute_on).value
-        fine_keys = {tf.obs_key_freq() for tf in time_frames if tf < execute_on}
-        fine_ts_int64 = exec_ts_int64 + exec_period_ns - 1
+        # Finer-than-execute_on frames are labelled by their bar's START -- only coarser
+        # ones get shifted to END labels above -- so looking one up at the exec bin's
+        # start label returns a bar that has barely begun (#282). See _search_ts.
+        self._exec_period_ns = tf_to_timedelta(execute_on).value
+        self._fine_period_ns = {
+            tf.obs_key_freq(): tf_to_timedelta(tf).value
+            for tf in time_frames if tf < execute_on
+        }
 
         # Convert resampled dfs to torch tensors for fast slicing.
         # Also convert timestamp indices to int64 (ns) and store as torch.long for searchsorted.
@@ -265,8 +259,9 @@ class MarketDataObservationSampler:
             self.torch_idx[key] = torch.from_numpy(ts_int64).to(torch.long)  # sorted 1D long tensor
 
             # Use numpy searchsorted once at init instead of torch searchsorted per step
-            search_ts = fine_ts_int64 if key in fine_keys else exec_ts_int64
-            obs_idx = np.searchsorted(ts_int64, search_ts, side='right') - 1
+            obs_idx = np.searchsorted(
+                ts_int64, self._search_ts(key, exec_ts_int64), side='right'
+            ) - 1
             self._obs_indices[key] = obs_idx
 
         # Execute-on base features tensor + index
@@ -350,18 +345,37 @@ class MarketDataObservationSampler:
 
         return obs, timestamp, truncated, ohlcv
 
+    def _search_ts(self, key: str, exec_ts_ns):
+        """Where to look `key` up, given an execution bin's start label.
+
+        Works on a scalar or an int64 array, so both lookup paths share one rule.
+
+        A frame at or coarser than execute_on is searched at the label itself. A finer
+        one is searched at the last label whose bar CLOSES at or before the bin ends.
+        Not the last bar that *starts* inside the bin: pandas aggregates a bar across
+        its whole span, so one starting at minute 70 with a 7-minute period carries a
+        close from minute 76 -- past a bin ending at 75, and into the future.
+        """
+        fine_period_ns = self._fine_period_ns.get(key)
+        if fine_period_ns is None:
+            return exec_ts_ns
+        return exec_ts_ns + self._exec_period_ns - fine_period_ns
+
     def get_observation(self, timestamp: pd.Timestamp) -> Dict[str, torch.Tensor]:
         """Return observation dict: { timeframe_key: tensor(shape=[ws, features]) }"""
         obs: Dict[str, torch.Tensor] = {}
         # convert timestamp to int64 ns
         ts_int = int(timestamp.value)  # pd.Timestamp.value is int64 ns
-        ts_t = torch.tensor(ts_int, dtype=torch.long)
 
         for tf, ws in zip(self.time_frames, self.window_sizes):
             key = tf.obs_key_freq()
 
             arr = self.torch_tensors[key]           # (N, F) float tensor
             idx_tensor = self.torch_idx[key]        # (N,) long sorted tensor
+
+            # Same rule as the precomputed path, or a finer frame would land on a
+            # different bar here than in get_sequential_observation()
+            ts_t = torch.tensor(self._search_ts(key, ts_int), dtype=torch.long)
 
             # pos = insertion index where ts_t would be placed (right=True)
             pos_t = torch.searchsorted(idx_tensor, ts_t, right=True)  # tensor([pos]) dtype long

--- a/torchtrade/envs/offline/infrastructure/sampler.py
+++ b/torchtrade/envs/offline/infrastructure/sampler.py
@@ -235,6 +235,21 @@ class MarketDataObservationSampler:
         # Using .as_unit('ns') ensures searchsorted comparisons are consistent.
         exec_ts_int64 = self.exec_times.as_unit('ns').asi8  # int64 nanoseconds
 
+        # Timeframes FINER than execute_on need a later search key. The resample loop
+        # shifts only coarser ones to END labels, so a finer frame is still labelled by
+        # its bar's START -- and searching it with the exec bin's start label returns the
+        # bar that starts there, leaving the fine window up to a full exec bar behind the
+        # close the trade actually fills at (#282). The execute_on frame lands right with
+        # the plain label only because its bin is already aggregated through the bin's
+        # end; a finer index has real per-bar granularity and does not.
+        #
+        # Exclusive upper bound, by one nanosecond: the window must reach the last bar
+        # inside the current bin and never the first bar of the next one, which has not
+        # happened at decision time.
+        exec_period_ns = tf_to_timedelta(execute_on).value
+        fine_keys = {tf.obs_key_freq() for tf in time_frames if tf < execute_on}
+        fine_ts_int64 = exec_ts_int64 + exec_period_ns - 1
+
         # Convert resampled dfs to torch tensors for fast slicing.
         # Also convert timestamp indices to int64 (ns) and store as torch.long for searchsorted.
         self.torch_tensors: Dict[str, torch.FloatTensor] = {}
@@ -250,7 +265,8 @@ class MarketDataObservationSampler:
             self.torch_idx[key] = torch.from_numpy(ts_int64).to(torch.long)  # sorted 1D long tensor
 
             # Use numpy searchsorted once at init instead of torch searchsorted per step
-            obs_idx = np.searchsorted(ts_int64, exec_ts_int64, side='right') - 1
+            search_ts = fine_ts_int64 if key in fine_keys else exec_ts_int64
+            obs_idx = np.searchsorted(ts_int64, search_ts, side='right') - 1
             self._obs_indices[key] = obs_idx
 
         # Execute-on base features tensor + index

--- a/torchtrade/envs/offline/infrastructure/sampler.py
+++ b/torchtrade/envs/offline/infrastructure/sampler.py
@@ -138,10 +138,8 @@ class MarketDataObservationSampler:
 
         # Calculate offset needed for higher timeframes (to account for END-time indexing)
         # We need extra data to ensure sufficient lookback after the offset.
-        # Must be the SAME test as the shift above -- reserving an offset for a timeframe
-        # that was never shifted just discards leading data. `!= execute_on` compared
-        # (value, unit), so 60Minute against execute_on=1Hour reserved an hour it did not
-        # need, and finer timeframes reserved their own period for no reason (#282).
+        # Must be the SAME test as the shift above: reserving an offset for a timeframe
+        # that was never shifted only discards leading data (#282).
         higher_tf_offsets = [tf_to_timedelta(tf) for tf in time_frames if tf > execute_on]
         max_offset = max(higher_tf_offsets) if higher_tf_offsets else pd.Timedelta(0)
 
@@ -355,6 +353,11 @@ class MarketDataObservationSampler:
         Not the last bar that *starts* inside the bin: pandas aggregates a bar across
         its whole span, so one starting at minute 70 with a 7-minute period carries a
         close from minute 76 -- past a bin ending at 75, and into the future.
+
+        Assumes a tz-naive index, as every dataset in this repo is. Minute and Hour
+        resample as fixed-width offsets and are DST-immune regardless, but a tz-AWARE
+        index with execute_on=Day anchors bins to local midnight, making them 23h or 25h
+        while _exec_period_ns stays 24h -- which would overshoot on a short day.
         """
         fine_period_ns = self._fine_period_ns.get(key)
         if fine_period_ns is None:

--- a/torchtrade/envs/offline/infrastructure/sampler.py
+++ b/torchtrade/envs/offline/infrastructure/sampler.py
@@ -378,7 +378,13 @@ class MarketDataObservationSampler:
         return exec_ts_ns + self._exec_period_ns - fine_period_ns
 
     def get_observation(self, timestamp: pd.Timestamp) -> Dict[str, torch.Tensor]:
-        """Return observation dict: { timeframe_key: tensor(shape=[ws, features]) }"""
+        """Return observation dict: { timeframe_key: tensor(shape=[ws, features]) }
+
+        `timestamp` must be an execution bin's START label, as `exec_times` produces and
+        `get_sequential_observation` returns. A timestamp part-way through a bin is
+        resolved against that bin, so a finer frame would end after the instant asked
+        for -- see _search_ts.
+        """
         obs: Dict[str, torch.Tensor] = {}
         # convert timestamp to int64 ns
         ts_int = int(timestamp.value)  # pd.Timestamp.value is int64 ns

--- a/torchtrade/envs/offline/infrastructure/sampler.py
+++ b/torchtrade/envs/offline/infrastructure/sampler.py
@@ -137,8 +137,12 @@ class MarketDataObservationSampler:
         latest_first_step = max(first_time_stamps)
 
         # Calculate offset needed for higher timeframes (to account for END-time indexing)
-        # We need extra data to ensure sufficient lookback after the offset
-        higher_tf_offsets = [tf_to_timedelta(tf) for tf in time_frames if tf != execute_on]
+        # We need extra data to ensure sufficient lookback after the offset.
+        # Must be the SAME test as the shift above -- reserving an offset for a timeframe
+        # that was never shifted just discards leading data. `!= execute_on` compared
+        # (value, unit), so 60Minute against execute_on=1Hour reserved an hour it did not
+        # need, and finer timeframes reserved their own period for no reason (#282).
+        higher_tf_offsets = [tf_to_timedelta(tf) for tf in time_frames if tf > execute_on]
         max_offset = max(higher_tf_offsets) if higher_tf_offsets else pd.Timedelta(0)
 
         # Filter execution times

--- a/torchtrade/envs/utils/timeframe.py
+++ b/torchtrade/envs/utils/timeframe.py
@@ -8,7 +8,6 @@ and Binance environments. It includes:
 """
 
 from enum import Enum
-from functools import total_ordering
 from typing import List, Union, Tuple
 import pandas as pd
 import re
@@ -22,7 +21,6 @@ class TimeFrameUnit(Enum):
     Day = 'D'       # Pandas freq for days
 
 
-@total_ordering
 class TimeFrame:
     """Represents a time interval with value and unit.
 
@@ -69,11 +67,39 @@ class TimeFrame:
             return NotImplemented
         return self.value == other.value and self.unit == other.unit
 
+    # Ordering compares DURATION; equality compares (value, unit). Two different keys, on
+    # purpose: 60Minute and 1Hour are the same length but produce different observation
+    # keys, and parse_timeframe_string warns that models trained on one will not work
+    # with the other.
+    #
+    # That is precisely why @total_ordering cannot be used here. It derives __gt__ as
+    # `not (self < other or self == other)`, so for two equal-duration spellings neither
+    # branch held and BOTH directions returned True -- which made sampler.py's
+    # `if tf > execute_on` shift a 60Minute frame that was not coarser than execute_on,
+    # leaving it a full bar stale (#282). So all four comparisons are spelled out.
     def __lt__(self, other):
-        """Less than comparison based on total minutes."""
+        """Less than, by total duration."""
         if not isinstance(other, TimeFrame):
             return NotImplemented
         return self.to_minutes() < other.to_minutes()
+
+    def __le__(self, other):
+        """Less than or equal, by total duration."""
+        if not isinstance(other, TimeFrame):
+            return NotImplemented
+        return self.to_minutes() <= other.to_minutes()
+
+    def __gt__(self, other):
+        """Greater than, by total duration."""
+        if not isinstance(other, TimeFrame):
+            return NotImplemented
+        return self.to_minutes() > other.to_minutes()
+
+    def __ge__(self, other):
+        """Greater than or equal, by total duration."""
+        if not isinstance(other, TimeFrame):
+            return NotImplemented
+        return self.to_minutes() >= other.to_minutes()
 
     def __hash__(self):
         """Make TimeFrame hashable for use in sets and as dict keys."""

--- a/torchtrade/envs/utils/timeframe.py
+++ b/torchtrade/envs/utils/timeframe.py
@@ -67,16 +67,12 @@ class TimeFrame:
             return NotImplemented
         return self.value == other.value and self.unit == other.unit
 
-    # Ordering compares DURATION; equality compares (value, unit). Two different keys, on
-    # purpose: 60Minute and 1Hour are the same length but produce different observation
-    # keys, and parse_timeframe_string warns that models trained on one will not work
-    # with the other.
-    #
-    # That is precisely why @total_ordering cannot be used here. It derives __gt__ as
-    # `not (self < other or self == other)`, so for two equal-duration spellings neither
-    # branch held and BOTH directions returned True -- which made sampler.py's
-    # `if tf > execute_on` shift a 60Minute frame that was not coarser than execute_on,
-    # leaving it a full bar stale (#282). So all four comparisons are spelled out.
+    # Ordering compares DURATION, equality compares (value, unit) -- so this is
+    # deliberately NOT a total order: for 60Minute vs 1Hour, <, > and == are all False.
+    # The sampler relies on that (`tf > execute_on` and `tf < execute_on` are not
+    # complements; equal durations fall through both). @total_ordering would derive
+    # __gt__ from those two keys and return True in BOTH directions (#282), so all four
+    # comparisons are spelled out.
     def __lt__(self, other):
         """Less than, by total duration."""
         if not isinstance(other, TimeFrame):


### PR DESCRIPTION
Closes #282 — both defects it filed.

## ⚠️ Breaking for trained policies

Two categories of config see different observations after this. Both need retraining.

| config | before | after |
|---|---|---|
| a timeframe **finer** than `execute_on` | up to a full execution bar stale | ends at the instant the trade fills |
| **same duration, different spelling** (`60Minute` alongside `execute_on=1Hour`) | wrongly shifted as if coarser — a bar stale | recognised as equal duration, not shifted |

The first covers the "Multi-Timeframe" and "Hierarchical" patterns in `docs/guides/sampler.md`.
Coarse-only configs, single-timeframe configs, and the replay path are unaffected.

## The convention this rests on

The env fills at **the last close in `obs[execute_on]`** — the observed bar's close, not its
label. Verified by intercepting `_execute_trade_if_needed` at its call site (with
`execute_on=5Minute`, the steps labelled minute 20 and 25 fill at minutes 24 and 29), and now
pinned by `TestExecutionPriceConvention`.

That was previously implicit, and getting it backwards is expensive in both directions: read
the label as the decision instant and the aggregation looks like it leaks a bar when it does
not; read it a bar late and real lookahead goes unnoticed.

## Defect 1 — every timeframe now ends at the same instant

The resample loop shifts only `tf > execute_on` to END labels, and `_obs_indices` searched
every timeframe with the exec bin's **start** label. The `execute_on` frame lands correctly on
that key only by accident — its bin is already aggregated through the bin's end. A finer index
has real per-bar granularity and got the bar that merely *starts* there, so a 1Minute window
sat 59 minutes behind the 1Hour window sampled beside it.

Finer frames are now looked up at **the last bar that CLOSES at or before the bin ends**
(`exec_ts + exec_period − fine_period`). Not the last bar that *starts* inside it: pandas
aggregates a bar across its whole span, so a 7-minute bar starting at minute 70 closes at 76,
past a bin ending at 75.

`get_observation()` ran its own search without this rule, so it disagreed with the precomputed
path — reachable through the exhaustion fallbacks in `sequential.py` and `onestep.py`, where a
truncated episode bootstraps its value estimate. Both paths now share `_search_ts`.

## Defect 2 — timeframes compare by duration, not spelling

`TimeFrame` orders on duration but compares equal on `(value, unit)`. Those are deliberately
different keys: `60Minute` and `1Hour` produce different observation keys, and
`parse_timeframe_string` already warns that models do not transfer between them.

`@total_ordering` cannot express that. It derives `__gt__` as `not (self < other or self ==
other)`, so for equal-duration spellings neither branch held and **both** directions returned
`True`. All four comparisons are now explicit on duration; the decorator is gone. `__eq__` and
`__hash__` are unchanged — duration-based equality would disagree with the `obs_key_freq()`
identity the sampler's dicts actually run on.

The slip had **three** sites, not the one #282 names: the anti-lookahead shift, the
`max_offset` accounting (which discarded leading data for frames that were never shifted), and
a third introduced by this PR itself and caught in round 3.

## Also

A tz-aware index with `execute_on >= 1Day` is now refused. `Day` is not a Tick offset, so
tz-aware daily bins follow local midnight and are 23h/25h wide across DST while the search
bound uses a fixed 24h — reaching an hour past the bin's real close, which is lookahead rather
than staleness. The guard is deliberately broader than the hazard: it also rejects fixed-offset
zones like UTC that are provably safe. Narrowing it means enumerating zone transitions against
the data's span, which is more machinery than a case with no current user, and the error names
the fix. `Minute`/`Hour` are Tick offsets, DST-immune, and explicitly still allowed.

## Testing

`2395 passed, 25 skipped`. Every assertion added here was verified by mutation — reverted, run,
and confirmed to fail the right cases and only those:

| mutant | caught by |
|---|---|
| revert the `get_observation` parity fix | `test_both_lookup_paths_agree_for_a_finer_frame` (sole detector) |
| "snap the fine grid to the bin" — safe but stale | the 3 non-divisor straddling cases; divisor correctly passes |
| remove the tz guard | the 2 `Day` cases; `Hour`/`Minute` correctly pass |
| `tf < execute_on` → `tf != execute_on` | the coarse-freshness bound in the three-timeframe test |
| restore the old `bin_end − 1ns` bound | the 3 non-divisor cases (6/30/20 min of lookahead) |

Three rewritten tests in `TestSamplerNoFutureLeakage` previously bounded on the bar's **label**
and so read this correction as a regression, reporting "Future leakage detected". They now bound
on the decision instant. Review confirmed by mutation that this made them *stronger*: the old
one-sided label bound could only detect data arriving too early, and was structurally blind to
the staleness this PR fixes.

## Review

Three rounds, all four reviewers each round, per CLAUDE.md. Each round found a defect in the
previous round's fix:

- **Round 1** — my defect-1 fix introduced real lookahead for non-divisor fine timeframes
  (measured: 6, 30 and 20 minutes). Only divisor pairs were tested, so nothing caught it.
- **Round 2** — the parity fix was shipped untested (reverting it survived all 712 tests), and
  the bound asserted safety but not freshness, so a stale-but-safe implementation passed.
- **Round 3** — a third spelling-vs-duration site, unpinned; and `docs/guides/sampler.md` still
  described the leaky bound that round 1 replaced.

Round 3's fixes changed no production logic — tests, docs and one docstring only — so the chain
ends there rather than by assertion.

## Follow-up filed, deliberately not here

**#320** — the coarse-timeframe END shift uses a fixed `pd.Timedelta`, so a Day-or-longer
*observation* frame on a tz-aware index becomes visible an hour before it closes. Same DST
hazard, mirrored to the observation side, and it predates this branch (#10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
