### PR TITLE
fix(envs): reject malformed OHLC at ingestion (#326)

### DIFF
--- a/docs/guides/sampler.md
+++ b/docs/guides/sampler.md
@@ -196,7 +196,7 @@ After reorder:      [open, high, low, close, volume, funding_rate, basis]
                      positions 0-4 (guaranteed)   positions 5+
 ```
 
-1. **Validation**: The sampler checks that OHLCV + timestamp columns are present. Extra columns are accepted. It also raises `ValueError` on any bar where `high < max(open, close)` or `low > min(open, close)` — a bar whose extremes do not bracket its own open and close is rejected rather than carried, because the exit rules read the extreme to decide whether a level was touched and the open to price a gapped fill, and on such a bar those two disagree.
+1. **Validation**: The sampler checks that OHLCV + timestamp columns are present. Extra columns are accepted. It also raises `ValueError` on any bar where `high < max(open, close)` or `low > min(open, close)` — a bar whose extremes do not bracket its own open and close is rejected rather than carried, because the exit rules read the extreme to decide whether a level was touched, and the scalar stop-loss additionally reads the open to price a gapped fill — on such a bar those two disagree.
 2. **Column reordering**: OHLCV is always placed at positions 0-4, auxiliary columns follow after. This preserves internal positional contracts.
 3. **Resampling**: When resampling to higher timeframes, auxiliary columns use `"last"` aggregation (the value at bar close), while OHLCV uses canonical rules (open=first, high=max, low=min, close=last, volume=sum).
 4. **Sparse data handling**: Auxiliary NaN values are forward-filled after resampling (see below).

--- a/docs/guides/sampler.md
+++ b/docs/guides/sampler.md
@@ -196,7 +196,7 @@ After reorder:      [open, high, low, close, volume, funding_rate, basis]
                      positions 0-4 (guaranteed)   positions 5+
 ```
 
-1. **Validation**: The sampler checks that OHLCV + timestamp columns are present. Extra columns are accepted.
+1. **Validation**: The sampler checks that OHLCV + timestamp columns are present. Extra columns are accepted. It also raises `ValueError` on any bar where `high < max(open, close)` or `low > min(open, close)` — a bar whose extremes do not bracket its own open and close is rejected rather than carried, because the exit rules read the extreme to decide whether a level was touched and the open to price a gapped fill, and on such a bar those two disagree.
 2. **Column reordering**: OHLCV is always placed at positions 0-4, auxiliary columns follow after. This preserves internal positional contracts.
 3. **Resampling**: When resampling to higher timeframes, auxiliary columns use `"last"` aggregation (the value at bar close), while OHLCV uses canonical rules (open=first, high=max, low=min, close=last, volume=sum).
 4. **Sparse data handling**: Auxiliary NaN values are forward-filled after resampling (see below).

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -211,6 +211,11 @@ def trending_up_df():
     open_prices = np.roll(close_prices, 1)
     open_prices[0] = initial_price
 
+    # On a trend the roll puts the open outside a band drawn off close alone, so the bar
+    # would claim a high below its own open (#326).
+    high_prices = np.maximum(high_prices, np.maximum(open_prices, close_prices))
+    low_prices = np.minimum(low_prices, np.minimum(open_prices, close_prices))
+
     volume = np.random.lognormal(10, 1, n_minutes)
 
     return pd.DataFrame({
@@ -242,6 +247,11 @@ def trending_down_df():
     low_prices = close_prices * 0.998
     open_prices = np.roll(close_prices, 1)
     open_prices[0] = initial_price
+
+    # On a trend the roll puts the open outside a band drawn off close alone, so the bar
+    # would claim a high below its own open (#326).
+    high_prices = np.maximum(high_prices, np.maximum(open_prices, close_prices))
+    low_prices = np.minimum(low_prices, np.minimum(open_prices, close_prices))
 
     volume = np.random.lognormal(10, 1, n_minutes)
 

--- a/tests/envs/binance/test_torch_env_futures.py
+++ b/tests/envs/binance/test_torch_env_futures.py
@@ -744,13 +744,18 @@ class TestWithReplayData:
         n = 200
         rng = np.random.default_rng(42)
         base = 50000 + np.cumsum(rng.normal(0, 50, n))
-        # close drawn off base can land outside a high/low drawn off base alone (#326).
+        # Drawn in the original order so the RNG stream is unchanged, then clamped:
+        # a close drawn off base can land outside a high/low drawn off base alone (#326).
+        high_raw = base + np.abs(rng.normal(30, 20, n))
+        low_raw = base - np.abs(rng.normal(30, 20, n))
         close = base + rng.normal(0, 20, n)
+        high_raw_clamped = np.maximum(high_raw, np.maximum(base, close))
+        low_raw_clamped = np.minimum(low_raw, np.minimum(base, close))
         return pd.DataFrame({
             "timestamp": pd.date_range("2024-01-01", periods=n, freq="1min"),
             "open": base,
-            "high": np.maximum(base + np.abs(rng.normal(30, 20, n)), np.maximum(base, close)),
-            "low": np.minimum(base - np.abs(rng.normal(30, 20, n)), np.minimum(base, close)),
+            "high": high_raw_clamped,
+            "low": low_raw_clamped,
             "close": close,
             "volume": rng.uniform(100, 1000, n),
         })

--- a/tests/envs/binance/test_torch_env_futures.py
+++ b/tests/envs/binance/test_torch_env_futures.py
@@ -744,12 +744,14 @@ class TestWithReplayData:
         n = 200
         rng = np.random.default_rng(42)
         base = 50000 + np.cumsum(rng.normal(0, 50, n))
+        # close drawn off base can land outside a high/low drawn off base alone (#326).
+        close = base + rng.normal(0, 20, n)
         return pd.DataFrame({
             "timestamp": pd.date_range("2024-01-01", periods=n, freq="1min"),
             "open": base,
-            "high": base + np.abs(rng.normal(30, 20, n)),
-            "low": base - np.abs(rng.normal(30, 20, n)),
-            "close": base + rng.normal(0, 20, n),
+            "high": np.maximum(base + np.abs(rng.normal(30, 20, n)), np.maximum(base, close)),
+            "low": np.minimum(base - np.abs(rng.normal(30, 20, n)), np.minimum(base, close)),
+            "close": close,
             "volume": rng.uniform(100, 1000, n),
         })
 

--- a/tests/envs/binance/test_torch_env_futures_sltp.py
+++ b/tests/envs/binance/test_torch_env_futures_sltp.py
@@ -1237,12 +1237,14 @@ class TestWithReplayData:
         n = 200
         timestamps = pd.date_range("2024-01-01", periods=n, freq="1min")
         base = 50000 + np.cumsum(np.random.default_rng(42).normal(0, 50, n))
+        # close drawn off base can land outside a high/low drawn off base alone (#326).
+        close = base + np.random.default_rng(45).normal(0, 20, n)
         return pd.DataFrame({
             "timestamp": timestamps,
             "open": base,
-            "high": base + np.abs(np.random.default_rng(43).normal(30, 20, n)),
-            "low": base - np.abs(np.random.default_rng(44).normal(30, 20, n)),
-            "close": base + np.random.default_rng(45).normal(0, 20, n),
+            "high": np.maximum(base + np.abs(np.random.default_rng(43).normal(30, 20, n)), np.maximum(base, close)),
+            "low": np.minimum(base - np.abs(np.random.default_rng(44).normal(30, 20, n)), np.minimum(base, close)),
+            "close": close,
             "volume": np.random.default_rng(46).uniform(100, 1000, n),
         })
 

--- a/tests/envs/bitget/test_torch_env_futures.py
+++ b/tests/envs/bitget/test_torch_env_futures.py
@@ -723,12 +723,14 @@ class TestWithReplayData:
         n = 200
         rng = np.random.default_rng(42)
         base = 50000 + np.cumsum(rng.normal(0, 50, n))
+        # close drawn off base can land outside a high/low drawn off base alone (#326).
+        close = base + rng.normal(0, 20, n)
         return pd.DataFrame({
             "timestamp": pd.date_range("2024-01-01", periods=n, freq="1min"),
             "open": base,
-            "high": base + np.abs(rng.normal(30, 20, n)),
-            "low": base - np.abs(rng.normal(30, 20, n)),
-            "close": base + rng.normal(0, 20, n),
+            "high": np.maximum(base + np.abs(rng.normal(30, 20, n)), np.maximum(base, close)),
+            "low": np.minimum(base - np.abs(rng.normal(30, 20, n)), np.minimum(base, close)),
+            "close": close,
             "volume": rng.uniform(100, 1000, n),
         })
 

--- a/tests/envs/bitget/test_torch_env_futures.py
+++ b/tests/envs/bitget/test_torch_env_futures.py
@@ -723,13 +723,18 @@ class TestWithReplayData:
         n = 200
         rng = np.random.default_rng(42)
         base = 50000 + np.cumsum(rng.normal(0, 50, n))
-        # close drawn off base can land outside a high/low drawn off base alone (#326).
+        # Drawn in the original order so the RNG stream is unchanged, then clamped:
+        # a close drawn off base can land outside a high/low drawn off base alone (#326).
+        high_raw = base + np.abs(rng.normal(30, 20, n))
+        low_raw = base - np.abs(rng.normal(30, 20, n))
         close = base + rng.normal(0, 20, n)
+        high_raw_clamped = np.maximum(high_raw, np.maximum(base, close))
+        low_raw_clamped = np.minimum(low_raw, np.minimum(base, close))
         return pd.DataFrame({
             "timestamp": pd.date_range("2024-01-01", periods=n, freq="1min"),
             "open": base,
-            "high": np.maximum(base + np.abs(rng.normal(30, 20, n)), np.maximum(base, close)),
-            "low": np.minimum(base - np.abs(rng.normal(30, 20, n)), np.minimum(base, close)),
+            "high": high_raw_clamped,
+            "low": low_raw_clamped,
             "close": close,
             "volume": rng.uniform(100, 1000, n),
         })

--- a/tests/envs/bitget/test_torch_env_futures_sltp.py
+++ b/tests/envs/bitget/test_torch_env_futures_sltp.py
@@ -919,12 +919,14 @@ class TestWithReplayData:
         n = 200
         timestamps = pd.date_range("2024-01-01", periods=n, freq="1min")
         base = 50000 + np.cumsum(np.random.default_rng(42).normal(0, 50, n))
+        # close drawn off base can land outside a high/low drawn off base alone (#326).
+        close = base + np.random.default_rng(45).normal(0, 20, n)
         return pd.DataFrame({
             "timestamp": timestamps,
             "open": base,
-            "high": base + np.abs(np.random.default_rng(43).normal(30, 20, n)),
-            "low": base - np.abs(np.random.default_rng(44).normal(30, 20, n)),
-            "close": base + np.random.default_rng(45).normal(0, 20, n),
+            "high": np.maximum(base + np.abs(np.random.default_rng(43).normal(30, 20, n)), np.maximum(base, close)),
+            "low": np.minimum(base - np.abs(np.random.default_rng(44).normal(30, 20, n)), np.minimum(base, close)),
+            "close": close,
             "volume": np.random.default_rng(46).uniform(100, 1000, n),
         })
 

--- a/tests/envs/bybit/test_torch_env_futures.py
+++ b/tests/envs/bybit/test_torch_env_futures.py
@@ -704,12 +704,14 @@ class TestWithReplayData:
         n = 200
         rng = np.random.default_rng(42)
         base = 50000 + np.cumsum(rng.normal(0, 50, n))
+        # close drawn off base can land outside a high/low drawn off base alone (#326).
+        close = base + rng.normal(0, 20, n)
         return pd.DataFrame({
             "timestamp": pd.date_range("2024-01-01", periods=n, freq="1min"),
             "open": base,
-            "high": base + np.abs(rng.normal(30, 20, n)),
-            "low": base - np.abs(rng.normal(30, 20, n)),
-            "close": base + rng.normal(0, 20, n),
+            "high": np.maximum(base + np.abs(rng.normal(30, 20, n)), np.maximum(base, close)),
+            "low": np.minimum(base - np.abs(rng.normal(30, 20, n)), np.minimum(base, close)),
+            "close": close,
             "volume": rng.uniform(100, 1000, n),
         })
 

--- a/tests/envs/bybit/test_torch_env_futures.py
+++ b/tests/envs/bybit/test_torch_env_futures.py
@@ -704,13 +704,18 @@ class TestWithReplayData:
         n = 200
         rng = np.random.default_rng(42)
         base = 50000 + np.cumsum(rng.normal(0, 50, n))
-        # close drawn off base can land outside a high/low drawn off base alone (#326).
+        # Drawn in the original order so the RNG stream is unchanged, then clamped:
+        # a close drawn off base can land outside a high/low drawn off base alone (#326).
+        high_raw = base + np.abs(rng.normal(30, 20, n))
+        low_raw = base - np.abs(rng.normal(30, 20, n))
         close = base + rng.normal(0, 20, n)
+        high_raw_clamped = np.maximum(high_raw, np.maximum(base, close))
+        low_raw_clamped = np.minimum(low_raw, np.minimum(base, close))
         return pd.DataFrame({
             "timestamp": pd.date_range("2024-01-01", periods=n, freq="1min"),
             "open": base,
-            "high": np.maximum(base + np.abs(rng.normal(30, 20, n)), np.maximum(base, close)),
-            "low": np.minimum(base - np.abs(rng.normal(30, 20, n)), np.minimum(base, close)),
+            "high": high_raw_clamped,
+            "low": low_raw_clamped,
             "close": close,
             "volume": rng.uniform(100, 1000, n),
         })

--- a/tests/envs/bybit/test_torch_env_futures_sltp.py
+++ b/tests/envs/bybit/test_torch_env_futures_sltp.py
@@ -775,12 +775,14 @@ class TestWithReplayData:
         n = 200
         timestamps = pd.date_range("2024-01-01", periods=n, freq="1min")
         base = 50000 + np.cumsum(np.random.default_rng(42).normal(0, 50, n))
+        # close drawn off base can land outside a high/low drawn off base alone (#326).
+        close = base + np.random.default_rng(45).normal(0, 20, n)
         return pd.DataFrame({
             "timestamp": timestamps,
             "open": base,
-            "high": base + np.abs(np.random.default_rng(43).normal(30, 20, n)),
-            "low": base - np.abs(np.random.default_rng(44).normal(30, 20, n)),
-            "close": base + np.random.default_rng(45).normal(0, 20, n),
+            "high": np.maximum(base + np.abs(np.random.default_rng(43).normal(30, 20, n)), np.maximum(base, close)),
+            "low": np.minimum(base - np.abs(np.random.default_rng(44).normal(30, 20, n)), np.minimum(base, close)),
+            "close": close,
             "volume": np.random.default_rng(46).uniform(100, 1000, n),
         })
 

--- a/tests/envs/offline/test_sampler.py
+++ b/tests/envs/offline/test_sampler.py
@@ -2212,11 +2212,11 @@ class TestObservationTimeframesShareOneInstant:
 
 
 @pytest.mark.parametrize("field,value,ok", [
-    ("high", 99.0, False),    # high below the open
-    ("low", 101.0, False),    # low above the close
-    ("high", 100.0, True),    # flat bar: equality is well-formed
-    ("low", 100.0, True),
-], ids=["high-below-open", "low-above-close", "high-equals", "low-equals"])
+    ("high", 100.1, False),   # below close (100.2) but above open -- pins max, not min
+    ("low", 100.1, False),    # above open (100.0) but below close -- pins min, not max
+    ("high", 100.2, True),    # touching the higher of the two is well-formed
+    ("low", 100.0, True),     # touching the lower of the two is well-formed
+], ids=["high-below-close", "low-above-open", "high-equals-close", "low-equals-open"])
 def test_malformed_ohlc_is_rejected_at_ingestion(field, value, ok):
     """A bar whose high/low do not bracket open and close is refused (#326).
 
@@ -2226,11 +2226,14 @@ def test_malformed_ohlc_is_rejected_at_ingestion(field, value, ok):
     in each rule is the boundary-validation invariant; a guard that absorbs the nonsense
     makes it silent, which is what let ~100 tests build impossible candles unnoticed.
     """
+    # open != close deliberately: with them equal, max(open, close) == min(open, close)
+    # and the cells cannot tell the right operand from the wrong one -- comparing high
+    # against min instead of max would pass every case.
     n = 30
     df = pd.DataFrame({
         "timestamp": pd.date_range("2024-01-01", periods=n, freq="1min"),
         "open": [100.0] * n, "high": [100.5] * n,
-        "low": [99.5] * n, "close": [100.0] * n, "volume": [1000.0] * n,
+        "low": [99.5] * n, "close": [100.2] * n, "volume": [1000.0] * n,
     })
     df.loc[5, field] = value
 
@@ -2243,5 +2246,5 @@ def test_malformed_ohlc_is_rejected_at_ingestion(field, value, ok):
     if ok:
         build()
     else:
-        with pytest.raises(ValueError, match="Malformed OHLC at row 5"):
+        with pytest.raises(ValueError, match="position 5"):
             build()

--- a/tests/envs/offline/test_sampler.py
+++ b/tests/envs/offline/test_sampler.py
@@ -2209,3 +2209,39 @@ class TestObservationTimeframesShareOneInstant:
                 build()
         else:
             build()  # must not raise
+
+
+@pytest.mark.parametrize("field,value,ok", [
+    ("high", 99.0, False),    # high below the open
+    ("low", 101.0, False),    # low above the close
+    ("high", 100.0, True),    # flat bar: equality is well-formed
+    ("low", 100.0, True),
+], ids=["high-below-open", "low-above-close", "high-equals", "low-equals"])
+def test_malformed_ohlc_is_rejected_at_ingestion(field, value, ok):
+    """A bar whose high/low do not bracket open and close is refused (#326).
+
+    Every exit rule downstream reads the extreme to decide whether a level was touched
+    and the open to price a gapped fill, so on a malformed row those two disagree and the
+    engines can answer differently from one another. Validating here rather than guarding
+    in each rule is the boundary-validation invariant; a guard that absorbs the nonsense
+    makes it silent, which is what let ~100 tests build impossible candles unnoticed.
+    """
+    n = 30
+    df = pd.DataFrame({
+        "timestamp": pd.date_range("2024-01-01", periods=n, freq="1min"),
+        "open": [100.0] * n, "high": [100.5] * n,
+        "low": [99.5] * n, "close": [100.0] * n, "volume": [1000.0] * n,
+    })
+    df.loc[5, field] = value
+
+    def build():
+        MarketDataObservationSampler(
+            df, time_frames=[TimeFrame(1, TimeFrameUnit.Minute)], window_sizes=[5],
+            execute_on=TimeFrame(1, TimeFrameUnit.Minute),
+        )
+
+    if ok:
+        build()
+    else:
+        with pytest.raises(ValueError, match="Malformed OHLC at row 5"):
+            build()

--- a/tests/envs/offline/test_sampler.py
+++ b/tests/envs/offline/test_sampler.py
@@ -2220,9 +2220,9 @@ class TestObservationTimeframesShareOneInstant:
 def test_malformed_ohlc_is_rejected_at_ingestion(field, value, ok):
     """A bar whose high/low do not bracket open and close is refused (#326).
 
-    Every exit rule downstream reads the extreme to decide whether a level was touched
-    and the open to price a gapped fill, so on a malformed row those two disagree and the
-    engines can answer differently from one another. Validating here rather than guarding
+    Every exit rule reads the extreme to decide whether a level was touched, and the
+    scalar stop-loss additionally reads the open to price a gapped fill, so on a malformed
+    row those two disagree and the engines can answer differently from one another. Validating here rather than guarding
     in each rule is the boundary-validation invariant; a guard that absorbs the nonsense
     makes it silent, which is what let ~100 tests build impossible candles unnoticed.
     """

--- a/tests/envs/okx/conftest.py
+++ b/tests/envs/okx/conftest.py
@@ -181,13 +181,18 @@ def replay_df():
     n = 200
     rng = np.random.default_rng(42)
     base = 50000 + np.cumsum(rng.normal(0, 50, n))
-    # close drawn off base can land outside a high/low drawn off base alone (#326).
+    # Drawn in the original order so the RNG stream is unchanged, then clamped:
+    # a close drawn off base can land outside a high/low drawn off base alone (#326).
+    high_raw = base + np.abs(rng.normal(30, 20, n))
+    low_raw = base - np.abs(rng.normal(30, 20, n))
     close = base + rng.normal(0, 20, n)
+    high_raw_clamped = np.maximum(high_raw, np.maximum(base, close))
+    low_raw_clamped = np.minimum(low_raw, np.minimum(base, close))
     return pd.DataFrame({
         "timestamp": pd.date_range("2024-01-01", periods=n, freq="1min"),
         "open": base,
-        "high": np.maximum(base + np.abs(rng.normal(30, 20, n)), np.maximum(base, close)),
-        "low": np.minimum(base - np.abs(rng.normal(30, 20, n)), np.minimum(base, close)),
+        "high": high_raw_clamped,
+        "low": low_raw_clamped,
         "close": close,
         "volume": rng.uniform(100, 1000, n),
     })

--- a/tests/envs/okx/conftest.py
+++ b/tests/envs/okx/conftest.py
@@ -181,11 +181,13 @@ def replay_df():
     n = 200
     rng = np.random.default_rng(42)
     base = 50000 + np.cumsum(rng.normal(0, 50, n))
+    # close drawn off base can land outside a high/low drawn off base alone (#326).
+    close = base + rng.normal(0, 20, n)
     return pd.DataFrame({
         "timestamp": pd.date_range("2024-01-01", periods=n, freq="1min"),
         "open": base,
-        "high": base + np.abs(rng.normal(30, 20, n)),
-        "low": base - np.abs(rng.normal(30, 20, n)),
-        "close": base + rng.normal(0, 20, n),
+        "high": np.maximum(base + np.abs(rng.normal(30, 20, n)), np.maximum(base, close)),
+        "low": np.minimum(base - np.abs(rng.normal(30, 20, n)), np.minimum(base, close)),
+        "close": close,
         "volume": rng.uniform(100, 1000, n),
     })

--- a/tests/envs/test_fractional_actions.py
+++ b/tests/envs/test_fractional_actions.py
@@ -34,11 +34,16 @@ def sample_df():
     dates = pd.date_range(start='2024-01-01', periods=1000, freq='1Min')
     close_prices = 50000 + np.cumsum(np.random.randn(1000) * 100)  # Random walk around 50k
 
+    # high/low drawn off close alone can land inside a separately drawn open, giving a
+    # bar that claims a high below its own open (#326).
+    open_prices = close_prices + np.random.randn(1000) * 10
+    high_prices = close_prices + np.abs(np.random.randn(1000) * 20)
+    low_prices = close_prices - np.abs(np.random.randn(1000) * 20)
     df = pd.DataFrame({
         'timestamp': dates,
-        'open': close_prices + np.random.randn(1000) * 10,
-        'high': close_prices + np.abs(np.random.randn(1000) * 20),
-        'low': close_prices - np.abs(np.random.randn(1000) * 20),
+        'open': open_prices,
+        'high': np.maximum(high_prices, np.maximum(open_prices, close_prices)),
+        'low': np.minimum(low_prices, np.minimum(open_prices, close_prices)),
         'close': close_prices,
         'volume': np.random.randint(100, 1000, 1000)
     })

--- a/tests/envs/transforms/test_coverage_tracker.py
+++ b/tests/envs/transforms/test_coverage_tracker.py
@@ -24,11 +24,15 @@ def simple_df():
     dates = pd.date_range('2024-01-01', periods=n, freq='1min')
     close = 100 + np.cumsum(np.random.randn(n) * 0.1)
 
+    # high/low drawn off close alone can land inside a separately drawn open (#326).
+    open_ = close + np.random.randn(n) * 0.05
+    high = close + np.abs(np.random.randn(n) * 0.1)
+    low = close - np.abs(np.random.randn(n) * 0.1)
     df = pd.DataFrame({
         'timestamp': dates,
-        'open': close + np.random.randn(n) * 0.05,
-        'high': close + np.abs(np.random.randn(n) * 0.1),
-        'low': close - np.abs(np.random.randn(n) * 0.1),
+        'open': open_,
+        'high': np.maximum(high, np.maximum(open_, close)),
+        'low': np.minimum(low, np.minimum(open_, close)),
         'close': close,
         'volume': np.random.randint(100, 1000, n),
     })

--- a/tests/envs/transforms/test_timestamp.py
+++ b/tests/envs/transforms/test_timestamp.py
@@ -22,12 +22,16 @@ def simple_df():
     dates = pd.date_range("2024-01-01", periods=n, freq="1min")
     close = 100 + np.cumsum(np.random.randn(n) * 0.1)
 
+    # high/low drawn off close alone can land inside a separately drawn open (#326).
+    open_ = close + np.random.randn(n) * 0.05
+    high = close + np.abs(np.random.randn(n) * 0.1)
+    low = close - np.abs(np.random.randn(n) * 0.1)
     return pd.DataFrame(
         {
             "timestamp": dates,
-            "open": close + np.random.randn(n) * 0.05,
-            "high": close + np.abs(np.random.randn(n) * 0.1),
-            "low": close - np.abs(np.random.randn(n) * 0.1),
+            "open": open_,
+            "high": np.maximum(high, np.maximum(open_, close)),
+            "low": np.minimum(low, np.minimum(open_, close)),
             "close": close,
             "volume": np.random.randint(100, 1000, n),
         }

--- a/torchtrade/envs/offline/infrastructure/sampler.py
+++ b/torchtrade/envs/offline/infrastructure/sampler.py
@@ -43,8 +43,9 @@ class MarketDataObservationSampler:
             )
 
         # A bar whose high/low do not bracket its open and close is not a bar. Every exit
-        # rule downstream reads the extreme to decide whether a level was touched and the
-        # open to price a gapped fill, so on a malformed row those two disagree (#326).
+        # rule reads the extreme to decide whether a level was touched, and the scalar
+        # stop-loss additionally reads the open to price a gapped fill (#280) -- so on a
+        # malformed row those two disagree, and the engines can answer differently (#326).
         # Rejecting here rather than guarding in the rules is the boundary-validation
         # invariant: a guard that absorbs the nonsense makes it silent.
         # On numpy arrays rather than DataFrame.max(axis=1), which materialises a

--- a/torchtrade/envs/offline/infrastructure/sampler.py
+++ b/torchtrade/envs/offline/infrastructure/sampler.py
@@ -47,16 +47,19 @@ class MarketDataObservationSampler:
         # open to price a gapped fill, so on a malformed row those two disagree (#326).
         # Rejecting here rather than guarding in the rules is the boundary-validation
         # invariant: a guard that absorbs the nonsense makes it silent.
-        bad = (
-            (df["high"] < df[["open", "close"]].max(axis=1))
-            | (df["low"] > df[["open", "close"]].min(axis=1))
-        )
+        # On numpy arrays rather than DataFrame.max(axis=1), which materialises a
+        # two-column copy twice -- 287ms vs 7.6ms on a 2.5M-row frame, paid once per
+        # ParallelEnv worker.
+        o, h, l, c = (df[k].to_numpy() for k in ("open", "high", "low", "close"))
+        bad = (h < np.maximum(o, c)) | (l > np.minimum(o, c))
         if bad.any():
-            row = df.loc[df.index[bad][0]]
+            first = int(np.argmax(bad))
             raise ValueError(
-                f"Malformed OHLC at row {df.index[bad][0]}: open={row['open']}, "
-                f"high={row['high']}, low={row['low']}, close={row['close']}. "
-                "high must be >= max(open, close) and low <= min(open, close)."
+                f"Malformed OHLC in {int(bad.sum())} of {len(df)} rows. First at position "
+                f"{first} (index {df.index[first]}): open={o[first]}, high={h[first]}, "
+                f"low={l[first]}, close={c[first]}. high must be >= max(open, close) and "
+                "low <= min(open, close) -- if you built these bars, clamp high/low around "
+                "open and close rather than drawing them off close alone."
             )
 
         # Canonical OHLCV-first order for self.df. The row[:5] contract itself comes from

--- a/torchtrade/envs/offline/infrastructure/sampler.py
+++ b/torchtrade/envs/offline/infrastructure/sampler.py
@@ -42,6 +42,23 @@ class MarketDataObservationSampler:
                 f"Got columns: {list(df.columns)}"
             )
 
