### PR TITLE
fix(envs): let a stop that price crosses first beat the liquidation (#300)

### DIFF
--- a/tests/envs/offline/test_sequential_sltp.py
+++ b/tests/envs/offline/test_sequential_sltp.py
@@ -1270,12 +1270,11 @@ class TestLiquidationVsBracketOnADoubleBreachBar:
     sits on the same side as liquidation, so price cannot reach the further level without
     crossing the nearer one, and the bar's own extreme says which. Booking a liquidation
     where the stop was crossed first is not pessimism but an outcome the data contradicts:
-    400 instead of 5000 here.
+    400 instead of 5000 here, a 12.5x gap.
 
-    Nothing held this. A double-breach bar has existed since
-    TestSLTPRegression::test_liquidation_triggers_on_next_bar_futures, but no test
-    asserted anything that *distinguishes* the two exits, so swapping the checks left
-    the whole offline suite green. All four quadrants of direction x trigger are
+    Nothing held this before #298: double-breach bars existed in the suite, but no test
+    asserted anything that *distinguishes* the two exits, so swapping the checks left the
+    whole offline suite green. All four quadrants of direction x trigger are
     covered because each is invisible to the other three: a reorder scoped to one of
     them passes every test the others pin.
     """

--- a/tests/envs/offline/test_sequential_sltp.py
+++ b/tests/envs/offline/test_sequential_sltp.py
@@ -1278,9 +1278,6 @@ class TestLiquidationVsBracketOnADoubleBreachBar:
     the whole offline suite green. All four quadrants of direction x trigger are
     covered because each is invisible to the other three: a reorder scoped to one of
     them passes every test the others pin.
-
-    All four quadrants of direction x trigger are covered because each is invisible to
-    the other three: a reorder scoped to one of them passes every test the others pin.
     """
 
     def test_a_bar_that_gapped_past_liquidation_still_liquidates(self):
@@ -1302,6 +1299,8 @@ class TestLiquidationVsBracketOnADoubleBreachBar:
             f"a gapped-open bar must liquidate, not fill the stop -- got "
             f"{env.history.action_types}"
         )
+        # 400 is an #314 number: the liquidation books at liq_price even though the bar
+        # opened below it. When that is fixed this expectation moves with it.
         assert env.balance == pytest.approx(400.0)
 
     # The action tuple is spelled out rather than derived: create_sltp_action_map
@@ -1358,10 +1357,6 @@ class TestLiquidationVsBracketOnADoubleBreachBar:
                 "a take-profit pre-empted the liquidation on a bar that breached both, "
                 f"where the ordering is genuinely unresolvable -- got {exits}"
             )
-        # Liquidation deliberately leaves the brackets armed, so the price can be read
-        # back afterwards. Asserting it lies INSIDE the bar pins the collision itself:
-        # a level moved off the wick and a wick shrunk off the level both fail here,
-        # where pinning the price as a constant would only catch the first.
         # Pins the collision itself: a level moved off the wick and a wick shrunk off the
         # level both fail here, where pinning the price as a constant catches only the
         # first. On a stop row the level is consumed by the exit, so it is read from the

