### PR TITLE
fix(envs): walk the offset's calendar when relabelling coarse bars to their END (#320)

### DIFF
--- a/tests/envs/offline/test_sampler.py
+++ b/tests/envs/offline/test_sampler.py
@@ -2248,3 +2248,41 @@ def test_malformed_ohlc_is_rejected_at_ingestion(field, value, ok):
     else:
         with pytest.raises(ValueError, match="position 5"):
             build()
+
+
+def test_coarse_bar_is_not_visible_before_a_dst_lengthened_day_closes():
+    """A Day bin spanning a DST fall-back is 25h wide, not 24h (#320).
+
+    Coarse frames are relabelled to their END so only completed bars are visible. Adding
+    a FIXED 1D to the bin's start labels a 25h bin an hour before it actually closed, so
+    the agent sees it early -- lookahead, not staleness.
+
+    The mirror of this on the execution side is refused outright by the guard from #282
+    (tz-aware plus execute_on >= Day). That guard does not reach here: a Day OBSERVATION
+    frame under a sub-day execute_on is a supported config, and is what this pins.
+    """
+    execute_on = TimeFrame(1, TimeFrameUnit.Hour)
+    idx = pd.date_range("2024-10-28", "2024-11-08", freq="1h", tz="America/New_York")
+    close = 100 + np.arange(len(idx), dtype=float)
+    df = pd.DataFrame({
+        "timestamp": idx, "open": close, "high": close + 1, "low": close - 1,
+        "close": close, "volume": 1000.0,
+    })
+
+    sampler = MarketDataObservationSampler(
+        df=df,
+        time_frames=[execute_on, TimeFrame(1, TimeFrameUnit.Day)],
+        window_sizes=[4, 2],
+        execute_on=execute_on,
+    )
+
+    # The truth: each bin's real close is where the NEXT bin starts.
+    raw = df.set_index("timestamp").resample("1D").agg({"close": "last"}).dropna()
+    true_ends = raw.index.shift(1, freq="1D")
+
+    labelled = sampler.resampled_dfs["1Day"].index
+    early = [(a, b) for a, b in zip(labelled, true_ends) if a < b]
+    assert not early, (
+        f"{len(early)} coarse bar(s) labelled before they closed, e.g. {early[0][0]} "
+        f"vs a real close of {early[0][1]} -- the agent would see them early"
+    )

