### PR TITLE
fix(envs): route live trade paths through the dust rule (#283)

### DIFF
--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -28,6 +28,7 @@ from torchtrade.envs.core.state import (
     PositionUnknownError,
     advance_hold_counter,
     position_direction_from_status,
+    position_qty_from_status,
 )
 
 
@@ -457,8 +458,9 @@ def test_unknown_status_refuses_to_build_account_state():
         TorchTradeFuturesLiveEnv._get_observation(env)
 
 
-# Envs that size from a live query, now via the ONE shared accessor rather than three
-# byte-identical copies (#283). A rename would empty this and pytest would SKIP rather
+# Envs that RESOLVE the shared accessor, which replaced three byte-identical copies
+# (#283). Note okx resolves it but sizes in _step instead, so these cells prove wiring
+# rather than okx's own path. A rename would empty this and pytest would SKIP rather
 # than fail -- the hazard this file guards against elsewhere with its own len()
 # assertions.
 _SIZING_ENVS = [c for c in NON_SLTP_ENVS if hasattr(c, "_get_current_position_quantity")]
@@ -554,8 +556,10 @@ def test_position_sizing_refuses_an_unknown_status(env_cls):
     gone. _step normally raises earlier, on its own status read -- this is the path when
     the outage begins between the two get_status() calls inside a single step.
 
-    All four futures envs, because the accessor is now shared (#283). Alpaca spells the
-    same second query inline and is covered through _step by the composite test instead.
+    All four resolve the accessor since it was shared (#283), though okx sizes in _step
+    and never calls it -- these cells prove the MRO wiring, and okx's real path is covered
+    by test_okx_sizes_through_the_dust_rule_in_step. Alpaca spells the same second query
+    inline and is covered through _step by the composite test.
     """
     env = SimpleNamespace(
         trader=SimpleNamespace(get_status=lambda: {"position_status": POSITION_UNKNOWN})
@@ -839,9 +843,9 @@ def test_a_dust_residual_does_not_look_like_a_position_to_the_trade_path(env_cls
     (-1e-12, 0.0),
     (1e-9, 0.0),        # exactly at the epsilon, which is inclusive
     (1.1e-9, 1.1e-9),   # just past it: a real, if tiny, position
-    (2.5, 2.5),
+    (-2.5, -2.5),      # a real SHORT: nothing else here holds a negative
     ("2.5", 2.5),       # exchanges return strings; the old form passed one through
-], ids=["none", "zero", "dust-long", "dust-short", "at-eps", "past-eps", "long", "string"])
+], ids=["none", "zero", "dust-long", "dust-short", "at-eps", "past-eps", "short", "string"])
 def test_position_qty_from_status_is_the_one_size_rule(qty, expected):
     """Direct cover for the helper (#283), which okx reaches without the accessor.
 
@@ -850,15 +854,48 @@ def test_position_qty_from_status_is_the_one_size_rule(qty, expected):
     returned whatever it was given, so an uncoerced path would have made the downstream
     `abs(current_qty) > 0` raise TypeError rather than size an order.
     """
-    from torchtrade.envs.core.state import position_qty_from_status
-
     status = None if qty is None else SimpleNamespace(qty=qty)
     assert position_qty_from_status(status) == expected
 
 
 def test_position_qty_from_status_refuses_an_unknown_status():
     """An outage is not flat -- the same rule position_direction_from_status enforces."""
-    from torchtrade.envs.core.state import position_qty_from_status
-
-    with pytest.raises(PositionUnknownError):
+    # match=: without it this passes whether or not the helper has its own guard, because
+    # _PositionUnknown.__getattr__("qty") raises the same type anyway.
+    with pytest.raises(PositionUnknownError, match="treating it as a size"):
         position_qty_from_status(POSITION_UNKNOWN)
+
+
+def test_okx_sizes_through_the_dust_rule_in_step():
+    """okx sizes in _step, not through the inherited accessor -- drive the real path.
+
+    The accessor cells above resolve on okx but okx never calls it, so reverting okx's own
+    read to `position_status.qty if position_status else 0.0` left the whole suite green.
+    This is the only cell that fails on that.
+    """
+    from torchtrade.envs.live.okx.env import OKXFuturesTorchTradingEnv
+
+    seen = {}
+
+    def _capture(desired_action, *, current_qty, current_price):
+        seen["current_qty"] = current_qty
+        raise RuntimeError("stop here; the stand-in cannot finish a step")
+
+    env = SimpleNamespace(
+        position=PositionState(),
+        trader=SimpleNamespace(
+            get_status=lambda: {
+                "position_status": SimpleNamespace(qty=1e-12, mark_price=100.0)
+            },
+            get_mark_price=lambda: 100.0,
+        ),
+        action_levels=[-1.0, 0.0, 1.0],
+        _sync_position_from_exchange=lambda ps: None,
+        _execute_trade_if_needed=_capture,
+    )
+    with pytest.raises(RuntimeError):
+        OKXFuturesTorchTradingEnv._step(env, {"action": 1})
+
+    assert seen["current_qty"] == 0.0, (
+        "a 1e-12 residual reached okx's sizing path as a live position"
+    )

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -789,7 +789,7 @@ def test_position_unknown_identity_survives_a_round_trip():
     assert copy.deepcopy({"position_status": POSITION_UNKNOWN})["position_status"] is POSITION_UNKNOWN
 
 
-@pytest.mark.parametrize("env_cls", NON_SLTP_ENVS, ids=lambda c: c.__name__)
+@pytest.mark.parametrize("env_cls", FUTURES_ENVS, ids=lambda c: c.__name__)
 def test_no_live_env_reforks_the_position_quantity_accessor(env_cls):
     """The size accessor lives on the shared base, and must stay there (#283).
 
@@ -799,7 +799,10 @@ def test_no_live_env_reforks_the_position_quantity_accessor(env_cls):
     that never happened.
 
     Structural, not behavioural: a re-forked copy that has not drifted yet passes every
-    behavioural test, which is exactly how three of them survived.
+    behavioural test, which is exactly how three of them survived. Over FUTURES_ENVS, not
+    just the non-SLTP ones: the SLTP variants inherit the accessor without calling it
+    today, so a fork there would be dead code -- and dead-but-wrong is the state the three
+    originals were in.
     """
     assert "_get_current_position_quantity" not in vars(env_cls), (
         f"{env_cls.__name__} redefines _get_current_position_quantity. The dust rule "
@@ -827,3 +830,35 @@ def test_a_dust_residual_does_not_look_like_a_position_to_the_trade_path(env_cls
     assert env_cls._get_current_position_quantity(env) == 0.0, (
         "a 1e-12 residual must read as flat, not as a position to close"
     )
+
+
+@pytest.mark.parametrize("qty,expected", [
+    (None, 0.0),        # no position at all
+    (0.0, 0.0),
+    (1e-12, 0.0),       # dust left by a full close
+    (-1e-12, 0.0),
+    (1e-9, 0.0),        # exactly at the epsilon, which is inclusive
+    (1.1e-9, 1.1e-9),   # just past it: a real, if tiny, position
+    (2.5, 2.5),
+    ("2.5", 2.5),       # exchanges return strings; the old form passed one through
+], ids=["none", "zero", "dust-long", "dust-short", "at-eps", "past-eps", "long", "string"])
+def test_position_qty_from_status_is_the_one_size_rule(qty, expected):
+    """Direct cover for the helper (#283), which okx reaches without the accessor.
+
+    The string cell is not hypothetical: binance, bybit and okx all read qty off the wire
+    as a string. They coerce at construction today, but the deleted hand-rolled form
+    returned whatever it was given, so an uncoerced path would have made the downstream
+    `abs(current_qty) > 0` raise TypeError rather than size an order.
+    """
+    from torchtrade.envs.core.state import position_qty_from_status
+
+    status = None if qty is None else SimpleNamespace(qty=qty)
+    assert position_qty_from_status(status) == expected
+
+
+def test_position_qty_from_status_refuses_an_unknown_status():
+    """An outage is not flat -- the same rule position_direction_from_status enforces."""
+    from torchtrade.envs.core.state import position_qty_from_status
+
+    with pytest.raises(PositionUnknownError):
+        position_qty_from_status(POSITION_UNKNOWN)

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -457,10 +457,12 @@ def test_unknown_status_refuses_to_build_account_state():
         TorchTradeFuturesLiveEnv._get_observation(env)
 
 
-# A rename would empty this and pytest would SKIP rather than fail -- the hazard this
-# file guards against elsewhere with its own len() assertions.
-_SIZING_ENVS = [c for c in NON_SLTP_ENVS if "_get_current_position_quantity" in vars(c)]
-assert len(_SIZING_ENVS) == 3, f"expected 3 envs that size from a live query, got {_SIZING_ENVS}"
+# Envs that size from a live query, now via the ONE shared accessor rather than three
+# byte-identical copies (#283). A rename would empty this and pytest would SKIP rather
+# than fail -- the hazard this file guards against elsewhere with its own len()
+# assertions.
+_SIZING_ENVS = [c for c in NON_SLTP_ENVS if hasattr(c, "_get_current_position_quantity")]
+assert len(_SIZING_ENVS) == 4, f"expected 4 envs that size from a live query, got {_SIZING_ENVS}"
 
 _FAILING_FETCH_EXCHANGES = ["binance", "bitget", "bybit", "okx", "alpaca"]
 
@@ -547,13 +549,13 @@ def test_reading_a_field_off_an_unknown_status_says_why():
 def test_position_sizing_refuses_an_unknown_status(env_cls):
     """_get_current_position_quantity must not size an order off a phantom flat account.
 
-    Its `position.qty if position is not None else 0.0` reads an outage as 0 quantity,
-    so the delta is computed against a position the exchange never said was gone. _step
-    normally raises earlier, on its own status read -- this is the path when the outage
-    begins between the two get_status() calls inside a single step.
+    The hand-rolled `position.qty if position is not None else 0.0` read an outage as 0
+    quantity, so the delta was computed against a position the exchange never said was
+    gone. _step normally raises earlier, on its own status read -- this is the path when
+    the outage begins between the two get_status() calls inside a single step.
 
-    3 of 5: okx takes current_qty from _step, and alpaca spells the same second query
-    inline, so both are covered through _step by the composite test instead.
+    All four futures envs, because the accessor is now shared (#283). Alpaca spells the
+    same second query inline and is covered through _step by the composite test instead.
     """
     env = SimpleNamespace(
         trader=SimpleNamespace(get_status=lambda: {"position_status": POSITION_UNKNOWN})
@@ -785,3 +787,43 @@ def test_position_unknown_identity_survives_a_round_trip():
     # __getattr__ that probe raises a trading error from inside a copy.
     assert copy.deepcopy(POSITION_UNKNOWN) is POSITION_UNKNOWN
     assert copy.deepcopy({"position_status": POSITION_UNKNOWN})["position_status"] is POSITION_UNKNOWN
+
+
+@pytest.mark.parametrize("env_cls", NON_SLTP_ENVS, ids=lambda c: c.__name__)
+def test_no_live_env_reforks_the_position_quantity_accessor(env_cls):
+    """The size accessor lives on the shared base, and must stay there (#283).
+
+    Three envs carried a byte-identical `position.qty if position is not None else 0.0`,
+    which returned a dust residual rather than 0 -- so `abs(current_qty) > 0` fired on a
+    flat account, closed nothing, and still advanced current_action_level from a trade
+    that never happened.
+
+    Structural, not behavioural: a re-forked copy that has not drifted yet passes every
+    behavioural test, which is exactly how three of them survived.
+    """
+    assert "_get_current_position_quantity" not in vars(env_cls), (
+        f"{env_cls.__name__} redefines _get_current_position_quantity. The dust rule "
+        "lives in position_qty_from_status -- inherit it rather than re-deriving qty."
+    )
+
+
+@pytest.mark.parametrize("env_cls", _SIZING_ENVS, ids=lambda c: c.__name__)
+def test_a_dust_residual_does_not_look_like_a_position_to_the_trade_path(env_cls):
+    """The concrete failure from #283, at the seam every sizing path reads.
+
+    An exchange can leave a float residual after a full close. Read as a live position it
+    makes `abs(current_qty) > 0` true on a flat account, so action 0.0 calls
+    close_position() on nothing -- and still advances current_action_level from a trade
+    that never happened, which freezes the duplicate-action guard (invariant 2).
+
+    The account_state paths already honoured the dust rule; only the TRADE paths
+    hand-rolled it, which is why nothing caught this.
+    """
+    env = SimpleNamespace(
+        trader=SimpleNamespace(
+            get_status=lambda: {"position_status": SimpleNamespace(qty=1e-12)}
+        )
+    )
+    assert env_cls._get_current_position_quantity(env) == 0.0, (
+        "a 1e-12 residual must read as flat, not as a position to close"
+    )

--- a/torchtrade/envs/core/state.py
+++ b/torchtrade/envs/core/state.py
@@ -81,6 +81,31 @@ def position_direction_from_status(position_status) -> int:
     return 1 if qty > 0 else -1
 
 
+def position_qty_from_status(position_status) -> float:
+    """The signed size the exchange holds, with dust read as flat. None means flat.
+
+    The size twin of position_direction_from_status, and it exists for the same reason:
+    the account_state paths honoured the dust rule while the TRADE paths hand-rolled
+    `position.qty if position is not None else 0.0`, so a 1e-12 residual made
+    `abs(current_qty) > 0` true on a flat account. That called close_position() on nothing
+    and still advanced current_action_level from a trade that never happened, freezing the
+    duplicate-action guard (#283).
+
+    Returning exactly 0.0 rather than the residual means every downstream `== 0`,
+    `abs(...) > 0` and `< 0` test is correct without each one repeating the epsilon.
+
+    POSITION_UNKNOWN raises, for the same reason it does there: an outage read as flat is
+    the whole bug.
+    """
+    if position_status is POSITION_UNKNOWN:
+        raise PositionUnknownError(
+            "exchange status is unknown; the caller must handle this rather than "
+            "treating it as a size"
+        )
+    qty = 0.0 if position_status is None else float(position_status.qty)
+    return 0.0 if abs(qty) <= POSITION_DUST_EPS else qty
+
+
 def binarize_action_type(action_type: str) -> int:
     """Convert action type string to binarized action value.
 

--- a/torchtrade/envs/live/binance/env.py
+++ b/torchtrade/envs/live/binance/env.py
@@ -210,12 +210,6 @@ class BinanceFuturesTorchTradingEnv(BinanceBaseTorchTradingEnv):
 
         return next_tensordict
 
-    def _get_current_position_quantity(self) -> float:
-        """Get current position quantity from trader status."""
-        status = self.trader.get_status()
-        position = status.get("position_status")
-        return position.qty if position is not None else 0.0
-
     def _create_trade_info(self, executed=False, **kwargs) -> Dict:
         """Create trade info dictionary with defaults."""
         info = {

--- a/torchtrade/envs/live/bitget/env.py
+++ b/torchtrade/envs/live/bitget/env.py
@@ -210,12 +210,6 @@ class BitgetFuturesTorchTradingEnv(BitgetBaseTorchTradingEnv):
 
         return next_tensordict
 
-    def _get_current_position_quantity(self) -> float:
-        """Get current position quantity from trader status."""
-        status = self.trader.get_status()
-        position = status.get("position_status")
-        return position.qty if position is not None else 0.0
-
     def _create_trade_info(self, executed=False, **kwargs) -> Dict:
         """Create trade info dictionary with defaults."""
         info = {

--- a/torchtrade/envs/live/bybit/env.py
+++ b/torchtrade/envs/live/bybit/env.py
@@ -168,12 +168,6 @@ class BybitFuturesTorchTradingEnv(BybitBaseTorchTradingEnv):
 
         return next_tensordict
 
-    def _get_current_position_quantity(self) -> float:
-        """Get current position quantity from trader status."""
-        status = self.trader.get_status()
-        position = status.get("position_status")
-        return position.qty if position is not None else 0.0
-
     def _create_trade_info(self, executed=False, **kwargs) -> Dict:
         """Create trade info dictionary with defaults."""
         info = {

--- a/torchtrade/envs/live/okx/env.py
+++ b/torchtrade/envs/live/okx/env.py
@@ -14,6 +14,7 @@ from torchtrade.envs.live.okx.order_executor import (
     MarginMode,
     PositionMode,
 )
+from torchtrade.envs.core.state import position_qty_from_status
 from torchtrade.envs.live.okx.base import OKXBaseTorchTradingEnv
 from torchtrade.envs.utils.fractional_sizing import (
     calculate_fractional_position,
@@ -108,12 +109,13 @@ class OKXFuturesTorchTradingEnv(OKXBaseTorchTradingEnv):
         """Execute one environment step."""
         status = self.trader.get_status()
         position_status = status.get("position_status", None)
-        if position_status:
-            current_price = position_status.mark_price
-            position_size = position_status.qty
-        else:
-            current_price = self.trader.get_mark_price()
-            position_size = 0.0
+        # Size through the canonical rule, not `position_status.qty` raw: a dust residual
+        # read as a live position makes abs(current_qty) > 0 true on a flat account, so
+        # action 0.0 closes nothing and still advances current_action_level (#283).
+        position_size = position_qty_from_status(position_status)
+        current_price = (
+            position_status.mark_price if position_status else self.trader.get_mark_price()
+        )
 
         # No-op today (this env's _execute_trade_if_needed recomputes qty live and never reads
         # current_action_level), but keeps the field consistent so adding a duplicate-action

--- a/torchtrade/envs/live/shared/futures_live_base.py
+++ b/torchtrade/envs/live/shared/futures_live_base.py
@@ -13,8 +13,11 @@ import torch
 from tensordict import TensorDict, TensorDictBase
 
 from torchtrade.envs.core.live import TorchTradeLiveEnv
-from torchtrade.envs.core.state import position_qty_from_status
-from torchtrade.envs.core.state import advance_hold_counter, position_direction_from_status
+from torchtrade.envs.core.state import (
+    advance_hold_counter,
+    position_direction_from_status,
+    position_qty_from_status,
+)
 
 
 class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):

--- a/torchtrade/envs/live/shared/futures_live_base.py
+++ b/torchtrade/envs/live/shared/futures_live_base.py
@@ -13,6 +13,7 @@ import torch
 from tensordict import TensorDict, TensorDictBase
 
 from torchtrade.envs.core.live import TorchTradeLiveEnv
+from torchtrade.envs.core.state import position_qty_from_status
 from torchtrade.envs.core.state import advance_hold_counter, position_direction_from_status
 
 
@@ -130,3 +131,12 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
         """Calculate total portfolio value (includes unrealized PnL)."""
         balance = self.trader.get_account_balance()
         return balance.get("total_margin_balance", 0)
+
+    def _get_current_position_quantity(self) -> float:
+        """The signed size the exchange holds, dust read as flat.
+
+        One copy: binance, bitget and bybit each carried a byte-identical
+        `position.qty if position is not None else 0.0`, which returned the residual
+        rather than 0 and let `abs(current_qty) > 0` fire on a flat account (#283).
+        """
+        return position_qty_from_status(self.trader.get_status().get("position_status"))


### PR DESCRIPTION
Refs #283 — fixes the **futures trade-execution sizing paths**. Scope is deliberately narrower than the issue's full list; see below.

## The bug

`CLAUDE.md` invariant 1: every qty→direction conversion must go through `position_direction_from_status` / `POSITION_DUST_EPS`. The **account_state** paths did. The **trade** paths hand-rolled it:

```python
return position.qty if position is not None else 0.0     # returns the residual
```

A `1e-12` residual left by a full close makes `abs(current_qty) > 0` true on a flat account. Action `0.0` then calls `close_position()` on nothing — **and still advances `current_action_level` from a trade that never happened**, freezing the duplicate-action guard that invariant 2 exists to protect.

## The fix

`position_qty_from_status` joins `position_direction_from_status` in `core/state.py` as the **size twin of the same rule**: dust reads as exactly `0.0`, so every downstream `== 0`, `< 0` and `abs(...) > 0` is correct without each site repeating the epsilon. `POSITION_UNKNOWN` raises rather than returning a size — an outage read as flat is the whole bug.

binance, bitget and bybit each carried a **byte-identical** `_get_current_position_quantity` (verified against `main`). One dust-aware copy now lives on `TorchTradeFuturesLiveEnv`; the three are deleted. okx sizes from `_step` rather than through an accessor, so it calls the helper directly.

One incidental improvement: `float()` coercion. The old form returned a raw `str` unchanged, which would have made `abs(current_qty) > 0` raise `TypeError`.

## What this does NOT fix

Review was explicit that the issue's list is wider than this change, so stating it plainly:

| still hand-rolled | impact |
|---|---|
| `alpaca/env.py:239` raw qty read | the only remaining raw read on a **real trade path**; damped by a `$1 min_trade_value` gate. Alpaca is spot and cannot inherit the futures accessor |
| 9 × `position_size = position_status.qty` history writes (incl. all five `env_sltp.py`) | dust reaches `HistoryTracker` and any reward reading it |
| 3 × `close()` `qty != 0` warnings | spurious warning only |
| executor-level `qty == 0` / raw-payload `!= 0` | not on the sizing path |

The SLTP variants' *trade decision* is already dust-safe — it gates on `self.position.current_position`, which `core/live.py:218` writes through `position_direction_from_status`. Only their recorded `position_size` is not.

`POSITION_TOLERANCE_ABS` is a change of **denomination** on a live sizing threshold rather than a dust-rule violation, and is split out as **#339**. Two adjacent bitget/bybit parsing risks found while tracing are **#341**.

## The structural guard needed updating, not extending

`test_live_env_base.py` discovered envs by `"_get_current_position_quantity" in vars(c)` and asserted exactly 3 — so hoisting emptied it. Caught by its own `len()` assertion, which is what that assertion is for. It now discovers by `hasattr`, and a new cell asserts no env re-forks the accessor — over `FUTURES_ENVS`, not just the non-SLTP ones, because round 1 showed a fork onto an SLTP variant passed all 2150 tests.

## Testing

| mutation | result |
|---|---|
| revert the dust rule in the helper | **8 fail** — this PR's cells are the suite's only guard for it |
| drop `float()` coercion | **1 fail** |
| return `abs(qty)`, losing the sign | **1 fail** (0 before round 2) |
| revert **okx's own** `_step` read | **1 fail** (0 before round 2 — okx never calls the accessor) |
| delete the helper's `POSITION_UNKNOWN` guard | **1 fail** (0 before round 2 — the cell was vacuous) |
| re-fork the accessor onto a non-SLTP env | **15 fail** |
| re-fork onto an **SLTP** env | **1 fail** (0 before round 1) |
| rename the base method | collection **error**, not a silent skip |

`tests/envs`: **2167 passed, 19 skipped.**