+        # A bar whose high/low do not bracket its open and close is not a bar. Every exit
+        # rule downstream reads the extreme to decide whether a level was touched and the
+        # open to price a gapped fill, so on a malformed row those two disagree (#326).
+        # Rejecting here rather than guarding in the rules is the boundary-validation
+        # invariant: a guard that absorbs the nonsense makes it silent.
+        bad = (
+            (df["high"] < df[["open", "close"]].max(axis=1))
+            | (df["low"] > df[["open", "close"]].min(axis=1))
+        )
+        if bad.any():
+            row = df.loc[df.index[bad][0]]
+            raise ValueError(
+                f"Malformed OHLC at row {df.index[bad][0]}: open={row['open']}, "
+                f"high={row['high']}, low={row['low']}, close={row['close']}. "
+                "high must be >= max(open, close) and low <= min(open, close)."
+            )
+
         # Canonical OHLCV-first order for self.df. The row[:5] contract itself comes from
         # ohlcv_agg's key order, since pandas orders .agg(dict) output by dict key.
         ohlcv_cols = ["open", "high", "low", "close", "volume"]

--- a/torchtrade/envs/offline/sequential_sltp.py
+++ b/torchtrade/envs/offline/sequential_sltp.py
@@ -244,14 +244,13 @@ class SequentialTradingEnvSLTP(SequentialTradingEnv):
         low_price = ohlcv["low"]
         close_price = ohlcv["close"]
 
