### PR TITLE
fix(envs): four low-severity smells, three invisible to the suite (#290)

### DIFF
--- a/tests/envs/alpaca/test_torch_env_sltp.py
+++ b/tests/envs/alpaca/test_torch_env_sltp.py
@@ -304,3 +304,37 @@ class TestAlpacaSLTPTradingEnvClose:
 class TestAlpacaSLTPTradingEnvMultipleEpisodes:
     """Tests for running multiple episodes."""
 
+
+
+def test_sltp_history_records_price_and_position_on_a_flat_bar():
+    """The SLTP env read the price inline and never recorded the position (#290).
+
+    `position_status.current_price if position_status else 0.0` gives 0 on every flat bar,
+    where the non-SLTP sibling has a three-tier fallback -- so a reward function reading
+    history.base_prices saw a price of zero whenever the agent was out of the market. And
+    neither alpaca env passed position=, so history.positions was all zeros while every
+    other exchange recorded it.
+    """
+    config = AlpacaSLTPTradingEnvConfig(symbol="BTC/USD", window_sizes=[10])
+    trader = MockTrader(initial_cash=10000.0)
+    env = AlpacaSLTPTorchTradingEnv(
+        config=config, observer=MockObserver(window_sizes=[10]), trader=trader
+    )
+    env._wait_for_next_timestamp = lambda: None
+
+    env.reset()
+    env._step(TensorDict({"action": torch.tensor(0)}, batch_size=()))  # hold, stays flat
+    assert env.position.position_size == 0, "this cell must exercise the FLAT path"
+    assert env.history.base_prices[-1] > 0, (
+        f"flat bar recorded price {env.history.base_prices[-1]} -- the fallback chain "
+        "should have supplied one"
+    )
+
+    env._step(TensorDict({"action": torch.tensor(1)}, batch_size=()))  # open a bracket
+    env._step(TensorDict({"action": torch.tensor(0)}, batch_size=()))  # hold it
+    # The recorded size is the one held ENTERING the bar, as on every other live env, so
+    # it appears on the bar AFTER the one that opened the position.
+    assert env.history.positions[-1] != 0, (
+        "an open position must reach history.positions, not stay at the 0.0 default"
+    )
+    env.close()

--- a/tests/envs/alpaca/test_torch_env_sltp.py
+++ b/tests/envs/alpaca/test_torch_env_sltp.py
@@ -301,11 +301,6 @@ class TestAlpacaSLTPTradingEnvClose:
         assert env.trader.position_qty == 0.0
 
 
-class TestAlpacaSLTPTradingEnvMultipleEpisodes:
-    """Tests for running multiple episodes."""
-
-
-
 def test_sltp_history_records_price_and_position_on_a_flat_bar():
     """The SLTP env read the price inline and never recorded the position (#290).
 
@@ -324,7 +319,10 @@ def test_sltp_history_records_price_and_position_on_a_flat_bar():
 
     env.reset()
     env._step(TensorDict({"action": torch.tensor(0)}, batch_size=()))  # hold, stays flat
-    assert env.position.position_size == 0, "this cell must exercise the FLAT path"
+    # Asserted on the EXCHANGE, not on env.position.position_size: that field is never
+    # assigned on any alpaca env, so it reads 0.0 while the exchange holds a position and
+    # the guard would pass either way.
+    assert trader.get_status()["position_status"] is None, "this cell must be FLAT"
     assert env.history.base_prices[-1] > 0, (
         f"flat bar recorded price {env.history.base_prices[-1]} -- the fallback chain "
         "should have supplied one"

--- a/tests/envs/alpaca/test_torch_env_sltp.py
+++ b/tests/envs/alpaca/test_torch_env_sltp.py
@@ -301,24 +301,43 @@ class TestAlpacaSLTPTradingEnvClose:
         assert env.trader.position_qty == 0.0
 
 
-def test_sltp_history_records_price_and_position_on_a_flat_bar():
-    """The SLTP env read the price inline and never recorded the position (#290).
+@pytest.mark.parametrize("sltp", [True, False], ids=["sltp", "plain"])
+def test_alpaca_history_records_price_and_position_on_a_flat_bar(sltp):
+    """The SLTP env read the price inline, and neither env recorded the position (#290).
 
     `position_status.current_price if position_status else 0.0` gives 0 on every flat bar,
     where the non-SLTP sibling has a three-tier fallback -- so a reward function reading
-    history.base_prices saw a price of zero whenever the agent was out of the market. And
-    neither alpaca env passed position=, so history.positions was all zeros while every
-    other exchange recorded it.
+    history.base_prices saw zero whenever the agent was out of the market.
+
+    And neither alpaca env passed position= to record_step, so history.positions was all
+    zeros while every other exchange recorded it. BOTH envs are covered because the fix is
+    per-env: dropping it from the non-SLTP one passed the entire 2139-test suite.
     """
-    config = AlpacaSLTPTradingEnvConfig(symbol="BTC/USD", window_sizes=[10])
-    trader = MockTrader(initial_cash=10000.0)
-    env = AlpacaSLTPTorchTradingEnv(
-        config=config, observer=MockObserver(window_sizes=[10]), trader=trader
+    from torchtrade.envs.live.alpaca.env import (
+        AlpacaTorchTradingEnv, AlpacaTradingEnvConfig,
     )
+
+    trader = MockTrader(initial_cash=10000.0)
+    observer = MockObserver(window_sizes=[10])
+    if sltp:
+        env = AlpacaSLTPTorchTradingEnv(
+            config=AlpacaSLTPTradingEnvConfig(symbol="BTC/USD", window_sizes=[10]),
+            observer=observer, trader=trader,
+        )
+        open_action, hold_action = 1, 0
+    else:
+        env = AlpacaTorchTradingEnv(
+            config=AlpacaTradingEnvConfig(symbol="BTC/USD", window_sizes=[10]),
+            observer=observer, trader=trader,
+        )
+        open_action, hold_action = 2, 0  # action_levels [0.0, 0.5, 1.0]
     env._wait_for_next_timestamp = lambda: None
 
+    def step(a):
+        env._step(TensorDict({"action": torch.tensor(a)}, batch_size=()))
+
     env.reset()
-    env._step(TensorDict({"action": torch.tensor(0)}, batch_size=()))  # hold, stays flat
+    step(hold_action)
     # Asserted on the EXCHANGE, not on env.position.position_size: that field is never
     # assigned on any alpaca env, so it reads 0.0 while the exchange holds a position and
     # the guard would pass either way.
@@ -328,8 +347,8 @@ def test_sltp_history_records_price_and_position_on_a_flat_bar():
         "should have supplied one"
     )
 
-    env._step(TensorDict({"action": torch.tensor(1)}, batch_size=()))  # open a bracket
-    env._step(TensorDict({"action": torch.tensor(0)}, batch_size=()))  # hold it
+    step(open_action)
+    step(hold_action)
     # The recorded size is the one held ENTERING the bar, as on every other live env, so
     # it appears on the bar AFTER the one that opened the position.
     assert env.history.positions[-1] != 0, (

--- a/tests/envs/offline/test_sampler.py
+++ b/tests/envs/offline/test_sampler.py
@@ -2316,17 +2316,3 @@ def test_a_coarse_bar_is_labelled_exactly_when_its_bin_closes(start, days, gappy
     assert list(got) == list(want), (
         f"labelled {list(got)[:3]}... but the bins close at {list(want)[:3]}..."
     )
-
-
-def test_initial_cash_randomisation_can_draw_its_configured_maximum():
-    """np_rng.integers is half-open, so the configured max was unreachable (#290).
-
-    A user asking for [1000, 2000] got [1000, 1999]. Invisible at wide ranges, and the
-    whole point of the parameter at narrow ones.
-    """
-    from torchtrade.envs.offline.infrastructure.utils import InitialBalanceSampler
-
-    drawn = {int(InitialBalanceSampler([1000, 1005], seed=s).sample()) for s in range(200)}
-    assert drawn == {1000, 1001, 1002, 1003, 1004, 1005}, (
-        f"drew {sorted(drawn)} -- the configured bounds must both be reachable"
-    )

--- a/tests/envs/offline/test_sampler.py
+++ b/tests/envs/offline/test_sampler.py
@@ -2316,3 +2316,17 @@ def test_a_coarse_bar_is_labelled_exactly_when_its_bin_closes(start, days, gappy
     assert list(got) == list(want), (
         f"labelled {list(got)[:3]}... but the bins close at {list(want)[:3]}..."
     )
+
+
+def test_initial_cash_randomisation_can_draw_its_configured_maximum():
+    """np_rng.integers is half-open, so the configured max was unreachable (#290).
+
+    A user asking for [1000, 2000] got [1000, 1999]. Invisible at wide ranges, and the
+    whole point of the parameter at narrow ones.
+    """
+    from torchtrade.envs.offline.infrastructure.utils import InitialBalanceSampler
+
+    drawn = {int(InitialBalanceSampler([1000, 1005], seed=s).sample()) for s in range(200)}
+    assert drawn == {1000, 1001, 1002, 1003, 1004, 1005}, (
+        f"drew {sorted(drawn)} -- the configured bounds must both be reachable"
+    )

--- a/tests/envs/offline/test_seeding.py
+++ b/tests/envs/offline/test_seeding.py
@@ -376,3 +376,15 @@ class TestEnvironmentSeeding:
 
         # At least some initial conditions should differ due to different seeds
         assert balances1 != balances2, "Different seeds should produce different trajectories"
+
+
+def test_initial_cash_randomisation_can_draw_its_configured_maximum():
+    """np_rng.integers is half-open, so the configured max was unreachable (#290).
+
+    A user asking for [1000, 2000] got [1000, 1999]. Invisible at wide ranges, and the
+    whole point of the parameter at narrow ones.
+    """
+    drawn = {int(InitialBalanceSampler([1000, 1005], seed=s).sample()) for s in range(200)}
+    assert drawn == {1000, 1001, 1002, 1003, 1004, 1005}, (
+        f"drew {sorted(drawn)} -- the configured bounds must both be reachable"
+    )

--- a/tests/envs/offline/test_sequential_sltp.py
+++ b/tests/envs/offline/test_sequential_sltp.py
@@ -1376,23 +1376,25 @@ class TestLiquidationVsBracketOnADoubleBreachBar:
         )
 
 
-@pytest.mark.parametrize("leverage,expect_short", [(10, True), (1, False)],
-                         ids=["futures", "spot"])
-def test_sltp_env_keeps_its_configured_action_levels(sample_ohlcv_df, leverage, expect_short):
+def test_sltp_env_keeps_its_configured_action_levels(sample_ohlcv_df):
     """__init__ hands the parent a dummy [0.0] and must restore the real levels (#290).
 
     It restored them on the CONFIG only. The parent copies onto self during its own
     __init__, so self.action_levels stayed [0.0] forever -- allows_short read False on
     every SLTP env including 125x futures, and render_history drew those episodes as spot.
     Asserting the config alone cannot see it; the instance is where the leak was.
+
+    Futures only: on a spot env `allows_short` reads False under the bug too (the dummy
+    [0.0] has no negatives), so that cell died on the levels assertion alone -- a byte
+    identical failure, and no unique coverage.
     """
     config = SequentialTradingEnvSLTPConfig(
-        leverage=leverage, initial_cash=10000, action_levels=[-1, 0, 1],
+        leverage=10, initial_cash=10000, action_levels=[-1, 0, 1],
         execute_on=TimeFrame(1, TimeFrameUnit.Minute),
         time_frames=[TimeFrame(1, TimeFrameUnit.Minute)], window_sizes=[10], seed=42,
     )
     env = SequentialTradingEnvSLTP(sample_ohlcv_df, config, simple_feature_fn)
 
     assert env.action_levels == [-1, 0, 1]
-    assert env.allows_short is expect_short
+    assert env.allows_short is True
     env.close()

--- a/tests/envs/offline/test_sequential_sltp.py
+++ b/tests/envs/offline/test_sequential_sltp.py
@@ -1374,3 +1374,25 @@ class TestLiquidationVsBracketOnADoubleBreachBar:
             f"expected {expected_balance}; a stop row landing on 400 means liquidation "
             "won, and a take-profit row leaving 400 means it did not"
         )
+
+
+@pytest.mark.parametrize("leverage,expect_short", [(10, True), (1, False)],
+                         ids=["futures", "spot"])
+def test_sltp_env_keeps_its_configured_action_levels(sample_ohlcv_df, leverage, expect_short):
+    """__init__ hands the parent a dummy [0.0] and must restore the real levels (#290).
+
+    It restored them on the CONFIG only. The parent copies onto self during its own
+    __init__, so self.action_levels stayed [0.0] forever -- allows_short read False on
+    every SLTP env including 125x futures, and render_history drew those episodes as spot.
+    Asserting the config alone cannot see it; the instance is where the leak was.
+    """
+    config = SequentialTradingEnvSLTPConfig(
+        leverage=leverage, initial_cash=10000, action_levels=[-1, 0, 1],
+        execute_on=TimeFrame(1, TimeFrameUnit.Minute),
+        time_frames=[TimeFrame(1, TimeFrameUnit.Minute)], window_sizes=[10], seed=42,
+    )
+    env = SequentialTradingEnvSLTP(sample_ohlcv_df, config, simple_feature_fn)
+
+    assert env.action_levels == [-1, 0, 1]
+    assert env.allows_short is expect_short
+    env.close()

--- a/tests/envs/offline/test_vectorized_sequential_sltp.py
+++ b/tests/envs/offline/test_vectorized_sequential_sltp.py
@@ -551,3 +551,21 @@ class TestSLTPCanAfford:
             torch.full_like(env._balances, 100.0)
         ), "a refused open must cost nothing"
         env.close()
+
+
+def test_vec_sltp_env_keeps_its_configured_action_levels(sample_ohlcv_df):
+    """__init__ hands the parent a dummy and must restore the real levels (#290).
+
+    Twin of the scalar leak: restored on the CONFIG only, while the parent copies onto
+    self during its own __init__. This class has no allows_short, so the blast radius is
+    anything reading the levels off the env -- BaseLLMActor(action_levels=env.action_levels)
+    would build its action descriptions from [0.0, 1.0].
+    """
+    config = VectorizedSequentialTradingEnvSLTPConfig(
+        num_envs=2, leverage=10, initial_cash=10000, action_levels=[-1, 0, 1],
+        execute_on=TimeFrame(1, TimeFrameUnit.Minute),
+        time_frames=[TimeFrame(1, TimeFrameUnit.Minute)], window_sizes=[10], seed=42,
+    )
+    env = VectorizedSequentialTradingEnvSLTP(sample_ohlcv_df, config)
+    assert env.action_levels == [-1, 0, 1]
+    env.close()

--- a/tests/envs/offline/test_vectorized_sequential_sltp.py
+++ b/tests/envs/offline/test_vectorized_sequential_sltp.py
@@ -568,4 +568,7 @@ def test_vec_sltp_env_keeps_its_configured_action_levels(sample_ohlcv_df):
     )
     env = VectorizedSequentialTradingEnvSLTP(sample_ohlcv_df, config)
     assert env.action_levels == [-1, 0, 1]
+    # And the tensor the parent derives from them: restoring only the list would leave the
+    # env answering "what are my levels" two different ways.
+    assert env._action_levels_tensor.tolist() == [-1.0, 0.0, 1.0]
     env.close()

--- a/torchtrade/envs/live/alpaca/base.py
+++ b/torchtrade/envs/live/alpaca/base.py
@@ -370,16 +370,19 @@ class AlpacaBaseTorchTradingEnv(TorchTradeLiveEnv):
             Current price, or 0.0 if unavailable
 
         Raises:
-            PositionUnknownError: the exchange did not report the position. This is
-                where AlpacaTorchTradingEnv._step stops on an outage, before any trade is
-                sized; the SLTP env stops on its own inline read instead.
+            PositionUnknownError: the exchange did not report the position. Both alpaca
+                envs stop here, before any trade is sized -- POSITION_UNKNOWN is truthy
+                and raises on attribute access.
 
         Lives on the base rather than on AlpacaTorchTradingEnv because the SLTP env is a
-        sibling, not a subclass, and read `position_status.current_price if
+        sibling, not a subclass, and used to read `position_status.current_price if
         position_status else 0.0` inline -- so every flat bar recorded a price of 0 in its
         history (#290).
         """
-        # Try position status first
+        # Note: a caller that already resolved the status to None still pays a second
+        # get_status() here, because None cannot be told from "not supplied". Both alpaca
+        # envs do that on a flat bar. Negligible against alpaca's rate limit and matched
+        # by the non-SLTP env before this change, so left as-is rather than widening #290.
         if position_status is None:
             position_status = self.trader.get_status().get("position_status", None)
 

--- a/torchtrade/envs/live/alpaca/base.py
+++ b/torchtrade/envs/live/alpaca/base.py
@@ -1,5 +1,6 @@
 """Base class for Alpaca live trading environments."""
 
+import logging
 from abc import abstractmethod
 from typing import Callable, List, Optional
 
@@ -17,6 +18,9 @@ from torchtrade.envs.core.state import (
     advance_hold_counter,
     position_direction_from_status,
 )
+
+
+logger = logging.getLogger(__name__)
 
 
 class AlpacaBaseTorchTradingEnv(TorchTradeLiveEnv):
@@ -350,3 +354,47 @@ class AlpacaBaseTorchTradingEnv(TorchTradeLiveEnv):
         """Clean up resources."""
         self.trader.cancel_open_orders()
         self.trader.close_all_positions()
+
+    def _get_current_price(self, position_status=None) -> float:
+        """Get current market price with fallback chain.
+
+        Tries multiple sources in order:
+        1. Position status (if provided or fetched)
+        2. Trader's current_price attribute (for mocks)
+        3. Observer's get_current_price() (fetches from market data)
+
+        Args:
+            position_status: Optional position status to avoid redundant queries
+
+        Returns:
+            Current price, or 0.0 if unavailable
+
+        Raises:
+            PositionUnknownError: the exchange did not report the position. This is
+                where AlpacaTorchTradingEnv._step stops on an outage, before any trade is
+                sized; the SLTP env stops on its own inline read instead.
+
+        Lives on the base rather than on AlpacaTorchTradingEnv because the SLTP env is a
+        sibling, not a subclass, and read `position_status.current_price if
+        position_status else 0.0` inline -- so every flat bar recorded a price of 0 in its
+        history (#290).
+        """
+        # Try position status first
+        if position_status is None:
+            position_status = self.trader.get_status().get("position_status", None)
+
+        current_price = position_status.current_price if position_status else 0.0
+
+        # Fallback 1: trader's current_price attribute (for mocks)
+        if current_price <= 0 and hasattr(self.trader, 'current_price'):
+            current_price = self.trader.current_price
+
+        # Fallback 2: fetch from market data
+        if current_price <= 0:
+            try:
+                current_price = self.observer.get_current_price()
+                logger.info(f"Fetched current price from market data: {current_price}")
+            except Exception as e:
+                logger.warning(f"Could not fetch current price: {e}")
+
+        return current_price

--- a/torchtrade/envs/live/alpaca/env.py
+++ b/torchtrade/envs/live/alpaca/env.py
@@ -117,6 +117,9 @@ class AlpacaTorchTradingEnv(AlpacaBaseTorchTradingEnv):
         current_price = self._get_current_price(position_status)
 
         self._sync_position_from_exchange(position_status)
+        # From the exchange, as every other live env does: self.position.position_size is
+        # never populated on the alpaca envs (#290). Size held ENTERING the bar.
+        position_size = position_status.qty if position_status else 0.0
 
         # Calculate and execute trade if needed
         trade_info = self._execute_trade_if_needed(desired_action)
@@ -137,7 +140,8 @@ class AlpacaTorchTradingEnv(AlpacaBaseTorchTradingEnv):
             price=current_price,
             action=desired_action,
             reward=0.0,  # Placeholder, will be set after reward calculation
-            portfolio_value=new_portfolio_value
+            portfolio_value=new_portfolio_value,
+            position=position_size,
         )
 
         # Calculate reward using UPDATED history tracker
@@ -172,45 +176,6 @@ class AlpacaTorchTradingEnv(AlpacaBaseTorchTradingEnv):
             return no_trade
 
         return self._execute_fractional_action(desired_action)
-
-    def _get_current_price(self, position_status=None) -> float:
-        """Get current market price with fallback chain.
-
-        Tries multiple sources in order:
-        1. Position status (if provided or fetched)
-        2. Trader's current_price attribute (for mocks)
-        3. Observer's get_current_price() (fetches from market data)
-
-        Args:
-            position_status: Optional position status to avoid redundant queries
-
-        Returns:
-            Current price, or 0.0 if unavailable
-
-        Raises:
-            PositionUnknownError: the exchange did not report the position. This is where
-                AlpacaTorchTradingEnv._step stops on an outage, before any trade is
-                sized; the SLTP env stops on its own inline read instead.
-        """
-        # Try position status first
-        if position_status is None:
-            position_status = self.trader.get_status().get("position_status", None)
-
-        current_price = position_status.current_price if position_status else 0.0
-
-        # Fallback 1: trader's current_price attribute (for mocks)
-        if current_price <= 0 and hasattr(self.trader, 'current_price'):
-            current_price = self.trader.current_price
-
-        # Fallback 2: fetch from market data
-        if current_price <= 0:
-            try:
-                current_price = self.observer.get_current_price()
-                logger.info(f"Fetched current price from market data: {current_price}")
-            except Exception as e:
-                logger.warning(f"Could not fetch current price: {e}")
-
-        return current_price
 
     def _calculate_fractional_position(
         self, action_value: float, current_price: float

--- a/torchtrade/envs/live/alpaca/env_sltp.py
+++ b/torchtrade/envs/live/alpaca/env_sltp.py
@@ -137,7 +137,13 @@ class AlpacaSLTPTorchTradingEnv(SLTPMixin, AlpacaBaseTorchTradingEnv):
         # Get current price from trader status (avoids redundant observation call)
         status = self.trader.get_status()
         position_status = status.get("position_status", None)
-        current_price = position_status.current_price if position_status else 0.0
+        # Shared fallback chain, not an inline read: a flat bar has no position_status,
+        # and the inline form recorded a price of 0 for it (#290).
+        current_price = self._get_current_price(position_status)
+        # From the exchange, as every other live env does: the alpaca envs never populate
+        # self.position.position_size, so reading it recorded a flat history forever
+        # (#290). This is the size held ENTERING the bar, matching bybit.
+        position_size = position_status.qty if position_status else 0.0
 
         # Sync position state from exchange — this is the source of truth.
         # Detects SL/TP closures AND fixes state drift from failed bracket orders.
@@ -173,7 +179,8 @@ class AlpacaSLTPTorchTradingEnv(SLTPMixin, AlpacaBaseTorchTradingEnv):
             price=current_price,
             action=action_value,
             reward=0.0,  # Placeholder, will be set after reward calculation
-            portfolio_value=new_portfolio_value
+            portfolio_value=new_portfolio_value,
+            position=position_size,
         )
 
         # Calculate reward using UPDATED history tracker

--- a/torchtrade/envs/offline/infrastructure/utils.py
+++ b/torchtrade/envs/offline/infrastructure/utils.py
@@ -77,4 +77,8 @@ class InitialBalanceSampler:
         if isinstance(self.initial_cash, (int, float)):
             return float(self.initial_cash)
 
-        return float(self.np_rng.integers(self.initial_cash[0], self.initial_cash[1]))
+        # endpoint=True: integers() is half-open, so the configured maximum was the one
+        # value the sampler could never draw (#290).
+        return float(
+            self.np_rng.integers(self.initial_cash[0], self.initial_cash[1], endpoint=True)
+        )

--- a/torchtrade/envs/offline/sequential_sltp.py
+++ b/torchtrade/envs/offline/sequential_sltp.py
@@ -174,8 +174,13 @@ class SequentialTradingEnvSLTP(SequentialTradingEnv):
         # Initialize parent class (sets up base SequentialTradingEnv)
         super().__init__(df, config, feature_preprocessing_fn, reward_function)
 
-        # Restore original action_levels
+        # Restore original action_levels -- on the CONFIG and on the instance. The parent
+        # copies the dummy onto self during __init__, and restoring only the config left
+        # self.action_levels at [0.0] forever, so allows_short read False on every SLTP
+        # env including 125x futures, and render_history drew those episodes as spot
+        # (#290).
         config.action_levels = original_action_levels
+        self.action_levels = original_action_levels
 
         # Override action spec with SLTP action space
         self.action_spec = Categorical(len(self.action_map))

--- a/torchtrade/envs/offline/vectorized_sequential_sltp.py
+++ b/torchtrade/envs/offline/vectorized_sequential_sltp.py
@@ -136,11 +136,11 @@ class VectorizedSequentialTradingEnvSLTP(VectorizedSequentialTradingEnv):
             include_close_action=config.include_close_action,
         )
 
-        # Parent requires action_levels with >= 2 elements, but SLTP envs
-        # don't use fractional sizing. Temporarily set dummy levels for
-        # parent init, then restore. This is safe because the parent only
-        # reads action_levels during __init__ to build its action spec,
-        # which we override immediately after.
+        # Parent requires action_levels with >= 2 elements, but SLTP envs don't use
+        # fractional sizing. Dummy levels for parent init, restored below -- on the
+        # config, on the instance AND on the tensor the parent derives, because it copies
+        # all three during its own __init__ and "we override the action spec afterwards"
+        # covers only the first of them (#290).
         original_action_levels = config.action_levels
         config.action_levels = [0.0, 1.0]
 
@@ -152,6 +152,9 @@ class VectorizedSequentialTradingEnvSLTP(VectorizedSequentialTradingEnv):
         # as BaseLLMActor(action_levels=env.action_levels), gets [0.0, 1.0] (#290).
         config.action_levels = original_action_levels
         self.action_levels = original_action_levels
+        self._action_levels_tensor = torch.tensor(original_action_levels, dtype=MONEY_DTYPE)
+        if config.leverage == 1:  # same predicate as the parent, to stay twinned
+            self._action_levels_tensor = self._action_levels_tensor.clamp(min=0.0)
 
         # Override action spec with SLTP action count
         num_actions = len(self.action_map)

--- a/torchtrade/envs/offline/vectorized_sequential_sltp.py
+++ b/torchtrade/envs/offline/vectorized_sequential_sltp.py
@@ -146,7 +146,12 @@ class VectorizedSequentialTradingEnvSLTP(VectorizedSequentialTradingEnv):
 
         super().__init__(df, config, feature_preprocessing_fn)
 
+        # Restored on the CONFIG and on the instance: the parent copies the dummy onto
+        # self during its own __init__, so restoring only the config leaves
+        # self.action_levels at the dummy forever -- anything reading it off the env, such
+        # as BaseLLMActor(action_levels=env.action_levels), gets [0.0, 1.0] (#290).
         config.action_levels = original_action_levels
+        self.action_levels = original_action_levels
 
         # Override action spec with SLTP action count
         num_actions = len(self.action_map)


### PR DESCRIPTION
Refs #290 — fixes the four defects on that list. The two items that are *decisions* rather than defects are split out as **#336**, so this can be reviewed as a bug-fix PR.

One item on #290 needs no work: the dead `close_price` branches in `_check_sltp_trigger` went with the min/max rewrite in #316.

## Five sites fixed

**`action_levels` leaked — in both SLTP envs.** `__init__` hands the parent a dummy so its `action_spec` can be built, then restores the real levels **on the config only**. The parent copies onto `self` during its own `__init__`:

```
before:  config.action_levels=[-1, 0, 1]   env.action_levels=[0.0]     allows_short=False   # 10x futures
after:   config.action_levels=[-1, 0, 1]   env.action_levels=[-1,0,1]  allows_short=True
```

`render_history` therefore drew every futures episode as spot. Round 1 found the vectorized sibling has it too; round 2 found my fix for that one left the *derived tensor* still holding the dummy, so the env answered the same question two ways. Both now restored and pinned.

**`InitialBalanceSampler` could not draw its own maximum.** `integers` is half-open, so `initial_cash=[1000, 2000]` sampled `[1000, 1999]`.

> ⚠️ This shifts the seeded draw for ~51% of seeds. You cannot add a value to the support without changing the mapping, so runs randomising initial cash will not reproduce byte-for-byte. It also fixes `lo == hi`, which used to raise `ValueError: low >= high`.

**Alpaca recorded a price of 0 on every flat bar.** The SLTP env read `position_status.current_price if position_status else 0.0` inline, where its non-SLTP sibling has a three-tier fallback — and a flat bar has no `position_status`. `_get_current_price` moves to `AlpacaBaseTorchTradingEnv` so both share it (the SLTP env is a *sibling*, not a subclass, which is how they diverged).

**Alpaca recorded a flat position always.** Neither env passed `position=` to `record_step`, so `history.positions` was all zeros while every other exchange recorded it. Sourced from the exchange status as bybit/okx/binance/bitget do — the size held *entering* the bar.

## What review changed

Both rounds found the fix incomplete in ways I had not:

1. **Round 1**: the vectorized sibling was unfixed, and my new test carried a **dead assertion** — `env.position.position_size == 0`, meant to prove the cell was flat, on a field never assigned by any Alpaca env. It read `0.0` while the exchange held 0.1 BTC.
2. **Round 2**: the non-SLTP `position=` was **unpinned** (dropping it passed all 2139 tests) while this PR body claimed every fix failed when reverted; and my vec fix left the derived tensor stale.

## Testing

Four tests, each the sole killer of its own fix in a 2139-test suite. `tests/envs`: **2139 passed, 19 skipped**.