--- a/tests/envs/offline/test_sampler.py
+++ b/tests/envs/offline/test_sampler.py
@@ -2,6 +2,8 @@
 Tests for MarketDataObservationSampler.
 """
 
+import warnings
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -2250,39 +2252,58 @@ def test_malformed_ohlc_is_rejected_at_ingestion(field, value, ok):
             build()
 
 
-def test_coarse_bar_is_not_visible_before_a_dst_lengthened_day_closes():
-    """A Day bin spanning a DST fall-back is 25h wide, not 24h (#320).
+@pytest.mark.parametrize("start,days,gappy", [
+    ("2024-10-28", 11, False),  # window starts BEFORE the fall-back
+    ("2024-11-03", 8, False),   # window starts ON it -- poisons any regenerated grid
+    ("2024-03-08", 8, False),   # spring forward: the 23h bin
+    ("2024-11-01", 10, True),   # a dropped day, as a weekend or halt gives
+], ids=["before-transition", "on-transition", "spring-forward", "gappy"])
+def test_a_coarse_bar_is_never_visible_before_its_bin_closes(start, days, gappy):
+    """A tz-aware Day bin is 23h or 25h wide across DST, not 24h (#320).
 
-    Coarse frames are relabelled to their END so only completed bars are visible. Adding
-    a FIXED 1D to the bin's start labels a 25h bin an hour before it actually closed, so
-    the agent sees it early -- lookahead, not staleness.
+    Coarse frames are relabelled to their END so only completed bars are visible. Any
+    arithmetic on a bar's own label gets this wrong: a fixed +1D labels a 25h bin an hour
+    before it closed, so the agent sees it early. That is lookahead, not staleness.
 
-    The mirror of this on the execution side is refused outright by the guard from #282
-    (tz-aware plus execute_on >= Day). That guard does not reach here: a Day OBSERVATION
-    frame under a sub-day execute_on is a supported config, and is what this pins.
+    The four cells are the four ways label arithmetic fails, and each caught a real
+    defect. `on-transition` is why DatetimeIndex.shift is not the fix -- it regenerates
+    from bin_starts[0] + period, so a window starting on the transition day is wrong for
+    EVERY bar, not just one. `gappy` is why it silently is not the fix either: dropna
+    clears index.freq and .shift then degrades to the fixed arithmetic it replaced.
+
+    The oracle deliberately does not reuse the production code path: an oracle built from
+    the same call under test moves with it and is blind to exactly these regressions.
     """
     execute_on = TimeFrame(1, TimeFrameUnit.Hour)
-    idx = pd.date_range("2024-10-28", "2024-11-08", freq="1h", tz="America/New_York")
+    tz = "America/New_York"
+    idx = pd.date_range(pd.Timestamp(start, tz=tz), periods=days * 24, freq="1h")
     close = 100 + np.arange(len(idx), dtype=float)
     df = pd.DataFrame({
         "timestamp": idx, "open": close, "high": close + 1, "low": close - 1,
         "close": close, "volume": 1000.0,
     })
+    if gappy:
+        cut = pd.Timestamp(start, tz=tz)
+        df = df[(df.timestamp < cut + pd.Timedelta("3D")) | (df.timestamp >= cut + pd.Timedelta("4D"))]
 
-    sampler = MarketDataObservationSampler(
-        df=df,
-        time_frames=[execute_on, TimeFrame(1, TimeFrameUnit.Day)],
-        window_sizes=[4, 2],
-        execute_on=execute_on,
-    )
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")  # the gappy cell trips the data-gap banner
+        sampler = MarketDataObservationSampler(
+            df=df,
+            time_frames=[execute_on, TimeFrame(1, TimeFrameUnit.Day)],
+            window_sizes=[4, 2],
+            execute_on=execute_on,
+        )
 
-    # The truth: each bin's real close is where the NEXT bin starts.
-    raw = df.set_index("timestamp").resample("1D").agg({"close": "last"}).dropna()
-    true_ends = raw.index.shift(1, freq="1D")
+    # Independent oracle: each bin's real close is where the next bin starts, taken off a
+    # date_range grid rather than by shifting any label.
+    full = df.set_index("timestamp").resample("1D").agg({"close": "last"})
+    edges = pd.date_range(full.index[0], periods=len(full) + 1, freq="1D", tz=tz)
+    true_ends = edges[1:][full.index.get_indexer(full.dropna().index)]
 
     labelled = sampler.resampled_dfs["1Day"].index
     early = [(a, b) for a, b in zip(labelled, true_ends) if a < b]
     assert not early, (
-        f"{len(early)} coarse bar(s) labelled before they closed, e.g. {early[0][0]} "
-        f"vs a real close of {early[0][1]} -- the agent would see them early"
+        f"{len(early)} of {len(labelled)} coarse bar(s) labelled before they closed, "
+        f"e.g. {early[0][0]} vs a real close of {early[0][1]} -- seen early"
     )

--- a/tests/envs/offline/test_sampler.py
+++ b/tests/envs/offline/test_sampler.py
@@ -2,6 +2,7 @@
 Tests for MarketDataObservationSampler.
 """
 
+import datetime
 import warnings
 
 import numpy as np
@@ -2252,39 +2253,48 @@ def test_malformed_ohlc_is_rejected_at_ingestion(field, value, ok):
             build()
 
 
-@pytest.mark.parametrize("start,days,gappy", [
-    ("2024-10-28", 11, False),  # window starts BEFORE the fall-back
-    ("2024-11-03", 8, False),   # window starts ON it -- poisons any regenerated grid
-    ("2024-03-08", 8, False),   # spring forward: the 23h bin
-    ("2024-11-01", 10, True),   # a dropped day, as a weekend or halt gives
-], ids=["before-transition", "on-transition", "spring-forward", "gappy"])
-def test_a_coarse_bar_is_never_visible_before_its_bin_closes(start, days, gappy):
+@pytest.mark.parametrize("start,days,gappy,tz", [
+    ("2024-10-28", 11, False, "America/New_York"),  # window starts BEFORE the fall-back
+    ("2024-11-03", 8, False, "America/New_York"),   # starts ON it -- poisons a regenerated grid
+    ("2024-03-08", 8, False, "America/New_York"),   # spring forward: the 23h bin, LATE not early
+    ("2024-11-01", 10, True, "America/New_York"),   # a dropped calendar day (weekend, halt)
+    ("2024-03-07", 8, False, "America/Havana"),     # DST step lands ON local midnight
+], ids=["before-transition", "on-transition", "spring-forward", "gappy", "midnight-dst"])
+def test_a_coarse_bar_is_labelled_exactly_when_its_bin_closes(start, days, gappy, tz):
     """A tz-aware Day bin is 23h or 25h wide across DST, not 24h (#320).
 
     Coarse frames are relabelled to their END so only completed bars are visible. Any
     arithmetic on a bar's own label gets this wrong: a fixed +1D labels a 25h bin an hour
-    before it closed, so the agent sees it early. That is lookahead, not staleness.
+    before it closed, so the agent sees it early -- lookahead, not staleness.
 
-    The four cells are the four ways label arithmetic fails, and each caught a real
-    defect. `on-transition` is why DatetimeIndex.shift is not the fix -- it regenerates
-    from bin_starts[0] + period, so a window starting on the transition day is wrong for
-    EVERY bar, not just one. `gappy` is why it silently is not the fix either: dropna
-    clears index.freq and .shift then degrades to the fixed arithmetic it replaced.
+    Each cell is a way that arithmetic fails, and each caught a real defect:
+      on-transition   DatetimeIndex.shift regenerates from bin_starts[0] + period, so a
+                      window starting on the transition day is wrong for EVERY bar.
+      gappy           dropna clears index.freq and .shift silently degrades to the fixed
+                      arithmetic it replaced. The cut is on a LOCAL calendar boundary --
+                      an absolute 72h Timedelta straddles two dates across a 25h day and
+                      drops nothing.
+      spring-forward  the only LATE-direction case, which an "is not early" assertion
+                      cannot see.
+      midnight-dst    zones whose DST step lands on local midnight make that midnight
+                      nonexistent, where a tz-aware date_range raises but resample does
+                      not.
 
-    The oracle deliberately does not reuse the production code path: an oracle built from
-    the same call under test moves with it and is blind to exactly these regressions.
+    Asserts EQUALITY, not absence of lookahead: a coarse frame stale by whole bins is
+    also wrong, and passes any one-sided check. The oracle is the calendar definition of
+    a day boundary -- it uses neither resample nor date_range, so it cannot move with the
+    implementation the way a re-derived one would.
     """
     execute_on = TimeFrame(1, TimeFrameUnit.Hour)
-    tz = "America/New_York"
-    idx = pd.date_range(pd.Timestamp(start, tz=tz), periods=days * 24, freq="1h")
+    idx = pd.date_range(pd.Timestamp(start, tz="UTC"), periods=days * 24, freq="1h").tz_convert(tz)
     close = 100 + np.arange(len(idx), dtype=float)
     df = pd.DataFrame({
         "timestamp": idx, "open": close, "high": close + 1, "low": close - 1,
         "close": close, "volume": 1000.0,
     })
     if gappy:
-        cut = pd.Timestamp(start, tz=tz)
-        df = df[(df.timestamp < cut + pd.Timedelta("3D")) | (df.timestamp >= cut + pd.Timedelta("4D"))]
+        drop = sorted({t.date() for t in df.timestamp})[3]  # one whole LOCAL day
+        df = df[[t.date() != drop for t in df.timestamp]]
 
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")  # the gappy cell trips the data-gap banner
@@ -2295,15 +2305,14 @@ def test_a_coarse_bar_is_never_visible_before_its_bin_closes(start, days, gappy)
             execute_on=execute_on,
         )
 
-    # Independent oracle: each bin's real close is where the next bin starts, taken off a
-    # date_range grid rather than by shifting any label.
-    full = df.set_index("timestamp").resample("1D").agg({"close": "last"})
-    edges = pd.date_range(full.index[0], periods=len(full) + 1, freq="1D", tz=tz)
-    true_ends = edges[1:][full.index.get_indexer(full.dropna().index)]
+    # Oracle: a day bin ends at the next local calendar midnight. Pure definition.
+    dates = sorted({t.date() for t in df.timestamp})
+    want = pd.DatetimeIndex(
+        [pd.Timestamp(d + datetime.timedelta(days=1)).tz_localize(
+            tz, nonexistent="shift_forward", ambiguous=True) for d in dates]
+    )
 
-    labelled = sampler.resampled_dfs["1Day"].index
-    early = [(a, b) for a, b in zip(labelled, true_ends) if a < b]
-    assert not early, (
-        f"{len(early)} of {len(labelled)} coarse bar(s) labelled before they closed, "
-        f"e.g. {early[0][0]} vs a real close of {early[0][1]} -- seen early"
+    got = sampler.resampled_dfs["1Day"].index
+    assert list(got) == list(want), (
+        f"labelled {list(got)[:3]}... but the bins close at {list(want)[:3]}..."
     )

--- a/torchtrade/envs/offline/infrastructure/sampler.py
+++ b/torchtrade/envs/offline/infrastructure/sampler.py
@@ -126,11 +126,12 @@ class MarketDataObservationSampler:
         self.resampled_dfs: Dict[str, pd.DataFrame] = {}
         first_time_stamps = []
         for tf, proc_fn in zip(time_frames, processing_fns):
-            resampled = (
-                self.df.resample(tf.to_pandas_freq())
-                .agg(full_agg)
-                .dropna(subset=list(ohlcv_agg.keys()))
-            )
+            binned = self.df.resample(tf.to_pandas_freq()).agg(full_agg)
+            # The complete bin grid, before empty bins are dropped. A bin's real END is
+            # where the NEXT bin starts, so the END labels below are read off this grid
+            # rather than computed from a bar's own label (#320).
+            bin_starts = binned.index
+            resampled = binned.dropna(subset=list(ohlcv_agg.keys()))
             # Forward-fill auxiliary NaN (sparse aux data persists last known value)
             if aux_cols:
                 resampled[aux_cols] = resampled[aux_cols].ffill().fillna(0)
@@ -140,12 +141,27 @@ class MarketDataObservationSampler:
             # Only completed bars will be visible to the agent at any execution time
             # Only shift timeframes that are HIGHER (coarser) than the execution timeframe
             if tf > execute_on:
-                # .shift(freq=) walks the offset's own calendar rather than adding a fixed
-                # duration. They agree everywhere except a tz-aware Day-or-longer bin
-                # across a DST boundary, where the real bin is 23h or 25h wide: a fixed
-                # +1D there labels a 25h bin an hour before it closed, making it visible
-                # early. That is lookahead, not staleness (#320).
-                resampled.index = resampled.index.shift(1, freq=tf.to_pandas_freq())
+                # Relabel each bar to where its bin actually ends: the start of the next
+                # bin on the full grid. Arithmetic on the label instead -- whether a fixed
+                # +period or DatetimeIndex.shift -- is wrong on a tz-aware Day-or-longer
+                # frame, because those bins follow LOCAL midnight and are 23h or 25h wide
+                # across a DST transition. A fixed +1D labels a 25h bin an hour before it
+                # closed, i.e. shows it early: lookahead, not staleness (#320).
+                #
+                # Reading the grid rather than shifting also survives the two cases that
+                # make .shift unusable here: it regenerates from `bin_starts[0] + period`,
+                # so a window STARTING on a transition day is off for every bar, and it
+                # silently degrades to fixed arithmetic once dropna clears index.freq --
+                # which any gap (a weekend, a halt) does.
+                edges = pd.date_range(
+                    bin_starts[0], periods=len(bin_starts) + 1,
+                    freq=tf.to_pandas_freq(), tz=bin_starts.tz,
+                )
+                # rename: the END labels must keep the index's name, which the
+                # feature-processing path below reset_index()es on.
+                resampled.index = edges[1:][
+                    bin_starts.get_indexer(resampled.index)
+                ].rename(bin_starts.name)
 
             if proc_fn is not None:
                 resampled = proc_fn(resampled)

--- a/torchtrade/envs/offline/infrastructure/sampler.py
+++ b/torchtrade/envs/offline/infrastructure/sampler.py
@@ -136,6 +136,11 @@ class MarketDataObservationSampler:
             if aux_cols:
                 resampled[aux_cols] = resampled[aux_cols].ffill().fillna(0)
 
+            # Before the relabel: it reads bin_starts[0], which IndexErrors on an empty
+            # frame and would mask this message when a coarse frame is listed first.
+            if len(resampled) == 0:
+                raise ValueError(f"Resampled dataframe for timeframe {tf.obs_key_freq()} is empty")
+
             # Fix lookahead bias: shift higher timeframe bars forward by their period
             # This ensures bars are indexed by their END time, not START time
             # Only completed bars will be visible to the agent at any execution time
@@ -153,10 +158,25 @@ class MarketDataObservationSampler:
                 # so a window STARTING on a transition day is off for every bar, and it
                 # silently degrades to fixed arithmetic once dropna clears index.freq --
                 # which any gap (a weekend, a halt) does.
-                edges = pd.date_range(
-                    bin_starts[0], periods=len(bin_starts) + 1,
-                    freq=tf.to_pandas_freq(), tz=bin_starts.tz,
-                )
+                n_edges = len(bin_starts) + 1
+                freq = tf.to_pandas_freq()
+                if bin_starts.tz is None or tf < TimeFrame(1, TimeFrameUnit.Day):
+                    edges = pd.date_range(
+                        bin_starts[0], periods=n_edges, freq=freq, tz=bin_starts.tz
+                    )
+                else:
+                    # Day-or-longer tz-aware bins follow LOCAL midnight, and in zones whose
+                    # DST step lands ON midnight (Havana, Beirut, Santiago, ...) that
+                    # midnight is nonexistent or ambiguous -- tz-aware date_range raises
+                    # there while resample resolves it. Walk the wall clock and re-localize
+                    # the way resample's own binner does, so those zones keep working.
+                    # Sub-day bins must NOT take this path: they walk absolute time, and a
+                    # wall-clock walk would skip an hour at spring-forward.
+                    edges = pd.date_range(
+                        bin_starts[0].tz_localize(None), periods=n_edges, freq=freq
+                    ).tz_localize(
+                        bin_starts.tz, nonexistent="shift_forward", ambiguous=True
+                    )
                 # rename: the END labels must keep the index's name, which the
                 # feature-processing path below reset_index()es on.
                 resampled.index = edges[1:][
@@ -178,9 +198,6 @@ class MarketDataObservationSampler:
                 if "index" in resampled.columns:
                     resampled = resampled.drop(columns=["index"])
 
-            # ensure not empty
-            if len(resampled) == 0:
-                raise ValueError(f"Resampled dataframe for timeframe {tf.obs_key_freq()} is empty")
 
             self.resampled_dfs[tf.obs_key_freq()] = resampled
             first_time_stamps.append(resampled.index.min())

--- a/torchtrade/envs/offline/infrastructure/sampler.py
+++ b/torchtrade/envs/offline/infrastructure/sampler.py
@@ -140,8 +140,12 @@ class MarketDataObservationSampler:
             # Only completed bars will be visible to the agent at any execution time
             # Only shift timeframes that are HIGHER (coarser) than the execution timeframe
             if tf > execute_on:
-                offset = pd.Timedelta(tf.to_pandas_freq())
-                resampled.index = resampled.index + offset
+                # .shift(freq=) walks the offset's own calendar rather than adding a fixed
+                # duration. They agree everywhere except a tz-aware Day-or-longer bin
+                # across a DST boundary, where the real bin is 23h or 25h wide: a fixed
+                # +1D there labels a 25h bin an hour before it closed, making it visible
+                # early. That is lookahead, not staleness (#320).
+                resampled.index = resampled.index.shift(1, freq=tf.to_pandas_freq())
 
             if proc_fn is not None:
                 resampled = proc_fn(resampled)


### PR DESCRIPTION
Closes #320. Found during the #282 review; the defect itself predates it (#10).

## The bug

Coarse frames are relabelled to their END time so only *completed* bars are visible. The relabel added a **fixed** `pd.Timedelta`. A tz-aware `1D` bin follows **local midnight** and is 23h or 25h wide across DST, so on `America/New_York`:

```
bin starting 2024-11-03 00:00-04:00  -> labelled 2024-11-03 23:00-05:00
                                        but really closes 2024-11-04 00:00-05:00
```

Visible an hour before it closed — **lookahead, not staleness**.

## The fix

Read a bin's END **off the grid** — where the next bin starts — rather than doing arithmetic on the bar's own label.

## Two wrong answers rejected along the way

Both were caught by review, and both are why the fix looks the way it does:

**`DatetimeIndex.shift(1, freq=)`** — my first attempt, and *worse than the bug*. `Day` is a `Tick` in pandas, so `.shift` only differs from `+` by regenerating the range from `bin_starts[0] + period`. Consequences: a window starting **on** a transition day was wrong for every bar (8/8 early vs main's 1/8, introducing 19 lookahead events where main had none); `dropna` clears `index.freq`, so on any gappy frame it silently degraded to the arithmetic it replaced; and it could change the index length and raise.

**Rejecting tz-aware input** (#320's other suggestion) — over-rejects. UTC has no DST, so its Day bins really are 24h and the old arithmetic was correct for them.

## One regression the fix itself introduced, then fixed

`pd.date_range(..., tz=)` **raises where `resample` succeeds**, in zones whose DST step lands on local midnight (Havana, Beirut, Santiago, Asunción, Cairo, Tehran) — reachable with `execute_on=1h` + a coarse `1Day` frame, which #282's guard does not cover. Day-or-longer edges now walk the wall clock and re-localize the way `resample`'s own binner does. The branch is required, not tidiness: sub-day bins walk *absolute* time and a wall-clock walk would skip an hour at spring-forward.

## Verification

Against an oracle using neither `resample` nor `date_range` — the calendar definition of a day boundary:

| scenario | main | `.shift` | **this** |
|---|---|---|---|
| starts before transition | 1 early | clean | **clean** |
| starts **on** transition | 1 early | **8 early** | **clean** |
| spring forward | 1 late | clean | **clean** |
| gappy | 1 early | clean | **clean** |
| midnight-DST zone | ok | ok | **clean** (branch raised before the fix) |
| UTC / tz-naive | clean | clean | **clean** |

Byte-identical on every fixture that ships: 1,384 `resampled_dfs` index constructions across the offline + replay suites, **0 differing hashes**. Perf is a wash (0.458s vs 0.462s on 1M rows).

## Testing

5 cells, each justified by a distinct failure mode, asserting **equality** rather than "not early" — a frame stale by whole bins passed the one-sided version. Mutants killed: fixed offset 4/5, `.shift` 1/5, off-by-one-bin 5/5, off-by-two 5/5 (the last two killed **nothing** before).

#282's guard is untouched and still needed — it covers the execution side, a different mechanism.