-        # Open, extreme and close are all tested for each side, and the stop is tested
-        # before the take-profit. On a well-formed bar the extreme subsumes the other two,
-        # so this is the plainer statement of the same rule -- verified identical over
-        # 300k well-formed bars. It differs only where high/low fail to bracket open and
-        # close, and there it is the STRICTLY more pessimistic form: the stop still wins,
-        # where an ordering that deferred the close test would hand the bar to the
-        # take-profit. Nothing validates OHLC at ingestion, so that case is reachable from
-        # a caller's DataFrame, and the pessimistic answer is the one to converge on.
+        # Stop before take-profit, deliberately (see the docstring's pessimism note).
+        #
+        # The extreme alone would do: since #326 the sampler rejects any bar whose high
+        # and low fail to bracket its open and close, so min(open, low, close) IS low on
+        # every bar that can reach here. The triple is kept because it states the rule
+        # without depending on that invariant holding -- these three lines were, until
+        # #316, forked across two engines that disagreed on exactly the malformed case.
         if self.position.position_size > 0:
             if self.stop_loss > 0 and min(open_price, low_price, close_price) <= self.stop_loss:
                 return "sl"

--- a/torchtrade/envs/offline/sequential_sltp.py
+++ b/torchtrade/envs/offline/sequential_sltp.py
@@ -246,11 +246,16 @@ class SequentialTradingEnvSLTP(SequentialTradingEnv):
 
         # Stop before take-profit, deliberately (see the docstring's pessimism note).
         #
