### PR TITLE
chore(envs): drop 10 hardcoded truncated writes that #272 made no-ops (#313)

### DIFF
--- a/tests/envs/alpaca/test_torch_env.py
+++ b/tests/envs/alpaca/test_torch_env.py
@@ -271,14 +271,19 @@ class TestAlpacaTorchTradingEnvStep:
         assert "reward" in td_out.keys()
 
     def test_step_contains_done(self, env):
-        """Test that step returns done flag."""
-        env.reset()
-        td_in = TensorDict({"action": torch.tensor(1)}, batch_size=())
-        td_out = env._step(td_in)
+        """A stepped env emits the whole done family (#272).
 
-        assert "done" in td_out.keys()
-        assert "terminated" in td_out.keys()
-        assert "truncated" in td_out.keys()
+        Goes through step(), not _step(): truncated is filled by EnvBase from the done
+        spec, so asserting it on _step's raw output would pin a hardcoded write rather
+        than the spec that makes the collector work (#313).
+        """
+        td = env.reset()
+        td["action"] = torch.tensor(1)
+        nxt = env.step(td)["next"]
+
+        for key in ("done", "terminated", "truncated"):
+            assert key in nxt.keys(), f"{key} missing from the emitted step"
+        assert nxt["truncated"].dtype is torch.bool
 
     def test_step_buy_action(self, env):
         """Test buy action (action=2)."""

--- a/tests/envs/alpaca/test_torch_env.py
+++ b/tests/envs/alpaca/test_torch_env.py
@@ -159,9 +159,15 @@ class TestAlpacaTorchTradingEnvReset:
             trader=mock_trader,
         )
 
