### PR TITLE
test(envs): give the suite a fixture that can actually gap (#315)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -71,18 +71,20 @@ def sample_ohlcv_df():
 def gappy_ohlcv_df():
     """Random walk whose bars periodically GAP: open[i] != close[i-1].
 
-    Every other OHLCV fixture in this file builds `open = np.roll(close, 1)`, so
-    `open[i] == close[i-1]` exactly and a bar can never open beyond a bracket set off the
-    previous close. That is a structural blind spot, not an oversight in any one test: it
-    is why the gapped-stop mispricing in #280 survived the whole suite in four separate
-    engines (#315).
+    Every other OHLCV fixture in this file has `open[i] == close[i-1]` exactly, so a bar
+    can never open beyond a bracket set off the previous close. That is a structural blind
+    spot, not an oversight in any one test: it is why the gapped-stop mispricing in #280
+    survived the whole suite in four separate engines (#315).
 
     Gap size is bounded on both sides. It must be large against the walk's own volatility
     (0.1% per bar) so a gap clears a bracket outright rather than grazing it, and small
     against the liquidation band at the highest leverage under test -- at 25x that band is
-    ~4%, and a gap wider than it liquidates the position before any bracket can fire,
-    which degenerates the cell into a liquidation test. 2% satisfies both. Direction
-    alternates so long and short brackets are each exercised.
+    1/25 - 0.004 maintenance = 3.6%, and a gap wider than it liquidates the position
+    before a bracket can fire, degenerating the cell into a liquidation test.
+
+    2% sits between measured cliffs: below ~0.5% gaps stop clearing the bracket, and at
+    ~3% the first liquidations appear. Direction alternates so long and short brackets are
+    each exercised.
     """
     rng = np.random.default_rng(20260811)
     n = 1440

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -82,9 +82,10 @@ def gappy_ohlcv_df():
     1/25 - 0.004 maintenance = 3.6%, and a gap wider than it liquidates the position
     before a bracket can fire, degenerating the cell into a liquidation test.
 
-    2% sits between measured cliffs: below ~0.5% gaps stop clearing the bracket, and at
-    ~3% the first liquidations appear. Direction alternates so long and short brackets are
-    each exercised.
+    2% sits between measured cliffs: gaps stop clearing the bracket below ~0.3% (0.2%
+    yields zero gapped fills, 0.5% already degrades to 30 of 51), and the first
+    liquidations appear at ~3%. Direction alternates so long and short brackets are each
+    exercised.
     """
     rng = np.random.default_rng(20260811)
     n = 1440

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,6 +68,49 @@ def sample_ohlcv_df():
 
 
 @pytest.fixture
+def gappy_ohlcv_df():
+    """Random walk whose bars periodically GAP: open[i] != close[i-1].
+
+    Every other OHLCV fixture in this file builds `open = np.roll(close, 1)`, so
+    `open[i] == close[i-1]` exactly and a bar can never open beyond a bracket set off the
+    previous close. That is a structural blind spot, not an oversight in any one test: it
+    is why the gapped-stop mispricing in #280 survived the whole suite in four separate
+    engines (#315).
+
+    Gap size is bounded on both sides. It must be large against the walk's own volatility
+    (0.1% per bar) so a gap clears a bracket outright rather than grazing it, and small
+    against the liquidation band at the highest leverage under test -- at 25x that band is
+    ~4%, and a gap wider than it liquidates the position before any bracket can fire,
+    which degenerates the cell into a liquidation test. 2% satisfies both. Direction
+    alternates so long and short brackets are each exercised.
+    """
+    rng = np.random.default_rng(20260811)
+    n = 1440
+    gap_every, gap_size = 7, 0.02
+
+    close_prices = 100.0 * np.exp(np.cumsum(rng.normal(0, 0.001, n)))
+
+    # open[i] gaps off close[i-1]; every gap_every-th bar jumps, alternating direction.
+    prev_close = np.concatenate(([100.0], close_prices[:-1]))
+    idx = np.arange(n)
+    jump = np.where(idx % gap_every == 0, gap_size, 0.0)
+    jump[idx % (2 * gap_every) == 0] *= -1.0
+    open_prices = prev_close * (1.0 + jump)
+
+    high_prices = np.maximum(open_prices, close_prices) * (1 + np.abs(rng.normal(0, 0.002, n)))
+    low_prices = np.minimum(open_prices, close_prices) * (1 - np.abs(rng.normal(0, 0.002, n)))
+
+    return pd.DataFrame({
+        "timestamp": pd.date_range("2024-01-01", periods=n, freq="1min"),
+        "open": open_prices,
+        "high": high_prices,
+        "low": low_prices,
+        "close": close_prices,
+        "volume": rng.lognormal(10, 1, n),
+    })
+
+
+@pytest.fixture
 def large_ohlcv_df():
     """
     Create a larger synthetic OHLCV DataFrame for stress testing.

--- a/tests/envs/offline/test_vec_sltp_scalar_equivalence.py
+++ b/tests/envs/offline/test_vec_sltp_scalar_equivalence.py
@@ -213,7 +213,7 @@ def _run_sltp_sequence(
     # open. Both weaker forms shipped: first cells that opened nothing at all, then cells
     # that opened once and held for 99 steps with no bracket ever firing -- which a
     # "position was open" check reads as maximally healthy. Healthy cells measure 8-38
-    # opens and 4-13 bracket exits, so these floors have room.
+    # opens and 4-22 bracket exits, so these floors have room.
     if random_steps is not None:
         kinds = collections.Counter(scalar.history.action_types)
         opens = kinds["long"] + kinds["short"]
@@ -621,11 +621,15 @@ class TestSLTPScalarVecEquivalenceTradeModesAndLock:
         """The gappy arm exists because this harness was structurally blind to #280.
 
         Every fixture it used built open == previous close, so no bar could open beyond a
-        bracket -- reverting the gapped-stop rule in BOTH engines left all of these cells
-        green. The harness only detects divergence between the engines, so a shared wrong
-        answer needs a fixture that can produce the input at all (#315).
+        bracket and the gap-fill rule was never reached. What the gappy arm buys is
+        detection of a ONE-ENGINE drift: reverting the rule in only the vectorized engine
+        used to leave every cell green, and now fails 9, all on this arm.
+
+        It does NOT catch a revert of both engines -- measured 18/18 green. This harness
+        only compares the two engines to each other, so a shared wrong answer is invisible
+        here by construction, whatever the fixture. That case is pinned directly by
+        tests/envs/offline/fundamental/test_gap_fills.py (#315).
         """
-        df = request.getfixturevalue(fixture)
         if lock and leverage == 1:
             pytest.skip(
                 "lock is inert in spot: with no shorts and no close action the agent can "
@@ -634,19 +638,22 @@ class TestSLTPScalarVecEquivalenceTradeModesAndLock:
                 "(same action histogram, balance and position), so this cell is a copy."
             )
         mismatches = _run_sltp_sequence(
-            df,
+            request.getfixturevalue(fixture),
             leverage=leverage,
             fee=0.001,
             max_traj=120,
             random_steps=100,
             trade_mode=trade_mode,
             lock=lock,
-            # The continuous fixture only spans +5.9%/-1.7%, so the default +/-5% brackets
-            # can never trigger: as shipped this grid fired zero stops across all twelve
-            # cells. The gappy fixture's 6% jumps clear these levels outright.
+            # Both fixtures need these overrides. The continuous one spans only
+            # +5.9%/-1.7%, so the default +/-5% brackets never trigger -- as shipped this
+            # grid fired zero stops across all twelve cells. The gappy one gaps 2%, whose
+            # widest excursion from an entry is ~2.9% over ten bars, so it does not reach
+            # +/-5% either.
             sl_levels=[-0.005],
             tp_levels=[0.005],
-            label=f"sltp-{fixture}-{trade_mode}-{'locked' if lock else 'unlocked'}-lev{leverage}",
+            label=f"sltp-{'gappy' if 'gappy' in fixture else 'continuous'}"
+                  f"-{trade_mode}-{'locked' if lock else 'unlocked'}-lev{leverage}",
         )
         assert not mismatches, "\n".join(mismatches)
 

--- a/tests/envs/offline/test_vec_sltp_scalar_equivalence.py
+++ b/tests/envs/offline/test_vec_sltp_scalar_equivalence.py
@@ -615,7 +615,17 @@ class TestSLTPScalarVecEquivalenceTradeModesAndLock:
     @pytest.mark.parametrize("trade_mode", ["fractional", "notional", "quantity"])
     @pytest.mark.parametrize("lock", [False, True], ids=["unlocked", "locked"])
     @pytest.mark.parametrize("leverage", [1, 25], ids=["spot", "lev25"])
-    def test_random_actions_match(self, sample_ohlcv_df, trade_mode, lock, leverage):
+    @pytest.mark.parametrize("fixture", ["sample_ohlcv_df", "gappy_ohlcv_df"],
+                             ids=["continuous", "gappy"])
+    def test_random_actions_match(self, request, fixture, trade_mode, lock, leverage):
+        """The gappy arm exists because this harness was structurally blind to #280.
+
+        Every fixture it used built open == previous close, so no bar could open beyond a
+        bracket -- reverting the gapped-stop rule in BOTH engines left all of these cells
+        green. The harness only detects divergence between the engines, so a shared wrong
+        answer needs a fixture that can produce the input at all (#315).
+        """
+        df = request.getfixturevalue(fixture)
         if lock and leverage == 1:
             pytest.skip(
                 "lock is inert in spot: with no shorts and no close action the agent can "
@@ -624,18 +634,19 @@ class TestSLTPScalarVecEquivalenceTradeModesAndLock:
                 "(same action histogram, balance and position), so this cell is a copy."
             )
         mismatches = _run_sltp_sequence(
-            sample_ohlcv_df,
+            df,
             leverage=leverage,
             fee=0.001,
             max_traj=120,
             random_steps=100,
             trade_mode=trade_mode,
             lock=lock,
-            # The fixture only spans +5.9%/-1.7%, so the default +/-5% brackets can never
-            # trigger: as shipped this grid fired zero stops across all twelve cells.
+            # The continuous fixture only spans +5.9%/-1.7%, so the default +/-5% brackets
+            # can never trigger: as shipped this grid fired zero stops across all twelve
+            # cells. The gappy fixture's 6% jumps clear these levels outright.
             sl_levels=[-0.005],
             tp_levels=[0.005],
-            label=f"sltp-{trade_mode}-{'locked' if lock else 'unlocked'}-lev{leverage}",
+            label=f"sltp-{fixture}-{trade_mode}-{'locked' if lock else 'unlocked'}-lev{leverage}",
         )
         assert not mismatches, "\n".join(mismatches)
 

--- a/tests/envs/offline/test_vec_sltp_scalar_equivalence.py
+++ b/tests/envs/offline/test_vec_sltp_scalar_equivalence.py
@@ -213,7 +213,7 @@ def _run_sltp_sequence(
     # open. Both weaker forms shipped: first cells that opened nothing at all, then cells
     # that opened once and held for 99 steps with no bracket ever firing -- which a
     # "position was open" check reads as maximally healthy. Healthy cells measure 8-38
-    # opens and 4-22 bracket exits, so these floors have room.
+    # opens and 4-13 bracket exits, so these floors have room.
     if random_steps is not None:
         kinds = collections.Counter(scalar.history.action_types)
         opens = kinds["long"] + kinds["short"]
@@ -615,21 +615,7 @@ class TestSLTPScalarVecEquivalenceTradeModesAndLock:
     @pytest.mark.parametrize("trade_mode", ["fractional", "notional", "quantity"])
     @pytest.mark.parametrize("lock", [False, True], ids=["unlocked", "locked"])
     @pytest.mark.parametrize("leverage", [1, 25], ids=["spot", "lev25"])
-    @pytest.mark.parametrize("fixture", ["sample_ohlcv_df", "gappy_ohlcv_df"],
-                             ids=["continuous", "gappy"])
-    def test_random_actions_match(self, request, fixture, trade_mode, lock, leverage):
-        """The gappy arm exists because this harness was structurally blind to #280.
-
-        Every fixture it used built open == previous close, so no bar could open beyond a
-        bracket and the gap-fill rule was never reached. What the gappy arm buys is
-        detection of a ONE-ENGINE drift: reverting the rule in only the vectorized engine
-        used to leave every cell green, and now fails 9, all on this arm.
-
-        It does NOT catch a revert of both engines -- measured 18/18 green. This harness
-        only compares the two engines to each other, so a shared wrong answer is invisible
-        here by construction, whatever the fixture. That case is pinned directly by
-        tests/envs/offline/fundamental/test_gap_fills.py (#315).
-        """
+    def test_random_actions_match(self, sample_ohlcv_df, trade_mode, lock, leverage):
         if lock and leverage == 1:
             pytest.skip(
                 "lock is inert in spot: with no shorts and no close action the agent can "
@@ -638,22 +624,50 @@ class TestSLTPScalarVecEquivalenceTradeModesAndLock:
                 "(same action histogram, balance and position), so this cell is a copy."
             )
         mismatches = _run_sltp_sequence(
-            request.getfixturevalue(fixture),
+            sample_ohlcv_df,
             leverage=leverage,
             fee=0.001,
             max_traj=120,
             random_steps=100,
             trade_mode=trade_mode,
             lock=lock,
-            # Both fixtures need these overrides. The continuous one spans only
-            # +5.9%/-1.7%, so the default +/-5% brackets never trigger -- as shipped this
-            # grid fired zero stops across all twelve cells. The gappy one gaps 2%, whose
-            # widest excursion from an entry is ~2.9% over ten bars, so it does not reach
-            # +/-5% either.
+            # The fixture only spans +5.9%/-1.7%, so the default +/-5% brackets can never
+            # trigger: as shipped this grid fired zero stops across all twelve cells.
             sl_levels=[-0.005],
             tp_levels=[0.005],
-            label=f"sltp-{'gappy' if 'gappy' in fixture else 'continuous'}"
-                  f"-{trade_mode}-{'locked' if lock else 'unlocked'}-lev{leverage}",
+            label=f"sltp-{trade_mode}-{'locked' if lock else 'unlocked'}-lev{leverage}",
+        )
+        assert not mismatches, "\n".join(mismatches)
+
+    @pytest.mark.parametrize("lock", [False, True], ids=["unlocked", "locked"])
+    def test_random_actions_match_across_a_gap(self, gappy_ohlcv_df, lock):
+        """The same comparison on bars that GAP, which no other fixture can produce (#315).
+
+        Not here to catch a one-engine revert of the gap rule itself -- test_gap_fills.py
+        pins that directly. What only this reaches is the DOWNSTREAM consumers of a gapped
+        fill price: fee, margin and PnL are all computed off exec_price, and a mutant that
+        charges the exit fee against the bracket while leaving the PnL fix intact kills
+        these two cells and nothing else in the offline or replay suites. test_gap_fills.py
+        runs at zero fee, so nothing there observes those consumers; the grid above has
+        fees but never gaps, so exec_price equals the bracket and the mutation is a no-op.
+
+        Two cells, not a fixture axis over the grid above: measured across 11 gap
+        mutations, trade_mode and leverage are pure duplication on gappy data, and only
+        the lock axis and the presence of shorts change what is reached.
+        """
+        mismatches = _run_sltp_sequence(
+            gappy_ohlcv_df,
+            leverage=25,
+            fee=0.001,
+            max_traj=120,
+            random_steps=100,
+            trade_mode="notional",
+            lock=lock,
+            # 2% gaps never reach the default +/-5% brackets, so the grid's overrides are
+            # needed here too.
+            sl_levels=[-0.005],
+            tp_levels=[0.005],
+            label=f"sltp-gappy-{'locked' if lock else 'unlocked'}",
         )
         assert not mismatches, "\n".join(mismatches)
 


### PR DESCRIPTION
Closes #315. Fallout from #311.

## The blind spot

Every OHLCV fixture in `tests/conftest.py` builds `open = np.roll(close, 1)`, so `open[i] == close[i-1]` **exactly**. A price gap is by definition `open[i] != close[i-1]`. No fixture in the repo could construct one — which is why the gapped-stop mispricing in #280 survived the whole suite, in four independent engines.

## The fixture

`gappy_ohlcv_df` — the same random walk, with periodic 2% jumps in alternating directions.

**Gap size is bounded on both sides**, and that is the non-obvious part:

- **Large** against the walk's own 0.1%-per-bar volatility, so a gap clears a bracket. Below ~0.3% gaps stop clearing it at all (0.2% → zero gapped fills).
- **Small** against the liquidation band at the highest leverage under test — at 25x that band is `1/25 - 0.004 maintenance = 3.6%`. First liquidations appear at ~3%; my first attempt at 6% degenerated a cell into a liquidation test and tripped the harness's own vacuity guard.

## Where it is wired, and why *this* justification

Two cells on the scalar-vs-vectorized SLTP equivalence harness.

The obvious justification is wrong, and review caught it: this is **not** needed to catch a one-engine drift of the gap rule — `test_gap_fills.py` pins that directly. What only gappy data reaches is the **downstream consumers** of a gapped fill price. Fee, margin and PnL are all computed off `exec_price`:

| | fee mutant (charge the exit fee against the bracket, PnL fix intact) |
|---|---|
| `test_gap_fills.py` | passes — runs at `transaction_fee=0.0`, so no consumer is observable |
| existing equivalence grid | passes — has fees, but never gaps, so `exec_price == bracket` and the mutation is inert |
| **these 2 cells** | **fail** |

Measured: 2 failed, 754 passed across offline + replay.

## Two cells, not nine

The first draft added a `continuous`/`gappy` fixture axis over the whole 12-cell grid. Mutation testing across 11 gap mutations showed `trade_mode` is pure duplication on gappy data and leverage nearly so — `lev25 × notional` alone kills every one. Only the lock axis and the presence of shorts change what is reached. A separate 2-cell test also leaves the existing grid untouched.

The continuous arm stays, and now has a reason on record: max `hold_counter` is 26 there versus 6 on gappy data (2% gaps stop positions out fast), and two hold-counter saturation mutants are killed **only** by continuous cells.

## Scope

This does not catch a revert of **both** engines — the harness only detects divergence between them, so a shared wrong answer is invisible here by construction (measured 18/18 green). That case is pinned by `test_gap_fills.py`.

## Testing

Tests only. `test_vec_sltp_scalar_equivalence.py` + `test_gap_fills.py`: 64 passed, 3 skipped. Offline + replay: 756 passed.