-        # The extreme alone would do: since #326 the sampler rejects any bar whose high
-        # and low fail to bracket its open and close, so min(open, low, close) IS low on
-        # every bar that can reach here. The triple is kept because it states the rule
-        # without depending on that invariant holding -- these three lines were, until
-        # #316, forked across two engines that disagreed on exactly the malformed case.
+        # The extreme alone would do. #326 rejects malformed bars at ingestion, and
+        # resampling preserves that -- open/high/low/close aggregate as first/max/min/last,
+        # all selections from rows inside the bar, and `last` skips NaN, so the surviving
+        # close always comes from a row whose own high the max already covers (checked
+        # over 60 NaN-scattered frames: zero malformed resampled bars). So
+        # min(open, low, close) IS low here.
+        #
+        # The triple stays because it states the rule without depending on that chain:
+        # until #316 these three lines were forked across two engines whose only
+        # disagreement was on exactly the malformed case.
         if self.position.position_size > 0:
             if self.stop_loss > 0 and min(open_price, low_price, close_price) <= self.stop_loss:
                 return "sl"


### PR DESCRIPTION
Closes #326. Surfaced by @CharlieHelps while reviewing #325.

## The gap

Nothing validated that a bar satisfies `low <= min(open, close)` and `high >= max(open, close)`. Required *columns* were checked; the invariant they must satisfy was not.

