### PR TITLE
fix(envs): count an unsettled position in the alpaca bankruptcy baseline (#284)

### DIFF
--- a/tests/envs/alpaca/test_torch_env.py
+++ b/tests/envs/alpaca/test_torch_env.py
@@ -806,3 +806,37 @@ class TestAlpacaTorchTradingEnvSeed:
         # Should not raise
 
 
+
+
+def test_bankruptcy_baseline_counts_a_position_that_has_not_settled_yet():
+    """__init__ closes positions, then pins the baseline -- but the close does not block.
+
+    close_all_positions() submits market orders and returns. Reading account.cash at that
+    instant excludes whatever is still tied up in the unsettled position, so an env
+    constructed holding $9k of BTC against $1k cash pinned its baseline at 1000 and
+    _check_termination then fired below $100 instead of $1000 -- a 10x understatement of
+    the account it is protecting (#284).
+
+    The baseline must be the same quantity termination compares against, which is
+    _get_portfolio_value: cash PLUS position value. Reading account.cash made it a
+    different measurement, which is why settlement timing could change it at all.
+    """
+    class UnsettledTrader(MockTrader):
+        def close_all_positions(self):
+            return {}  # submitted, not filled -- the position is still open
+
+    trader = UnsettledTrader(initial_cash=1000.0)
+    trader.position_qty, trader.avg_entry_price = 0.09, 100000.0
+    trader.position_value = 9000.0
+
+    env = AlpacaTorchTradingEnv(
+        config=AlpacaTradingEnvConfig(symbol="BTC/USD", window_sizes=[10]),
+        observer=MockObserver(window_sizes=[10]),
+        trader=trader,
+    )
+
+    assert env.initial_portfolio_value == pytest.approx(10000.0), (
+        f"baseline {env.initial_portfolio_value} ignores the {trader.position_value} "
+        "still held in an unsettled position"
+    )
+    env.close()

--- a/tests/envs/alpaca/test_torch_env.py
+++ b/tests/envs/alpaca/test_torch_env.py
@@ -813,9 +813,9 @@ def test_bankruptcy_baseline_counts_a_position_that_has_not_settled_yet():
 
     close_all_positions() submits market orders and returns. Reading account.cash at that
     instant excludes whatever is still tied up in the unsettled position, so an env
-    constructed holding $9k of BTC against $1k cash pinned its baseline at 1000 and
-    _check_termination then fired below $100 instead of $1000 -- a 10x understatement of
-    the account it is protecting (#284).
+    constructed holding 8765 of BTC against 1234 cash pinned its baseline at 1234 rather
+    than 9999, and _check_termination then fired an order of magnitude too low -- on the
+    account it exists to protect (#284).
 
     The baseline must be the same quantity termination compares against, which is
     _get_portfolio_value: cash PLUS position value. Reading account.cash made it a
@@ -838,6 +838,10 @@ def test_bankruptcy_baseline_counts_a_position_that_has_not_settled_yet():
         trader=trader,
     )
 
+    # The fixture carries all of this test's power and nothing else asserts it: swap
+    # UnsettledTrader back for a plain MockTrader and the close settles, cash becomes 9999
+    # on its own, and the test passes against the bug.
+    assert trader.position_qty > 0, "fixture no longer models an unsettled close"
     assert env.initial_portfolio_value == pytest.approx(9999.0), (
         f"baseline {env.initial_portfolio_value} ignores the {trader.position_value} "
         "still held in an unsettled position"

--- a/tests/envs/alpaca/test_torch_env.py
+++ b/tests/envs/alpaca/test_torch_env.py
@@ -825,9 +825,12 @@ def test_bankruptcy_baseline_counts_a_position_that_has_not_settled_yet():
         def close_all_positions(self):
             return {}  # submitted, not filled -- the position is still open
 
-    trader = UnsettledTrader(initial_cash=1000.0)
-    trader.position_qty, trader.avg_entry_price = 0.09, 100000.0
-    trader.position_value = 9000.0
+    # 1234 + 8765, chosen so the expected 9999 collides with nothing: MockTrader
+    # defaults initial_cash to 10000, so an expected 10000 would pass against
+    # account.cash too if someone ever dropped the explicit cash argument.
+    trader = UnsettledTrader(initial_cash=1234.0)
+    trader.position_qty, trader.avg_entry_price = 0.08765, 100000.0
+    trader.position_value = 8765.0
 
     env = AlpacaTorchTradingEnv(
         config=AlpacaTradingEnvConfig(symbol="BTC/USD", window_sizes=[10]),
@@ -835,7 +838,7 @@ def test_bankruptcy_baseline_counts_a_position_that_has_not_settled_yet():
         trader=trader,
     )
 
-    assert env.initial_portfolio_value == pytest.approx(10000.0), (
+    assert env.initial_portfolio_value == pytest.approx(9999.0), (
         f"baseline {env.initial_portfolio_value} ignores the {trader.position_value} "
         "still held in an unsettled position"
     )

--- a/torchtrade/envs/live/alpaca/base.py
+++ b/torchtrade/envs/live/alpaca/base.py
@@ -300,7 +300,6 @@ class AlpacaBaseTorchTradingEnv(TorchTradeLiveEnv):
         # Get current state
         account = self.trader.client.get_account()
         self.balance = float(account.cash)
-        self.last_portfolio_value = self.balance
 
         status = self.trader.get_status()
         position_status = status.get("position_status")

--- a/torchtrade/envs/live/alpaca/base.py
+++ b/torchtrade/envs/live/alpaca/base.py
@@ -103,10 +103,17 @@ class AlpacaBaseTorchTradingEnv(TorchTradeLiveEnv):
         self.trader.close_all_positions()
         self.trader.cancel_open_orders()
 
-        # Get initial portfolio value
-        account = self.trader.client.get_account()
-        cash = float(account.cash)
-        self.initial_portfolio_value = cash
+        # The env's own measure, not account.cash. close_all_positions() above submits
+        # market orders and does not block, so cash at this instant excludes whatever is
+        # still tied up in an unsettled position: constructed holding $9k of BTC against
+        # $1k cash, the baseline pinned at 1000 and _check_termination then fired below
+        # $100 rather than $1000 (#284).
+        #
+        # Using _get_portfolio_value rather than account.portfolio_value keeps the
+        # baseline the SAME quantity that termination compares against -- cash plus
+        # position value -- so the two cannot drift apart. The futures bases already read
+        # an equity figure for this reason.
+        self.initial_portfolio_value = self._get_portfolio_value()
 
         # Build observation specs
         self._build_observation_specs()

--- a/torchtrade/envs/live/binance/base.py
+++ b/torchtrade/envs/live/binance/base.py
@@ -194,7 +194,6 @@ class BinanceBaseTorchTradingEnv(TorchTradeFuturesLiveEnv):
         # Get current state
         balance = self.trader.get_account_balance()
         self.balance = balance.get("available_balance", 0)
-        self.last_portfolio_value = self._get_portfolio_value()
 
         status = self.trader.get_status()
         position_status = status.get("position_status")

--- a/torchtrade/envs/live/bitget/base.py
+++ b/torchtrade/envs/live/bitget/base.py
@@ -212,7 +212,6 @@ class BitgetBaseTorchTradingEnv(TorchTradeFuturesLiveEnv):
         # Get current state
         balance = self.trader.get_account_balance()
         self.balance = balance.get("available_balance", 0)
-        self.last_portfolio_value = self._get_portfolio_value()
 
         status = self.trader.get_status()
         position_status = status.get("position_status")

--- a/torchtrade/envs/live/bybit/base.py
+++ b/torchtrade/envs/live/bybit/base.py
@@ -174,7 +174,6 @@ class BybitBaseTorchTradingEnv(TorchTradeFuturesLiveEnv):
 
         balance = self.trader.get_account_balance()
         self.balance = balance.get("available_balance", 0)
-        self.last_portfolio_value = self._get_portfolio_value()
 
         status = self.trader.get_status()
         position_status = status.get("position_status")

--- a/torchtrade/envs/live/okx/base.py
+++ b/torchtrade/envs/live/okx/base.py
@@ -176,7 +176,6 @@ class OKXBaseTorchTradingEnv(TorchTradeFuturesLiveEnv):
 
         balance = self.trader.get_account_balance()
         self.balance = balance.get("available_balance", 0)
-        self.last_portfolio_value = self._get_portfolio_value()
 
         status = self.trader.get_status()
         position_status = status.get("position_status")


### PR DESCRIPTION
Closes #284.

## The bug

`AlpacaBaseTorchTradingEnv.__init__` calls `close_all_positions()` — which **submits market orders and returns**, it does not block — then immediately reads `account.cash` as `initial_portfolio_value`.

Reproduced against a trader whose close hasn't settled:

```
cash=1000.0  position value=9000.0
initial_portfolio_value = 10000.0   (cash-only gave 1000)
bankruptcy fires below   = 1000.0   (cash-only gave 100)
```

A 10× understatement of the account the check exists to protect.

## The deeper problem

Cash was never the right quantity. `_check_termination` compares against `_get_portfolio_value()`, which is **cash + position value** — so the baseline was measured in different units from the thing it bounds. *That* is why settlement timing could move it at all.

Using the env's own method makes both the same measurement by construction, and the fix no longer depends on the close having settled. The four futures bases already read an equity figure for exactly this reason (`bybit/base.py:89`: *"Bankruptcy baseline on total_margin_balance (equity)"*).

`_get_portfolio_value`'s own docstring already names the hazard — *"cash alone feeds `_check_termination`, and for a held position that is most of the portfolio missing"* — it just wasn't applied at construction.

## Testing

New test constructs the env with an unsettled close and asserts the baseline is 10000, not 1000. Reverting to `account.cash` fails it; nothing else in the 2139-test suite noticed.