--- a/tests/envs/offline/test_sequential_sltp.py
+++ b/tests/envs/offline/test_sequential_sltp.py
@@ -1145,7 +1145,7 @@ SHORT_TIGHT = ("short", 0.025, -0.025)
 
 
 def _run_sltp(actions, *, leverage, sl_levels, tp_levels, wick_high=None,
-              wick_low=None, include_close=False):
+              wick_low=None, wick_open=None, include_close=False):
     """Run `actions` through a flat 100.0 series carrying one wick at bar 20.
 
     reset() caches bar 10, so action k executes at bar 10+k and is exposed to bar
@@ -1166,6 +1166,8 @@ def _run_sltp(actions, *, leverage, sl_levels, tp_levels, wick_high=None,
         df.loc[20, "high"] = wick_high
     if wick_low is not None:
         df.loc[20, "low"] = wick_low
+    if wick_open is not None:  # a bar that GAPPED to its open rather than trading down to it
+        df.loc[20, "open"] = wick_open
 
     config = SequentialTradingEnvSLTPConfig(
         leverage=leverage, initial_cash=10000,
@@ -1256,9 +1258,19 @@ class TestAgentActionPrecedesNextBarTrigger:
         assert env.balance == pytest.approx(10000.0), "a flat round trip must not move the balance"
 
 
-class TestLiquidationTakesPriorityOverBrackets:
-    """When one bar breaches both a bracket and the liquidation price, the liquidation
-    must win (#298).
+class TestLiquidationVsBracketOnADoubleBreachBar:
+    """Which exit wins when one bar breaches both a bracket and liquidation (#298, #300).
+
+    Liquidation wins against a TAKE-PROFIT, and that is a pessimistic convention rather
+    than a physical claim: the two sit on opposite sides of entry, so a bar reaching both
+    says nothing about the order, and assuming the worse of two irreconcilable orderings
+    is the only sound choice -- the same reasoning as SL-before-TP.
+
+    The STOP-LOSS rows are the other case, and used to answer the same way (#300). A stop
+    sits on the same side as liquidation, so price cannot reach the further level without
+    crossing the nearer one, and the bar's own extreme says which. Booking a liquidation
+    where the stop was crossed first is not pessimism but an outcome the data contradicts:
+    400 instead of 5000 here.
 
     Nothing held this. A double-breach bar has existed since
     TestSLTPRegression::test_liquidation_triggers_on_next_bar_futures, but no test
@@ -1267,44 +1279,65 @@ class TestLiquidationTakesPriorityOverBrackets:
     covered because each is invisible to the other three: a reorder scoped to one of
     them passes every test the others pin.
 
-    What this pins is the env's documented pessimistic convention, not a claim about
-    physical fill order; #300 tracks whether the rule should be conditional. Either
-    way this class pins today's behaviour.
+    All four quadrants of direction x trigger are covered because each is invisible to
+    the other three: a reorder scoped to one of them passes every test the others pin.
     """
+
+    def test_a_bar_that_gapped_past_liquidation_still_liquidates(self):
+        """A stop nearer than liquidation does NOT save a position on a gapped bar.
+
+        The exemption rests on continuity -- price crossing the nearer level on its way to
+        the further one. A bar that OPENS past the liquidation price crossed nothing: the
+        margin was gone before it began, and no resting order could have worked first.
+
+        Same 10x long as the long-stop row (stop 95, liquidation 90.4), but the bar opens
+        at 85 rather than trading down to 88.
+        """
+        env = _run_sltp(
+            [HOLD] * 5 + [("long", -0.05, 0.50)] + [HOLD] * 4,
+            leverage=10, sl_levels=[-0.05], tp_levels=[0.50],
+            wick_low=85.0, wick_open=85.0,
+        )
+        assert "liquidation" in env.history.action_types, (
+            f"a gapped-open bar must liquidate, not fill the stop -- got "
+            f"{env.history.action_types}"
+        )
+        assert env.balance == pytest.approx(400.0)
 
     # The action tuple is spelled out rather than derived: create_sltp_action_map
     # stores a short as ("short", tp, sl) -- the pair swapped, not negated -- so a
     # derived tuple raises KeyError rather than opening the wrong position.
     @pytest.mark.parametrize(
-        "action,stoploss_levels,takeprofit_levels,wick_low,wick_high,armed", [
+        "action,stoploss_levels,takeprofit_levels,wick_low,wick_high,armed,expected_balance", [
             # 10x long: liquidation 90.4, SL 95, low 88 breaches both.
-            (("long", -0.05, 0.50), [-0.05], [0.50], 88.0, None, "stop_loss"),
+            (("long", -0.05, 0.50), [-0.05], [0.50], 88.0, None, "stop_loss", 5000.0),
             # 10x short: liquidation 109.6, SL 105, high 112 breaches both. The short
             # branches of _check_liquidation, _check_sltp_trigger and
             # _execute_liquidation are all separate code from the long ones.
-            (("short", 0.05, -0.50), [-0.50], [0.05], None, 112.0, "stop_loss"),
+            (("short", 0.05, -0.50), [-0.50], [0.05], None, 112.0, "stop_loss", 5000.0),
             # 10x long: liquidation 90.4 on the low, TP 150 on the high. The SL is put
             # at 50, outside the bar, so the documented SL-before-TP bias cannot mask
             # the TP.
-            (("long", -0.50, 0.50), [-0.50], [0.50], 88.0, 155.0, "take_profit"),
+            (("long", -0.50, 0.50), [-0.50], [0.50], 88.0, 155.0, "take_profit", 400.0),
             # 10x short: liquidation 109.6 on the high, TP 90 on the low, SL 150
             # outside the bar. Only a mutation scoped to BOTH short and tp reaches
             # this one, which is why it is the quadrant that stayed hidden longest.
-            (("short", 0.50, -0.10), [-0.10], [0.50], 88.0, 112.0, "take_profit"),
+            (("short", 0.50, -0.10), [-0.10], [0.50], 88.0, 112.0, "take_profit", 400.0),
         ],
         ids=["long-stop", "short-stop", "long-take-profit", "short-take-profit"],
     )
-    def test_a_bar_breaching_both_liquidates_rather_than_closing_at_the_bracket(
-        self, action, stoploss_levels, takeprofit_levels, wick_low, wick_high, armed
+    def test_the_exit_price_reaches_first_is_the_one_that_fires(
+        self, action, stoploss_levels, takeprofit_levels, wick_low, wick_high, armed,
+        expected_balance,
     ):
-        """All four liquidate 1000 units at a liquidation price 9.6 from entry, so all
-        four balance 400 -- one number, because the liquidation arm is agnostic to both
-        direction and bracket type. The discrimination is in the counterfactuals, which
-        are row-specific: the stop would leave 5000, the long TP 60000, the short TP
-        20000.
+        """The take-profit rows liquidate 1000 units 9.6 from entry, balancing 400. The
+        stop rows fill at a stop 5.0 from entry, balancing 5000 -- the 12x gap that makes
+        this worth conditioning on rather than always taking the liquidation.
 
-        The label is what fires today; the balance is the backstop that survives a
-        future exit type reusing it.
+        The counterfactuals are row-specific and that is the point: on a stop row 400
+        means liquidation wrongly pre-empted a stop the price crossed first, and on a
+        take-profit row 60000 (long) or 20000 (short) means the bracket wrongly
+        pre-empted a liquidation whose ordering the bar cannot resolve.
         """
         # Opens at index 5 (bar 15) and holds; the four trailing holds land the
         # position on bar 20, which is where the wick is.
@@ -1313,20 +1346,37 @@ class TestLiquidationTakesPriorityOverBrackets:
             leverage=10, sl_levels=stoploss_levels, tp_levels=takeprofit_levels,
             wick_low=wick_low, wick_high=wick_high,
         )
-        assert "liquidation" in env.history.action_types, (
-            "a bracket exit pre-empted the liquidation on a bar that breached both"
-        )
+        stop_wins = armed == "stop_loss"
+        exits = env.history.action_types
+        if stop_wins:
+            assert "sltp_sl" in exits, (
+                "liquidation pre-empted a stop that sits between entry and the "
+                f"liquidation price, so price crossed it first -- got {exits}"
+            )
+        else:
+            assert "liquidation" in exits, (
+                "a take-profit pre-empted the liquidation on a bar that breached both, "
+                f"where the ordering is genuinely unresolvable -- got {exits}"
+            )
         # Liquidation deliberately leaves the brackets armed, so the price can be read
         # back afterwards. Asserting it lies INSIDE the bar pins the collision itself:
         # a level moved off the wick and a wick shrunk off the level both fail here,
         # where pinning the price as a constant would only catch the first.
-        price = getattr(env, armed)
+        # Pins the collision itself: a level moved off the wick and a wick shrunk off the
+        # level both fail here, where pinning the price as a constant catches only the
+        # first. On a stop row the level is consumed by the exit, so it is read from the
+        # config rather than off the env.
         low = wick_low if wick_low is not None else 100.0
         high = wick_high if wick_high is not None else 100.0
+        # action[1] is the stop pct the action map hands the bracket calculator, already
+        # signed per side (negative long, positive short) -- not stoploss_levels[0], which
+        # the map SWAPS with the take-profit for shorts.
+        price = 100.0 * (1 + action[1]) if stop_wins else getattr(env, armed)
         assert low <= price <= high, (
             f"{armed}={price} sits outside the bar [{low}, {high}] -- this row no "
             "longer tests a double breach"
         )
-        assert env.balance == pytest.approx(400.0), (
-            "closed at the liquidation price; anything else means the bracket won"
+        assert env.balance == pytest.approx(expected_balance), (
+            f"expected {expected_balance}; a stop row landing on 400 means liquidation "
+            "won, and a take-profit row leaving 400 means it did not"
         )

--- a/tests/envs/offline/test_vec_sltp_scalar_equivalence.py
+++ b/tests/envs/offline/test_vec_sltp_scalar_equivalence.py
@@ -584,34 +584,43 @@ class TestSLTPScalarVecEquivalencePriority:
     _apply_bar_exits, the vectorized as an exemption mask handed to _apply_liquidation --
     so one could change without the other.
 
-    Both cells matter because the rule is conditional. A stop between entry and the
-    liquidation price is crossed first, so it fills; a take-profit is on the other side
-    of entry, so the ordering is unresolvable and the liquidation stands. An engine that
-    reverted either half in isolation diverges here.
+    Every cell matters because the rule is conditional on three things at once, each of
+    which one engine could get wrong alone: whether the stop lies between entry and the
+    liquidation price, whether the bar merely GAPPED past both, and which side the
+    position is on. The take-profit cell is here because a take-profit sits on the OTHER
+    side of entry, so its ordering is unresolvable and the liquidation must still stand --
+    an engine that exempted take-profits too would pass every stop cell.
 
     The vec side has no action_types record, so its exit is pinned by numeric parity with
     the scalar rather than by a label of its own.
     """
 
-    @pytest.mark.parametrize("sl_levels,tp_levels,gap_open,expect", [
-        # 10x long at 100: liquidation 90.4, bar low 88 breaches both.
-        ([-0.05], [0.50], None, "sltp_sl"),      # stop 95 -- between entry and liquidation
-        ([-0.50], [0.50], None, "liquidation"),  # stop 50 -- beyond it, liquidation first
-        # Same nearer stop, but the bar OPENS at 85: nothing was crossed on the way, so
-        # the continuity argument does not apply and the liquidation stands.
-        ([-0.05], [0.50], 85.0, "liquidation"),
-    ], ids=["stop-inside-liquidation", "stop-beyond-liquidation", "gapped-past-liquidation"])
+    @pytest.mark.parametrize(
+        "side,sl_levels,tp_levels,low,high,gap_open,expect", [
+            # 10x LONG at 100, liquidation 90.4.
+            ("long", [-0.05], [0.50], 88.0, None, None, "sltp_sl"),        # stop 95, inside
+            ("long", [-0.15], [0.50], 84.0, None, None, "liquidation"),    # stop 85, beyond
+            ("long", [-0.05], [0.50], 85.0, None, 85.0, "liquidation"),    # gapped past it
+            ("long", [-0.50], [0.10], 88.0, 112.0, None, "liquidation"),   # take-profit loses
+            # 10x SHORT at 100, liquidation 109.6. Every short branch is separate code,
+            # and a vec-only short regression is what this file exists to catch.
+            ("short", [-0.50], [0.05], None, 112.0, None, "sltp_sl"),      # stop 105, inside
+            ("short", [-0.50], [0.15], None, 116.0, None, "liquidation"),  # stop 115, beyond
+            ("short", [-0.50], [0.05], None, 115.0, 115.0, "liquidation"), # gapped past it
+        ],
+        ids=["long-stop-inside", "long-stop-beyond", "long-gapped", "long-take-profit",
+             "short-stop-inside", "short-stop-beyond", "short-gapped"],
+    )
     def test_both_envs_agree_which_exit_price_reaches_first(
-        self, sl_levels, tp_levels, gap_open, expect
+        self, side, sl_levels, tp_levels, low, high, gap_open, expect
     ):
-        df = _flat_df(bar=20, low=88.0 if gap_open is None else gap_open, open_=gap_open)
-        long_action = 1
-        actions = [0] * 5 + [long_action] + [0] * 4
+        df = _flat_df(bar=20, low=low, high=high, open_=gap_open)
+        actions = [0] * 5 + [1 if side == "long" else 2] + [0] * 4
 
         mismatches = _run_sltp_sequence(
             df, actions, leverage=10,
             sl_levels=sl_levels, tp_levels=tp_levels,
-            label=f"sltp-priority-{expect}",
+            label=f"sltp-priority-{side}-{expect}-sl{sl_levels[0]}",
             expect_action_type=expect,
         )
         assert not mismatches, "\n".join(mismatches)

--- a/tests/envs/offline/test_vec_sltp_scalar_equivalence.py
+++ b/tests/envs/offline/test_vec_sltp_scalar_equivalence.py
@@ -464,7 +464,7 @@ class TestSLTPScalarVecEquivalenceTrending:
 # ============================================================================
 
 
-def _flat_df(bar=20, low=None, high=None, n=50):
+def _flat_df(bar=20, low=None, high=None, open_=None, n=50):
     """Flat 100.0 series, optionally with one bar carrying a single excursion."""
     prices = np.full(n, 100.0)
     df = pd.DataFrame({
@@ -479,6 +479,8 @@ def _flat_df(bar=20, low=None, high=None, n=50):
         df.loc[bar, "low"] = low
     if high is not None:
         df.loc[bar, "high"] = high
+    if open_ is not None:  # the bar GAPPED to its open rather than trading there
+        df.loc[bar, "open"] = open_
     return df
 
 
@@ -576,30 +578,41 @@ class TestSLTPScalarVecEquivalenceCloseVsTrigger:
 
 
 class TestSLTPScalarVecEquivalencePriority:
-    """A bar breaching both the stop and the liquidation price must liquidate in BOTH
-    envs (#298).
+    """Both envs must resolve a double-breach bar the same way (#298, #300).
 
-    They encode the precedence differently -- the scalar as an if/else chain, the
-    vectorized by zeroing the position inside the liquidation branch so the trigger
-    masks cannot see it -- so one could be reordered without the other. At this
-    harness's initial_cash of 1000 the liquidation leaves 40 where the stop would
-    leave 500 -- the same scenario the scalar test pins at ten times the cash.
+    They encode the precedence differently -- the scalar as a guard inside
+    _apply_bar_exits, the vectorized as an exemption mask handed to _apply_liquidation --
+    so one could change without the other.
 
-    The vec side has no action_types record, so its liquidation is pinned by numeric
-    parity with the scalar rather than by a label of its own.
+    Both cells matter because the rule is conditional. A stop between entry and the
+    liquidation price is crossed first, so it fills; a take-profit is on the other side
+    of entry, so the ordering is unresolvable and the liquidation stands. An engine that
+    reverted either half in isolation diverges here.
+
+    The vec side has no action_types record, so its exit is pinned by numeric parity with
+    the scalar rather than by a label of its own.
     """
 
-    def test_liquidation_wins_over_the_bracket_in_both_envs(self):
-        df = _flat_df(bar=20, low=88.0)
-        # 10x long at 100: SL 95, liquidation 90.4, bar low 88 breaches both.
+    @pytest.mark.parametrize("sl_levels,tp_levels,gap_open,expect", [
+        # 10x long at 100: liquidation 90.4, bar low 88 breaches both.
+        ([-0.05], [0.50], None, "sltp_sl"),      # stop 95 -- between entry and liquidation
+        ([-0.50], [0.50], None, "liquidation"),  # stop 50 -- beyond it, liquidation first
+        # Same nearer stop, but the bar OPENS at 85: nothing was crossed on the way, so
+        # the continuity argument does not apply and the liquidation stands.
+        ([-0.05], [0.50], 85.0, "liquidation"),
+    ], ids=["stop-inside-liquidation", "stop-beyond-liquidation", "gapped-past-liquidation"])
+    def test_both_envs_agree_which_exit_price_reaches_first(
+        self, sl_levels, tp_levels, gap_open, expect
+    ):
+        df = _flat_df(bar=20, low=88.0 if gap_open is None else gap_open, open_=gap_open)
         long_action = 1
         actions = [0] * 5 + [long_action] + [0] * 4
 
         mismatches = _run_sltp_sequence(
             df, actions, leverage=10,
-            sl_levels=[-0.05], tp_levels=[0.50],
-            label="sltp-liquidation-over-bracket",
-            expect_action_type="liquidation",
+            sl_levels=sl_levels, tp_levels=tp_levels,
+            label=f"sltp-priority-{expect}",
+            expect_action_type=expect,
         )
         assert not mismatches, "\n".join(mismatches)
 

--- a/torchtrade/envs/offline/sequential_sltp.py
+++ b/torchtrade/envs/offline/sequential_sltp.py
@@ -286,6 +286,17 @@ class SequentialTradingEnvSLTP(SequentialTradingEnv):
         The exception is a bar that OPENED past liquidation. Nothing was crossed on the
         way there, the margin was already gone when the bar began, and no resting order
         could have worked first.
+
+        Scope: this covers a gap at the bar BOUNDARY, which OHLC records. A hole INSIDE a
+        bar does not appear in OHLC at all -- price can jump 96 to 88 without ever
+        printing 95 -- and there this fills the stop where the old rule liquidated, i.e.
+        trades one unresolvable case from pessimistic to optimistic. Same class as #280,
+        and not visible at this resolution.
+
+        The `trigger != "sl"` guard below is geometrically unreachable rather than
+        load-bearing: if liquidation fired and the stop is nearer, price passed the stop,
+        so _check_sltp_trigger has already returned "sl". It is kept because it states the
+        rule, and because it is the twin of the vectorized mask's own sl_trigger term.
         """
         if trigger != "sl":
             return False

--- a/torchtrade/envs/offline/sequential_sltp.py
+++ b/torchtrade/envs/offline/sequential_sltp.py
@@ -269,6 +269,37 @@ class SequentialTradingEnvSLTP(SequentialTradingEnv):
 
         return None
 
+    def _stop_is_reached_first(self, trigger: Optional[str], ohlcv: dict) -> bool:
+        """Does a triggered stop sit between entry and the liquidation price? (#300)
+
+        Liquidation otherwise outranks the bracket, and for a take-profit that is right:
+        the two sit on OPPOSITE sides of entry, so a bar that reached both says nothing
+        about which came first, and assuming the worse of two irreconcilable orderings is
+        the only sound choice -- the same reasoning as SL-before-TP.
+
+        A stop-loss is not that case. It sits on the SAME side as liquidation, so price
+        cannot reach the further level without crossing the nearer one on the way, and the
+        bar's own extreme is enough to know which. Booking a liquidation when the stop was
+        crossed first is not pessimism, it is an outcome the data contradicts -- and an
+        expensive one: at 10x on 10000 cash it leaves 400 where the stop leaves 5000.
+
+        The exception is a bar that OPENED past liquidation. Nothing was crossed on the
+        way there, the margin was already gone when the bar began, and no resting order
+        could have worked first.
+        """
+        if trigger != "sl":
+            return False
+
+        is_long = self.position.position_size > 0
+        open_price = ohlcv["open"]
+        if is_long:
+            gapped_past_liquidation = open_price <= self.liquidation_price
+            stop_is_nearer = self.stop_loss > self.liquidation_price
+        else:
+            gapped_past_liquidation = open_price >= self.liquidation_price
+            stop_is_nearer = self.stop_loss < self.liquidation_price
+        return stop_is_nearer and not gapped_past_liquidation
+
     def _apply_bar_exits(self, ohlcv: dict) -> Optional[Dict]:
         """Apply a bar to the held position: liquidation first, then a bracket.
 
@@ -278,10 +309,11 @@ class SequentialTradingEnvSLTP(SequentialTradingEnv):
 
         Returns the trade_info of whatever fired, or None if the position survived.
         """
-        if self._check_liquidation(ohlcv):
+        trigger = self._check_sltp_trigger(ohlcv)
+
+        if self._check_liquidation(ohlcv) and not self._stop_is_reached_first(trigger, ohlcv):
             return self._execute_liquidation()
 
-        trigger = self._check_sltp_trigger(ohlcv)
         if trigger is None:
             return None
 

--- a/torchtrade/envs/offline/vectorized_sequential.py
+++ b/torchtrade/envs/offline/vectorized_sequential.py
@@ -565,7 +565,7 @@ class VectorizedSequentialTradingEnv(EnvBase):
         self,
         high_prices: torch.Tensor,
         low_prices: torch.Tensor,
-        exempt: Optional[torch.Tensor] = None,
+        exempt_fn: Optional[Callable[[], torch.Tensor]] = None,
     ) -> None:
         """Close every position whose bar range breached its liquidation price.
 
@@ -578,9 +578,11 @@ class VectorizedSequentialTradingEnv(EnvBase):
         subclass depends on that -- see the note at its call site for which gates it
         leaves False -- so this must not become a mask-and-defer.
 
-        `exempt` marks lanes whose stop-loss sits between entry and the liquidation price,
-        so price crossed the stop on the way (#300). The base env has no brackets and
-        never passes it.
+        `exempt_fn` returns the lanes whose stop-loss sits between entry and the
+        liquidation price, so price crossed the stop on the way (#300). A callable rather
+        than a tensor because the mask costs a full set of tensor ops and is discarded on
+        the overwhelming majority of steps -- calling it behind the early-out below keeps
+        it off the hot path. The base env has no brackets and never passes it.
         """
         if self.config.leverage <= 1:
             return
@@ -588,10 +590,12 @@ class VectorizedSequentialTradingEnv(EnvBase):
         long_liq = (self._position_sizes > 0) & (low_prices <= liq_price)
         short_liq = (self._position_sizes < 0) & (high_prices >= liq_price)
         liq_mask = long_liq | short_liq
-        if exempt is not None:
-            liq_mask = liq_mask & ~exempt
         if not liq_mask.any():
             return
+        if exempt_fn is not None:
+            liq_mask = liq_mask & ~exempt_fn()
+            if not liq_mask.any():
+                return
 
         # PnL at the liquidation price (both directions, via signed sizes)
         pnl = (liq_price - self._entry_prices) * self._position_sizes

--- a/torchtrade/envs/offline/vectorized_sequential.py
+++ b/torchtrade/envs/offline/vectorized_sequential.py
@@ -562,7 +562,10 @@ class VectorizedSequentialTradingEnv(EnvBase):
         return obs_td
 
     def _apply_liquidation(
-        self, high_prices: torch.Tensor, low_prices: torch.Tensor
+        self,
+        high_prices: torch.Tensor,
+        low_prices: torch.Tensor,
+        exempt: Optional[torch.Tensor] = None,
     ) -> None:
         """Close every position whose bar range breached its liquidation price.
 
@@ -574,6 +577,10 @@ class VectorizedSequentialTradingEnv(EnvBase):
         Positions are zeroed rather than left for a downstream mask to skip. The SLTP
         subclass depends on that -- see the note at its call site for which gates it
         leaves False -- so this must not become a mask-and-defer.
+
+        `exempt` marks lanes whose stop-loss sits between entry and the liquidation price,
+        so price crossed the stop on the way (#300). The base env has no brackets and
+        never passes it.
         """
         if self.config.leverage <= 1:
             return
@@ -581,6 +588,8 @@ class VectorizedSequentialTradingEnv(EnvBase):
         long_liq = (self._position_sizes > 0) & (low_prices <= liq_price)
         short_liq = (self._position_sizes < 0) & (high_prices >= liq_price)
         liq_mask = long_liq | short_liq
+        if exempt is not None:
+            liq_mask = liq_mask & ~exempt
         if not liq_mask.any():
             return
 

--- a/torchtrade/envs/offline/vectorized_sequential_sltp.py
+++ b/torchtrade/envs/offline/vectorized_sequential_sltp.py
@@ -315,7 +315,8 @@ class VectorizedSequentialTradingEnvSLTP(VectorizedSequentialTradingEnv):
         # is NOT exempt. A bar that opened past liquidation is not exempt either: nothing
         # was crossed on the way, the margin was gone before the bar began.
         self._apply_liquidation(
-            new_high, new_low, exempt=self._stop_reached_first_mask(new_open, new_high, new_low)
+            new_high, new_low,
+            exempt_fn=lambda: self._stop_reached_first_mask(new_open, new_high, new_low),
         )
 
         has_position = self._position_sizes != 0

--- a/torchtrade/envs/offline/vectorized_sequential_sltp.py
+++ b/torchtrade/envs/offline/vectorized_sequential_sltp.py
@@ -267,6 +267,32 @@ class VectorizedSequentialTradingEnvSLTP(VectorizedSequentialTradingEnv):
 
         return obs_td
 
+    def _stop_reached_first_mask(
+        self, new_open: torch.Tensor, new_high: torch.Tensor, new_low: torch.Tensor
+    ) -> torch.Tensor:
+        """Lanes whose triggered stop is crossed before liquidation (#300).
+
+        Tensor twin of SequentialTradingEnvSLTP._stop_is_reached_first; that method
+        carries the reasoning. Kept as its own tensor expression rather than a shared
+        helper for the same reason as stop_fill_price: this is a hot path and the scalar
+        form would force per-lane tensor construction. The equivalence harness is what
+        holds the two together.
+        """
+        if self.config.leverage <= 1:
+            return torch.zeros_like(self._position_sizes, dtype=torch.bool)
+
+        liq = self._compute_liq_prices()
+        is_long = self._position_sizes > 0
+        is_short = self._position_sizes < 0
+        has_sl = self._sl_prices > 0
+
+        sl_trigger = (is_long & has_sl & (new_low <= self._sl_prices)) | (
+            is_short & has_sl & (new_high >= self._sl_prices)
+        )
+        stop_is_nearer = torch.where(is_long, self._sl_prices > liq, self._sl_prices < liq)
+        gapped_past_liq = torch.where(is_long, new_open <= liq, new_open >= liq)
+        return sl_trigger & stop_is_nearer & ~gapped_past_liq
+
     def _apply_exit_checks(
         self,
         new_open: torch.Tensor,
@@ -281,7 +307,16 @@ class VectorizedSequentialTradingEnvSLTP(VectorizedSequentialTradingEnv):
         # scalar env. Stale values are harmless: the trigger masks below gate on
         # can_trigger (via has_position) AND is_long/is_short, and every one of those is
         # False once _apply_liquidation has zeroed the position.
-        self._apply_liquidation(new_high, new_low)
+        #
+        # Except where a triggered stop sits between entry and the liquidation price:
+        # price cannot reach the further level without crossing the nearer one, so the
+        # bracket fills first (#300). Tensor twin of the scalar
+        # SequentialTradingEnvSLTP._stop_is_reached_first -- see it for why a take-profit
+        # is NOT exempt. A bar that opened past liquidation is not exempt either: nothing
+        # was crossed on the way, the margin was gone before the bar began.
+        self._apply_liquidation(
+            new_high, new_low, exempt=self._stop_reached_first_mask(new_open, new_high, new_low)
+        )
 
         has_position = self._position_sizes != 0
         has_brackets = (self._sl_prices > 0) | (self._tp_prices > 0)

--- a/torchtrade/envs/offline/vectorized_sequential_sltp.py
+++ b/torchtrade/envs/offline/vectorized_sequential_sltp.py
@@ -273,10 +273,10 @@ class VectorizedSequentialTradingEnvSLTP(VectorizedSequentialTradingEnv):
         """Lanes whose triggered stop is crossed before liquidation (#300).
 
         Tensor twin of SequentialTradingEnvSLTP._stop_is_reached_first; that method
-        carries the reasoning. Kept as its own tensor expression rather than a shared
-        helper for the same reason as stop_fill_price: this is a hot path and the scalar
-        form would force per-lane tensor construction. The equivalence harness is what
-        holds the two together.
+        carries the reasoning. Kept as its own tensor expression rather than routed
+        through the scalar form, which would force per-lane tensor construction on a path
+        that runs millions of times -- the same shape as the tensorised stop_fill_price
+        below. The equivalence harness is what holds the two together.
         """
         if self.config.leverage <= 1:
             return torch.zeros_like(self._position_sizes, dtype=torch.bool)


### PR DESCRIPTION
Closes #300. Raised during the #299 review; pre-existing, not a regression.

## The rule today, and where it is wrong

Both offline SLTP engines take the liquidation unconditionally when a bar breaches it *and* a bracket.

Against a **take-profit** that is right, for the same reason SL beats TP: the two sit on **opposite** sides of entry, so a bar reaching both says nothing about the order. Assuming the worse of two irreconcilable orderings is the only sound choice.

A **stop-loss** is not that case:

| | bracket | liquidation | continuous path from entry | today | correct |
|---|---|---|---|---|---|
| stop inside liq distance | SL 95 | 90.4 | must cross 95 before 90.4 | liquidation | **stop** |
| stop beyond it | SL 50 | 90.4 | must cross 90.4 before 50 | liquidation | liquidation |

A stop sits on the **same** side as liquidation, so price cannot reach the further level without crossing the nearer one — and the bar's own extreme says which. Booking a liquidation where the stop was crossed first isn't pessimism, it's an outcome the data contradicts. At 10x that's **400 against 5000**, a 12x gap, in the *ordinary* configuration where a trader's stop sits inside their liquidation distance.

## The one exception

A bar that **opened** past the liquidation price crossed nothing on the way. The margin was gone before the bar began and no resting order could have worked first — so the liquidation stands. This is why the fix is a predicate rather than a bare comparison.

## Implementation

- Scalar: `_stop_is_reached_first` guards the liquidation branch in `_apply_bar_exits` (the single exit surface from #316).
- Vectorized: an **exemption mask** handed to the shared `_apply_liquidation`, rather than re-deriving the priority. The base env has no brackets and passes nothing, so it is unaffected.

## Testing

#299 deliberately pinned the old behaviour "so a deliberate change will surface as a clear test update rather than silent drift" — it did. Two of its four quadrants change answer; the two take-profit quadrants do not.

Mutation-checked, and two guards were unpinned until their own cell existed:

| mutation | result |
|---|---|
| scalar reverted to the old rule | 3 fail |
| **vectorized only** reverted (one-engine drift) | 1 fail |
| scalar drops the gapped-open guard | 1 fail *(0 before adding its cell)* |
| vectorized drops the gapped-open guard | 1 fail *(0 before adding its cell)* |

`tests/envs/offline` + `tests/envs/replay`: **775 passed, 3 skipped.**