That matters because every exit rule downstream reads the **extreme** to decide whether a level was touched, and the **open** to price a gapped fill (#280). On a malformed row those two disagree, and the engines can answer differently from one another — which is the divergence #325 had to resolve by converging on the pessimistic branch.

## The fix

One check in `MarketDataObservationSampler.__init__`, which is the boundary. Guarding inside each rule instead would absorb the nonsense and make it silent — precisely how this went unnoticed.

## What turning it on revealed

**74 failures + 32 errors.** But the cause was concentrated in **seven builders**, all the same shape — `high`/`low` drawn off `close` alone while `open` is drawn separately, so a bar can claim a high below its own open:

| builder | blast radius |
|---|---|
| `conftest.py` `trending_up_df` / `trending_down_df` | **every** offline, vectorized and equivalence failure |
| 3 inline builders (`test_fractional_actions`, `test_coverage_tracker`, `test_timestamp`) | 61 |
| `replay_df`, copy-pasted across 7 exchange test files in 2 variants | 14 |

All are clamped the way `conftest.sample_ohlcv_df` already did, so no fixture changes shape or distribution beyond becoming well-formed.

## What this unblocks

#325 chose the more pessimistic trigger branch specifically because malformed rows were reachable. With this in place the trigger rules only ever see bars where the extreme subsumes open and close, so that reasoning becomes belt-and-braces rather than load-bearing.

## Testing

New parametrized test pins the boundary check itself (rejects a high below the open and a low above the close; accepts equality, since a flat bar is well-formed). Suite: **2404 passed, 19 skipped** (excluding the slow `test_examples` subprocess job, which CI runs).