+    def test_step_emits_the_whole_done_family(self, env):
+        from tests.envs.base_exchange_tests import (
+            assert_the_step_emits_the_whole_done_family as assert_done_family,
+        )
+        assert_done_family(env)
+
     def test_check_env_specs_passes(self, env):
         """check_env_specs compares the emitted step against every declared spec;
-        catches a done spec missing the truncated key each _step writes (#272)."""
+        catches a done spec missing a key the emitted step carries (#272)."""
         with patch.object(type(env), "_wait_for_next_timestamp"):
             check_env_specs(env)
 

--- a/tests/envs/alpaca/test_torch_env.py
+++ b/tests/envs/alpaca/test_torch_env.py
@@ -167,7 +167,8 @@ class TestAlpacaTorchTradingEnvReset:
 
     def test_check_env_specs_passes(self, env):
         """check_env_specs compares the emitted step against every declared spec;
-        catches a done spec missing a key the emitted step carries (#272)."""
+        the done family comes from the spec on both sides here, so a narrowed done spec
+        is NOT what this catches -- see assert_the_step_emits_the_whole_done_family."""
         with patch.object(type(env), "_wait_for_next_timestamp"):
             check_env_specs(env)
 
@@ -275,21 +276,6 @@ class TestAlpacaTorchTradingEnvStep:
         td_out = env._step(td_in)
 
         assert "reward" in td_out.keys()
-
-    def test_step_contains_done(self, env):
-        """A stepped env emits the whole done family (#272).
-
-        Goes through step(), not _step(): truncated is filled by EnvBase from the done
-        spec, so asserting it on _step's raw output would pin a hardcoded write rather
-        than the spec that makes the collector work (#313).
-        """
-        td = env.reset()
-        td["action"] = torch.tensor(1)
-        nxt = env.step(td)["next"]
-
-        for key in ("done", "terminated", "truncated"):
-            assert key in nxt.keys(), f"{key} missing from the emitted step"
-        assert nxt["truncated"].dtype is torch.bool
 
     def test_step_buy_action(self, env):
         """Test buy action (action=2)."""

--- a/tests/envs/alpaca/test_torch_env_sltp.py
+++ b/tests/envs/alpaca/test_torch_env_sltp.py
@@ -136,7 +136,8 @@ class TestAlpacaSLTPTradingEnvReset:
 
     def test_check_env_specs_passes(self, env):
         """check_env_specs compares the emitted step against every declared spec;
-        catches a done spec missing a key the emitted step carries (#272)."""
+        the done family comes from the spec on both sides here, so a narrowed done spec
+        is NOT what this catches -- see assert_the_step_emits_the_whole_done_family."""
         with patch.object(type(env), "_wait_for_next_timestamp"):
             check_env_specs(env)
 

--- a/tests/envs/alpaca/test_torch_env_sltp.py
+++ b/tests/envs/alpaca/test_torch_env_sltp.py
@@ -213,20 +213,13 @@ class TestAlpacaSLTPTradingEnvStep:
 
         assert env.position.current_position == 1
 
-    def test_step_contains_reward_and_done(self, env):
-        """A stepped env emits reward and the whole done family (#272).
-
-        Goes through step(), not _step(): truncated is filled by EnvBase from the done
-        spec, so asserting it on _step's raw output would pin a hardcoded write rather
-        than the spec that makes the collector work (#313).
-        """
+    def test_step_contains_reward(self, env):
+        """The done family is asserted by assert_the_step_emits_the_whole_done_family."""
         td = env.reset()
         td["action"] = torch.tensor(1)
         nxt = env.step(td)["next"]
 
-        for key in ("reward", "done", "terminated", "truncated"):
-            assert key in nxt.keys(), f"{key} missing from the emitted step"
-        assert nxt["truncated"].dtype is torch.bool
+        assert "reward" in nxt.keys()
 
     def test_cannot_buy_when_holding(self, env):
         """Test that buying when already holding doesn't execute."""

--- a/tests/envs/alpaca/test_torch_env_sltp.py
+++ b/tests/envs/alpaca/test_torch_env_sltp.py
@@ -128,9 +128,15 @@ class TestAlpacaSLTPTradingEnvReset:
             trader=mock_trader,
         )
 
+    def test_step_emits_the_whole_done_family(self, env):
+        from tests.envs.base_exchange_tests import (
+            assert_the_step_emits_the_whole_done_family as assert_done_family,
+        )
+        assert_done_family(env)
+
     def test_check_env_specs_passes(self, env):
         """check_env_specs compares the emitted step against every declared spec;
-        catches a done spec missing the truncated key each _step writes (#272)."""
+        catches a done spec missing a key the emitted step carries (#272)."""
         with patch.object(type(env), "_wait_for_next_timestamp"):
             check_env_specs(env)
 

--- a/tests/envs/alpaca/test_torch_env_sltp.py
+++ b/tests/envs/alpaca/test_torch_env_sltp.py
@@ -207,15 +207,19 @@ class TestAlpacaSLTPTradingEnvStep:
         assert env.position.current_position == 1
 
     def test_step_contains_reward_and_done(self, env):
-        """Test that step returns reward and done flags."""
-        env.reset()
-        td_in = TensorDict({"action": torch.tensor(1)}, batch_size=())
-        td_out = env._step(td_in)
+        """A stepped env emits reward and the whole done family (#272).
 
-        assert "reward" in td_out.keys()
-        assert "done" in td_out.keys()
-        assert "terminated" in td_out.keys()
-        assert "truncated" in td_out.keys()
+        Goes through step(), not _step(): truncated is filled by EnvBase from the done
+        spec, so asserting it on _step's raw output would pin a hardcoded write rather
+        than the spec that makes the collector work (#313).
+        """
+        td = env.reset()
+        td["action"] = torch.tensor(1)
+        nxt = env.step(td)["next"]
+
+        for key in ("reward", "done", "terminated", "truncated"):
+            assert key in nxt.keys(), f"{key} missing from the emitted step"
+        assert nxt["truncated"].dtype is torch.bool
 
     def test_cannot_buy_when_holding(self, env):
         """Test that buying when already holding doesn't execute."""

--- a/tests/envs/base_exchange_tests.py
+++ b/tests/envs/base_exchange_tests.py
@@ -325,7 +325,7 @@ def assert_a_direct_flip_does_not_age_the_new_position(
     )
 
 
-def assert_the_step_emits_the_whole_done_family(env, action=0):
+def assert_the_step_emits_the_whole_done_family(env):
     """A stepped live env emits done, terminated AND truncated (#272).
 
     Deliberate coverage, replacing a tripwire that #313 disarmed. While every live _step
@@ -340,7 +340,7 @@ def assert_the_step_emits_the_whole_done_family(env, action=0):
     """
     with patch.object(type(env), "_wait_for_next_timestamp"):
         td = env.reset()
-        td["action"] = torch.tensor(action)
+        td["action"] = torch.tensor(0)
         nxt = env.step(td)["next"]
 
     for key in ("done", "terminated", "truncated"):
@@ -349,5 +349,6 @@ def assert_the_step_emits_the_whole_done_family(env, action=0):
             "family by hand (#313), so a key absent here means the shared full_done_spec "
             "stopped declaring it."
         )
-    assert nxt["truncated"].dtype is torch.bool
+        assert nxt[key].dtype is torch.bool, f"{key} is {nxt[key].dtype}, not bool"
+        assert nxt[key].shape == (1,), f"{key} has shape {tuple(nxt[key].shape)}, not (1,)"
     assert not nxt["truncated"].any(), "a live env never truncates itself"

--- a/tests/envs/base_exchange_tests.py
+++ b/tests/envs/base_exchange_tests.py
@@ -323,3 +323,31 @@ def assert_a_direct_flip_does_not_age_the_new_position(
         f"a one-step-old short reports {holding_time} bars (the long aged to {aged}): the flip "
         f"never passed through flat, so the counter was never reset"
     )
+
+
+def assert_the_step_emits_the_whole_done_family(env, action=0):
+    """A stepped live env emits done, terminated AND truncated (#272).
+
+    Deliberate coverage, replacing a tripwire that #313 disarmed. While every live _step
+    wrote truncated by hand, a done spec missing the key showed up in check_env_specs as
+    keys_in_real_not_in_fake. Once the hardcoded writes went, both the real and the fake
+    rollout lack it, so check_env_specs cannot see a narrowed spec at all -- verified: the
+    same spec mutation fails on the pre-#313 code and passes after it.
+
+    So the spec is now the sole source of truncated, and this is what pins it. Goes
+    through step(), not _step(): filling the family from the spec is EnvBase's job, and
+    asserting it on _step's raw output would pin an implementation detail instead.
+    """
+    with patch.object(type(env), "_wait_for_next_timestamp"):
+        td = env.reset()
+        td["action"] = torch.tensor(action)
+        nxt = env.step(td)["next"]
+
+    for key in ("done", "terminated", "truncated"):
+        assert key in nxt.keys(), (
+            f"{key} missing from the emitted step. The live envs no longer write the done "
+            "family by hand (#313), so a key absent here means the shared full_done_spec "
+            "stopped declaring it."
+        )
+    assert nxt["truncated"].dtype is torch.bool
+    assert not nxt["truncated"].any(), "a live env never truncates itself"

--- a/tests/envs/binance/test_torch_env_futures.py
+++ b/tests/envs/binance/test_torch_env_futures.py
@@ -92,9 +92,15 @@ class TestBinanceFuturesTorchTradingEnv:
                 )
                 return env
 
+    def test_step_emits_the_whole_done_family(self, env):
+        from tests.envs.base_exchange_tests import (
+            assert_the_step_emits_the_whole_done_family as assert_done_family,
+        )
+        assert_done_family(env)
+
     def test_check_env_specs_passes(self, env):
         """check_env_specs compares the emitted step against every declared spec;
-        catches a done spec missing the truncated key each _step writes (#272)."""
+        catches a done spec missing a key the emitted step carries (#272)."""
         with patch.object(type(env), "_wait_for_next_timestamp"):
             check_env_specs(env)
 

--- a/tests/envs/binance/test_torch_env_futures.py
+++ b/tests/envs/binance/test_torch_env_futures.py
@@ -100,7 +100,8 @@ class TestBinanceFuturesTorchTradingEnv:
 
     def test_check_env_specs_passes(self, env):
         """check_env_specs compares the emitted step against every declared spec;
-        catches a done spec missing a key the emitted step carries (#272)."""
+        the done family comes from the spec on both sides here, so a narrowed done spec
+        is NOT what this catches -- see assert_the_step_emits_the_whole_done_family."""
         with patch.object(type(env), "_wait_for_next_timestamp"):
             check_env_specs(env)
 

--- a/tests/envs/binance/test_torch_env_futures_sltp.py
+++ b/tests/envs/binance/test_torch_env_futures_sltp.py
@@ -96,9 +96,15 @@ class TestBinanceFuturesSLTPTorchTradingEnv:
                 )
                 return env
 
+    def test_step_emits_the_whole_done_family(self, env):
+        from tests.envs.base_exchange_tests import (
+            assert_the_step_emits_the_whole_done_family as assert_done_family,
+        )
+        assert_done_family(env)
+
     def test_check_env_specs_passes(self, env):
         """check_env_specs compares the emitted step against every declared spec;
-        catches a done spec missing the truncated key each _step writes (#272)."""
+        catches a done spec missing a key the emitted step carries (#272)."""
         with patch.object(type(env), "_wait_for_next_timestamp"):
             check_env_specs(env)
 

--- a/tests/envs/binance/test_torch_env_futures_sltp.py
+++ b/tests/envs/binance/test_torch_env_futures_sltp.py
@@ -104,7 +104,8 @@ class TestBinanceFuturesSLTPTorchTradingEnv:
 
     def test_check_env_specs_passes(self, env):
         """check_env_specs compares the emitted step against every declared spec;
-        catches a done spec missing a key the emitted step carries (#272)."""
+        the done family comes from the spec on both sides here, so a narrowed done spec
+        is NOT what this catches -- see assert_the_step_emits_the_whole_done_family."""
         with patch.object(type(env), "_wait_for_next_timestamp"):
             check_env_specs(env)
 

--- a/tests/envs/bitget/test_torch_env_futures.py
+++ b/tests/envs/bitget/test_torch_env_futures.py
@@ -95,9 +95,15 @@ class TestBitgetFuturesTorchTradingEnv:
                 )
                 return env
 
+    def test_step_emits_the_whole_done_family(self, env):
+        from tests.envs.base_exchange_tests import (
+            assert_the_step_emits_the_whole_done_family as assert_done_family,
+        )
+        assert_done_family(env)
+
     def test_check_env_specs_passes(self, env):
         """check_env_specs compares the emitted step against every declared spec;
-        catches a done spec missing the truncated key each _step writes (#272)."""
+        catches a done spec missing a key the emitted step carries (#272)."""
         with patch.object(type(env), "_wait_for_next_timestamp"):
             check_env_specs(env)
 

--- a/tests/envs/bitget/test_torch_env_futures.py
+++ b/tests/envs/bitget/test_torch_env_futures.py
@@ -216,23 +216,6 @@ class TestBitgetFuturesTorchTradingEnv:
             assert isinstance(reward, torch.Tensor)
             assert reward.shape == (1,)
 
-    def test_done_tensor_shape(self, env):
-        """Test that done flags are tensors with correct shape."""
-        with patch.object(env, "_wait_for_next_timestamp"):
-            env.reset()
-
-            action_td = TensorDict({"action": torch.tensor(2)}, batch_size=())  # 0.0
-            next_td = env.step(action_td)
-
-            done = next_td["next"]["done"]
-            terminated = next_td["next"]["terminated"]
-            truncated = next_td["next"]["truncated"]
-
-            assert isinstance(done, torch.Tensor)
-            assert isinstance(terminated, torch.Tensor)
-            assert isinstance(truncated, torch.Tensor)
-            assert done.shape == (1,)
-
     @pytest.mark.parametrize("done_on_bankruptcy,expected_done", [
         (True, True),    # portfolio collapses below the threshold -> episode terminates
         (False, False),  # same collapse, check disabled -> keep trading

--- a/tests/envs/bitget/test_torch_env_futures_sltp.py
+++ b/tests/envs/bitget/test_torch_env_futures_sltp.py
@@ -353,23 +353,6 @@ class TestBitgetFuturesSLTPTorchTradingEnv:
             assert isinstance(reward, torch.Tensor)
             assert reward.shape == (1,)
 
-    def test_done_tensor_shape(self, env):
-        """Test that done flags are tensors with correct shape."""
-        with patch.object(env, "_wait_for_next_timestamp"):
-            env.reset()
-
-            action_td = TensorDict({"action": torch.tensor(0)}, batch_size=())
-            next_td = env.step(action_td)
-
-            done = next_td["next"]["done"]
-            terminated = next_td["next"]["terminated"]
-            truncated = next_td["next"]["truncated"]
-
-            assert isinstance(done, torch.Tensor)
-            assert isinstance(terminated, torch.Tensor)
-            assert isinstance(truncated, torch.Tensor)
-            assert done.shape == (1,)
-
     @pytest.mark.parametrize("done_on_bankruptcy,expected_done", [
         (True, True),    # portfolio collapses below the threshold -> episode terminates
         (False, False),  # same collapse, check disabled -> keep trading

--- a/tests/envs/bitget/test_torch_env_futures_sltp.py
+++ b/tests/envs/bitget/test_torch_env_futures_sltp.py
@@ -100,9 +100,15 @@ class TestBitgetFuturesSLTPTorchTradingEnv:
                 )
                 return env
 
+    def test_step_emits_the_whole_done_family(self, env):
+        from tests.envs.base_exchange_tests import (
+            assert_the_step_emits_the_whole_done_family as assert_done_family,
+        )
+        assert_done_family(env)
+
     def test_check_env_specs_passes(self, env):
         """check_env_specs compares the emitted step against every declared spec;
-        catches a done spec missing the truncated key each _step writes (#272)."""
+        catches a done spec missing a key the emitted step carries (#272)."""
         with patch.object(type(env), "_wait_for_next_timestamp"):
             check_env_specs(env)
 

--- a/tests/envs/bybit/test_torch_env_futures.py
+++ b/tests/envs/bybit/test_torch_env_futures.py
@@ -81,9 +81,15 @@ class TestBybitFuturesTorchTradingEnv:
                     trader=mock_trader,
                 )
 
+    def test_step_emits_the_whole_done_family(self, env):
+        from tests.envs.base_exchange_tests import (
+            assert_the_step_emits_the_whole_done_family as assert_done_family,
+        )
+        assert_done_family(env)
+
     def test_check_env_specs_passes(self, env):
         """check_env_specs compares the emitted step against every declared spec;
-        catches a done spec missing the truncated key each _step writes (#272)."""
+        catches a done spec missing a key the emitted step carries (#272)."""
         with patch.object(type(env), "_wait_for_next_timestamp"):
             check_env_specs(env)
 

--- a/tests/envs/bybit/test_torch_env_futures.py
+++ b/tests/envs/bybit/test_torch_env_futures.py
@@ -89,7 +89,8 @@ class TestBybitFuturesTorchTradingEnv:
 
     def test_check_env_specs_passes(self, env):
         """check_env_specs compares the emitted step against every declared spec;
-        catches a done spec missing a key the emitted step carries (#272)."""
+        the done family comes from the spec on both sides here, so a narrowed done spec
+        is NOT what this catches -- see assert_the_step_emits_the_whole_done_family."""
         with patch.object(type(env), "_wait_for_next_timestamp"):
             check_env_specs(env)
 

--- a/tests/envs/bybit/test_torch_env_futures.py
+++ b/tests/envs/bybit/test_torch_env_futures.py
@@ -180,17 +180,14 @@ class TestBybitFuturesTorchTradingEnv:
             env.step(action_td)
             mock_trader.trade.assert_called()
 
-    def test_reward_and_done_tensor_shapes(self, env):
-        """Test that reward and done flags have correct tensor shapes."""
+    def test_reward_tensor_shape(self, env):
+        """The done family is asserted by assert_the_step_emits_the_whole_done_family."""
         with patch.object(env, "_wait_for_next_timestamp"):
             env.reset()
             action_td = TensorDict({"action": torch.tensor(2)}, batch_size=())
             next_td = env.step(action_td)
 
             assert next_td["next"]["reward"].shape == (1,)
-            assert next_td["next"]["done"].shape == (1,)
-            assert next_td["next"]["terminated"].shape == (1,)
-            assert next_td["next"]["truncated"].shape == (1,)
 
     @pytest.mark.parametrize("done_on_bankruptcy,expected_done", [
         (True, True),    # portfolio collapses below the threshold -> episode terminates

--- a/tests/envs/bybit/test_torch_env_futures_sltp.py
+++ b/tests/envs/bybit/test_torch_env_futures_sltp.py
@@ -224,9 +224,6 @@ class TestBybitFuturesSLTPTorchTradingEnv:
             next_td = env.step(action_td)
 
             assert next_td["next"]["reward"].shape == (1,)
-            assert next_td["next"]["done"].shape == (1,)
-            assert next_td["next"]["terminated"].shape == (1,)
-            assert next_td["next"]["truncated"].shape == (1,)
 
     @pytest.mark.parametrize("done_on_bankruptcy,expected_done", [
         (True, True),    # portfolio collapses below the threshold -> episode terminates

--- a/tests/envs/bybit/test_torch_env_futures_sltp.py
+++ b/tests/envs/bybit/test_torch_env_futures_sltp.py
@@ -51,7 +51,8 @@ class TestBybitFuturesSLTPTorchTradingEnv:
 
     def test_check_env_specs_passes(self, env):
         """check_env_specs compares the emitted step against every declared spec;
-        catches a done spec missing a key the emitted step carries (#272)."""
+        the done family comes from the spec on both sides here, so a narrowed done spec
+        is NOT what this catches -- see assert_the_step_emits_the_whole_done_family."""
         with patch.object(type(env), "_wait_for_next_timestamp"):
             check_env_specs(env)
 

--- a/tests/envs/bybit/test_torch_env_futures_sltp.py
+++ b/tests/envs/bybit/test_torch_env_futures_sltp.py
@@ -43,9 +43,15 @@ class TestBybitFuturesSLTPTorchTradingEnv:
                     trader=mock_env_trader,
                 )
 
+    def test_step_emits_the_whole_done_family(self, env):
+        from tests.envs.base_exchange_tests import (
+            assert_the_step_emits_the_whole_done_family as assert_done_family,
+        )
+        assert_done_family(env)
+
     def test_check_env_specs_passes(self, env):
         """check_env_specs compares the emitted step against every declared spec;
-        catches a done spec missing the truncated key each _step writes (#272)."""
+        catches a done spec missing a key the emitted step carries (#272)."""
         with patch.object(type(env), "_wait_for_next_timestamp"):
             check_env_specs(env)
 

--- a/tests/envs/okx/test_torch_env_futures.py
+++ b/tests/envs/okx/test_torch_env_futures.py
@@ -123,15 +123,12 @@ class TestOKXFuturesTorchTradingEnv:
             env.step(TensorDict({"action": torch.tensor(action_idx)}, batch_size=()))
             mock_env_trader.trade.assert_called()
 
-    def test_reward_and_done_tensor_shapes(self, env):
-        """Test that reward and done flags have correct tensor shapes."""
+    def test_reward_tensor_shape(self, env):
+        """The done family is asserted by assert_the_step_emits_the_whole_done_family."""
         with patch.object(env, "_wait_for_next_timestamp"):
             env.reset()
             next_td = env.step(TensorDict({"action": torch.tensor(2)}, batch_size=()))
             assert next_td["next"]["reward"].shape == (1,)
-            assert next_td["next"]["done"].shape == (1,)
-            assert next_td["next"]["terminated"].shape == (1,)
-            assert next_td["next"]["truncated"].shape == (1,)
 
     @pytest.mark.parametrize("done_on_bankruptcy,expected_done", [
         (True, True),    # portfolio collapses below the threshold -> episode terminates

--- a/tests/envs/okx/test_torch_env_futures.py
+++ b/tests/envs/okx/test_torch_env_futures.py
@@ -52,9 +52,15 @@ class TestOKXFuturesTorchTradingEnv:
                 config=env_config, observer=mock_observer, trader=mock_env_trader,
             )
 
+    def test_step_emits_the_whole_done_family(self, env):
+        from tests.envs.base_exchange_tests import (
+            assert_the_step_emits_the_whole_done_family as assert_done_family,
+        )
+        assert_done_family(env)
+
     def test_check_env_specs_passes(self, env):
         """check_env_specs compares the emitted step against every declared spec;
-        catches a done spec missing the truncated key each _step writes (#272)."""
+        catches a done spec missing a key the emitted step carries (#272)."""
         with patch.object(type(env), "_wait_for_next_timestamp"):
             check_env_specs(env)
 

--- a/tests/envs/okx/test_torch_env_futures.py
+++ b/tests/envs/okx/test_torch_env_futures.py
@@ -60,7 +60,8 @@ class TestOKXFuturesTorchTradingEnv:
 
     def test_check_env_specs_passes(self, env):
         """check_env_specs compares the emitted step against every declared spec;
-        catches a done spec missing a key the emitted step carries (#272)."""
+        the done family comes from the spec on both sides here, so a narrowed done spec
+        is NOT what this catches -- see assert_the_step_emits_the_whole_done_family."""
         with patch.object(type(env), "_wait_for_next_timestamp"):
             check_env_specs(env)
 

--- a/tests/envs/okx/test_torch_env_futures_sltp.py
+++ b/tests/envs/okx/test_torch_env_futures_sltp.py
@@ -154,9 +154,6 @@ class TestOKXFuturesSLTPTorchTradingEnv:
             env.reset()
             next_td = env.step(TensorDict({"action": torch.tensor(0)}, batch_size=()))
             assert next_td["next"]["reward"].shape == (1,)
-            assert next_td["next"]["done"].shape == (1,)
-            assert next_td["next"]["terminated"].shape == (1,)
-            assert next_td["next"]["truncated"].shape == (1,)
 
     @pytest.mark.parametrize("done_on_bankruptcy,expected_done", [
         (True, True),    # portfolio collapses below the threshold -> episode terminates

--- a/tests/envs/okx/test_torch_env_futures_sltp.py
+++ b/tests/envs/okx/test_torch_env_futures_sltp.py
@@ -38,7 +38,8 @@ class TestOKXFuturesSLTPTorchTradingEnv:
 
     def test_check_env_specs_passes(self, env):
         """check_env_specs compares the emitted step against every declared spec;
-        catches a done spec missing a key the emitted step carries (#272)."""
+        the done family comes from the spec on both sides here, so a narrowed done spec
+        is NOT what this catches -- see assert_the_step_emits_the_whole_done_family."""
         with patch.object(type(env), "_wait_for_next_timestamp"):
             check_env_specs(env)
 

--- a/tests/envs/okx/test_torch_env_futures_sltp.py
+++ b/tests/envs/okx/test_torch_env_futures_sltp.py
@@ -30,9 +30,15 @@ class TestOKXFuturesSLTPTorchTradingEnv:
                 config=env_config, observer=mock_env_observer, trader=mock_env_trader,
             )
 
+    def test_step_emits_the_whole_done_family(self, env):
+        from tests.envs.base_exchange_tests import (
+            assert_the_step_emits_the_whole_done_family as assert_done_family,
+        )
+        assert_done_family(env)
+
     def test_check_env_specs_passes(self, env):
         """check_env_specs compares the emitted step against every declared spec;
-        catches a done spec missing the truncated key each _step writes (#272)."""
+        catches a done spec missing a key the emitted step carries (#272)."""
         with patch.object(type(env), "_wait_for_next_timestamp"):
             check_env_specs(env)
 

--- a/tests/envs/test_spec_contracts.py
+++ b/tests/envs/test_spec_contracts.py
@@ -20,7 +20,9 @@ fake one and both would lack the key. `assert_the_step_emits_the_whole_done_fami
 against all ten live envs, is what catches it there. The offline envs still write
 `truncated` themselves -- they genuinely truncate -- so their `check_env_specs` does still
 catch it, and so does `test_a_collector_batch_carries_truncated` below. Dropping
-`truncated` from the shared spec fails 23 tests across all three of those guards.
+`truncated` from the shared spec fails 21 tests: 17 across those three guards -- 10 live
+done-family cells, 6 offline `check_env_specs` cases and the collector test -- plus 4
+offline `test_action_types_recorded` cells that witness it incidentally.
 """
 
 import ast

--- a/tests/envs/test_spec_contracts.py
+++ b/tests/envs/test_spec_contracts.py
@@ -7,11 +7,18 @@ as thoroughly. `check_env_specs()` catches neither: it builds its dummy batch fr
 `spec.zero()` and a real rollout, never `.rand()`. Use `Unbounded(shape=..., dtype=...)`,
 or finite numbers where a bound is real.
 
-**The done spec is declared exactly once** (#272). Every `_step` writes a `truncated`
-key, but TorchRL's default done spec carries only `done` and `terminated`, so anything
-pre-allocating from the spec drops it with no error at all. `TorchTradeBaseEnv` now
-declares all three for live and offline alike; the tests at the end of this file guard
-that one declaration against both drift and silent loss.
+**The done spec is declared exactly once** (#272). TorchRL's default done spec carries
+only `done` and `terminated`, so anything pre-allocating from the spec drops `truncated`
+with no error at all. `TorchTradeBaseEnv` declares all three for live and offline alike;
+the tests at the end of this file guard that one declaration against both drift and
+silent loss.
+
+Since #313 the live `_step` methods no longer write `truncated` by hand, so that
+declaration is its only source. One consequence is worth knowing: `check_env_specs` can
+no longer catch a *narrowed* done spec, because it compares a real rollout against a fake
+one and both would lack the key. The ten
+`assert_the_step_emits_the_whole_done_family` cells are what catch it now -- verified by
+dropping `truncated` from the spec, which fails all ten.
 """
 
 import ast

--- a/tests/envs/test_spec_contracts.py
+++ b/tests/envs/test_spec_contracts.py
@@ -13,12 +13,14 @@ with no error at all. `TorchTradeBaseEnv` declares all three for live and offlin
 the tests at the end of this file guard that one declaration against both drift and
 silent loss.
 
-Since #313 the live `_step` methods no longer write `truncated` by hand, so that
-declaration is its only source. One consequence is worth knowing: `check_env_specs` can
-no longer catch a *narrowed* done spec, because it compares a real rollout against a fake
-one and both would lack the key. The ten
-`assert_the_step_emits_the_whole_done_family` cells are what catch it now -- verified by
-dropping `truncated` from the spec, which fails all ten.
+Since #313 the LIVE `_step` methods no longer write `truncated` by hand, so for them the
+declaration is its only source. One consequence is worth knowing: their `check_env_specs`
+can no longer catch a *narrowed* done spec, because it compares a real rollout against a
+fake one and both would lack the key. `assert_the_step_emits_the_whole_done_family`, run
+against all ten live envs, is what catches it there. The offline envs still write
+`truncated` themselves -- they genuinely truncate -- so their `check_env_specs` does still
+catch it, and so does `test_a_collector_batch_carries_truncated` below. Dropping
+`truncated` from the shared spec fails 23 tests across all three of those guards.
 """
 
 import ast
@@ -295,8 +297,9 @@ def test_no_env_declares_its_own_done_spec(env_cls):
     write, `setattr(self, "full_done_spec", ...)`, or a helper outside the MRO -- passes.
 
     What happens to those next turns on the payload, not the form. Any of them that
-    removes or narrows truncated is still caught by the ten check_env_specs tests and by
-    test_a_collector_batch_carries_truncated, which name the missing key. Any of them
+    removes or narrows truncated is still caught by the ten
+    assert_the_step_emits_the_whole_done_family cells on the live side, by the offline
+    check_env_specs tests, and by test_a_collector_batch_carries_truncated. Any of them
     that installs an IDENTICAL copy is caught by neither -- and that is the same blind
     spot this test exists to close for plain assignment: a copy nothing can see until the
     day it drifts, which is the failure mode that left this repo with three diverging
@@ -331,8 +334,9 @@ def test_a_collector_batch_carries_truncated(sample_ohlcv_df):
     The env here is offline, which never had the bug -- its spec already declared
     truncated. The mechanism is env-agnostic and a collector is cheap on this side, where
     the live envs would need broker mocks and a patched clock. So this pins the shared
-    declaration going forward; the ten check_env_specs tests are what cover the live
-    regression itself.
+    declaration going forward; the ten assert_the_step_emits_the_whole_done_family cells
+    are what cover the live regression itself, since #313 left the live check_env_specs
+    tests unable to see a narrowed done spec.
     """
     from torchrl.collectors import Collector
 

--- a/torchtrade/envs/core/base.py
+++ b/torchtrade/envs/core/base.py
@@ -56,11 +56,15 @@ class TorchTradeBaseEnv(EnvBase):
 
         # TorchRL's default done spec carries only done and terminated, so anything
         # pre-allocating from the spec (collectors, ParallelEnv) drops truncated silently
-        # (#272). This declaration is now the SOLE source of the key: since #313 the live
-        # _step methods no longer write it by hand, and EnvBase._complete_done fills it
-        # from here. That also means check_env_specs can no longer catch a narrowed spec
-        # -- real and fake would both lack the key -- so the guard is
-        # assert_the_step_emits_the_whole_done_family, run against all ten live envs.
+        # (#272).
+        #
+        # For the LIVE envs this declaration is the only source of the key: since #313
+        # their _step methods no longer write it and EnvBase._complete_done fills it from
+        # here. One consequence -- their check_env_specs can no longer catch a narrowed
+        # done spec, since real and fake rollouts would both lack the key. The live guard
+        # is assert_the_step_emits_the_whole_done_family, run against all ten. The offline
+        # envs still write truncated themselves, and meaningfully (they do truncate), so
+        # their check_env_specs does still catch it.
         self.full_done_spec = Composite(
             done=Categorical(2, dtype=torch.bool, shape=(1,)),
             terminated=Categorical(2, dtype=torch.bool, shape=(1,)),

--- a/torchtrade/envs/core/base.py
+++ b/torchtrade/envs/core/base.py
@@ -54,9 +54,13 @@ class TorchTradeBaseEnv(EnvBase):
         # Create reward spec (common across all environments)
         self.reward_spec = Unbounded(shape=(1,), dtype=torch.float)
 
-        # Every _step writes a truncated key, but TorchRL's default done spec carries only
-        # done and terminated -- anything pre-allocating from the spec (collectors,
-        # ParallelEnv) then drops it silently (#272).
+        # TorchRL's default done spec carries only done and terminated, so anything
+        # pre-allocating from the spec (collectors, ParallelEnv) drops truncated silently
+        # (#272). This declaration is now the SOLE source of the key: since #313 the live
+        # _step methods no longer write it by hand, and EnvBase._complete_done fills it
+        # from here. That also means check_env_specs can no longer catch a narrowed spec
+        # -- real and fake would both lack the key -- so the guard is
+        # assert_the_step_emits_the_whole_done_family, run against all ten live envs.
         self.full_done_spec = Composite(
             done=Categorical(2, dtype=torch.bool, shape=(1,)),
             terminated=Categorical(2, dtype=torch.bool, shape=(1,)),

--- a/torchtrade/envs/live/alpaca/env.py
+++ b/torchtrade/envs/live/alpaca/env.py
@@ -151,7 +151,6 @@ class AlpacaTorchTradingEnv(AlpacaBaseTorchTradingEnv):
 
         next_tensordict.set("reward", torch.tensor([reward], dtype=torch.float))
         next_tensordict.set("done", torch.tensor([done], dtype=torch.bool))
-        next_tensordict.set("truncated", torch.tensor([False], dtype=torch.bool))
         next_tensordict.set("terminated", torch.tensor([done], dtype=torch.bool))
 
         return next_tensordict

--- a/torchtrade/envs/live/alpaca/env_sltp.py
+++ b/torchtrade/envs/live/alpaca/env_sltp.py
@@ -187,7 +187,6 @@ class AlpacaSLTPTorchTradingEnv(SLTPMixin, AlpacaBaseTorchTradingEnv):
 
         next_tensordict.set("reward", torch.tensor([reward], dtype=torch.float))
         next_tensordict.set("done", torch.tensor([done], dtype=torch.bool))
-        next_tensordict.set("truncated", torch.tensor([False], dtype=torch.bool))
         next_tensordict.set("terminated", torch.tensor([done], dtype=torch.bool))
 
         return next_tensordict

--- a/torchtrade/envs/live/binance/env.py
+++ b/torchtrade/envs/live/binance/env.py
@@ -206,7 +206,6 @@ class BinanceFuturesTorchTradingEnv(BinanceBaseTorchTradingEnv):
 
         next_tensordict.set("reward", torch.tensor([reward], dtype=torch.float))
         next_tensordict.set("done", torch.tensor([done], dtype=torch.bool))
-        next_tensordict.set("truncated", torch.tensor([False], dtype=torch.bool))
         next_tensordict.set("terminated", torch.tensor([done], dtype=torch.bool))
 
         return next_tensordict

--- a/torchtrade/envs/live/binance/env_sltp.py
+++ b/torchtrade/envs/live/binance/env_sltp.py
@@ -240,7 +240,6 @@ class BinanceFuturesSLTPTorchTradingEnv(SLTPMixin, BinanceBaseTorchTradingEnv):
 
         next_tensordict.set("reward", torch.tensor([reward], dtype=torch.float))
         next_tensordict.set("done", torch.tensor([done], dtype=torch.bool))
-        next_tensordict.set("truncated", torch.tensor([False], dtype=torch.bool))
         next_tensordict.set("terminated", torch.tensor([done], dtype=torch.bool))
 
         return next_tensordict

--- a/torchtrade/envs/live/bitget/env.py
+++ b/torchtrade/envs/live/bitget/env.py
@@ -206,7 +206,6 @@ class BitgetFuturesTorchTradingEnv(BitgetBaseTorchTradingEnv):
 
         next_tensordict.set("reward", torch.tensor([reward], dtype=torch.float))
         next_tensordict.set("done", torch.tensor([done], dtype=torch.bool))
-        next_tensordict.set("truncated", torch.tensor([False], dtype=torch.bool))
         next_tensordict.set("terminated", torch.tensor([done], dtype=torch.bool))
 
         return next_tensordict

--- a/torchtrade/envs/live/bitget/env_sltp.py
+++ b/torchtrade/envs/live/bitget/env_sltp.py
@@ -244,7 +244,6 @@ class BitgetFuturesSLTPTorchTradingEnv(SLTPMixin, BitgetBaseTorchTradingEnv):
 
         next_tensordict.set("reward", torch.tensor([reward], dtype=torch.float))
         next_tensordict.set("done", torch.tensor([done], dtype=torch.bool))
-        next_tensordict.set("truncated", torch.tensor([False], dtype=torch.bool))
         next_tensordict.set("terminated", torch.tensor([done], dtype=torch.bool))
 
         return next_tensordict

--- a/torchtrade/envs/live/bybit/env.py
+++ b/torchtrade/envs/live/bybit/env.py
@@ -164,7 +164,6 @@ class BybitFuturesTorchTradingEnv(BybitBaseTorchTradingEnv):
 
         next_tensordict.set("reward", torch.tensor([reward], dtype=torch.float))
         next_tensordict.set("done", torch.tensor([done], dtype=torch.bool))
-        next_tensordict.set("truncated", torch.tensor([False], dtype=torch.bool))
         next_tensordict.set("terminated", torch.tensor([done], dtype=torch.bool))
 
         return next_tensordict

--- a/torchtrade/envs/live/bybit/env_sltp.py
+++ b/torchtrade/envs/live/bybit/env_sltp.py
@@ -203,7 +203,6 @@ class BybitFuturesSLTPTorchTradingEnv(SLTPMixin, BybitBaseTorchTradingEnv):
 
         next_tensordict.set("reward", torch.tensor([reward], dtype=torch.float))
         next_tensordict.set("done", torch.tensor([done], dtype=torch.bool))
-        next_tensordict.set("truncated", torch.tensor([False], dtype=torch.bool))
         next_tensordict.set("terminated", torch.tensor([done], dtype=torch.bool))
 
         return next_tensordict

--- a/torchtrade/envs/live/okx/env.py
+++ b/torchtrade/envs/live/okx/env.py
@@ -167,7 +167,6 @@ class OKXFuturesTorchTradingEnv(OKXBaseTorchTradingEnv):
 
         next_tensordict.set("reward", torch.tensor([reward], dtype=torch.float))
         next_tensordict.set("done", torch.tensor([done], dtype=torch.bool))
-        next_tensordict.set("truncated", torch.tensor([False], dtype=torch.bool))
         next_tensordict.set("terminated", torch.tensor([done], dtype=torch.bool))
 
         return next_tensordict

--- a/torchtrade/envs/live/okx/env_sltp.py
+++ b/torchtrade/envs/live/okx/env_sltp.py
@@ -202,7 +202,6 @@ class OKXFuturesSLTPTorchTradingEnv(SLTPMixin, OKXBaseTorchTradingEnv):
 
         next_tensordict.set("reward", torch.tensor([reward], dtype=torch.float))
         next_tensordict.set("done", torch.tensor([done], dtype=torch.bool))
-        next_tensordict.set("truncated", torch.tensor([False], dtype=torch.bool))
         next_tensordict.set("terminated", torch.tensor([done], dtype=torch.bool))
 
         return next_tensordict


### PR DESCRIPTION
Closes #313. Follow-up to #272/#317.

## The cleanup

All 10 live-exchange `_step()` methods wrote:

```python
next_tensordict.set("truncated", torch.tensor([False], dtype=torch.bool))
```

Since #272 declared `truncated` in the shared `full_done_spec`, `EnvBase._complete_done` fills it after every step. Verified the auto-fill is byte-identical to the deleted line:

```
auto-filled : value=[False] dtype=torch.bool shape=(1,)
deleted line: value=[False] dtype=torch.bool shape=(1,)
IDENTICAL: True
```

The 10 `_reset()` methods never wrote it and have always relied on exactly this path, so `_step` is now consistent with `_reset`.

## One nuance the issue got wrong

It called the writes *"provably no-ops"*. That holds for the real `step()` path but **not** for `_step()` called directly — and two tests did exactly that while asserting `truncated` was present:

- `test_torch_env.py::test_step_contains_done`
- `test_torch_env_sltp.py::test_step_contains_reward_and_done`

They were pinning the hardcoded write rather than the spec that makes the collector work. Both now go through `step()`. Asserting the done family on `_step`'s raw output tests an implementation detail — emitting it is `EnvBase`'s job, not `_step`'s.

## Testing

`tests/envs`: **2111 passed, 19 skipped**. `check_env_specs` and the collector-truncated backstop from #272 are what make this safe, and both still pass.