### PR TITLE
test(envs): stop test_sltp_triggers_recorded implying a wait it never does (#318)

### DIFF
--- a/tests/envs/offline/fundamental/test_portfolio_accounting.py
+++ b/tests/envs/offline/fundamental/test_portfolio_accounting.py
@@ -399,8 +399,15 @@ class TestHistoryRecording:
         assert any(at in ["flat", "close"] for at in futures_env.history.action_types), \
             f"Futures close should be 'flat' or 'close', got {futures_env.history.action_types}"
 
-    def test_sltp_triggers_recorded(self, price_change_df):
-        """SL/TP triggers should be recorded as sltp_sl or sltp_tp."""
+    def test_sltp_triggers_recorded(self):
+        """SL/TP triggers should be recorded as sltp_sl or sltp_tp.
+
+        Recording only. The trigger bar here opens at 106, past the 105 take-profit, so
+        this does reach a gapped bracket -- but the FILL PRICE it produces is pinned by
+        test_gap_fills.py, which owns that rule across all four engines. Asserting it
+        again here would only restate a branch (`execution_price = self.take_profit`)
+        that depends on neither the bar nor the leverage.
+        """
         config = SequentialTradingEnvSLTPConfig(
             execute_on="1Hour",
             time_frames=["1Hour"],
@@ -429,16 +436,10 @@ class TestHistoryRecording:
         env = SequentialTradingEnvSLTP(df, config)
         td = env.reset()
 
-        # Open long
+        # Open long. The bracket fires on the very next bar, inside this same step, so
+        # there is nothing to hold for.
         td["action"] = 1
-        td = env.step(td)["next"]
-
-        # Hold until TP triggers
-        for _ in range(5):
-            if td["done"]:
-                break
-            td["action"] = 0
-            td = env.step(td)["next"]
+        env.step(td)
 
         # Check if TP was recorded
         has_sltp_exit = any(at in ["sltp_sl", "sltp_tp"] for at in env.history.action_types)

--- a/tests/envs/offline/fundamental/test_portfolio_accounting.py
+++ b/tests/envs/offline/fundamental/test_portfolio_accounting.py
@@ -419,6 +419,10 @@ class TestHistoryRecording:
             stoploss_levels=[-0.05],  # 5% SL
             takeprofit_levels=[0.05],  # 5% TP
             include_hold_action=True,
+            # Without this the start bar is random, and most starts land ON the 106 bar,
+            # where entry is 106 and the take-profit at 111.3 is never reached. The test
+            # passed only because the default seed happens to start at index 1.
+            random_start=False,
         )
 
         # Create data that will trigger TP
@@ -441,7 +445,6 @@ class TestHistoryRecording:
         td["action"] = 1
         env.step(td)
 
-        # Check if TP was recorded
         has_sltp_exit = any(at in ["sltp_sl", "sltp_tp"] for at in env.history.action_types)
         assert has_sltp_exit, \
             f"SL/TP trigger should be recorded, got {env.history.action_types}"


### PR DESCRIPTION
Closes #318. Fallout from #311.

## What the issue asked

`TestHistoryRecording::test_sltp_triggers_recorded` builds `prices = [100, 100, 106, ...]` against a 105 take-profit, so its trigger bar **opens past the bracket**. It reaches a genuinely gapped bracket and asserts only the exit *label*. The issue offered two fixes: add a price assertion, or note explicitly that fill pricing is covered elsewhere.

**I tried the first. Review showed it was the wrong one**, so this PR does the second plus the two real defects that turned up.

## Why not the price assertion

The take-profit branch is `execution_price = self.take_profit` — a constant depending on neither the bar nor the leverage. So a "leverage-1 gapped take-profit" exercises no code path the suite wasn't already exercising:

- `test_gap_fills.py::test_sltp_engines_fill_a_gapped_bracket_alike[scalar-*-tp-gap]` — same engine, same branch, purpose-built for this rule, on a stronger fixture.
- `test_sequential_sltp.py::TestSLTPRegression[take-profit-next-bar]` — already pins a **leverage-1** take-profit fill at 10250.

15 tests in total kill the chase-the-gap mutation. A 16th adds nothing, and it would widen a history-recording test's subject to fill pricing.

My first draft's docstring also claimed this was "the only gapped bracket in the suite at leverage 1". That is **false** — `ReplayOrderExecutor` defaults to `leverage=1`, so four cells in `test_gap_fills.py` are leverage-1 gapped brackets, two of them take-profit gaps.

## What this PR actually fixes

1. **A dead loop.** The open and the take-profit fire in the *same* `env.step` call — after the single opening step, `action_types == ['hold', 'sltp_tp']` and the position is already flat. The five-iteration "Hold until TP triggers" loop below it ran entirely on a flat account; both assertions held before it started.
2. **An unused fixture parameter.** The test took `price_change_df` and never touched it, building its own frame inline.
3. **A docstring** recording that this test reaches a gapped bracket deliberately without asserting the fill, and where that rule *is* pinned — so the next reader doesn't re-derive the analysis above.

## Testing

Tests only. `test_portfolio_accounting.py`: 12 passed. Still non-vacuous for its own subject — mutating the recorded exit label to `"hold"` fails it.
