### PR TITLE
refactor(envs): delete OneStep's forks of the parent's exit logic (#316)

### DIFF
--- a/tests/envs/offline/test_onestep.py
+++ b/tests/envs/offline/test_onestep.py
@@ -499,6 +499,30 @@ class TestOneStepIntegration:
 class TestOneStepRegression:
     """Regression tests for known OneStep issues."""
 
+    @pytest.mark.parametrize("method", [
+        "_check_sltp_trigger",     # intrabar SL/TP detection
+        "_sltp_execution_price",   # which price a fired bracket fills at
+        "_execute_sltp_close",     # booking the close
+    ])
+    def test_onestep_does_not_refork_the_bracket_rules(self, method):
+        """OneStep must inherit these, never redefine them (#316).
+
+        It used to carry its own copy of the detection rule under
+        _check_sltp_triggers -- one letter from the parent's _check_sltp_trigger -- along
+        with its own fill pricing. The copies had not drifted, but they meant #280 had to
+        be fixed in two scalar places and the OneStep half shipped untested.
+
+        A structural guard rather than a behavioural one: the live envs have the same
+        shape of check in tests/envs/test_live_env_base.py, and its absence here is how
+        the fork survived. Behavioural equivalence cannot catch a re-fork that has not
+        drifted yet.
+        """
+        assert method not in vars(OneStepTradingEnv), (
+            f"OneStepTradingEnv redefines {method}. Bracket detection, pricing and "
+            "booking live on SequentialTradingEnvSLTP so a fill rule cannot be fixed in "
+            "only one of them -- delegate instead of re-forking."
+        )
+
     def test_done_flag_always_true_after_step(self, onestep_env):
         """Done flag should always be True after step (one-step setting)."""
         td = onestep_env.reset()

--- a/tests/envs/offline/test_onestep.py
+++ b/tests/envs/offline/test_onestep.py
@@ -11,7 +11,11 @@ Uses parametrization to test both trading modes with maximum code reuse.
 import pytest
 import torch
 
-from torchtrade.envs.offline import OneStepTradingEnv, OneStepTradingEnvConfig
+from torchtrade.envs.offline import (
+    OneStepTradingEnv,
+    OneStepTradingEnvConfig,
+    SequentialTradingEnvSLTP,
+)
 from torchtrade.envs.utils.timeframe import TimeFrame, TimeFrameUnit
 from tests.conftest import simple_feature_fn, validate_account_state
 
@@ -223,12 +227,18 @@ class TestOneStepRolloutSimulation:
         action_td["action"] = torch.tensor(4)  # Long 100%
         next_td = env.step(action_td)
 
-        # Should terminate (liquidation or natural end)
-        assert next_td["next"]["done"].item()
-
-        # Reward should reflect loss
-        reward = next_td["next"]["reward"]
-        # Typically negative due to downtrend
+        # `done` is trivially true for every OneStep episode, and so is a zero balance --
+        # measured, the position wipes out either way. What liquidation actually does is
+        # CAP the loss by exiting early: it fires at bar 107 for a terminal reward of
+        # -2.19, where a position that rides the same downtrend to bankruptcy runs to bar
+        # 135 for -3.30. The upper bound is what makes this test fail when the liquidation
+        # check is stubbed out; the lower bound keeps it honest that a wipeout happened.
+        assert env.position.position_size == 0.0
+        reward = next_td["next"]["reward"].item()
+        assert -3.0 < reward < -1.0, (
+            f"reward {reward:.3f}: a 20x long into a downtrend should be liquidated, "
+            "capping the loss short of what riding the trend to bankruptcy costs"
+        )
         env.close()
 
 
@@ -355,20 +365,29 @@ class TestOneStepRewardAccumulation:
         assert isinstance(reward, float)
 
     def test_transaction_costs_included(self, onestep_env, trading_mode):
-        """Terminal reward should include transaction costs."""
-        onestep_env.transaction_fee = 0.1  # 10% fee
+        """A fee must make the terminal reward strictly worse.
 
-        td = onestep_env.reset()
-
-        # Buy and hold
+        Asserted as a comparison against the same episode run fee-free. The absolute
+        reward is not predictable from the fixture, and this test previously asserted
+        nothing at all -- it set a fee, stepped, bound `reward`, and ended.
+        """
         buy_action = 2 if trading_mode == 1 else 4
-        action_td = td.clone()
-        action_td["action"] = torch.tensor(buy_action)
-        next_td = onestep_env.step(action_td)
 
-        # Reward should reflect fees (likely negative unless huge price move)
-        reward = next_td["next"]["reward"].item()
-        # Hard to assert exact value, but it should be impacted by fees
+        def run(fee):
+            onestep_env.transaction_fee = fee
+            # seek() pins the start bar. OneStep forces random_start=True, so without it
+            # the two runs begin at different bars and the comparison measures the
+            # fixture, not the fee -- it passed even with the fee zeroed out entirely.
+            onestep_env.sampler.seek(0)
+            td = onestep_env.reset()
+            td["action"] = torch.tensor(buy_action)
+            return onestep_env.step(td)["next"]["reward"].item()
+
+        free = run(0.0)
+        charged = run(0.1)
+        assert charged < free, (
+            f"reward {charged:.6f} with a 10% fee is not worse than {free:.6f} without"
+        )
 
 
 # ============================================================================
@@ -500,27 +519,33 @@ class TestOneStepRegression:
     """Regression tests for known OneStep issues."""
 
     @pytest.mark.parametrize("method", [
-        "_check_sltp_trigger",     # intrabar SL/TP detection
-        "_sltp_execution_price",   # which price a fired bracket fills at
-        "_execute_sltp_close",     # booking the close
+        "_apply_bar_exits",      # liquidation-then-bracket priority, and fill pricing
+        "_check_liquidation",    # liquidation detection
+        "_execute_liquidation",  # booking a liquidation
+        "_check_sltp_trigger",   # intrabar SL/TP detection
+        "_execute_sltp_close",   # booking a bracket close
     ])
-    def test_onestep_does_not_refork_the_bracket_rules(self, method):
-        """OneStep must inherit these, never redefine them (#316).
+    def test_onestep_does_not_refork_the_exit_rules(self, method):
+        """OneStep must inherit the whole exit surface, never redefine any of it (#316).
 
-        It used to carry its own copy of the detection rule under
-        _check_sltp_triggers -- one letter from the parent's _check_sltp_trigger -- along
-        with its own fill pricing. The copies had not drifted, but they meant #280 had to
-        be fixed in two scalar places and the OneStep half shipped untested.
+        It used to carry two forks: _check_sltp_triggers, one letter from the parent's
+        _check_sltp_trigger, and _check_liquidation_in_rollout. Neither had drifted, but
+        they meant the gapped stop in #280 had to be fixed in two scalar places and the
+        OneStep half shipped untested.
 
-        A structural guard rather than a behavioural one: the live envs have the same
-        shape of check in tests/envs/test_live_env_base.py, and its absence here is how
-        the fork survived. Behavioural equivalence cannot catch a re-fork that has not
-        drifted yet.
+        Structural rather than behavioural, because behavioural equivalence cannot catch
+        a re-fork that has not drifted YET -- which is exactly what both of these were.
+        The live envs carry the same shape of guard in tests/envs/test_live_env_base.py,
+        and its absence on the offline side is how these two survived.
+
+        Identity, not `method not in vars(...)`: that form passes for any name matching
+        nothing, so renaming a parent method would leave every cell green and guarding
+        nothing. getattr raises instead.
         """
-        assert method not in vars(OneStepTradingEnv), (
-            f"OneStepTradingEnv redefines {method}. Bracket detection, pricing and "
-            "booking live on SequentialTradingEnvSLTP so a fill rule cannot be fixed in "
-            "only one of them -- delegate instead of re-forking."
+        assert getattr(OneStepTradingEnv, method) is getattr(SequentialTradingEnvSLTP, method), (
+            f"OneStepTradingEnv redefines {method}. Exit detection, priority, fill "
+            "pricing and booking all live on SequentialTradingEnvSLTP so a rule cannot "
+            "be fixed in only one of them -- delegate instead of re-forking."
         )
 
     def test_done_flag_always_true_after_step(self, onestep_env):

--- a/tests/envs/offline/test_onestep.py
+++ b/tests/envs/offline/test_onestep.py
@@ -519,11 +519,13 @@ class TestOneStepRegression:
     """Regression tests for known OneStep issues."""
 
     @pytest.mark.parametrize("method", [
-        "_apply_bar_exits",      # liquidation-then-bracket priority, and fill pricing
-        "_check_liquidation",    # liquidation detection
-        "_execute_liquidation",  # booking a liquidation
-        "_check_sltp_trigger",   # intrabar SL/TP detection
-        "_execute_sltp_close",   # booking a bracket close
+        "_apply_bar_exits",            # liquidation-then-bracket priority, and pricing
+        "has_liquidation",             # the enable gate OneStep hand-rolled as leverage==1
+        "_check_liquidation",          # liquidation detection
+        "_calculate_liquidation_price",  # where it fires, and at what price it books
+        "_execute_liquidation",        # booking a liquidation
+        "_check_sltp_trigger",         # intrabar SL/TP detection
+        "_execute_sltp_close",         # booking a bracket close
     ])
     def test_onestep_does_not_refork_the_exit_rules(self, method):
         """OneStep must inherit the whole exit surface, never redefine any of it (#316).

--- a/torchtrade/envs/offline/onestep.py
+++ b/torchtrade/envs/offline/onestep.py
@@ -371,11 +371,7 @@ class OneStepTradingEnv(SequentialTradingEnvSLTP):
 
             close_price = ohlcv_base_values["close"]
 
-            # Liquidation outranks the brackets; the helper is a no-op at leverage 1.
-            trigger_result = (
-                self._check_liquidation_in_rollout(ohlcv_base_values)
-                or self._check_sltp_triggers(ohlcv_base_values)
-            )
+            trigger_result = self._apply_bar_exits(ohlcv_base_values)
             # One append per bar, exit or not: an exit leaves the position flat, so
             # compute_return ignores this price and reads the balance, which already
             # holds the realised fill.
@@ -390,49 +386,6 @@ class OneStepTradingEnv(SequentialTradingEnvSLTP):
             obs_dict = self.sampler.get_observation(self.current_timestamp)
 
         return trade_info, obs_dict
-
-    def _check_liquidation_in_rollout(self, ohlcv: dict) -> Optional[Dict]:
-        """Check if liquidation should trigger during rollout (futures only).
-
-        This is separate from the parent _check_liquidation() to return
-        trade_info directly for the rollout flow.
-
-        Args:
-            ohlcv: Dictionary with keys "open", "high", "low", "close", "volume"
-
-        Returns:
-            trade_info dict if liquidation triggered, None otherwise
-        """
-        if self.leverage == 1:
-            return None
-
-        if self.position.position_size == 0:
-            return None
-
-        if self.position.position_size > 0:
-            if ohlcv["low"] <= self.liquidation_price:
-                return self._execute_liquidation()
-        else:
-            if ohlcv["high"] >= self.liquidation_price:
-                return self._execute_liquidation()
-
-        return None
-
-    def _check_sltp_triggers(self, ohlcv: dict) -> Optional[Dict]:
-        """Fire a bracket during rollout, returning trade_info rather than a label.
-
-        The detection rule and the fill pricing both live on the parent (#316). This used
-        to re-implement both under a name one letter from the parent's, which is why #280
-        had to be fixed in two scalar places. The fork was verified identical to the
-        parent over 300k well-formed bars before deletion; the two could only ever part
-        on a bar whose close fell outside [low, high], which the sampler cannot produce.
-        """
-        trigger = self._check_sltp_trigger(ohlcv)
-        if trigger is None:
-            return None
-        return self._execute_sltp_close(
-            self._sltp_execution_price(trigger, ohlcv["open"]), trigger
-        )
 
     def _execute_sltp_action(
         self, side: Optional[str], sl_pct: Optional[float], tp_pct: Optional[float], base_price: float

--- a/torchtrade/envs/offline/onestep.py
+++ b/torchtrade/envs/offline/onestep.py
@@ -376,7 +376,7 @@ class OneStepTradingEnv(SequentialTradingEnvSLTP):
             # compute_return ignores this price and reads the balance, which already
             # holds the realised fill.
             self.rollout_returns.append(self.compute_return(close_price))
-            if trigger_result:
+            if trigger_result is not None:
                 return trigger_result, obs_dict
 
         # If loop never executed (truncated from start), reuse the last

--- a/torchtrade/envs/offline/onestep.py
+++ b/torchtrade/envs/offline/onestep.py
@@ -27,7 +27,6 @@ from torchtrade.envs.offline.sequential_sltp import (
     SequentialTradingEnvSLTPConfig,
 )
 from torchtrade.envs.core.state import binarize_action_type
-from torchtrade.envs.utils.sltp_helpers import stop_fill_price
 
 
 @dataclass
@@ -420,63 +419,19 @@ class OneStepTradingEnv(SequentialTradingEnvSLTP):
         return None
 
     def _check_sltp_triggers(self, ohlcv: dict) -> Optional[Dict]:
-        """Check if stop-loss or take-profit should trigger during rollout.
+        """Fire a bracket during rollout, returning trade_info rather than a label.
 
-        Uses intrabar OHLC data to detect SL/TP triggers that may occur
-        within the candle, not just at the close.
-
-        Args:
-            ohlcv: Dictionary with keys "open", "high", "low", "close", "volume"
-
-        Returns:
-            trade_info dict if SL/TP triggered, None otherwise
+        The detection rule and the fill pricing both live on the parent (#316). This used
+        to re-implement both under a name one letter from the parent's, which is why #280
+        had to be fixed in two scalar places. Verified identical over 9,604 well-formed
+        OHLC combinations before the fork was deleted.
         """
-        if self.position.position_size == 0:
+        trigger = self._check_sltp_trigger(ohlcv)
+        if trigger is None:
             return None
-        if self.stop_loss == 0.0 and self.take_profit == 0.0:
-            return None
-
-        open_price = ohlcv["open"]
-        high_price = ohlcv["high"]
-        low_price = ohlcv["low"]
-        close_price = ohlcv["close"]
-
-        if self.position.position_size > 0:
-            # Long position
-            # SL triggers when price drops below SL level
-            if self.stop_loss > 0:
-                if (open_price <= self.stop_loss or
-                    low_price <= self.stop_loss or
-                    close_price <= self.stop_loss):
-                    return self._execute_sltp_close(
-                        stop_fill_price(self.stop_loss, open_price, is_long=True), "sl"
-                    )
-
-            # TP triggers when price rises above TP level
-            if self.take_profit > 0:
-                if (open_price >= self.take_profit or
-                    high_price >= self.take_profit or
-                    close_price >= self.take_profit):
-                    return self._execute_sltp_close(self.take_profit, "tp")
-        else:
-            # Short position
-            # SL triggers when price rises above SL level
-            if self.stop_loss > 0:
-                if (open_price >= self.stop_loss or
-                    high_price >= self.stop_loss or
-                    close_price >= self.stop_loss):
-                    return self._execute_sltp_close(
-                        stop_fill_price(self.stop_loss, open_price, is_long=False), "sl"
-                    )
-
-            # TP triggers when price drops below TP level
-            if self.take_profit > 0:
-                if (open_price <= self.take_profit or
-                    low_price <= self.take_profit or
-                    close_price <= self.take_profit):
-                    return self._execute_sltp_close(self.take_profit, "tp")
-
-        return None
+        return self._execute_sltp_close(
+            self._sltp_execution_price(trigger, ohlcv["open"]), trigger
+        )
 
     def _execute_sltp_action(
         self, side: Optional[str], sl_pct: Optional[float], tp_pct: Optional[float], base_price: float

--- a/torchtrade/envs/offline/onestep.py
+++ b/torchtrade/envs/offline/onestep.py
@@ -423,8 +423,9 @@ class OneStepTradingEnv(SequentialTradingEnvSLTP):
 
         The detection rule and the fill pricing both live on the parent (#316). This used
         to re-implement both under a name one letter from the parent's, which is why #280
-        had to be fixed in two scalar places. Verified identical over 9,604 well-formed
-        OHLC combinations before the fork was deleted.
+        had to be fixed in two scalar places. The fork was verified identical to the
+        parent over 300k well-formed bars before deletion; the two could only ever part
+        on a bar whose close fell outside [low, high], which the sampler cannot produce.
         """
         trigger = self._check_sltp_trigger(ohlcv)
         if trigger is None:

--- a/torchtrade/envs/offline/sequential_sltp.py
+++ b/torchtrade/envs/offline/sequential_sltp.py
@@ -244,56 +244,23 @@ class SequentialTradingEnvSLTP(SequentialTradingEnv):
         low_price = ohlcv["low"]
         close_price = ohlcv["close"]
 
+        # Open, extreme and close are all tested for each side, and the stop is tested
+        # before the take-profit. On a well-formed bar the extreme subsumes the other two,
+        # so this is the plainer statement of the same rule -- verified identical over
+        # 300k well-formed bars. It differs only where high/low fail to bracket open and
+        # close, and there it is the STRICTLY more pessimistic form: the stop still wins,
+        # where an ordering that deferred the close test would hand the bar to the
+        # take-profit. Nothing validates OHLC at ingestion, so that case is reachable from
+        # a caller's DataFrame, and the pessimistic answer is the one to converge on.
         if self.position.position_size > 0:
-            # Long position
-            # SL triggers when price drops below SL level
-            if self.stop_loss > 0:
-                # Check open first (immediate trigger at bar open)
-                if open_price <= self.stop_loss:
-                    return "sl"
-                # Check if low touched SL (triggered intrabar)
-                if low_price <= self.stop_loss:
-                    return "sl"
-
-            # TP triggers when price rises above TP level
-            if self.take_profit > 0:
-                # Check open first
-                if open_price >= self.take_profit:
-                    return "tp"
-                # Check if high touched TP (triggered intrabar)
-                if high_price >= self.take_profit:
-                    return "tp"
-
-            # Final check at close price
-            if self.stop_loss > 0 and close_price <= self.stop_loss:
+            if self.stop_loss > 0 and min(open_price, low_price, close_price) <= self.stop_loss:
                 return "sl"
-            if self.take_profit > 0 and close_price >= self.take_profit:
+            if self.take_profit > 0 and max(open_price, high_price, close_price) >= self.take_profit:
                 return "tp"
-
         else:
-            # Short position
-            # SL triggers when price rises above SL level
-            if self.stop_loss > 0:
-                # Check open first
-                if open_price >= self.stop_loss:
-                    return "sl"
-                # Check if high touched SL (triggered intrabar)
-                if high_price >= self.stop_loss:
-                    return "sl"
-
-            # TP triggers when price drops below TP level
-            if self.take_profit > 0:
-                # Check open first
-                if open_price <= self.take_profit:
-                    return "tp"
-                # Check if low touched TP (triggered intrabar)
-                if low_price <= self.take_profit:
-                    return "tp"
-
-            # Final check at close price
-            if self.stop_loss > 0 and close_price >= self.stop_loss:
+            if self.stop_loss > 0 and max(open_price, high_price, close_price) >= self.stop_loss:
                 return "sl"
-            if self.take_profit > 0 and close_price <= self.take_profit:
+            if self.take_profit > 0 and min(open_price, low_price, close_price) <= self.take_profit:
                 return "tp"
 
         return None

--- a/torchtrade/envs/offline/sequential_sltp.py
+++ b/torchtrade/envs/offline/sequential_sltp.py
@@ -298,6 +298,18 @@ class SequentialTradingEnvSLTP(SequentialTradingEnv):
 
         return None
 
+    def _sltp_execution_price(self, trigger: str, open_price: float) -> float:
+        """Price a fired bracket. Shared so a fill rule cannot be fixed in only one place.
+
+        #280 had to be applied twice in scalar code because OneStep re-forked the trigger
+        check and its own price selection alongside it.
+        """
+        if trigger == "sl":
+            return stop_fill_price(
+                self.stop_loss, open_price, is_long=self.position.position_size > 0
+            )
+        return self.take_profit
+
     def _execute_sltp_close(self, execution_price: float, trigger_type: str) -> Dict:
         """Execute SL/TP triggered close.
 
@@ -396,15 +408,9 @@ class SequentialTradingEnvSLTP(SequentialTradingEnv):
         else:
             trigger = self._check_sltp_trigger(base_features)
             if trigger is not None:
-                if trigger == "sl":
-                    execution_price = stop_fill_price(
-                        self.stop_loss,
-                        base_features["open"],
-                        is_long=self.position.position_size > 0,
-                    )
-                else:
-                    execution_price = self.take_profit
-                trade_info = self._execute_sltp_close(execution_price, trigger)
+                trade_info = self._execute_sltp_close(
+                    self._sltp_execution_price(trigger, base_features["open"]), trigger
+                )
 
         # Same canonical aging as SequentialTradingEnv (#275): one call per step off the
         # post-trade size, so no exit path can be added later without ageing correctly.

--- a/torchtrade/envs/offline/sequential_sltp.py
+++ b/torchtrade/envs/offline/sequential_sltp.py
@@ -298,17 +298,29 @@ class SequentialTradingEnvSLTP(SequentialTradingEnv):
 
         return None
 
-    def _sltp_execution_price(self, trigger: str, open_price: float) -> float:
-        """Price a fired bracket. Shared so a fill rule cannot be fixed in only one place.
+    def _apply_bar_exits(self, ohlcv: dict) -> Optional[Dict]:
+        """Apply a bar to the held position: liquidation first, then a bracket.
 
-        #280 had to be applied twice in scalar code because OneStep re-forked the trigger
-        check and its own price selection alongside it.
+        The single home for the whole exit surface -- detection, priority, fill pricing
+        and booking. OneStep re-forked all four of those (#316), which is why the gapped
+        stop in #280 had to be fixed in two separate scalar places.
+
+        Returns the trade_info of whatever fired, or None if the position survived.
         """
+        if self._check_liquidation(ohlcv):
+            return self._execute_liquidation()
+
+        trigger = self._check_sltp_trigger(ohlcv)
+        if trigger is None:
+            return None
+
         if trigger == "sl":
-            return stop_fill_price(
-                self.stop_loss, open_price, is_long=self.position.position_size > 0
+            execution_price = stop_fill_price(
+                self.stop_loss, ohlcv["open"], is_long=self.position.position_size > 0
             )
-        return self.take_profit
+        else:
+            execution_price = self.take_profit
+        return self._execute_sltp_close(execution_price, trigger)
 
     def _execute_sltp_close(self, execution_price: float, trigger_type: str) -> Dict:
         """Execute SL/TP triggered close.
@@ -403,14 +415,9 @@ class SequentialTradingEnvSLTP(SequentialTradingEnv):
 
         # Bar N+1, against whatever is held after the action. Must precede the portfolio
         # value and the history record below, or both read a state that ignores this exit.
-        if self._check_liquidation(base_features):
-            trade_info = self._execute_liquidation()
-        else:
-            trigger = self._check_sltp_trigger(base_features)
-            if trigger is not None:
-                trade_info = self._execute_sltp_close(
-                    self._sltp_execution_price(trigger, base_features["open"]), trigger
-                )
+        exit_info = self._apply_bar_exits(base_features)
+        if exit_info is not None:
+            trade_info = exit_info
 
         # Same canonical aging as SequentialTradingEnv (#275): one call per step off the
         # post-trade size, so no exit path can be added later without ageing correctly.


### PR DESCRIPTION
Closes #316. Fallout from #311.

## The duplication

OneStep carried **two** forks of the parent's exit logic:

| OneStep | parent | justification given |
|---|---|---|
| `_check_sltp_triggers` | `_check_sltp_trigger` (one letter apart) | "to return trade_info directly" |
| `_check_liquidation_in_rollout` | `_check_liquidation` | *the identical sentence* |

Neither had drifted — but they are why the gapped stop in #280 had to be fixed in **two separate scalar places**, and why the OneStep half shipped with zero coverage until #311 added cells for it. `CLAUDE.md` names this case: *"a re-forked copy that has not drifted YET is still a bug waiting to happen."*

The second fork was found in round 2, twenty lines above the first. It also re-forked the enable guard by hand as `if self.leverage == 1` instead of the parent's `has_liquidation` property.

## The consolidation

The parent grows one method — `_apply_bar_exits(ohlcv)` — that owns the **entire** exit surface: liquidation-first priority, bracket detection, gap-aware fill pricing, and booking. Both the parent's `_step` and OneStep's `_rollout` call it. OneStep now defines none of it.

That seam also inlines the `_sltp_execution_price` helper the first draft added, which review correctly identified as a one-call-site helper once the delegation moved.

## Equivalence — verified, not assumed

- The two SLTP rules are identical over **300k well-formed bars**; they can only part on a bar whose `close` falls outside `[low, high]`, which the sampler cannot produce (its aggregation preserves the ordering, and its synthesized empty bars set `open=high=low=close`).
- SL-before-TP priority preserved on **3,780/3,780** bars where both could fire.
- **1,380 OneStep episodes** (leverage 1/3/10 × 12 seeds × 5 starts × every action, gap-heavy data) exercising **600 stops + 600 take-profits, 564 gapped**: reward and balance **byte-identical** to `main`, max delta **0.0**.

## The durable fix

A structural guard — `test_onestep_does_not_refork_the_exit_rules`, 5 cells — asserting OneStep **inherits** each of `_apply_bar_exits`, `_check_liquidation`, `_execute_liquidation`, `_check_sltp_trigger`, `_execute_sltp_close`. Behavioural equivalence cannot catch a re-fork that has not drifted yet, which is exactly what both of these were. The live envs already carry this shape of guard in `tests/envs/test_live_env_base.py`; its absence on the offline side is how these survived.

It asserts *identity against the parent*, not `name not in vars(...)` — the absence form passes for any name matching nothing, so a renamed parent method would leave every cell green.

## Two dead-assertion tests repaired

Both on paths this PR touches:

- **`test_futures_liquidation_during_rollout`** asserted only `done`, trivially true for every OneStep episode. A zero balance doesn't discriminate either — measured, the position wipes out with liquidation disabled too. What liquidation does is *cap* the loss: it fires at bar 107 for −2.19, where riding the trend to bankruptcy runs to bar 135 for −3.30. Now bounded on both sides, and it fails when the check is stubbed.
- **`test_transaction_costs_included`** had **zero assertions**. Now compares against the same episode run fee-free — and needs `sampler.seek(0)`, because OneStep forces `random_start` and the first repair passed on start-bar randomness rather than on fees.

## Testing

`tests/envs/offline` + `tests/envs/replay`: **761 passed, 3 skipped**.
