### PR TITLE
fix(live): stop live envs reading fabricated numbers as safe (#277)

### DIFF
--- a/tests/envs/binance/test_torch_env_futures.py
+++ b/tests/envs/binance/test_torch_env_futures.py
@@ -383,15 +383,17 @@ class TestBinanceFuturesTorchTradingEnv:
 
     @pytest.mark.parametrize("qty,liq_price,expected_dtl", [
         (0.001, 45000.0, pytest.approx(0.1018, rel=1e-2)),   # long normal: (50100-45000)/50100
-        (0.001, 0.0, 1.0),                                   # long zero-liq -> unknown -> 1.0
+        (0.001, 0.0, pytest.approx(0.0978, rel=1e-3)),   # long, venue omits liq: 50000*(1-1/10+0.004)=45200
         (-0.001, 55000.0, pytest.approx(0.0978, rel=1e-2)),  # short normal: (55000-50100)/50100
-        (-0.001, 0.0, 1.0),                                  # short zero-liq -> unknown -> 1.0 (the fix)
+        (-0.001, 0.0, pytest.approx(0.0938, rel=1e-3)),  # short, venue omits liq: 50000*(1+1/10-0.004)=54800
     ], ids=["long-normal", "long-zero-liq", "short-normal", "short-zero-liq"])
     def test_distance_to_liquidation(self, env, mock_trader, qty, liq_price, expected_dtl):
         """distance_to_liquidation (account_state[5]) across long/short x normal/zero-liq.
 
-        A zero/absent liq price (cross-margin, or .get(..., 0)) must read 1.0 -- for a short the
-        unguarded (0 - price)/price = 0.0 would falsely signal AT liquidation. Matches bybit/okx.
+        A zero/absent liq price (cross-margin) is estimated from leverage rather than read
+        as 1.0, which reported a levered position as being as safe as a flat account (#277).
+        The estimate also has to land before the subtraction: an unguarded (0 - price)/price
+        clamps to 0.0, the opposite lie, falsely signalling a short is AT liquidation.
         """
         from torchtrade.envs.live.binance.order_executor import PositionStatus
 

--- a/tests/envs/bitget/test_torch_env_futures.py
+++ b/tests/envs/bitget/test_torch_env_futures.py
@@ -361,15 +361,17 @@ class TestBitgetFuturesTorchTradingEnv:
 
     @pytest.mark.parametrize("qty,liq_price,expected_dtl", [
         (0.001, 45000.0, pytest.approx(0.1018, rel=1e-2)),   # long normal: (50100-45000)/50100
-        (0.001, 0.0, 1.0),                                   # long zero-liq -> unknown -> 1.0
+        (0.001, 0.0, pytest.approx(0.0978, rel=1e-3)),   # long, venue omits liq: 50000*(1-1/10+0.004)=45200
         (-0.001, 55000.0, pytest.approx(0.0978, rel=1e-2)),  # short normal: (55000-50100)/50100
-        (-0.001, 0.0, 1.0),                                  # short zero-liq -> unknown -> 1.0 (the fix)
+        (-0.001, 0.0, pytest.approx(0.0938, rel=1e-3)),  # short, venue omits liq: 50000*(1+1/10-0.004)=54800
     ], ids=["long-normal", "long-zero-liq", "short-normal", "short-zero-liq"])
     def test_distance_to_liquidation(self, env, mock_trader, qty, liq_price, expected_dtl):
         """distance_to_liquidation (account_state[5]) across long/short x normal/zero-liq.
 
-        A zero/absent liq price (cross-margin, or .get(..., 0)) must read 1.0 -- for a short the
-        unguarded (0 - price)/price = 0.0 would falsely signal AT liquidation. Matches bybit/okx.
+        A zero/absent liq price (cross-margin) is estimated from leverage rather than read
+        as 1.0, which reported a levered position as being as safe as a flat account (#277).
+        The estimate also has to land before the subtraction: an unguarded (0 - price)/price
+        clamps to 0.0, the opposite lie, falsely signalling a short is AT liquidation.
         """
         from torchtrade.envs.live.bitget.order_executor import PositionStatus
 

--- a/tests/envs/bybit/test_torch_env_futures.py
+++ b/tests/envs/bybit/test_torch_env_futures.py
@@ -445,12 +445,12 @@ class TestBybitZeroLiquidationPrice:
 
     @pytest.mark.parametrize("qty,liq_price,expected_dtl", [
         (0.001, 45000.0, pytest.approx(0.1018, rel=1e-2)),  # Long normal: (50100-45000)/50100
-        (0.001, 0.0, 1.0),                                   # Long zero liq: unknown → 1.0
+        (0.001, 0.0, pytest.approx(0.0978, rel=1e-3)),   # long, venue omits liq: 50000*(1-1/10+0.004)=45200
         (-0.001, 55000.0, pytest.approx(0.0978, rel=1e-2)),  # Short normal: (55000-50100)/50100
-        (-0.001, 0.0, 1.0),                                   # Short zero liq: unknown → 1.0
+        (-0.001, 0.0, pytest.approx(0.0938, rel=1e-3)),  # short, venue omits liq: 50000*(1+1/10-0.004)=54800
     ], ids=["long-normal", "long-zero-liq", "short-normal", "short-zero-liq"])
     def test_distance_to_liquidation(self, env, mock_env_trader, qty, liq_price, expected_dtl):
-        """Zero liquidation price must return 1.0 (consistent with Binance/Bitget)."""
+        """distance_to_liquidation, with and without a liquidation price from the venue."""
         from torchtrade.envs.live.bybit.order_executor import PositionStatus
 
         mock_env_trader.get_status = MagicMock(return_value={

--- a/tests/envs/offline/test_sequential.py
+++ b/tests/envs/offline/test_sequential.py
@@ -1126,3 +1126,25 @@ class TestExecutionPriceConvention:
                 "about which bar the decision belongs to"
             )
         env.close()
+
+
+def test_liquidation_price_refuses_a_zero_entry_price():
+    """The offline route of the #277 guard: 0.0 back would read as "no position".
+
+    `_calculate_liquidation_price` returns 0.0 for the two legitimate no-liquidation
+    cases (spot, and no position), so a third 0.0 meaning "the entry price was garbage"
+    is indistinguishable from them downstream. Re-inlining the arithmetic here without
+    the guard is what this catches.
+    """
+    from types import SimpleNamespace
+    from torchtrade.envs.offline.sequential import (
+        SequentialTradingEnv, SequentialTradingEnvConfig,
+    )
+
+    env = SimpleNamespace(
+        has_liquidation=True,
+        leverage=10,
+        maintenance_margin_rate=SequentialTradingEnvConfig().maintenance_margin_rate,
+    )
+    with pytest.raises(ValueError, match="entry_price must be positive"):
+        SequentialTradingEnv._calculate_liquidation_price(env, 0.0, 1.0)

--- a/tests/envs/okx/test_torch_env_futures.py
+++ b/tests/envs/okx/test_torch_env_futures.py
@@ -344,12 +344,12 @@ class TestOKXZeroLiquidationPrice:
 
     @pytest.mark.parametrize("qty,liq_price,expected_dtl", [
         (0.001, 45000.0, pytest.approx(0.1018, rel=1e-2)),
-        (0.001, 0.0, 1.0),
+        (0.001, 0.0, pytest.approx(0.0978, rel=1e-3)),   # long, venue omits liq: 50000*(1-1/10+0.004)=45200
         (-0.001, 55000.0, pytest.approx(0.0978, rel=1e-2)),
-        (-0.001, 0.0, 1.0),
+        (-0.001, 0.0, pytest.approx(0.0938, rel=1e-3)),  # short, venue omits liq: 50000*(1+1/10-0.004)=54800
     ], ids=["long-normal", "long-zero-liq", "short-normal", "short-zero-liq"])
     def test_distance_to_liquidation(self, env, mock_env_trader, qty, liq_price, expected_dtl):
-        """Zero liquidation price must return 1.0 (consistent with other exchanges)."""
+        """distance_to_liquidation, with and without a liquidation price from the venue."""
         from torchtrade.envs.live.okx.order_executor import PositionStatus
 
         mock_env_trader.get_status = MagicMock(return_value={

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -1351,6 +1351,10 @@ def test_every_live_env_validates_its_bankruptcy_baseline():
     terminates. Indexing the key stops an adapter fabricating the 0, and this stops a
     genuinely empty account starting an episode that can never terminate.
 
+    Checks for the finiteness test specifically, not just a positivity one: `not (x > 0)`
+    catches NaN but passes `+inf`, and `is_bankrupt(current=1e9, initial=inf)` is True --
+    every step of every episode would read bankrupt.
+
     Structural because the assignment sits inside per-exchange `_reset` scaffolding that
     needs a live client to reach. Four copies of one line is itself the drift risk the
     shared base exists to remove -- hoisting it is follow-up work (#345).
@@ -1365,7 +1369,7 @@ def test_every_live_env_validates_its_bankruptcy_baseline():
 
     unguarded = [
         p.parent.name for p in bases
-        if "if not (self.initial_portfolio_value > 0):" not in p.read_text()
+        if "math.isfinite(self.initial_portfolio_value)" not in p.read_text()
     ]
     assert unguarded == [], (
         f"{unguarded} assign initial_portfolio_value without rejecting a non-positive "
@@ -1571,3 +1575,57 @@ def test_polymarket_accepts_the_endpoints_of_the_probability_range(price):
     from torchtrade.envs.live.polymarket.market_scanner import _valid_price
 
     assert _valid_price(price, "yes_price", "some-market") == float(price)
+
+
+@pytest.mark.parametrize("field,value", [
+    ("cash", float("nan")),
+    ("cash", float("inf")),
+    ("market_value", float("nan")),
+], ids=["nan-cash", "inf-cash", "nan-market-value"])
+def test_alpaca_refuses_to_size_a_trade_from_a_non_finite_read(field, value):
+    """The worst path in this PR: these reads size a REAL order.
+
+    A NaN makes delta_qty NaN; `nan > 0` is False so the caller always takes the SELL
+    branch; and in trade_mode="notional" a sell is intercepted as close_position(). One
+    garbage tick would liquidate the entire position. `total_portfolio <= 0` cannot see
+    that, which is why the check is on finiteness.
+    """
+    from torchtrade.envs.live.alpaca.env import AlpacaTorchTradingEnv
+
+    cash = value if field == "cash" else 10000.0
+    market_value = value if field == "market_value" else 1000.0
+    env = SimpleNamespace(
+        trader=SimpleNamespace(
+            client=SimpleNamespace(get_account=lambda: SimpleNamespace(cash=str(cash))),
+            get_status=lambda: {"position_status": SimpleNamespace(
+                qty=10.0, market_value=market_value)},
+        ),
+    )
+    with pytest.raises(ValueError, match="refusing to size a trade against it"):
+        AlpacaTorchTradingEnv._calculate_fractional_position(env, 1.0, 100.0)
+
+
+def test_alpaca_portfolio_value_refuses_a_non_finite_read():
+    """alpaca's _step calls this BEFORE building an observation, and its value feeds the
+    reward and _check_termination -- so the observation guard can never catch it."""
+    from torchtrade.envs.live.alpaca.base import AlpacaBaseTorchTradingEnv
+
+    env = SimpleNamespace(
+        trader=SimpleNamespace(
+            get_status=lambda: {"position_status": None},
+            client=SimpleNamespace(get_account=lambda: SimpleNamespace(cash="nan")),
+        ),
+    )
+    with pytest.raises(ValueError, match="non-finite portfolio value"):
+        AlpacaBaseTorchTradingEnv._get_portfolio_value(env)
+
+
+@pytest.mark.parametrize("field", ["volume24hr", "volume", "liquidity", "spread"])
+def test_polymarket_refuses_non_finite_market_numbers(field):
+    """Three of these four are the market half of the observation tensor, and
+    `_filter_markets` compares them with `<`/`>`, which NaN passes -- so garbage survives
+    filtering and reaches the policy network."""
+    from torchtrade.envs.live.polymarket.market_scanner import _finite
+
+    with pytest.raises(ValueError, match="not a finite non-negative number"):
+        _finite("nan", field, "some-market")

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -1356,7 +1356,7 @@ def test_every_live_env_validates_its_bankruptcy_baseline():
     every step of every episode would read bankrupt.
 
     Structural because the assignment sits inside per-exchange `_reset` scaffolding that
-    needs a live client to reach. Four copies of one line is itself the drift risk the
+    needs a live client to reach. Five copies of one line is itself the drift risk the
     shared base exists to remove -- hoisting it is follow-up work (#345).
     """
     live_root = pathlib.Path(inspect.getfile(TorchTradeLiveEnv)).parent.parent / "live"
@@ -1629,3 +1629,48 @@ def test_polymarket_refuses_non_finite_market_numbers(field):
 
     with pytest.raises(ValueError, match="not a finite non-negative number"):
         _finite("nan", field, "some-market")
+
+
+def test_alpaca_sizing_refuses_a_non_finite_position_quantity():
+    """Alpaca hand-rolled `float(position_status.qty)` here, bypassing the dust rule.
+
+    The dust half of that is absorbed downstream -- a 1e-12 difference in delta_qty loses
+    to the $1 minimum-trade tolerance -- so this asserts the half that survives: a NaN qty
+    used to flow into `delta_qty = target_qty - current_qty`, and `nan > 0` is False, so
+    the trade fell to the SELL branch. In trade_mode="notional" a sell is intercepted as
+    close_position(). Going through position_qty_from_status raises instead.
+    """
+    from torchtrade.envs.live.alpaca.env import AlpacaTorchTradingEnv
+
+    submitted = []
+    env = SimpleNamespace(
+        trader=SimpleNamespace(
+            get_status=lambda: {"position_status": SimpleNamespace(
+                qty=float("nan"), market_value=1000.0, current_price=100.0)},
+            trade=lambda **kw: submitted.append(kw) or True,
+        ),
+        _get_current_price=lambda ps: 100.0,
+        _calculate_fractional_position=lambda *a, **k: (1000.0, 10.0),
+    )
+    with pytest.raises(ValueError, match="non-finite position quantity"):
+        AlpacaTorchTradingEnv._execute_fractional_action(env, 1.0)
+    assert submitted == [], f"an order was submitted from a NaN quantity: {submitted}"
+
+
+@pytest.mark.parametrize("exchange", ["binance", "bitget", "bybit", "okx"])
+def test_futures_sizing_rejects_a_non_finite_balance(exchange):
+    """`not (x > 0)` catches NaN but passes +inf, and these four lines are this PR's own.
+
+    An inf balance sizes an inf target: bitget's amount rounding then yields NaN and hands
+    it to create_order, while binance and bybit raise an undiagnosable OverflowError
+    mid-step. The alpaca sibling written in the same commit is safe only because it
+    isfinite-checks its inputs first.
+    """
+    src = (pathlib.Path(inspect.getfile(TorchTradeLiveEnv)).parent.parent
+           / "live" / exchange / "env.py").read_text()
+    assert "if not (total_balance > 0):" not in src, (
+        f"{exchange} sizes against a balance guarded by `not (x > 0)`, which +inf passes"
+    )
+    assert "math.isfinite(total_balance)" in src, (
+        f"{exchange} does not check that the sizing balance is finite"
+    )

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -1033,12 +1033,15 @@ def test_unusable_inputs_raise_instead_of_pricing_a_liquidation(kwargs, match):
         isolated_liquidation_price(**args)
 
 
-@pytest.mark.parametrize("position_value,equity", [
-    (100.0, 0.0),
-    (100.0, -50.0),
-    (100.0, float("nan")),
+@pytest.mark.parametrize("position_value,equity,match", [
+    (100.0, 0.0, "refusing to report this account as flat"),
+    (100.0, -50.0, "refusing to report this account as flat"),
+    # NaN is caught earlier and more specifically, by the equity finiteness check: on a
+    # FLAT account the held-position guard cannot see it, and the same value reaches
+    # is_bankrupt(), where `nan < threshold * initial` is False -- termination disabled.
+    (100.0, float("nan"), "non-finite equity"),
 ], ids=["zero-equity", "negative-equity", "nan-equity"])
-def test_position_held_against_unusable_equity_refuses_to_report_flat(position_value, equity):
+def test_position_held_against_unusable_equity_refuses_to_report_flat(position_value, equity, match):
     """A held position must never divide out to 0.0% exposure.
 
     The NaN cell is not hypothetical pedantry: written `total_balance <= 0`, the raise is
@@ -1049,7 +1052,7 @@ def test_position_held_against_unusable_equity_refuses_to_report_flat(position_v
     env = _futures_env_stub(
         _open_position(position_value / 100.0), {"total_margin_balance": equity}
     )
-    with pytest.raises(ValueError, match="refusing to report this account as flat"):
+    with pytest.raises(ValueError, match=match):
         TorchTradeFuturesLiveEnv._get_observation(env)
 
 
@@ -1396,7 +1399,7 @@ def test_fractional_leverage_still_gets_a_real_distance(qty):
     assert distance < 1.0
 
 
-def test_no_adapter_falls_back_to_config_leverage_with_or():
+def test_no_adapter_swaps_a_venue_reported_zero_leverage_for_the_config():
     """`float(pos.get("leverage") or self.leverage)` swaps a venue-reported 0 for the config.
 
     A numeric 0 is falsy, so `or` silently substitutes a leverage the venue never
@@ -1407,6 +1410,13 @@ def test_no_adapter_falls_back_to_config_leverage_with_or():
     Structural because the behavioural cells construct PositionStatus directly and so
     cannot see the adapter's parsing at all -- which is why this regression survived a
     mutation run that killed everything else.
+
+    Scope, stated so this is not mistaken for more than it is: a MISSING or BLANK venue
+    leverage still falls back to the config value, deliberately, because refusing would
+    leave OKX and bybit cross accounts unable to produce an observation at all. That
+    fallback is only as good as set_leverage having worked, which #277's unfixed half is
+    about. What this forbids is the silent case -- a leverage the venue did report, as 0,
+    being swapped for a different number.
     """
     live_root = pathlib.Path(inspect.getfile(TorchTradeLiveEnv)).parent.parent / "live"
     offenders = [
@@ -1419,3 +1429,75 @@ def test_no_adapter_falls_back_to_config_leverage_with_or():
         f"venue leverage falls back to the config value via `or` at {offenders}; test "
         f"`in (None, \"\")` so a genuine 0 stays 0 and fails loudly downstream"
     )
+
+
+def test_flat_account_with_non_finite_equity_still_raises():
+    """The held-position guard is keyed on direction, so a flat account bypasses it.
+
+    That matters because the same equity reaches is_bankrupt(), where
+    `nan < threshold * initial` is False -- bankruptcy silently disabled for the rest of
+    the episode, on an account whose equity the venue could not report.
+    """
+    env = _futures_env_stub(None, {"total_margin_balance": float("nan")})
+    with pytest.raises(ValueError, match="non-finite equity"):
+        TorchTradeFuturesLiveEnv._get_observation(env)
+
+
+def _alpaca_env_stub(position_status, cash):
+    """Stand-in for AlpacaBaseTorchTradingEnv._get_observation. Spot, so no leverage."""
+    from torchtrade.envs.live.alpaca.base import AlpacaBaseTorchTradingEnv  # noqa: F401
+
+    return SimpleNamespace(
+        observer=SimpleNamespace(
+            get_observations=lambda **k: {}, get_keys=lambda: [],
+            get_current_price=lambda: 100.0,
+        ),
+        trader=SimpleNamespace(
+            get_status=lambda: {"position_status": position_status},
+            client=SimpleNamespace(get_account=lambda: SimpleNamespace(cash=str(cash))),
+        ),
+        config=SimpleNamespace(include_base_features=False),
+        position=PositionState(),
+        account_state_key="account_state",
+        market_data_keys=[],
+    )
+
+
+def _alpaca_position(qty=1.0, market_value=1000.0, avg_entry_price=100.0,
+                     current_price=102.0, unrealized_plpc=0.02):
+    return SimpleNamespace(
+        qty=qty, market_value=market_value, avg_entry_price=avg_entry_price,
+        current_price=current_price, unrealized_plpc=unrealized_plpc,
+    )
+
+
+@pytest.mark.parametrize("field", [
+    "qty", "market_value", "avg_entry_price", "current_price", "unrealized_plpc",
+])
+def test_alpaca_non_finite_venue_numbers_refuse_to_build_an_account_state(field):
+    """Spot is not exempt from any of this (#277).
+
+    Alpaca was the one live env left without the guards after the futures four got them --
+    the same shape as the bankruptcy baseline, where the guard excluded alpaca by name and
+    so skipped the one env still carrying the bug. A NaN unrealized_plpc here goes
+    straight into the observation tensor and on into the policy network.
+    """
+    from torchtrade.envs.live.alpaca.base import AlpacaBaseTorchTradingEnv
+
+    position = _alpaca_position()
+    setattr(position, field, float("nan"))
+    env = _alpaca_env_stub(position, cash=10000.0)
+
+    with pytest.raises(ValueError, match=f"non-finite {field}"):
+        AlpacaBaseTorchTradingEnv._get_observation(env)
+
+
+def test_alpaca_position_held_against_wiped_portfolio_refuses_to_report_flat():
+    """Invariant #3 on the spot env: `portfolio_value > 0 else 0.0` read a held position
+    as flat whenever margin debt exceeded the position's market value."""
+    from torchtrade.envs.live.alpaca.base import AlpacaBaseTorchTradingEnv
+
+    env = _alpaca_env_stub(_alpaca_position(market_value=1000.0), cash=-1000.0)
+
+    with pytest.raises(ValueError, match="refusing to report this account as flat"):
+        AlpacaBaseTorchTradingEnv._get_observation(env)

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -22,6 +22,7 @@ import torchtrade.envs  # noqa: F401  -- registers every live env as a subclass
 from torchtrade.envs.core.live import TorchTradeLiveEnv
 from torchtrade.envs.live.shared.futures_live_base import TorchTradeFuturesLiveEnv
 from torchtrade.envs.utils.sltp_mixin import SLTPMixin
+from torchtrade.envs.utils.liquidation import isolated_liquidation_price
 from torchtrade.envs.core.state import (
     POSITION_UNKNOWN,
     PositionState,
@@ -899,3 +900,150 @@ def test_okx_sizes_through_the_dust_rule_in_step():
     assert seen["current_qty"] == 0.0, (
         "a 1e-12 residual reached okx's sizing path as a live position"
     )
+
+
+# --- #277: account_state must not fail open on missing venue fields ---------------
+
+
+def _futures_env_stub(position_status, balance, leverage=20):
+    """Minimal stand-in for calling TorchTradeFuturesLiveEnv._get_observation directly.
+
+    Same shape as test_unknown_status_refuses_to_build_account_state above: one call
+    site, because all 12 futures envs resolve _get_observation to this one
+    implementation and test_no_futures_env_reforks_the_shared_observation proves it.
+    """
+    return SimpleNamespace(
+        observer=SimpleNamespace(get_observations=lambda **k: {}, get_keys=lambda: []),
+        trader=SimpleNamespace(
+            get_status=lambda: {"position_status": position_status},
+            get_account_balance=lambda: balance,
+            get_mark_price=lambda: 100.0,
+        ),
+        config=SimpleNamespace(include_base_features=False, leverage=leverage),
+        position=PositionState(),
+        account_state_key="account_state",
+        market_data_keys=[],
+    )
+
+
+def _open_position(qty, *, entry_price=100.0, mark_price=100.0, leverage=20,
+                   liquidation_price=0.0):
+    return SimpleNamespace(
+        qty=qty,
+        notional_value=qty * mark_price,
+        entry_price=entry_price,
+        mark_price=mark_price,
+        unrealized_pnl_pct=0.0,
+        leverage=leverage,
+        liquidation_price=liquidation_price,
+    )
+
+
+@pytest.mark.parametrize("qty,expected", [
+    (1.0, (100.0 - 100.0 * (1 - 1 / 20 + 0.004)) / 100.0),   # long: liq below
+    (-1.0, (100.0 * (1 + 1 / 20 - 0.004) - 100.0) / 100.0),  # short: liq above
+], ids=["long", "short"])
+def test_cross_margin_position_without_liq_price_does_not_read_as_flat(qty, expected):
+    """The #277 bug: bybit/OKX send liqPrice="" for cross, which arrived here as 0.0.
+
+    `liquidation_price <= 0` then took the same branch as "no position at all" and
+    reported 1.0 -- a 20x position four percent from liquidation reading exactly as safe
+    as a flat spot account. Asserts the isolated-margin estimate, not merely "< 1.0", so
+    a fallback that returns any arbitrary smaller number still fails.
+    """
+    env = _futures_env_stub(_open_position(qty), {"total_margin_balance": 1000.0})
+    obs = TorchTradeFuturesLiveEnv._get_observation(env)
+    distance = obs["account_state"][5].item()
+
+    assert distance == pytest.approx(expected, rel=1e-5)
+    assert distance < 1.0, "an open levered position still reads as safe as flat"
+
+
+def test_venue_liq_price_is_used_verbatim_when_present():
+    """The fallback is for an absent price, not a second opinion on a published one.
+
+    Isolated-margin venues do publish liqPrice; estimating over the top of it would put
+    the live observation at odds with the exchange that will actually do the liquidating.
+    90.0 here is deliberately NOT what the isolated formula gives (95.4).
+    """
+    env = _futures_env_stub(
+        _open_position(1.0, liquidation_price=90.0), {"total_margin_balance": 1000.0}
+    )
+    obs = TorchTradeFuturesLiveEnv._get_observation(env)
+
+    assert obs["account_state"][5].item() == pytest.approx(0.1, rel=1e-6)
+
+
+def test_flat_account_still_reads_as_maximally_far_from_liquidation():
+    """The other half of invariant #3: the fallback must not make a flat account look risky.
+
+    The fallback reads entry_price off position_status, which is None when flat -- so a
+    fallback hoisted above the position check would raise here rather than report 1.0.
+    """
+    env = _futures_env_stub(None, {"total_margin_balance": 1000.0})
+    obs = TorchTradeFuturesLiveEnv._get_observation(env)
+
+    assert obs["account_state"][5].item() == 1.0
+    assert obs["account_state"][0].item() == 0.0
+
+
+def test_missing_balance_key_raises_rather_than_reporting_zero_exposure():
+    """`.get("total_margin_balance", 0)` made a broken adapter report every position flat.
+
+    All four adapters build the key unconditionally, so its absence is a bug in the
+    adapter, and 0.0 exposure is the one answer guaranteed to be wrong.
+    """
+    env = _futures_env_stub(_open_position(1.0), {"available_balance": 1000.0})
+    with pytest.raises(KeyError, match="total_margin_balance"):
+        TorchTradeFuturesLiveEnv._get_observation(env)
+
+
+def test_position_held_against_zero_equity_refuses_to_report_flat_exposure():
+    """Equity wiped with the position still on: exposure is unbounded, and it is not 0.0."""
+    env = _futures_env_stub(_open_position(1.0), {"total_margin_balance": 0.0})
+    with pytest.raises(ValueError, match="refusing to report this account as flat"):
+        TorchTradeFuturesLiveEnv._get_observation(env)
+
+
+def test_empty_flat_account_is_zero_exposure_not_an_error():
+    """The zero-equity guard must not fire on an account that is simply empty and flat."""
+    env = _futures_env_stub(None, {"total_margin_balance": 0.0})
+    obs = TorchTradeFuturesLiveEnv._get_observation(env)
+
+    assert obs["account_state"][0].item() == 0.0
+
+
+@pytest.mark.parametrize("kwargs,match", [
+    ({"leverage": 0}, "leverage must be positive"),
+    ({"entry_price": 0.0}, "entry_price must be positive"),
+], ids=["zero-leverage", "zero-entry"])
+def test_unusable_inputs_raise_instead_of_pricing_a_liquidation(kwargs, match):
+    """Without these the venue's own bad data produces 0.0, which reads as distance 1.0.
+
+    That is #277 again by a different route: a zero liquidation price is indistinguishable
+    from the flat case downstream, so the caller must never receive one.
+    """
+    args = {"entry_price": 100.0, "is_long": True, "leverage": 10}
+    args.update(kwargs)
+    with pytest.raises(ValueError, match=match):
+        isolated_liquidation_price(**args)
+
+
+@pytest.mark.parametrize("is_long", [True, False], ids=["long", "short"])
+def test_live_fallback_agrees_with_the_offline_env_it_trains_against(is_long):
+    """Live and offline must place liquidation at the same price for the same position.
+
+    This is the reason the rule was extracted rather than copied: a policy trained on the
+    offline geometry reads account_state[5] live and must be reading the same quantity.
+    Compares against the offline env's own method, so re-inlining either copy fails here.
+    """
+    from torchtrade.envs.offline.sequential import SequentialTradingEnv
+
+    offline = SimpleNamespace(
+        has_liquidation=True, leverage=20, maintenance_margin_rate=0.004
+    )
+    expected = SequentialTradingEnv._calculate_liquidation_price(
+        offline, 100.0, 1.0 if is_long else -1.0
+    )
+
+    assert isolated_liquidation_price(100.0, is_long=is_long, leverage=20) == expected

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -1298,7 +1298,9 @@ def test_non_finite_venue_numbers_refuse_to_build_an_account_state(field):
     setattr(position, field, float("nan"))
     env = _futures_env_stub(position, {"total_margin_balance": 1000.0})
 
-    with pytest.raises(ValueError, match=f"non-finite {field}"):
+    # qty is caught upstream, by the dust rule, before this loop runs -- it has to be,
+    # because the live _steps sync and trade on the direction it returns.
+    with pytest.raises(ValueError, match=f"non-finite ({field}|position quantity)"):
         TorchTradeFuturesLiveEnv._get_observation(env)
 
 
@@ -1488,7 +1490,9 @@ def test_alpaca_non_finite_venue_numbers_refuse_to_build_an_account_state(field)
     setattr(position, field, float("nan"))
     env = _alpaca_env_stub(position, cash=10000.0)
 
-    with pytest.raises(ValueError, match=f"non-finite {field}"):
+    # qty is caught upstream, by the dust rule, before this loop runs -- it has to be,
+    # because the live _steps sync and trade on the direction it returns.
+    with pytest.raises(ValueError, match=f"non-finite ({field}|position quantity)"):
         AlpacaBaseTorchTradingEnv._get_observation(env)
 
 
@@ -1501,3 +1505,59 @@ def test_alpaca_position_held_against_wiped_portfolio_refuses_to_report_flat():
 
     with pytest.raises(ValueError, match="refusing to report this account as flat"):
         AlpacaBaseTorchTradingEnv._get_observation(env)
+
+
+@pytest.mark.parametrize("qty", [float("nan"), float("inf"), float("-inf")],
+                         ids=["nan", "inf", "-inf"])
+def test_dust_rule_refuses_a_non_finite_quantity(qty):
+    """A NaN qty read as a SHORT, upstream of every finiteness check in the envs.
+
+    `abs(nan) <= eps` is False and `nan > 0` is False, so it fell through to -1. That
+    matters more than a bad observation: alpaca's _step syncs the position and executes a
+    trade on this direction BEFORE building an observation, so a fabricated short drove a
+    trade decision on a long-only spot account.
+    """
+    with pytest.raises(ValueError, match="non-finite position quantity"):
+        position_direction_from_status(SimpleNamespace(qty=qty))
+    with pytest.raises(ValueError, match="non-finite position quantity"):
+        position_qty_from_status(SimpleNamespace(qty=qty))
+
+
+def test_portfolio_value_refuses_non_finite_equity():
+    """`_get_portfolio_value` is a SECOND fetch and the literal argument to
+    _check_termination, so guarding only the observation's read leaves the two able to
+    disagree -- a NaN here alone reaches is_bankrupt(), where it is silently False."""
+    env = SimpleNamespace(
+        trader=SimpleNamespace(
+            get_account_balance=lambda: {"total_margin_balance": float("nan")}
+        )
+    )
+    with pytest.raises(ValueError, match="non-finite equity"):
+        TorchTradeFuturesLiveEnv._get_portfolio_value(env)
+
+
+@pytest.mark.parametrize("cash", [float("nan"), float("inf")], ids=["nan", "inf"])
+def test_alpaca_non_finite_cash_refuses_to_build_an_account_state(cash):
+    """cash IS alpaca's equity -- the whole of portfolio_value when flat, and the
+    bankruptcy baseline. Guarded on a FLAT account, where the held-position raise (keyed
+    on direction) cannot see it. `+inf` is included because `not (x > 0)` passes it."""
+    from torchtrade.envs.live.alpaca.base import AlpacaBaseTorchTradingEnv
+
+    env = _alpaca_env_stub(None, cash=cash)
+    with pytest.raises(ValueError, match="non-finite cash balance"):
+        AlpacaBaseTorchTradingEnv._get_observation(env)
+
+
+@pytest.mark.parametrize("price", ["nan", "inf", "0", "-0.5", "1.5"],
+                         ids=["nan", "inf", "zero", "negative", "above-one"])
+def test_polymarket_refuses_a_price_that_is_not_a_probability(price):
+    """`_compute_payoff` guards `fill_price <= 0`, which NaN and +inf compare False to.
+
+    A garbage price then flows into self.cash -- polymarket's equity and its only
+    bankruptcy input. Once cash is NaN it stays NaN, is_bankrupt is False for the rest of
+    the episode, and every reward is NaN.
+    """
+    from torchtrade.envs.live.polymarket.market_scanner import _valid_price
+
+    with pytest.raises(ValueError, match="not a probability"):
+        _valid_price(price, "yes_price", "some-market")

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -1548,8 +1548,8 @@ def test_alpaca_non_finite_cash_refuses_to_build_an_account_state(cash):
         AlpacaBaseTorchTradingEnv._get_observation(env)
 
 
-@pytest.mark.parametrize("price", ["nan", "inf", "0", "-0.5", "1.5"],
-                         ids=["nan", "inf", "zero", "negative", "above-one"])
+@pytest.mark.parametrize("price", ["nan", "inf", "-inf", "-0.5", "1.5"],
+                         ids=["nan", "inf", "-inf", "negative", "above-one"])
 def test_polymarket_refuses_a_price_that_is_not_a_probability(price):
     """`_compute_payoff` guards `fill_price <= 0`, which NaN and +inf compare False to.
 
@@ -1561,3 +1561,13 @@ def test_polymarket_refuses_a_price_that_is_not_a_probability(price):
 
     with pytest.raises(ValueError, match="not a probability"):
         _valid_price(price, "yes_price", "some-market")
+
+
+@pytest.mark.parametrize("price", ["0", "0.0", "1", "1.0", "0.5"])
+def test_polymarket_accepts_the_endpoints_of_the_probability_range(price):
+    """0 and 1 are legitimate for a near-resolved market, and rejecting them would have
+    broken scanning on live data -- the per-market handler did not catch ValueError, so
+    one such market would have aborted the entire scan rather than being skipped."""
+    from torchtrade.envs.live.polymarket.market_scanner import _valid_price
+
+    assert _valid_price(price, "yes_price", "some-market") == float(price)

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -12,6 +12,7 @@ an exchange that did not answer must not read as either.
 
 import ast
 import pathlib
+import re
 import inspect
 import math
 from types import SimpleNamespace
@@ -22,7 +23,10 @@ import torchtrade.envs  # noqa: F401  -- registers every live env as a subclass
 from torchtrade.envs.core.live import TorchTradeLiveEnv
 from torchtrade.envs.live.shared.futures_live_base import TorchTradeFuturesLiveEnv
 from torchtrade.envs.utils.sltp_mixin import SLTPMixin
-from torchtrade.envs.utils.liquidation import isolated_liquidation_price
+from torchtrade.envs.utils.liquidation import (
+    cross_liquidation_price,
+    isolated_liquidation_price,
+)
 from torchtrade.envs.core.state import (
     POSITION_UNKNOWN,
     PositionState,
@@ -1089,10 +1093,12 @@ def test_live_distance_to_liquidation_agrees_with_the_offline_env(leverage, is_l
     qty = 1.0 if is_long else -1.0
 
     offline = SimpleNamespace(
-        has_liquidation=leverage > 1,
         leverage=leverage,
         maintenance_margin_rate=SequentialTradingEnvConfig().maintenance_margin_rate,
     )
+    # The real property, not `leverage > 1` restated here: supplying the gate's own answer
+    # made this pass even with offline's has_liquidation mutated to always-False.
+    offline.has_liquidation = SequentialTradingEnv.has_liquidation.fget(offline)
     offline_distance = SequentialTradingEnv._calculate_distance_to_liquidation(
         offline, mark, SequentialTradingEnv._calculate_liquidation_price(offline, entry, qty), qty
     )
@@ -1119,23 +1125,149 @@ def test_portfolio_value_raises_on_missing_balance_key():
         TorchTradeFuturesLiveEnv._get_portfolio_value(env)
 
 
-def test_no_live_env_defaults_the_equity_key():
-    """Structural: `.get("total_margin_balance", 0)` must not come back anywhere (#277).
+def test_no_live_env_silently_defaults_a_money_field():
+    """Structural: no `.get("<money field>", 0)` anywhere under live/ (#277).
 
-    Five sites had it and it broke is_bankrupt() in both directions -- 0 as the baseline
-    means `current < threshold * 0` never fires and a wiped account trades on forever;
-    0 as the current value means instant false bankruptcy. Behavioural tests cover the
-    two in this file; the four per-exchange baselines are set inside _reset scaffolding
-    that needs a live client, so this guard is what keeps them fixed.
+    Five sites defaulted the equity key and it broke is_bankrupt() in both directions --
+    0 as the baseline means `current < threshold * 0` never fires and a wiped account
+    trades on; 0 as the current value is instant false bankruptcy. `notional` is here for
+    the same reason: binance defaulted it to 0, which zeroes exposure_pct and, before the
+    raise was re-keyed, also suppressed the non-positive-equity error on a held position.
+
+    Behavioural tests cover the two sites in this file; the four per-exchange baselines
+    are set inside _reset scaffolding that needs a live client, so this guard is what
+    keeps them fixed.
+
+    Matched by regex over both quote styles: the first version of this guard looked for
+    one literal spelling, and bitget's executor quotes its keys the other way -- four
+    more sizing paths were hiding behind that. Only a ZERO literal counts: bitget falls
+    back to a computed `abs(contracts * mark_price)` and binance's MIN_NOTIONAL filter
+    defaults to 100, and neither invents a flat account.
     """
-    live_root = pathlib.Path(TorchTradeLiveEnv.__module__.replace(".", "/")).parent.parent
-    offenders = [
-        f"{path.relative_to(live_root.parent)}:{i}"
-        for path in sorted((live_root / "live").rglob("*.py"))
-        for i, line in enumerate(path.read_text().splitlines(), 1)
-        if 'get("total_margin_balance"' in line
-    ]
+    live_root = pathlib.Path(inspect.getfile(TorchTradeLiveEnv)).parent.parent / "live"
+    pattern = re.compile(r"""\.get\(\s*["'](total_margin_balance|notional)["']\s*,\s*0(\.0+)?\s*\)""")
+    scanned, offenders = 0, []
+    for path in sorted(live_root.rglob("*.py")):
+        scanned += 1
+        for i, line in enumerate(path.read_text().splitlines(), 1):
+            if pattern.search(line):
+                offenders.append(f"{path.relative_to(live_root.parent)}:{i}")
+
+    # Without this the guard passes by scanning nothing -- it did, from any cwd but the
+    # repo root, back when it built the path from a module name.
+    assert scanned > 10, f"guard scanned only {scanned} files under {live_root}"
     assert offenders == [], (
-        f"equity read with a silent default at {offenders}; index the key so a broken "
-        f"adapter raises instead of reporting a wiped or infinitely-rich account"
+        f"money field read with a silent default at {offenders}; index it, or fall back to "
+        f"a computed value, so a broken adapter cannot report a wiped or flat account"
     )
+
+
+# --- the cross-margin half of the estimate (#342 review) -------------------------
+
+
+@pytest.mark.parametrize("qty,expected_nearer", [
+    (1.0, 98.3936),    # long: cross sits ABOVE isolated's 95.40, i.e. nearer the mark
+    (-1.0, 101.5936),  # short: cross sits BELOW isolated's 104.60
+], ids=["long", "short"])
+def test_depleted_collateral_prices_liquidation_nearer_than_isolated(qty, expected_nearer):
+    """Isolated alone is not conservative, which is the whole reason cross is consulted.
+
+    The isolated formula sees only this position, so it answers the same 95.40 whether the
+    account is flush or nearly empty. Here a 100-notional 20x position is backed by 2.0 of
+    equity: cross liquidates at 98.39, well before isolated's 95.40, and reporting the
+    isolated distance would OVERSTATE the room left -- the fail-open this change removes,
+    reintroduced one level down.
+    """
+    env = _futures_env_stub(
+        _open_position(qty, leverage=20), {"total_margin_balance": 2.0}
+    )
+    obs = TorchTradeFuturesLiveEnv._get_observation(env)
+    distance = obs["account_state"][5].item()
+
+    assert distance == pytest.approx(abs(100.0 - expected_nearer) / 100.0, rel=1e-4)
+    # Strictly tighter than the isolated-only answer of 0.046.
+    assert distance < 0.046
+
+
+@pytest.mark.parametrize("qty", [1.0, -1.0], ids=["long", "short"])
+def test_amply_funded_account_falls_back_to_the_isolated_estimate(qty):
+    """The other side of `nearest`: cross must not be trusted alone either.
+
+    With equity far exceeding the position, the cross formula prices liquidation at an
+    absurd distance (-903 for a long) because it cannot see other positions' own
+    maintenance requirements or the venue's risk tiers. Taking the nearer of the two keeps
+    the isolated bound in exactly that case.
+    """
+    env = _futures_env_stub(
+        _open_position(qty, leverage=20), {"total_margin_balance": 1_000_000.0}
+    )
+    obs = TorchTradeFuturesLiveEnv._get_observation(env)
+
+    assert obs["account_state"][5].item() == pytest.approx(0.046, rel=1e-3)
+
+
+@pytest.mark.parametrize("kwargs,match", [
+    ({"mark_price": 0.0}, "mark_price must be positive"),
+    ({"mark_price": float("nan")}, "mark_price must be positive"),
+    ({"position_size": 0.0}, "flat position has no liquidation price"),
+], ids=["zero-mark", "nan-mark", "flat"])
+def test_cross_estimate_refuses_inputs_it_cannot_price(kwargs, match):
+    """Same contract as the isolated helper: never hand back a number that reads as safe."""
+    args = {"position_size": 1.0, "mark_price": 100.0, "equity": 5.0}
+    args.update(kwargs)
+    with pytest.raises(ValueError, match=match):
+        cross_liquidation_price(**args)
+
+
+@pytest.mark.parametrize("leverage", [0, -3, 0.5, float("nan")],
+                         ids=["zero", "negative", "fractional", "nan"])
+def test_nonsense_venue_leverage_refuses_to_report_a_distance(leverage):
+    """Reachable, not theoretical: OKX blanks `lever` on cross positions.
+
+    Its adapter then substitutes the CONFIG leverage, so an env left at the default 1x
+    against an account still on 20x arrives here with leverage 1 and no liquidation
+    price. Written `leverage <= 1`, the no-liquidation gate answered "maximally safe" for
+    that, and for 0, -3 and 0.5 besides -- #277 one field over. Offline refuses the same
+    inputs in __post_init__; live now refuses them here.
+    """
+    env = _futures_env_stub(_open_position(1.0, leverage=leverage), {"total_margin_balance": 1000.0})
+    with pytest.raises(ValueError, match="leverage must be at least 1"):
+        TorchTradeFuturesLiveEnv._get_observation(env)
+
+
+def test_held_position_with_no_reported_notional_still_refuses_zero_equity():
+    """The equity raise must key on the position, not on the notional backing it.
+
+    Keyed on `position_value > 0`, a venue that omitted the notional zeroed the second
+    conjunct and skipped the raise -- and binance defaulted exactly that field to 0 until
+    this PR. position_direction is the authoritative signal, and it goes through the dust
+    rule.
+    """
+    position = _open_position(1.0)
+    position.notional_value = 0.0
+    env = _futures_env_stub(position, {"total_margin_balance": 0.0})
+
+    with pytest.raises(ValueError, match="refusing to report this account as flat"):
+        TorchTradeFuturesLiveEnv._get_observation(env)
+
+
+@pytest.mark.parametrize("is_long", [True, False], ids=["long", "short"])
+def test_one_x_with_a_published_liq_price_deliberately_beats_offline(is_long):
+    """A known, accepted divergence -- recorded so it is a decision and not a surprise.
+
+    At 1x the offline env short-circuits on has_liquidation and reports 1.0. Live, when
+    the venue actually publishes a price for a 1x position, uses it: 0.996, because a 1x
+    long really is liquidated near zero rather than never. Live is the more accurate of
+    the two by 0.4%, so this is not forced into parity -- but it does mean
+    test_live_distance_to_liquidation_agrees_with_the_offline_env speaks only to the
+    no-published-price case.
+    """
+    qty = 1.0 if is_long else -1.0
+    published = 0.4 if is_long else 199.6
+    env = _futures_env_stub(
+        _open_position(qty, leverage=1, liquidation_price=published),
+        {"total_margin_balance": 1000.0},
+    )
+    obs = TorchTradeFuturesLiveEnv._get_observation(env)
+
+    assert obs["account_state"][5].item() == pytest.approx(0.996, rel=1e-4)

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -905,7 +905,7 @@ def test_okx_sizes_through_the_dust_rule_in_step():
 # --- #277: account_state must not fail open on missing venue fields ---------------
 
 
-def _futures_env_stub(position_status, balance, leverage=20):
+def _futures_env_stub(position_status, balance, leverage=5):
     """Minimal stand-in for calling TorchTradeFuturesLiveEnv._get_observation directly.
 
     Same shape as test_unknown_status_refuses_to_build_account_state above: one call
@@ -919,6 +919,8 @@ def _futures_env_stub(position_status, balance, leverage=20):
             get_account_balance=lambda: balance,
             get_mark_price=lambda: 100.0,
         ),
+        # Deliberately NOT the position's leverage: the fallback must use what the
+        # venue reports for the position, not what the config asked for.
         config=SimpleNamespace(include_base_features=False, leverage=leverage),
         position=PositionState(),
         account_state_key="account_state",
@@ -956,7 +958,6 @@ def test_cross_margin_position_without_liq_price_does_not_read_as_flat(qty, expe
     distance = obs["account_state"][5].item()
 
     assert distance == pytest.approx(expected, rel=1e-5)
-    assert distance < 1.0, "an open levered position still reads as safe as flat"
 
 
 def test_venue_liq_price_is_used_verbatim_when_present():
@@ -984,7 +985,6 @@ def test_flat_account_still_reads_as_maximally_far_from_liquidation():
     obs = TorchTradeFuturesLiveEnv._get_observation(env)
 
     assert obs["account_state"][5].item() == 1.0
-    assert obs["account_state"][0].item() == 0.0
 
 
 def test_missing_balance_key_raises_rather_than_reporting_zero_exposure():
@@ -998,13 +998,6 @@ def test_missing_balance_key_raises_rather_than_reporting_zero_exposure():
         TorchTradeFuturesLiveEnv._get_observation(env)
 
 
-def test_position_held_against_zero_equity_refuses_to_report_flat_exposure():
-    """Equity wiped with the position still on: exposure is unbounded, and it is not 0.0."""
-    env = _futures_env_stub(_open_position(1.0), {"total_margin_balance": 0.0})
-    with pytest.raises(ValueError, match="refusing to report this account as flat"):
-        TorchTradeFuturesLiveEnv._get_observation(env)
-
-
 def test_empty_flat_account_is_zero_exposure_not_an_error():
     """The zero-equity guard must not fire on an account that is simply empty and flat."""
     env = _futures_env_stub(None, {"total_margin_balance": 0.0})
@@ -1014,14 +1007,21 @@ def test_empty_flat_account_is_zero_exposure_not_an_error():
 
 
 @pytest.mark.parametrize("kwargs,match", [
-    ({"leverage": 0}, "leverage must be positive"),
+    ({"leverage": 0}, "leverage must be at least 1"),
+    ({"leverage": float("nan")}, "leverage must be at least 1"),
     ({"entry_price": 0.0}, "entry_price must be positive"),
-], ids=["zero-leverage", "zero-entry"])
+    ({"entry_price": float("nan")}, "entry_price must be positive"),
+], ids=["zero-leverage", "nan-leverage", "zero-entry", "nan-entry"])
 def test_unusable_inputs_raise_instead_of_pricing_a_liquidation(kwargs, match):
     """Without these the venue's own bad data produces 0.0, which reads as distance 1.0.
 
     That is #277 again by a different route: a zero liquidation price is indistinguishable
     from the flat case downstream, so the caller must never receive one.
+
+    The NaN cells are the reason the guards are spelled `not (x >= 1)` instead of `x < 1`.
+    NaN compares False to every operator, so the natural spelling passes it straight
+    through to arithmetic that yields NaN, and `max(0.0, nan)` returns 0.0 -- the exact
+    "reads as safe" answer, arrived at silently.
     """
     args = {"entry_price": 100.0, "is_long": True, "leverage": 10}
     args.update(kwargs)
@@ -1029,21 +1029,113 @@ def test_unusable_inputs_raise_instead_of_pricing_a_liquidation(kwargs, match):
         isolated_liquidation_price(**args)
 
 
+@pytest.mark.parametrize("position_value,equity", [
+    (100.0, 0.0),
+    (100.0, -50.0),
+    (100.0, float("nan")),
+], ids=["zero-equity", "negative-equity", "nan-equity"])
+def test_position_held_against_unusable_equity_refuses_to_report_flat(position_value, equity):
+    """A held position must never divide out to 0.0% exposure.
+
+    The NaN cell is not hypothetical pedantry: written `total_balance <= 0`, the raise is
+    skipped for NaN and the ternary beside it then takes its `else 0.0` arm, so the
+    position reports as flat -- invariant #3 -- with no error anywhere. Only the
+    `not (x > 0)` spelling catches all three.
+    """
+    env = _futures_env_stub(
+        _open_position(position_value / 100.0), {"total_margin_balance": equity}
+    )
+    with pytest.raises(ValueError, match="refusing to report this account as flat"):
+        TorchTradeFuturesLiveEnv._get_observation(env)
+
+
+@pytest.mark.parametrize("qty,mark", [(1.0, 94.0), (-1.0, 106.0)], ids=["long", "short"])
+def test_estimate_already_crossed_reads_as_at_liquidation(qty, mark):
+    """Past the estimated price, the clamp pins distance at 0.0 rather than going negative.
+
+    Worth pinning because the estimate is an isolated-margin one: a cross-margin position
+    is backed by the whole account and routinely survives past it, so it will sit at a
+    saturated 0.0 rather than degrading smoothly. That is the conservative direction, but
+    it is a real limit on what account_state[5] tells the policy under cross margin.
+    """
+    env = _futures_env_stub(
+        _open_position(qty, mark_price=mark, leverage=20), {"total_margin_balance": 1000.0}
+    )
+    obs = TorchTradeFuturesLiveEnv._get_observation(env)
+
+    assert obs["account_state"][5].item() == 0.0
+
+
+@pytest.mark.parametrize("leverage", [1, 2, 20], ids=lambda l: f"{l}x")
 @pytest.mark.parametrize("is_long", [True, False], ids=["long", "short"])
-def test_live_fallback_agrees_with_the_offline_env_it_trains_against(is_long):
-    """Live and offline must place liquidation at the same price for the same position.
+def test_live_distance_to_liquidation_agrees_with_the_offline_env(leverage, is_long):
+    """Same position, same account_state[5], offline and live.
 
     This is the reason the rule was extracted rather than copied: a policy trained on the
     offline geometry reads account_state[5] live and must be reading the same quantity.
-    Compares against the offline env's own method, so re-inlining either copy fails here.
+
+    Compares the two end to end rather than the two liquidation prices, because the gates
+    around the arithmetic are where they diverged -- offline returns "no liquidation" at
+    1x via has_liquidation, and a live fallback without that gate priced a 1x long at
+    mmr*entry and reported 0.996 against offline's 1.0. 1x is the live config default, so
+    that divergence was the common case. Nothing here supplies a rate to both sides: the
+    offline one comes from its config default and the live one from the helper's.
     """
-    from torchtrade.envs.offline.sequential import SequentialTradingEnv
+    from torchtrade.envs.offline.sequential import (
+        SequentialTradingEnv, SequentialTradingEnvConfig,
+    )
+
+    entry = mark = 100.0
+    qty = 1.0 if is_long else -1.0
 
     offline = SimpleNamespace(
-        has_liquidation=True, leverage=20, maintenance_margin_rate=0.004
+        has_liquidation=leverage > 1,
+        leverage=leverage,
+        maintenance_margin_rate=SequentialTradingEnvConfig().maintenance_margin_rate,
     )
-    expected = SequentialTradingEnv._calculate_liquidation_price(
-        offline, 100.0, 1.0 if is_long else -1.0
+    offline_distance = SequentialTradingEnv._calculate_distance_to_liquidation(
+        offline, mark, SequentialTradingEnv._calculate_liquidation_price(offline, entry, qty), qty
     )
 
-    assert isolated_liquidation_price(100.0, is_long=is_long, leverage=20) == expected
+    env = _futures_env_stub(
+        _open_position(qty, entry_price=entry, mark_price=mark, leverage=leverage),
+        {"total_margin_balance": 1000.0},
+    )
+    live_distance = TorchTradeFuturesLiveEnv._get_observation(env)["account_state"][5].item()
+
+    assert live_distance == pytest.approx(offline_distance, rel=1e-6)
+
+
+def test_portfolio_value_raises_on_missing_balance_key():
+    """`_get_portfolio_value` feeds the `current` side of is_bankrupt().
+
+    Defaulting it to 0 makes `current < threshold * initial` true for any funded
+    account -- instant false bankruptcy on an adapter bug rather than a loud failure.
+    """
+    env = SimpleNamespace(
+        trader=SimpleNamespace(get_account_balance=lambda: {"available_balance": 1000.0})
+    )
+    with pytest.raises(KeyError, match="total_margin_balance"):
+        TorchTradeFuturesLiveEnv._get_portfolio_value(env)
+
+
+def test_no_live_env_defaults_the_equity_key():
+    """Structural: `.get("total_margin_balance", 0)` must not come back anywhere (#277).
+
+    Five sites had it and it broke is_bankrupt() in both directions -- 0 as the baseline
+    means `current < threshold * 0` never fires and a wiped account trades on forever;
+    0 as the current value means instant false bankruptcy. Behavioural tests cover the
+    two in this file; the four per-exchange baselines are set inside _reset scaffolding
+    that needs a live client, so this guard is what keeps them fixed.
+    """
+    live_root = pathlib.Path(TorchTradeLiveEnv.__module__.replace(".", "/")).parent.parent
+    offenders = [
+        f"{path.relative_to(live_root.parent)}:{i}"
+        for path in sorted((live_root / "live").rglob("*.py"))
+        for i, line in enumerate(path.read_text().splitlines(), 1)
+        if 'get("total_margin_balance"' in line
+    ]
+    assert offenders == [], (
+        f"equity read with a silent default at {offenders}; index the key so a broken "
+        f"adapter raises instead of reporting a wiped or infinitely-rich account"
+    )

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -1219,9 +1219,13 @@ def test_cross_estimate_refuses_inputs_it_cannot_price(kwargs, match):
         cross_liquidation_price(**args)
 
 
-@pytest.mark.parametrize("leverage", [0, -3, 0.5, float("nan")],
-                         ids=["zero", "negative", "fractional", "nan"])
-def test_nonsense_venue_leverage_refuses_to_report_a_distance(leverage):
+@pytest.mark.parametrize("leverage,match", [
+    (0, "leverage must be at least 1"),
+    (-3, "leverage must be at least 1"),
+    (0.5, "leverage must be at least 1"),
+    (float("nan"), "non-finite leverage"),
+], ids=["zero", "negative", "fractional", "nan"])
+def test_nonsense_venue_leverage_refuses_to_report_a_distance(leverage, match):
     """Reachable, not theoretical: OKX blanks `lever` on cross positions.
 
     Its adapter then substitutes the CONFIG leverage, so an env left at the default 1x
@@ -1231,7 +1235,7 @@ def test_nonsense_venue_leverage_refuses_to_report_a_distance(leverage):
     inputs in __post_init__; live now refuses them here.
     """
     env = _futures_env_stub(_open_position(1.0, leverage=leverage), {"total_margin_balance": 1000.0})
-    with pytest.raises(ValueError, match="leverage must be at least 1"):
+    with pytest.raises(ValueError, match=match):
         TorchTradeFuturesLiveEnv._get_observation(env)
 
 
@@ -1271,3 +1275,108 @@ def test_one_x_with_a_published_liq_price_deliberately_beats_offline(is_long):
     obs = TorchTradeFuturesLiveEnv._get_observation(env)
 
     assert obs["account_state"][5].item() == pytest.approx(0.996, rel=1e-4)
+
+
+@pytest.mark.parametrize("field", ["mark_price", "liquidation_price", "qty"])
+def test_non_finite_venue_numbers_refuse_to_build_an_account_state(field):
+    """NaN defeats every comparison downstream, so it is caught once at the source.
+
+    A NaN liquidation price passes `<= 0`, skips the fallback, reaches the arithmetic and
+    clamps to a distance of 0.0 -- a healthy 20x position reported as AT liquidation on
+    one garbage tick. Fail-closed, but silently, and on the wrong side of the truth.
+    """
+    position = _open_position(1.0, leverage=20)
+    setattr(position, field, float("nan"))
+    env = _futures_env_stub(position, {"total_margin_balance": 1000.0})
+
+    with pytest.raises(ValueError, match=f"non-finite {field}"):
+        TorchTradeFuturesLiveEnv._get_observation(env)
+
+
+def test_no_adapter_fabricates_zero_equity():
+    """Indexing `total_margin_balance` only helps if the adapter doesn't invent the value.
+
+    Three of the four coerced a missing or blank venue field to 0.0 and published it under
+    the key -- `.get('total', 0)`, `.get("totalEquity", 0)`, `.get("totalEq") or "0"` --
+    so every downstream guard saw a well-formed 0 rather than an error: the bankruptcy
+    baseline became 0 (and `current < threshold * 0` never fires), sizing refused to
+    trade, exposure_pct read flat. That is #277's mechanism surviving one layer below the
+    code hardened for it.
+
+    Structural rather than behavioural: reaching these lines needs a faithful fake of
+    three different venue clients, and a wrong fake proves nothing about the adapter. The
+    guard is on the coercion itself, which is the thing that must not come back.
+    """
+    live_root = pathlib.Path(inspect.getfile(TorchTradeLiveEnv)).parent.parent / "live"
+    equity_key = r"""["'](total|totalEquity|totalEq|totalMarginBalance)["']"""
+    pattern = re.compile(
+        rf"""\.get\(\s*{equity_key}\s*,\s*0"""       # .get("totalEquity", 0)
+        rf"""|\.get\(\s*{equity_key}\s*\)\s*or\s*["']?0"""  # .get("totalEq") or "0"
+    )
+    scanned, offenders = 0, []
+    for path in sorted(live_root.rglob("order_executor.py")):
+        scanned += 1
+        for i, line in enumerate(path.read_text().splitlines(), 1):
+            # Comment lines are skipped so a comment explaining the banned pattern (there
+            # is one, at the bitget fix) does not read as the pattern itself.
+            if not line.lstrip().startswith("#") and pattern.search(line):
+                offenders.append(f"{path.relative_to(live_root.parent)}:{i}")
+
+    assert scanned >= 4, f"guard scanned only {scanned} executors under {live_root}"
+    assert offenders == [], (
+        f"equity coerced to zero at {offenders}; raise on a missing or blank venue field "
+        f"so it fails where it is diagnosable, not as a plausible 0 three layers down"
+    )
+
+
+def test_every_futures_env_validates_its_bankruptcy_baseline():
+    """A baseline of 0 disables bankruptcy permanently: `current < threshold * 0` is never
+    true for any non-negative equity, so the account can be wiped out and the episode
+    trades on. Indexing the key stops an adapter fabricating the 0, and this stops a
+    genuinely empty account starting an episode that can never terminate.
+
+    Structural because the assignment sits inside per-exchange `_reset` scaffolding that
+    needs a live client to reach. Four copies of one line is itself the drift risk the
+    shared base exists to remove -- hoisting it is follow-up work (#345).
+    """
+    live_root = pathlib.Path(inspect.getfile(TorchTradeLiveEnv)).parent.parent / "live"
+    bases = sorted(live_root.glob("*/base.py"))
+    futures = [p for p in bases if p.parent.name != "alpaca"]
+    assert len(futures) == 4, f"expected 4 futures bases, found {[p.parent.name for p in futures]}"
+
+    unguarded = [
+        p.parent.name for p in futures
+        if "if not (self.initial_portfolio_value > 0):" not in p.read_text()
+    ]
+    assert unguarded == [], (
+        f"{unguarded} assign initial_portfolio_value without rejecting a non-positive "
+        f"baseline, which silently disables the bankruptcy check for the whole episode"
+    )
+
+
+@pytest.mark.parametrize("exchange", ["binance", "bitget", "bybit", "okx"])
+def test_adapters_do_not_truncate_fractional_leverage(exchange):
+    """`int(float("1.5"))` is 1, and 1 takes the no-liquidation branch.
+
+    bybit and okx coerced venue leverage with `int(float(...))`, so any leverage in
+    [1, 2) arrived as exactly 1 -- and the `== 1` gate then handed that position the
+    maximally-safe distance of 1.0, on the very cross-margin path the fallback exists
+    for. #277 surviving inside the branch written to stop it.
+    """
+    src = (pathlib.Path(inspect.getfile(TorchTradeLiveEnv)).parent.parent
+           / "live" / exchange / "order_executor.py").read_text()
+    assert "leverage=int(" not in src, (
+        f"{exchange} truncates venue leverage to int; 1.5x becomes 1x and reads as unlevered"
+    )
+
+
+@pytest.mark.parametrize("qty", [1.0, -1.0], ids=["long", "short"])
+def test_fractional_leverage_still_gets_a_real_distance(qty):
+    """The behavioural half of the above: 1.5x must not read as maximally safe."""
+    env = _futures_env_stub(
+        _open_position(qty, leverage=1.5), {"total_margin_balance": 1000.0}
+    )
+    distance = TorchTradeFuturesLiveEnv._get_observation(env)["account_state"][5].item()
+
+    assert distance == pytest.approx(1 / 1.5 - 0.004, rel=1e-4)
+    assert distance < 1.0

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -1277,7 +1277,13 @@ def test_one_x_with_a_published_liq_price_deliberately_beats_offline(is_long):
     assert obs["account_state"][5].item() == pytest.approx(0.996, rel=1e-4)
 
 
-@pytest.mark.parametrize("field", ["mark_price", "liquidation_price", "qty"])
+@pytest.mark.parametrize("field", [
+    "mark_price", "liquidation_price", "qty",
+    # These three reach account_state directly. notional_value is the worst of the set:
+    # exposure_pct = nan/equity puts NaN into the tensor handed to the policy, where a
+    # NaN liquidation price at least clamped to a number first.
+    "notional_value", "unrealized_pnl_pct", "entry_price",
+])
 def test_non_finite_venue_numbers_refuse_to_build_an_account_state(field):
     """NaN defeats every comparison downstream, so it is caught once at the source.
 
@@ -1306,6 +1312,11 @@ def test_no_adapter_fabricates_zero_equity():
     Structural rather than behavioural: reaching these lines needs a faithful fake of
     three different venue clients, and a wrong fake proves nothing about the adapter. The
     guard is on the coercion itself, which is the thing that must not come back.
+
+    Note for anyone writing the behavioural version: all three adapters wrap their body in
+    `except Exception as e: raise RuntimeError(...) from e`, so the ValueError surfaces to
+    the caller as a RuntimeError with the message preserved. It still raises rather than
+    returning a fabricated balance, which is the property that matters here.
     """
     live_root = pathlib.Path(inspect.getfile(TorchTradeLiveEnv)).parent.parent / "live"
     equity_key = r"""["'](total|totalEquity|totalEq|totalMarginBalance)["']"""
@@ -1329,10 +1340,10 @@ def test_no_adapter_fabricates_zero_equity():
     )
 
 
-def test_every_futures_env_validates_its_bankruptcy_baseline():
-    """A baseline of 0 disables bankruptcy permanently: `current < threshold * 0` is never
-    true for any non-negative equity, so the account can be wiped out and the episode
-    trades on. Indexing the key stops an adapter fabricating the 0, and this stops a
+def test_every_live_env_validates_its_bankruptcy_baseline():
+    """A baseline of 0 disables bankruptcy above zero: `current < threshold * 0` reduces
+    to `current < 0`, so it survives only for negative equity and a wipeout to zero never
+    terminates. Indexing the key stops an adapter fabricating the 0, and this stops a
     genuinely empty account starting an episode that can never terminate.
 
     Structural because the assignment sits inside per-exchange `_reset` scaffolding that
@@ -1341,11 +1352,14 @@ def test_every_futures_env_validates_its_bankruptcy_baseline():
     """
     live_root = pathlib.Path(inspect.getfile(TorchTradeLiveEnv)).parent.parent / "live"
     bases = sorted(live_root.glob("*/base.py"))
-    futures = [p for p in bases if p.parent.name != "alpaca"]
-    assert len(futures) == 4, f"expected 4 futures bases, found {[p.parent.name for p in futures]}"
+    # Alpaca included, not exempted: it inherits the same _check_termination and the same
+    # is_bankrupt, and an unfunded paper account -- the documented default -- yields a
+    # baseline of exactly 0. Excluding it left the one env still carrying the bug as the
+    # one the guard skipped.
+    assert len(bases) >= 5, f"expected 5+ live bases, found {[p.parent.name for p in bases]}"
 
     unguarded = [
-        p.parent.name for p in futures
+        p.parent.name for p in bases
         if "if not (self.initial_portfolio_value > 0):" not in p.read_text()
     ]
     assert unguarded == [], (
@@ -1380,3 +1394,28 @@ def test_fractional_leverage_still_gets_a_real_distance(qty):
 
     assert distance == pytest.approx(1 / 1.5 - 0.004, rel=1e-4)
     assert distance < 1.0
+
+
+def test_no_adapter_falls_back_to_config_leverage_with_or():
+    """`float(pos.get("leverage") or self.leverage)` swaps a venue-reported 0 for the config.
+
+    A numeric 0 is falsy, so `or` silently substitutes a leverage the venue never
+    confirmed and the position gets a plausible liquidation distance computed from it --
+    #277 on the field that was being hardened. bitget reads ccxt's unified `leverage`,
+    which is a number rather than a REST string, so `0` arrives falsy there today.
+
+    Structural because the behavioural cells construct PositionStatus directly and so
+    cannot see the adapter's parsing at all -- which is why this regression survived a
+    mutation run that killed everything else.
+    """
+    live_root = pathlib.Path(inspect.getfile(TorchTradeLiveEnv)).parent.parent / "live"
+    offenders = [
+        f"{path.relative_to(live_root.parent)}:{i}"
+        for path in sorted(live_root.rglob("order_executor.py"))
+        for i, line in enumerate(path.read_text().splitlines(), 1)
+        if not line.lstrip().startswith("#") and "or self.leverage" in line
+    ]
+    assert offenders == [], (
+        f"venue leverage falls back to the config value via `or` at {offenders}; test "
+        f"`in (None, \"\")` so a genuine 0 stays 0 and fails loudly downstream"
+    )

--- a/torchtrade/envs/core/state.py
+++ b/torchtrade/envs/core/state.py
@@ -76,6 +76,15 @@ def position_direction_from_status(position_status) -> int:
             "treating it as a direction"
         )
     qty = 0.0 if position_status is None else float(position_status.qty)
+    # A NaN qty fails `abs(qty) <= eps` and then `qty > 0`, so it fell through to -1 and
+    # read as a SHORT. This rule runs before any finiteness check the envs apply, and
+    # alpaca's _step syncs and trades on the result before building an observation -- so a
+    # fabricated -1 drives a trade on a long-only account (#277).
+    if not math.isfinite(qty):
+        raise ValueError(
+            f"exchange reported a non-finite position quantity ({qty}); refusing to "
+            f"read a direction from it"
+        )
     if abs(qty) <= POSITION_DUST_EPS:
         return 0
     return 1 if qty > 0 else -1
@@ -103,6 +112,11 @@ def position_qty_from_status(position_status) -> float:
             "treating it as a size"
         )
     qty = 0.0 if position_status is None else float(position_status.qty)
+    if not math.isfinite(qty):
+        raise ValueError(
+            f"exchange reported a non-finite position quantity ({qty}); refusing to "
+            f"read a size from it"
+        )
     return 0.0 if abs(qty) <= POSITION_DUST_EPS else qty
 
 

--- a/torchtrade/envs/live/alpaca/base.py
+++ b/torchtrade/envs/live/alpaca/base.py
@@ -219,6 +219,16 @@ class AlpacaBaseTorchTradingEnv(TorchTradeLiveEnv):
         status = self.trader.get_status()
         account = self.trader.client.get_account()
         cash = float(account.cash)
+        # cash IS alpaca's equity: it is the whole of portfolio_value when flat, and the
+        # bankruptcy baseline and every reward derive from it. A NaN passes the
+        # held-position guard below (which is keyed on direction) and reaches
+        # is_bankrupt(), where `nan < threshold * initial` is False -- termination off
+        # for the episode. `not isfinite` and not `<= 0`, since +inf passes that too.
+        if not math.isfinite(cash):
+            raise ValueError(
+                f"venue reported a non-finite cash balance ({cash}); refusing to derive "
+                f"an account state or a bankruptcy check from it"
+            )
         position_status = status.get("position_status", None)
 
         # Calculate portfolio value
@@ -240,8 +250,11 @@ class AlpacaBaseTorchTradingEnv(TorchTradeLiveEnv):
             except Exception:
                 current_price = 0.0
         else:
-            # Same finiteness contract as the futures envs (#277): every venue number this
-            # branch reads goes into account_state, and NaN passes every comparison below
+            # Same finiteness contract as the futures envs (#277). market_value and
+            # unrealized_plpc reach account_state directly; avg_entry_price and
+            # current_price are read but unused here, and are checked anyway so the
+            # contract does not depend on which locals happen to be dead. NaN passes
+            # every comparison below
             # -- a NaN market_value reads as a flat account holding a position, a NaN
             # unrealized_plpc goes into the tensor and on into the policy network. Spot is
             # not exempt from invariant #3.

--- a/torchtrade/envs/live/alpaca/base.py
+++ b/torchtrade/envs/live/alpaca/base.py
@@ -1,6 +1,7 @@
 """Base class for Alpaca live trading environments."""
 
 import logging
+import math
 from abc import abstractmethod
 from typing import Callable, List, Optional
 
@@ -239,6 +240,23 @@ class AlpacaBaseTorchTradingEnv(TorchTradeLiveEnv):
             except Exception:
                 current_price = 0.0
         else:
+            # Same finiteness contract as the futures envs (#277): every venue number this
+            # branch reads goes into account_state, and NaN passes every comparison below
+            # -- a NaN market_value reads as a flat account holding a position, a NaN
+            # unrealized_plpc goes into the tensor and on into the policy network. Spot is
+            # not exempt from invariant #3.
+            for _name, _value in (
+                ("qty", position_status.qty),
+                ("market_value", position_status.market_value),
+                ("avg_entry_price", position_status.avg_entry_price),
+                ("current_price", position_status.current_price),
+                ("unrealized_plpc", position_status.unrealized_plpc),
+            ):
+                if not math.isfinite(float(_value)):
+                    raise ValueError(
+                        f"venue reported a non-finite {_name} ({_value}) for an open "
+                        f"position; refusing to derive an account state from it"
+                    )
             position_value = position_status.market_value
             entry_price = position_status.avg_entry_price
             current_price = position_status.current_price
@@ -247,6 +265,15 @@ class AlpacaBaseTorchTradingEnv(TorchTradeLiveEnv):
 
         # Calculate new 6-element account state
         # Element 0: exposure_pct (position_value / portfolio_value)
+        # A position held against a non-positive portfolio value has no exposure_pct to
+        # report -- the ratio is unbounded -- and `else 0.0` reports the one value that is
+        # certainly wrong: a flat-looking account that is holding a position (#277).
+        # `not (x > 0)` because NaN compares False to everything.
+        if not (portfolio_value > 0) and position_direction != 0:
+            raise ValueError(
+                f"Position worth {position_value} held against a non-positive portfolio "
+                f"value ({portfolio_value}); refusing to report this account as flat."
+            )
         exposure_pct = position_value / portfolio_value if portfolio_value > 0 else 0.0
 
         # Element 2: unrealized_pnl_pct (inherited from Alpaca)

--- a/torchtrade/envs/live/alpaca/base.py
+++ b/torchtrade/envs/live/alpaca/base.py
@@ -114,6 +114,14 @@ class AlpacaBaseTorchTradingEnv(TorchTradeLiveEnv):
         # position value -- so the two cannot drift apart. The futures bases already read
         # an equity figure for this reason.
         self.initial_portfolio_value = self._get_portfolio_value()
+        if not (self.initial_portfolio_value > 0):
+            raise ValueError(
+                f"cannot start an episode on a portfolio value of "
+                f"{self.initial_portfolio_value}: the bankruptcy baseline would be 0, "
+                f"and `current < threshold * 0` reduces to `current < 0`, so it never "
+                f"fires above zero equity -- an unfunded paper account would trade on "
+                f"with the check disabled"
+            )
 
         # Build observation specs
         self._build_observation_specs()

--- a/torchtrade/envs/live/alpaca/base.py
+++ b/torchtrade/envs/live/alpaca/base.py
@@ -115,7 +115,7 @@ class AlpacaBaseTorchTradingEnv(TorchTradeLiveEnv):
         # position value -- so the two cannot drift apart. The futures bases already read
         # an equity figure for this reason.
         self.initial_portfolio_value = self._get_portfolio_value()
-        if not (self.initial_portfolio_value > 0):
+        if not math.isfinite(self.initial_portfolio_value) or self.initial_portfolio_value <= 0:
             raise ValueError(
                 f"cannot start an episode on a portfolio value of "
                 f"{self.initial_portfolio_value}: the bankruptcy baseline would be 0, "
@@ -331,11 +331,23 @@ class AlpacaBaseTorchTradingEnv(TorchTradeLiveEnv):
         self.balance = float(account.cash)
 
         if position_status is None:
-            return self.balance
-        # An unknown status raises on the .market_value read rather than taking the flat
-        # branch above: cash alone feeds _check_termination, and for a held position that
-        # is most of the portfolio missing -- an outage would read as a near-total loss.
-        return self.balance + position_status.market_value
+            portfolio_value = self.balance
+        else:
+            # An unknown status raises on the .market_value read rather than taking the flat
+            # branch above: cash alone feeds _check_termination, and for a held position that
+            # is most of the portfolio missing -- an outage would read as a near-total loss.
+            portfolio_value = self.balance + position_status.market_value
+
+        # Guarded here as well as in _get_observation, because this is a SEPARATE fetch and
+        # it is the value that reaches _check_termination and the reward. alpaca's _step
+        # calls it BEFORE building an observation, so a NaN here is recorded and rewarded
+        # against before the observation guard could ever fire (#277).
+        if not math.isfinite(portfolio_value):
+            raise ValueError(
+                f"venue reported a non-finite portfolio value ({portfolio_value}); "
+                f"refusing to run a bankruptcy check or compute a reward against it"
+            )
+        return portfolio_value
 
     def _reset(self, tensordict: TensorDictBase, **kwargs) -> TensorDictBase:
         """Reset the environment."""

--- a/torchtrade/envs/live/alpaca/env.py
+++ b/torchtrade/envs/live/alpaca/env.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from typing import Dict, List, Optional, Union, Callable
 import logging
+import math
 
 import torch
 
@@ -12,6 +13,7 @@ from torchtrade.envs.live.alpaca.order_executor import AlpacaOrderClass, TradeMo
 from tensordict import TensorDictBase
 from torchrl.data import Categorical
 from torchtrade.envs.live.alpaca.base import AlpacaBaseTorchTradingEnv
+from torchtrade.envs.core.state import position_qty_from_status
 
 @dataclass
 class AlpacaTradingEnvConfig:
@@ -210,8 +212,19 @@ class AlpacaTorchTradingEnv(AlpacaBaseTorchTradingEnv):
         # Total portfolio value
         total_portfolio = cash + current_position_value
 
+        # These two reads size a real order. A NaN makes delta_qty NaN, `nan > 0` is False
+        # so the caller always takes the SELL branch, and in notional mode a sell is
+        # intercepted as close_position() -- one garbage tick liquidates the whole
+        # position (#277). `<= 0` below cannot see that; isfinite can.
+        for _name, _value in (("cash", cash), ("position market_value", current_position_value)):
+            if not math.isfinite(_value):
+                raise ValueError(
+                    f"venue reported a non-finite {_name} ({_value}); refusing to size a "
+                    f"trade against it"
+                )
+
         # Validate portfolio value
-        if total_portfolio <= 0:
+        if not (total_portfolio > 0):
             logger.warning("No portfolio value available for fractional position sizing")
             return 0.0, 0.0
 
@@ -236,10 +249,13 @@ class AlpacaTorchTradingEnv(AlpacaBaseTorchTradingEnv):
 
         # Get current position and price from exchange
         position_status = self.trader.get_status().get("position_status", None)
-        current_qty = float(position_status.qty) if position_status else 0.0
+        # Through the dust rule, not a hand-rolled float(): this is the one qty->size
+        # conversion in the live tree that bypassed it, so it saw neither the dust epsilon
+        # nor the non-finite guard (#277, #283).
+        current_qty = position_qty_from_status(position_status)
         current_price = self._get_current_price(position_status)
 
-        if current_price <= 0:
+        if not (current_price > 0) or not math.isfinite(current_price):
             logger.error(
                 f"Cannot execute trade: invalid or missing price data. "
                 f"price={current_price}, has_position={position_status is not None}, "

--- a/torchtrade/envs/live/binance/base.py
+++ b/torchtrade/envs/live/binance/base.py
@@ -1,5 +1,6 @@
 """Base class for Binance live trading environments."""
 
+import math
 from abc import abstractmethod
 from typing import Callable, List, Optional
 
@@ -106,7 +107,7 @@ class BinanceBaseTorchTradingEnv(TorchTradeFuturesLiveEnv):
         # above zero equity and the account could be wiped out with the episode
         # running on (#277).
         self.initial_portfolio_value = balance["total_margin_balance"]
-        if not (self.initial_portfolio_value > 0):
+        if not math.isfinite(self.initial_portfolio_value) or self.initial_portfolio_value <= 0:
             raise ValueError(
                 f"cannot start an episode on equity of "
                 f"{self.initial_portfolio_value}: the bankruptcy baseline would be 0, "

--- a/torchtrade/envs/live/binance/base.py
+++ b/torchtrade/envs/live/binance/base.py
@@ -102,15 +102,17 @@ class BinanceBaseTorchTradingEnv(TorchTradeFuturesLiveEnv):
         # excludes unrealized PnL (a real skew here); bitget/bybit/okx map both keys to equity.
         balance = self.trader.get_account_balance()
         # Indexed: a default of 0 makes the bankruptcy baseline 0, and
-        # `current < threshold * 0` is never true -- the account could be wiped
-        # out and the episode would run on (#277).
+        # `current < threshold * 0` reduces to `current < 0` -- so it never fires
+        # above zero equity and the account could be wiped out with the episode
+        # running on (#277).
         self.initial_portfolio_value = balance["total_margin_balance"]
         if not (self.initial_portfolio_value > 0):
             raise ValueError(
                 f"cannot start an episode on equity of "
                 f"{self.initial_portfolio_value}: the bankruptcy baseline would be 0, "
-                f"and `current < threshold * 0` never fires -- the account could be "
-                f"wiped out and the episode would trade on"
+                f"and `current < threshold * 0` reduces to `current < 0`, so it never "
+                f"fires above zero equity -- the account could be wiped out with "
+                f"the episode trading on"
             )
 
         # Build observation specs

--- a/torchtrade/envs/live/binance/base.py
+++ b/torchtrade/envs/live/binance/base.py
@@ -101,7 +101,10 @@ class BinanceBaseTorchTradingEnv(TorchTradeFuturesLiveEnv):
         # portfolio_value and the current side of the check. Binance's total_wallet_balance
         # excludes unrealized PnL (a real skew here); bitget/bybit/okx map both keys to equity.
         balance = self.trader.get_account_balance()
-        self.initial_portfolio_value = balance.get("total_margin_balance", 0)
+        # Indexed: a default of 0 makes the bankruptcy baseline 0, and
+        # `current < threshold * 0` is never true -- the account could be wiped
+        # out and the episode would run on (#277).
+        self.initial_portfolio_value = balance["total_margin_balance"]
 
         # Build observation specs
         self._build_observation_specs()

--- a/torchtrade/envs/live/binance/base.py
+++ b/torchtrade/envs/live/binance/base.py
@@ -105,6 +105,13 @@ class BinanceBaseTorchTradingEnv(TorchTradeFuturesLiveEnv):
         # `current < threshold * 0` is never true -- the account could be wiped
         # out and the episode would run on (#277).
         self.initial_portfolio_value = balance["total_margin_balance"]
+        if not (self.initial_portfolio_value > 0):
+            raise ValueError(
+                f"cannot start an episode on equity of "
+                f"{self.initial_portfolio_value}: the bankruptcy baseline would be 0, "
+                f"and `current < threshold * 0` never fires -- the account could be "
+                f"wiped out and the episode would trade on"
+            )
 
         # Build observation specs
         self._build_observation_specs()

--- a/torchtrade/envs/live/binance/env.py
+++ b/torchtrade/envs/live/binance/env.py
@@ -1,3 +1,4 @@
+import math
 from dataclasses import dataclass
 from typing import Dict, List, Optional, Union, Callable
 import logging
@@ -360,7 +361,10 @@ class BinanceFuturesTorchTradingEnv(BinanceBaseTorchTradingEnv):
         # size a NaN position (#277).
         total_balance = balance_info['total_margin_balance']
 
-        if not (total_balance > 0):
+        # isfinite, not `not (x > 0)`: that catches NaN but passes +inf, and an inf
+        # balance sizes an inf target -- bitget's amount rounding then yields NaN and
+        # hands it to create_order. Same defect this PR fixed on the baselines (#277).
+        if not math.isfinite(total_balance) or total_balance <= 0:
             logger.warning("No balance for fractional position sizing")
             return 0.0, 0.0, "flat"
 

--- a/torchtrade/envs/live/binance/env.py
+++ b/torchtrade/envs/live/binance/env.py
@@ -355,9 +355,12 @@ class BinanceFuturesTorchTradingEnv(BinanceBaseTorchTradingEnv):
         # available_balance only shows free margin, which shrinks as positions grow,
         # causing repeated buys when the agent keeps requesting action=1.0.
         balance_info = self.trader.get_account_balance()
-        total_balance = balance_info.get('total_margin_balance', 0.0)
+        # Indexed, and `not (x > 0)`: defaulting to 0.0 turned a broken adapter into a
+        # permanent silent refusal to trade, and `<= 0` lets a NaN balance through to
+        # size a NaN position (#277).
+        total_balance = balance_info['total_margin_balance']
 
-        if total_balance <= 0:
+        if not (total_balance > 0):
             logger.warning("No balance for fractional position sizing")
             return 0.0, 0.0, "flat"
 

--- a/torchtrade/envs/live/binance/order_executor.py
+++ b/torchtrade/envs/live/binance/order_executor.py
@@ -343,7 +343,12 @@ class BinanceFuturesOrderClass:
                         unrealized_pnl=unrealized_pnl,
                         unrealized_pnl_pct=unrealized_pnl_pct,
                         mark_price=mark_price,
-                        leverage=float(pos.get("leverage") or self.leverage),
+                        # `in (None, "")` and not `or`: a venue-reported leverage of numeric 0 is
+                        # falsy, and `or` would swap it for the config value -- inventing a
+                        # liquidation distance from a leverage the venue never confirmed (#277).
+                        leverage=float(
+                            self.leverage if pos.get("leverage") in (None, "") else pos.get("leverage")
+                        ),
                         margin_type=pos.get("marginType", self.margin_type.value),
                         liquidation_price=float(pos.get("liquidationPrice", 0)),
                     )

--- a/torchtrade/envs/live/binance/order_executor.py
+++ b/torchtrade/envs/live/binance/order_executor.py
@@ -333,7 +333,11 @@ class BinanceFuturesOrderClass:
 
                     status["position_status"] = PositionStatus(
                         qty=qty,
-                        notional_value=float(pos.get("notional") or abs(qty * mark_price)),
+                        # `float(...) or` and not `get(...) or`: binance sends notional as a
+                        # STRING, and "0" is truthy, so the outer test has to be on the
+                        # parsed number. qty != 0 is guaranteed above, so the fallback is a
+                        # real notional rather than another 0 (#277).
+                        notional_value=float(pos.get("notional") or 0.0) or abs(qty * mark_price),
                         entry_price=entry_price,
                         unrealized_pnl=unrealized_pnl,
                         unrealized_pnl_pct=unrealized_pnl_pct,

--- a/torchtrade/envs/live/binance/order_executor.py
+++ b/torchtrade/envs/live/binance/order_executor.py
@@ -333,7 +333,7 @@ class BinanceFuturesOrderClass:
 
                     status["position_status"] = PositionStatus(
                         qty=qty,
-                        notional_value=float(pos.get("notional", 0)),
+                        notional_value=float(pos.get("notional") or abs(qty * mark_price)),
                         entry_price=entry_price,
                         unrealized_pnl=unrealized_pnl,
                         unrealized_pnl_pct=unrealized_pnl_pct,

--- a/torchtrade/envs/live/binance/order_executor.py
+++ b/torchtrade/envs/live/binance/order_executor.py
@@ -36,7 +36,8 @@ class PositionStatus:
     unrealized_pnl: float
     unrealized_pnl_pct: float
     mark_price: float
-    leverage: int
+    leverage: float  # float, not int: int() truncated 1.5x to 1x, which then took
+    # the no-liquidation branch and reported a levered position as safe (#277).
     margin_type: str
     liquidation_price: float
 
@@ -342,7 +343,7 @@ class BinanceFuturesOrderClass:
                         unrealized_pnl=unrealized_pnl,
                         unrealized_pnl_pct=unrealized_pnl_pct,
                         mark_price=mark_price,
-                        leverage=int(pos.get("leverage", self.leverage)),
+                        leverage=float(pos.get("leverage") or self.leverage),
                         margin_type=pos.get("marginType", self.margin_type.value),
                         liquidation_price=float(pos.get("liquidationPrice", 0)),
                     )

--- a/torchtrade/envs/live/bitget/base.py
+++ b/torchtrade/envs/live/bitget/base.py
@@ -112,15 +112,17 @@ class BitgetBaseTorchTradingEnv(TorchTradeFuturesLiveEnv):
         # excludes unrealized PnL (a real skew here); bitget/bybit/okx map both keys to equity.
         balance = self.trader.get_account_balance()
         # Indexed: a default of 0 makes the bankruptcy baseline 0, and
-        # `current < threshold * 0` is never true -- the account could be wiped
-        # out and the episode would run on (#277).
+        # `current < threshold * 0` reduces to `current < 0` -- so it never fires
+        # above zero equity and the account could be wiped out with the episode
+        # running on (#277).
         self.initial_portfolio_value = balance["total_margin_balance"]
         if not (self.initial_portfolio_value > 0):
             raise ValueError(
                 f"cannot start an episode on equity of "
                 f"{self.initial_portfolio_value}: the bankruptcy baseline would be 0, "
-                f"and `current < threshold * 0` never fires -- the account could be "
-                f"wiped out and the episode would trade on"
+                f"and `current < threshold * 0` reduces to `current < 0`, so it never "
+                f"fires above zero equity -- the account could be wiped out with "
+                f"the episode trading on"
             )
 
         # Build observation specs

--- a/torchtrade/envs/live/bitget/base.py
+++ b/torchtrade/envs/live/bitget/base.py
@@ -115,6 +115,13 @@ class BitgetBaseTorchTradingEnv(TorchTradeFuturesLiveEnv):
         # `current < threshold * 0` is never true -- the account could be wiped
         # out and the episode would run on (#277).
         self.initial_portfolio_value = balance["total_margin_balance"]
+        if not (self.initial_portfolio_value > 0):
+            raise ValueError(
+                f"cannot start an episode on equity of "
+                f"{self.initial_portfolio_value}: the bankruptcy baseline would be 0, "
+                f"and `current < threshold * 0` never fires -- the account could be "
+                f"wiped out and the episode would trade on"
+            )
 
         # Build observation specs
         self._build_observation_specs()

--- a/torchtrade/envs/live/bitget/base.py
+++ b/torchtrade/envs/live/bitget/base.py
@@ -1,5 +1,6 @@
 """Base class for Bitget live trading environments."""
 
+import math
 from abc import abstractmethod
 from typing import Callable, List, Optional
 
@@ -116,7 +117,7 @@ class BitgetBaseTorchTradingEnv(TorchTradeFuturesLiveEnv):
         # above zero equity and the account could be wiped out with the episode
         # running on (#277).
         self.initial_portfolio_value = balance["total_margin_balance"]
-        if not (self.initial_portfolio_value > 0):
+        if not math.isfinite(self.initial_portfolio_value) or self.initial_portfolio_value <= 0:
             raise ValueError(
                 f"cannot start an episode on equity of "
                 f"{self.initial_portfolio_value}: the bankruptcy baseline would be 0, "

--- a/torchtrade/envs/live/bitget/base.py
+++ b/torchtrade/envs/live/bitget/base.py
@@ -111,7 +111,10 @@ class BitgetBaseTorchTradingEnv(TorchTradeFuturesLiveEnv):
         # portfolio_value and the current side of the check. Binance's total_wallet_balance
         # excludes unrealized PnL (a real skew here); bitget/bybit/okx map both keys to equity.
         balance = self.trader.get_account_balance()
-        self.initial_portfolio_value = balance.get("total_margin_balance", 0)
+        # Indexed: a default of 0 makes the bankruptcy baseline 0, and
+        # `current < threshold * 0` is never true -- the account could be wiped
+        # out and the episode would run on (#277).
+        self.initial_portfolio_value = balance["total_margin_balance"]
 
         # Build observation specs
         self._build_observation_specs()

--- a/torchtrade/envs/live/bitget/env.py
+++ b/torchtrade/envs/live/bitget/env.py
@@ -288,9 +288,12 @@ class BitgetFuturesTorchTradingEnv(BitgetBaseTorchTradingEnv):
         # Use total_margin_balance (not available_balance) so the target reflects
         # the full portfolio, including margin already locked in open positions.
         balance_info = self.trader.get_account_balance()
-        total_balance = balance_info.get('total_margin_balance', 0.0)
+        # Indexed, and `not (x > 0)`: defaulting to 0.0 turned a broken adapter into a
+        # permanent silent refusal to trade, and `<= 0` lets a NaN balance through to
+        # size a NaN position (#277).
+        total_balance = balance_info['total_margin_balance']
 
-        if total_balance <= 0:
+        if not (total_balance > 0):
             logger.warning("No balance for fractional position sizing")
             return 0.0, 0.0, "flat"
 

--- a/torchtrade/envs/live/bitget/env.py
+++ b/torchtrade/envs/live/bitget/env.py
@@ -1,3 +1,4 @@
+import math
 from dataclasses import dataclass
 from typing import List, Optional, Union, Callable, Dict
 import logging
@@ -293,7 +294,10 @@ class BitgetFuturesTorchTradingEnv(BitgetBaseTorchTradingEnv):
         # size a NaN position (#277).
         total_balance = balance_info['total_margin_balance']
 
-        if not (total_balance > 0):
+        # isfinite, not `not (x > 0)`: that catches NaN but passes +inf, and an inf
+        # balance sizes an inf target -- bitget's amount rounding then yields NaN and
+        # hands it to create_order. Same defect this PR fixed on the baselines (#277).
+        if not math.isfinite(total_balance) or total_balance <= 0:
             logger.warning("No balance for fractional position sizing")
             return 0.0, 0.0, "flat"
 

--- a/torchtrade/envs/live/bitget/order_executor.py
+++ b/torchtrade/envs/live/bitget/order_executor.py
@@ -576,7 +576,12 @@ class BitgetFuturesOrderClass:
                         unrealized_pnl=unrealized_pnl,
                         unrealized_pnl_pct=unrealized_pnl_pct,
                         mark_price=mark_price,
-                        leverage=float(pos.get('leverage') or self.leverage),
+                        # `in (None, "")` and not `or`: a venue-reported leverage of numeric 0 is
+                        # falsy, and `or` would swap it for the config value -- inventing a
+                        # liquidation distance from a leverage the venue never confirmed (#277).
+                        leverage=float(
+                            self.leverage if pos.get('leverage') in (None, "") else pos.get('leverage')
+                        ),
                         margin_mode=pos.get('marginMode', self.margin_mode.value),
                         liquidation_price=float(pos.get('liquidationPrice', 0)),
                     )

--- a/torchtrade/envs/live/bitget/order_executor.py
+++ b/torchtrade/envs/live/bitget/order_executor.py
@@ -60,7 +60,8 @@ class PositionStatus:
     unrealized_pnl: float
     unrealized_pnl_pct: float
     mark_price: float
-    leverage: int
+    leverage: float  # float, not int: int() truncated 1.5x to 1x, which then took
+    # the no-liquidation branch and reported a levered position as safe (#277).
     margin_mode: str
     liquidation_price: float
 
@@ -575,7 +576,7 @@ class BitgetFuturesOrderClass:
                         unrealized_pnl=unrealized_pnl,
                         unrealized_pnl_pct=unrealized_pnl_pct,
                         mark_price=mark_price,
-                        leverage=int(pos.get('leverage', self.leverage)),
+                        leverage=float(pos.get('leverage') or self.leverage),
                         margin_mode=pos.get('marginMode', self.margin_mode.value),
                         liquidation_price=float(pos.get('liquidationPrice', 0)),
                     )
@@ -613,7 +614,16 @@ class BitgetFuturesOrderClass:
             logger.debug(f"USDT balance: {usdt_balance}")
 
             # Get total equity (includes unrealized PnL)
-            total = float(usdt_balance.get('total', 0))
+            # Not `.get('total', 0)`: fabricating 0 equity here is what made every
+            # downstream guard useless -- the bankruptcy baseline becomes 0 (so
+            # `current < threshold * 0` never fires), sizing refuses to trade, and
+            # exposure_pct reads flat. Fail at the boundary instead (#277).
+            raw_total = usdt_balance.get('total')
+            if raw_total is None or raw_total == '':
+                raise ValueError(
+                    f"bitget returned no USDT total equity (got {raw_total!r}); refusing "
+                    f"to report an equity of 0")
+            total = float(raw_total)
             free = float(usdt_balance.get('free', 0))
 
             # Unrealized PnL can be calculated from positions

--- a/torchtrade/envs/live/bybit/base.py
+++ b/torchtrade/envs/live/bybit/base.py
@@ -94,6 +94,13 @@ class BybitBaseTorchTradingEnv(TorchTradeFuturesLiveEnv):
         # `current < threshold * 0` is never true -- the account could be wiped
         # out and the episode would run on (#277).
         self.initial_portfolio_value = balance["total_margin_balance"]
+        if not (self.initial_portfolio_value > 0):
+            raise ValueError(
+                f"cannot start an episode on equity of "
+                f"{self.initial_portfolio_value}: the bankruptcy baseline would be 0, "
+                f"and `current < threshold * 0` never fires -- the account could be "
+                f"wiped out and the episode would trade on"
+            )
 
         # Build observation specs
         self._build_observation_specs()

--- a/torchtrade/envs/live/bybit/base.py
+++ b/torchtrade/envs/live/bybit/base.py
@@ -91,15 +91,17 @@ class BybitBaseTorchTradingEnv(TorchTradeFuturesLiveEnv):
         # excludes unrealized PnL (a real skew here); bitget/bybit/okx map both keys to equity.
         balance = self.trader.get_account_balance()
         # Indexed: a default of 0 makes the bankruptcy baseline 0, and
-        # `current < threshold * 0` is never true -- the account could be wiped
-        # out and the episode would run on (#277).
+        # `current < threshold * 0` reduces to `current < 0` -- so it never fires
+        # above zero equity and the account could be wiped out with the episode
+        # running on (#277).
         self.initial_portfolio_value = balance["total_margin_balance"]
         if not (self.initial_portfolio_value > 0):
             raise ValueError(
                 f"cannot start an episode on equity of "
                 f"{self.initial_portfolio_value}: the bankruptcy baseline would be 0, "
-                f"and `current < threshold * 0` never fires -- the account could be "
-                f"wiped out and the episode would trade on"
+                f"and `current < threshold * 0` reduces to `current < 0`, so it never "
+                f"fires above zero equity -- the account could be wiped out with "
+                f"the episode trading on"
             )
 
         # Build observation specs

--- a/torchtrade/envs/live/bybit/base.py
+++ b/torchtrade/envs/live/bybit/base.py
@@ -1,5 +1,6 @@
 """Base class for Bybit live trading environments."""
 import logging
+import math
 
 from abc import abstractmethod
 from typing import Callable, List, Optional
@@ -95,7 +96,7 @@ class BybitBaseTorchTradingEnv(TorchTradeFuturesLiveEnv):
         # above zero equity and the account could be wiped out with the episode
         # running on (#277).
         self.initial_portfolio_value = balance["total_margin_balance"]
-        if not (self.initial_portfolio_value > 0):
+        if not math.isfinite(self.initial_portfolio_value) or self.initial_portfolio_value <= 0:
             raise ValueError(
                 f"cannot start an episode on equity of "
                 f"{self.initial_portfolio_value}: the bankruptcy baseline would be 0, "

--- a/torchtrade/envs/live/bybit/base.py
+++ b/torchtrade/envs/live/bybit/base.py
@@ -90,7 +90,10 @@ class BybitBaseTorchTradingEnv(TorchTradeFuturesLiveEnv):
         # portfolio_value and the current side of the check. Binance's total_wallet_balance
         # excludes unrealized PnL (a real skew here); bitget/bybit/okx map both keys to equity.
         balance = self.trader.get_account_balance()
-        self.initial_portfolio_value = balance.get("total_margin_balance", 0)
+        # Indexed: a default of 0 makes the bankruptcy baseline 0, and
+        # `current < threshold * 0` is never true -- the account could be wiped
+        # out and the episode would run on (#277).
+        self.initial_portfolio_value = balance["total_margin_balance"]
 
         # Build observation specs
         self._build_observation_specs()

--- a/torchtrade/envs/live/bybit/env.py
+++ b/torchtrade/envs/live/bybit/env.py
@@ -233,7 +233,10 @@ class BybitFuturesTorchTradingEnv(BybitBaseTorchTradingEnv):
         # size a NaN position (#277).
         total_balance = balance_info['total_margin_balance']
 
-        if not (total_balance > 0):
+        # isfinite, not `not (x > 0)`: that catches NaN but passes +inf, and an inf
+        # balance sizes an inf target -- bitget's amount rounding then yields NaN and
+        # hands it to create_order. Same defect this PR fixed on the baselines (#277).
+        if not math.isfinite(total_balance) or total_balance <= 0:
             logger.warning("No balance for fractional position sizing")
             return 0.0, 0.0, "flat"
 

--- a/torchtrade/envs/live/bybit/env.py
+++ b/torchtrade/envs/live/bybit/env.py
@@ -228,9 +228,12 @@ class BybitFuturesTorchTradingEnv(BybitBaseTorchTradingEnv):
             return 0.0, 0.0, "flat"
 
         balance_info = self.trader.get_account_balance()
-        total_balance = balance_info.get('total_margin_balance', 0.0)
+        # Indexed, and `not (x > 0)`: defaulting to 0.0 turned a broken adapter into a
+        # permanent silent refusal to trade, and `<= 0` lets a NaN balance through to
+        # size a NaN position (#277).
+        total_balance = balance_info['total_margin_balance']
 
-        if total_balance <= 0:
+        if not (total_balance > 0):
             logger.warning("No balance for fractional position sizing")
             return 0.0, 0.0, "flat"
 

--- a/torchtrade/envs/live/bybit/order_executor.py
+++ b/torchtrade/envs/live/bybit/order_executor.py
@@ -51,7 +51,8 @@ class PositionStatus:
     unrealized_pnl: float
     unrealized_pnl_pct: float
     mark_price: float
-    leverage: int
+    leverage: float  # float, not int: int() truncated 1.5x to 1x, which then took
+    # the no-liquidation branch and reported a levered position as safe (#277).
     margin_mode: str
     liquidation_price: float
 
@@ -349,7 +350,7 @@ class BybitFuturesOrderClass:
                     unrealized_pnl=unrealized_pnl,
                     unrealized_pnl_pct=unrealized_pnl_pct,
                     mark_price=mark_price,
-                    leverage=int(float(pos.get("leverage", self.leverage))),
+                    leverage=float(pos.get("leverage") or self.leverage),
                     margin_mode=pos.get("tradeMode", str(self.margin_mode.to_pybit())),
                     liquidation_price=liq_price,
                 )
@@ -382,7 +383,13 @@ class BybitFuturesOrderClass:
                 raise RuntimeError("No account data returned from UNIFIED or CONTRACT account types")
 
             account = accounts[0]
-            total_equity = float(account.get("totalEquity", 0))
+            # See bitget: a fabricated 0 equity disables every downstream guard (#277).
+            raw_equity = account.get("totalEquity")
+            if raw_equity is None or raw_equity == "":
+                raise ValueError(
+                    f"bybit returned no total equity (got {raw_equity!r}); refusing to "
+                    f"report an equity of 0")
+            total_equity = float(raw_equity)
             available = float(account.get("totalAvailableBalance", 0))
             total_pnl = float(account.get("totalPerpUPL", 0))
             margin_balance = float(account.get("totalMarginBalance", total_equity))

--- a/torchtrade/envs/live/bybit/order_executor.py
+++ b/torchtrade/envs/live/bybit/order_executor.py
@@ -350,7 +350,12 @@ class BybitFuturesOrderClass:
                     unrealized_pnl=unrealized_pnl,
                     unrealized_pnl_pct=unrealized_pnl_pct,
                     mark_price=mark_price,
-                    leverage=float(pos.get("leverage") or self.leverage),
+                    # `in (None, "")` and not `or`: a venue-reported leverage of numeric 0 is
+                    # falsy, and `or` would swap it for the config value -- inventing a
+                    # liquidation distance from a leverage the venue never confirmed (#277).
+                    leverage=float(
+                        self.leverage if pos.get("leverage") in (None, "") else pos.get("leverage")
+                    ),
                     margin_mode=pos.get("tradeMode", str(self.margin_mode.to_pybit())),
                     liquidation_price=liq_price,
                 )

--- a/torchtrade/envs/live/okx/base.py
+++ b/torchtrade/envs/live/okx/base.py
@@ -94,15 +94,17 @@ class OKXBaseTorchTradingEnv(TorchTradeFuturesLiveEnv):
         # excludes unrealized PnL (a real skew here); bitget/bybit/okx map both keys to equity.
         balance = self.trader.get_account_balance()
         # Indexed: a default of 0 makes the bankruptcy baseline 0, and
-        # `current < threshold * 0` is never true -- the account could be wiped
-        # out and the episode would run on (#277).
+        # `current < threshold * 0` reduces to `current < 0` -- so it never fires
+        # above zero equity and the account could be wiped out with the episode
+        # running on (#277).
         self.initial_portfolio_value = balance["total_margin_balance"]
         if not (self.initial_portfolio_value > 0):
             raise ValueError(
                 f"cannot start an episode on equity of "
                 f"{self.initial_portfolio_value}: the bankruptcy baseline would be 0, "
-                f"and `current < threshold * 0` never fires -- the account could be "
-                f"wiped out and the episode would trade on"
+                f"and `current < threshold * 0` reduces to `current < 0`, so it never "
+                f"fires above zero equity -- the account could be wiped out with "
+                f"the episode trading on"
             )
 
         # Build observation specs

--- a/torchtrade/envs/live/okx/base.py
+++ b/torchtrade/envs/live/okx/base.py
@@ -97,6 +97,13 @@ class OKXBaseTorchTradingEnv(TorchTradeFuturesLiveEnv):
         # `current < threshold * 0` is never true -- the account could be wiped
         # out and the episode would run on (#277).
         self.initial_portfolio_value = balance["total_margin_balance"]
+        if not (self.initial_portfolio_value > 0):
+            raise ValueError(
+                f"cannot start an episode on equity of "
+                f"{self.initial_portfolio_value}: the bankruptcy baseline would be 0, "
+                f"and `current < threshold * 0` never fires -- the account could be "
+                f"wiped out and the episode would trade on"
+            )
 
         # Build observation specs
         self._build_observation_specs()

--- a/torchtrade/envs/live/okx/base.py
+++ b/torchtrade/envs/live/okx/base.py
@@ -1,5 +1,6 @@
 """Base class for OKX live trading environments."""
 import logging
+import math
 
 from abc import abstractmethod
 from typing import Callable, List, Optional
@@ -98,7 +99,7 @@ class OKXBaseTorchTradingEnv(TorchTradeFuturesLiveEnv):
         # above zero equity and the account could be wiped out with the episode
         # running on (#277).
         self.initial_portfolio_value = balance["total_margin_balance"]
-        if not (self.initial_portfolio_value > 0):
+        if not math.isfinite(self.initial_portfolio_value) or self.initial_portfolio_value <= 0:
             raise ValueError(
                 f"cannot start an episode on equity of "
                 f"{self.initial_portfolio_value}: the bankruptcy baseline would be 0, "

--- a/torchtrade/envs/live/okx/base.py
+++ b/torchtrade/envs/live/okx/base.py
@@ -93,7 +93,10 @@ class OKXBaseTorchTradingEnv(TorchTradeFuturesLiveEnv):
         # portfolio_value and the current side of the check. Binance's total_wallet_balance
         # excludes unrealized PnL (a real skew here); bitget/bybit/okx map both keys to equity.
         balance = self.trader.get_account_balance()
-        self.initial_portfolio_value = balance.get("total_margin_balance", 0)
+        # Indexed: a default of 0 makes the bankruptcy baseline 0, and
+        # `current < threshold * 0` is never true -- the account could be wiped
+        # out and the episode would run on (#277).
+        self.initial_portfolio_value = balance["total_margin_balance"]
 
         # Build observation specs
         self._build_observation_specs()

--- a/torchtrade/envs/live/okx/env.py
+++ b/torchtrade/envs/live/okx/env.py
@@ -233,9 +233,12 @@ class OKXFuturesTorchTradingEnv(OKXBaseTorchTradingEnv):
             return 0.0, 0.0, "flat"
 
         balance_info = self.trader.get_account_balance()
-        total_balance = balance_info.get('total_margin_balance', 0.0)
+        # Indexed, and `not (x > 0)`: defaulting to 0.0 turned a broken adapter into a
+        # permanent silent refusal to trade, and `<= 0` lets a NaN balance through to
+        # size a NaN position (#277).
+        total_balance = balance_info['total_margin_balance']
 
-        if total_balance <= 0:
+        if not (total_balance > 0):
             logger.warning("No balance for fractional position sizing")
             return 0.0, 0.0, "flat"
 

--- a/torchtrade/envs/live/okx/env.py
+++ b/torchtrade/envs/live/okx/env.py
@@ -238,7 +238,10 @@ class OKXFuturesTorchTradingEnv(OKXBaseTorchTradingEnv):
         # size a NaN position (#277).
         total_balance = balance_info['total_margin_balance']
 
-        if not (total_balance > 0):
+        # isfinite, not `not (x > 0)`: that catches NaN but passes +inf, and an inf
+        # balance sizes an inf target -- bitget's amount rounding then yields NaN and
+        # hands it to create_order. Same defect this PR fixed on the baselines (#277).
+        if not math.isfinite(total_balance) or total_balance <= 0:
             logger.warning("No balance for fractional position sizing")
             return 0.0, 0.0, "flat"
 

--- a/torchtrade/envs/live/okx/order_executor.py
+++ b/torchtrade/envs/live/okx/order_executor.py
@@ -44,7 +44,8 @@ class PositionStatus:
     unrealized_pnl: float
     unrealized_pnl_pct: float
     mark_price: float
-    leverage: int
+    leverage: float  # float, not int: int() truncated 1.5x to 1x, which then took
+    # the no-liquidation branch and reported a levered position as safe (#277).
     margin_mode: str
     liquidation_price: float
 
@@ -369,7 +370,7 @@ class OKXFuturesOrderClass:
                     unrealized_pnl=unrealized_pnl,
                     unrealized_pnl_pct=unrealized_pnl_pct,
                     mark_price=mark_price,
-                    leverage=int(float(pos.get("lever") or str(self.leverage))),
+                    leverage=float(pos.get("lever") or self.leverage),
                     margin_mode=pos.get("mgnMode", self.margin_mode.value),
                     liquidation_price=liq_price,
                 )
@@ -404,7 +405,13 @@ class OKXFuturesOrderClass:
                 raise RuntimeError("No account data returned from OKX")
 
             account = data[0]
-            total_equity = float(account.get("totalEq") or "0")
+            # See bitget: a fabricated 0 equity disables every downstream guard (#277).
+            raw_equity = account.get("totalEq")
+            if raw_equity is None or raw_equity == "":
+                raise ValueError(
+                    f"okx returned no total equity (got {raw_equity!r}); refusing to "
+                    f"report an equity of 0")
+            total_equity = float(raw_equity)
             # Available equity for trading
             details = account.get("details", [])
             available = 0.0

--- a/torchtrade/envs/live/okx/order_executor.py
+++ b/torchtrade/envs/live/okx/order_executor.py
@@ -370,7 +370,12 @@ class OKXFuturesOrderClass:
                     unrealized_pnl=unrealized_pnl,
                     unrealized_pnl_pct=unrealized_pnl_pct,
                     mark_price=mark_price,
-                    leverage=float(pos.get("lever") or self.leverage),
+                    # `in (None, "")` and not `or`: a venue-reported leverage of numeric 0 is
+                    # falsy, and `or` would swap it for the config value -- inventing a
+                    # liquidation distance from a leverage the venue never confirmed (#277).
+                    leverage=float(
+                        self.leverage if pos.get("lever") in (None, "") else pos.get("lever")
+                    ),
                     margin_mode=pos.get("mgnMode", self.margin_mode.value),
                     liquidation_price=liq_price,
                 )

--- a/torchtrade/envs/live/polymarket/market_scanner.py
+++ b/torchtrade/envs/live/polymarket/market_scanner.py
@@ -40,6 +40,7 @@ def _finite(raw_value, field, slug) -> float:
         )
     return value
 
+
 def _valid_price(raw_price, field, slug) -> float:
     """A market price must be a real probability, or the whole episode goes NaN.
 
@@ -315,11 +316,15 @@ class MarketScanner:
                 continue
             try:
                 markets.append(self._parse_market(raw))
-            except (KeyError, json.JSONDecodeError, IndexError, ValueError):
+            except (KeyError, json.JSONDecodeError, IndexError, ValueError) as exc:
                 # ValueError included so a single market with an unusable price is skipped
                 # rather than aborting the whole scan -- which is what a bare float() on a
                 # garbage price would have done here too, once it stopped being silent.
-                logger.warning("Failed to parse market: %s", raw.get("id", "unknown"))
+                # The reason, not just the id: adding ValueError above made this the sink
+                # for every diagnostic the price/finiteness guards emit, and without it a
+                # systematic API change silently empties the scan -- indistinguishable
+                # from "no markets matched the filter".
+                logger.warning("Failed to parse market %s: %s", raw.get("id", "unknown"), exc)
                 continue
 
         return self._filter_markets(markets)
@@ -362,10 +367,14 @@ class MarketScanner:
                 continue
             try:
                 return self._parse_market(raw)
-            except (KeyError, json.JSONDecodeError, IndexError, ValueError):
+            except (KeyError, json.JSONDecodeError, IndexError, ValueError) as exc:
                 # ValueError included so a single market with an unusable price is skipped
                 # rather than aborting the whole scan -- which is what a bare float() on a
                 # garbage price would have done here too, once it stopped being silent.
-                logger.warning("Failed to parse market: %s", raw.get("id", "unknown"))
+                # The reason, not just the id: adding ValueError above made this the sink
+                # for every diagnostic the price/finiteness guards emit, and without it a
+                # systematic API change silently empties the scan -- indistinguishable
+                # from "no markets matched the filter".
+                logger.warning("Failed to parse market %s: %s", raw.get("id", "unknown"), exc)
                 continue
         return None

--- a/torchtrade/envs/live/polymarket/market_scanner.py
+++ b/torchtrade/envs/live/polymarket/market_scanner.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -22,6 +23,24 @@ GAMMA_API_BASE = "https://gamma-api.polymarket.com"
 # well under the market cadence so retries never push us past the next resolution.
 _RETRY_ATTEMPTS = 3
 _RETRY_BACKOFF_SECONDS = 1.0
+
+
+def _valid_price(raw_price, field, slug) -> float:
+    """A market price must be a real probability, or the whole episode goes NaN.
+
+    `_compute_payoff` guards `fill_price <= 0`, which NaN and +inf both compare False to,
+    so a garbage price flows into `self.cash` -- polymarket's equity and its only
+    bankruptcy input. Once cash is NaN it stays NaN, `is_bankrupt` is False forever, and
+    every reward is NaN. The config is already validated in __post_init__; this is the
+    venue side of the same rule (#277).
+    """
+    price = float(raw_price)
+    if not math.isfinite(price) or not (0 < price <= 1):
+        raise ValueError(
+            f"market {slug!r} reported a {field} of {raw_price!r}, which is not a "
+            f"probability in (0, 1]; refusing to trade against it"
+        )
+    return price
 
 
 def _fetch_json_with_retry(
@@ -136,8 +155,8 @@ class MarketScanner:
             slug=raw["slug"],
             yes_token_id=clob_token_ids[0],
             no_token_id=clob_token_ids[1],
-            yes_price=float(outcome_prices[0]),
-            no_price=float(outcome_prices[1]),
+            yes_price=_valid_price(outcome_prices[0], "yes_price", raw.get("slug")),
+            no_price=_valid_price(outcome_prices[1], "no_price", raw.get("slug")),
             volume_24h=float(raw.get("volume24hr", 0)),
             total_volume=float(raw.get("volume", 0)),
             liquidity=float(raw.get("liquidity", 0)),

--- a/torchtrade/envs/live/polymarket/market_scanner.py
+++ b/torchtrade/envs/live/polymarket/market_scanner.py
@@ -35,10 +35,14 @@ def _valid_price(raw_price, field, slug) -> float:
     venue side of the same rule (#277).
     """
     price = float(raw_price)
-    if not math.isfinite(price) or not (0 < price <= 1):
+    # [0, 1] inclusive: a near-resolved market legitimately prices an outcome at 0 or 1,
+    # and _compute_payoff already guards fill_price <= 0. What is rejected is the garbage
+    # that guard cannot see -- NaN and +inf compare False to `<= 0` and flow straight into
+    # cash.
+    if not math.isfinite(price) or not (0 <= price <= 1):
         raise ValueError(
             f"market {slug!r} reported a {field} of {raw_price!r}, which is not a "
-            f"probability in (0, 1]; refusing to trade against it"
+            f"probability in [0, 1]; refusing to trade against it"
         )
     return price
 
@@ -296,7 +300,10 @@ class MarketScanner:
                 continue
             try:
                 markets.append(self._parse_market(raw))
-            except (KeyError, json.JSONDecodeError, IndexError):
+            except (KeyError, json.JSONDecodeError, IndexError, ValueError):
+                # ValueError included so a single market with an unusable price is skipped
+                # rather than aborting the whole scan -- which is what a bare float() on a
+                # garbage price would have done here too, once it stopped being silent.
                 logger.warning("Failed to parse market: %s", raw.get("id", "unknown"))
                 continue
 
@@ -340,7 +347,10 @@ class MarketScanner:
                 continue
             try:
                 return self._parse_market(raw)
-            except (KeyError, json.JSONDecodeError, IndexError):
+            except (KeyError, json.JSONDecodeError, IndexError, ValueError):
+                # ValueError included so a single market with an unusable price is skipped
+                # rather than aborting the whole scan -- which is what a bare float() on a
+                # garbage price would have done here too, once it stopped being silent.
                 logger.warning("Failed to parse market: %s", raw.get("id", "unknown"))
                 continue
         return None

--- a/torchtrade/envs/live/polymarket/market_scanner.py
+++ b/torchtrade/envs/live/polymarket/market_scanner.py
@@ -25,6 +25,21 @@ _RETRY_ATTEMPTS = 3
 _RETRY_BACKOFF_SECONDS = 1.0
 
 
+def _finite(raw_value, field, slug) -> float:
+    """Three of these four are the market half of the observation tensor.
+
+    `_filter_markets` compares them with `<`/`>`, which NaN passes, so a garbage volume or
+    liquidity survives filtering and lands in `_market_state` -- straight into the policy
+    network. Not a probability like the prices, so only finiteness and sign are checked.
+    """
+    value = float(raw_value)
+    if not math.isfinite(value) or value < 0:
+        raise ValueError(
+            f"market {slug!r} reported a {field} of {raw_value!r}, which is not a "
+            f"finite non-negative number; refusing to trade against it"
+        )
+    return value
+
 def _valid_price(raw_price, field, slug) -> float:
     """A market price must be a real probability, or the whole episode goes NaN.
 
@@ -161,10 +176,10 @@ class MarketScanner:
             no_token_id=clob_token_ids[1],
             yes_price=_valid_price(outcome_prices[0], "yes_price", raw.get("slug")),
             no_price=_valid_price(outcome_prices[1], "no_price", raw.get("slug")),
-            volume_24h=float(raw.get("volume24hr", 0)),
-            total_volume=float(raw.get("volume", 0)),
-            liquidity=float(raw.get("liquidity", 0)),
-            spread=float(raw.get("spread", 0)),
+            volume_24h=_finite(raw.get("volume24hr", 0), "volume_24h", raw.get("slug")),
+            total_volume=_finite(raw.get("volume", 0), "total_volume", raw.get("slug")),
+            liquidity=_finite(raw.get("liquidity", 0), "liquidity", raw.get("slug")),
+            spread=_finite(raw.get("spread", 0), "spread", raw.get("slug")),
             end_date=raw.get("endDate", ""),
             tags=raw.get("tags", []),
             neg_risk=raw.get("negRisk", False),

--- a/torchtrade/envs/live/shared/futures_live_base.py
+++ b/torchtrade/envs/live/shared/futures_live_base.py
@@ -235,7 +235,17 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
         balance = self.trader.get_account_balance()
         # Indexed, for the same reason as _get_observation above: this is the `current`
         # side of is_bankrupt(), where a default of 0 is instant false bankruptcy.
-        return balance["total_margin_balance"]
+        equity = balance["total_margin_balance"]
+        # Guarded here too, not only in _get_observation: this is a SECOND, independent
+        # fetch, and it is the literal argument to _check_termination. The two reads can
+        # disagree -- a NaN in this one alone would reach is_bankrupt(), where
+        # `nan < threshold * initial` is False, while the observation's read passed.
+        if not math.isfinite(equity):
+            raise ValueError(
+                f"venue reported a non-finite equity ({equity}); refusing to run a "
+                f"bankruptcy check against it"
+            )
+        return equity
 
     def _get_current_position_quantity(self) -> float:
         """The signed size the exchange holds, dust read as flat.

--- a/torchtrade/envs/live/shared/futures_live_base.py
+++ b/torchtrade/envs/live/shared/futures_live_base.py
@@ -102,25 +102,29 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
             liquidation_price = position_status.liquidation_price
 
         # Build 6-element account state
-        if total_balance > 0:
-            exposure_pct = position_value / total_balance
-        elif position_value == 0:
-            # An empty account is genuinely 0% exposed; this branch only exists so the
-            # division does not raise on it.
-            exposure_pct = 0.0
-        else:
-            # Equity gone with the position still on. There is no exposure_pct to report
-            # -- the ratio is unbounded -- and the old `else 0.0` reported the one value
-            # that is certainly wrong, handing the policy a flat-looking account that is
-            # actually holding an underwater position (invariant #3). Fail closed, like
-            # the unknown-status and get_account_balance() paths above.
+        # Equity gone with the position still on: there is no exposure_pct to report, the
+        # ratio being unbounded, and the old `else 0.0` reported the one value that is
+        # certainly wrong -- a flat-looking account that is actually holding an underwater
+        # position (invariant #3). Fail closed, like the unknown-status path above. An
+        # account that is merely empty still reports 0.0 exposure, which is true.
+        # `not (x > 0)` rather than `x <= 0`: NaN compares False to everything, so `<= 0`
+        # skips the raise and the ternary below then hands back 0.0 -- a held position
+        # reading flat, the exact bug this raise exists to prevent.
+        if not (total_balance > 0) and position_value > 0:
             raise ValueError(
                 f"Position worth {position_value} held against non-positive equity "
                 f"({total_balance}). The venue is mid-liquidation or reporting "
                 f"inconsistently; refusing to report this account as flat."
             )
+        exposure_pct = position_value / total_balance if total_balance > 0 else 0.0
 
         if position_size == 0 or current_price == 0:
+            distance_to_liquidation = 1.0
+        elif liquidation_price <= 0 and leverage <= 1:
+            # No leverage, nothing to be liquidated by, and the offline env says the same
+            # via its has_liquidation gate -- so this must NOT fall through to the
+            # arithmetic below, where a short would compute (0 - price)/price = -1 and
+            # clamp to 0.0, reporting an unlevered position as AT liquidation.
             distance_to_liquidation = 1.0
         else:
             if liquidation_price <= 0:
@@ -167,7 +171,9 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
     def _get_portfolio_value(self) -> float:
         """Calculate total portfolio value (includes unrealized PnL)."""
         balance = self.trader.get_account_balance()
-        return balance.get("total_margin_balance", 0)
+        # Indexed, for the same reason as _get_observation above: this is the `current`
+        # side of is_bankrupt(), where a default of 0 is instant false bankruptcy.
+        return balance["total_margin_balance"]
 
     def _get_current_position_quantity(self) -> float:
         """The signed size the exchange holds, dust read as flat.

--- a/torchtrade/envs/live/shared/futures_live_base.py
+++ b/torchtrade/envs/live/shared/futures_live_base.py
@@ -151,6 +151,11 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
                 # elsewhere have eaten the collateral, cross liquidates earlier than
                 # isolated says and the estimate would overstate the distance -- the same
                 # fail-open, reintroduced with extra steps.
+                #
+                # Still not a guaranteed bound: a second cross position's maintenance
+                # requirement is invisible to both estimates and would move liquidation
+                # nearer again (#344). That assumption -- this env owns the account -- is
+                # the same one exposure_pct and the bankruptcy baseline already make.
                 liquidation_price = nearest_liquidation_price(
                     position_size=position_size,
                     entry_price=position_status.entry_price,

--- a/torchtrade/envs/live/shared/futures_live_base.py
+++ b/torchtrade/envs/live/shared/futures_live_base.py
@@ -18,7 +18,7 @@ from torchtrade.envs.core.state import (
     position_direction_from_status,
     position_qty_from_status,
 )
-from torchtrade.envs.utils.liquidation import isolated_liquidation_price
+from torchtrade.envs.utils.liquidation import nearest_liquidation_price
 
 
 class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
@@ -110,7 +110,10 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
         # `not (x > 0)` rather than `x <= 0`: NaN compares False to everything, so `<= 0`
         # skips the raise and the ternary below then hands back 0.0 -- a held position
         # reading flat, the exact bug this raise exists to prevent.
-        if not (total_balance > 0) and position_value > 0:
+        # Keyed on position_direction (which goes through the dust rule), NOT on
+        # position_value: a venue that omits the notional would zero the second
+        # conjunct and skip the raise on a position that is very much held.
+        if not (total_balance > 0) and position_direction != 0:
             raise ValueError(
                 f"Position worth {position_value} held against non-positive equity "
                 f"({total_balance}). The venue is mid-liquidation or reporting "
@@ -120,25 +123,39 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
 
         if position_size == 0 or current_price == 0:
             distance_to_liquidation = 1.0
-        elif liquidation_price <= 0 and leverage <= 1:
+        elif liquidation_price <= 0 and leverage == 1:
             # No leverage, nothing to be liquidated by, and the offline env says the same
             # via its has_liquidation gate -- so this must NOT fall through to the
             # arithmetic below, where a short would compute (0 - price)/price = -1 and
             # clamp to 0.0, reporting an unlevered position as AT liquidation.
+            #
+            # `== 1`, not `<= 1`: leverage of 0, negative or fractional is venue nonsense,
+            # and letting it take this branch hands a held position the maximally-safe
+            # answer -- #277 one field over. Those fall through to the helper, which
+            # raises. Offline refuses the same inputs in __post_init__.
             distance_to_liquidation = 1.0
         else:
             if liquidation_price <= 0:
-                # Cross-margin venues omit the liquidation price (bybit sends liqPrice=""
-                # for unified/cross, OKX liqPx="" for cross) because the whole account
-                # backs the position, so there is no per-position price to publish.
+                # Cross-margin venues omit the liquidation price (OKX sends liqPx="" for
+                # cross) because the whole account backs the position, so there is no
+                # per-position price to publish. bybit blanks liqPrice for unified/cross
+                # too, but blanks `leverage` with it, so its adapter yields
+                # POSITION_UNKNOWN and raises before reaching here -- OKX is the venue
+                # that actually exercises this path.
                 # Defaulting to 1.0 reported a 20x long one move away from liquidation as
-                # exactly as safe as a flat spot account (#277). Fall back to the
-                # isolated-margin geometry the offline envs train against. Cross margin
-                # liquidates later than isolated, so this understates the distance -- it
-                # errs toward showing the policy more risk than it has, not less.
-                liquidation_price = isolated_liquidation_price(
-                    position_status.entry_price,
-                    is_long=position_size > 0,
+                # exactly as safe as a flat spot account (#277).
+                #
+                # Estimated from BOTH the isolated geometry and the account's equity,
+                # taking whichever is nearer. Isolated alone is not the conservative
+                # choice it looks like: it only sees this position, so once losses
+                # elsewhere have eaten the collateral, cross liquidates earlier than
+                # isolated says and the estimate would overstate the distance -- the same
+                # fail-open, reintroduced with extra steps.
+                liquidation_price = nearest_liquidation_price(
+                    position_size=position_size,
+                    entry_price=position_status.entry_price,
+                    mark_price=current_price,
+                    equity=total_balance,
                     leverage=leverage,
                 )
             if position_size > 0:

--- a/torchtrade/envs/live/shared/futures_live_base.py
+++ b/torchtrade/envs/live/shared/futures_live_base.py
@@ -9,6 +9,8 @@ Alpaca (spot) is NOT a futures env: it hardcodes leverage=1 and distance_to_liqu
 and reads cash rather than total_wallet_balance. It keeps its own `_get_observation` and
 inherits `TorchTradeLiveEnv` directly.
 """
+import math
+
 import torch
 from tensordict import TensorDict, TensorDictBase
 
@@ -94,6 +96,22 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
             leverage = float(self.config.leverage)
             liquidation_price = 0.0
         else:
+            # Every guard below is a comparison, and NaN compares False to all of them --
+            # a NaN liquidation price would skip the fallback, reach the arithmetic, and
+            # clamp to a distance of 0.0, telling the policy a healthy position is AT
+            # liquidation on one garbage tick. Checked once, here, rather than at each
+            # comparison (#277).
+            for _name, _value in (
+                ("qty", position_status.qty),
+                ("mark_price", position_status.mark_price),
+                ("leverage", position_status.leverage),
+                ("liquidation_price", position_status.liquidation_price),
+            ):
+                if not math.isfinite(_value):
+                    raise ValueError(
+                        f"venue reported a non-finite {_name} ({_value}) for an open "
+                        f"position; refusing to derive an account state from it"
+                    )
             position_size = position_status.qty
             position_value = abs(position_status.notional_value)
             current_price = position_status.mark_price

--- a/torchtrade/envs/live/shared/futures_live_base.py
+++ b/torchtrade/envs/live/shared/futures_live_base.py
@@ -18,6 +18,7 @@ from torchtrade.envs.core.state import (
     position_direction_from_status,
     position_qty_from_status,
 )
+from torchtrade.envs.utils.liquidation import isolated_liquidation_price
 
 
 class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
@@ -68,7 +69,10 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
         # exposure_pct read differently for the same position. total_margin_balance is uniformly
         # equity across all four, so exposure_pct is comparable cross-exchange (and matches the
         # portfolio value _get_portfolio_value returns).
-        total_balance = balance.get("total_margin_balance", 0)
+        # Indexed, not .get(..., 0): all four adapters build this key unconditionally, so a
+        # missing one means the adapter broke. The default turned that into a silent
+        # exposure_pct of 0.0 -- every position reading as flat, forever (#277).
+        total_balance = balance["total_margin_balance"]
         position_status = status.get("position_status", None)
 
         # Dust is not a position: gating on `is None` let a 1e-12 residual left behind a
@@ -98,11 +102,41 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
             liquidation_price = position_status.liquidation_price
 
         # Build 6-element account state
-        exposure_pct = position_value / total_balance if total_balance > 0 else 0.0
+        if total_balance > 0:
+            exposure_pct = position_value / total_balance
+        elif position_value == 0:
+            # An empty account is genuinely 0% exposed; this branch only exists so the
+            # division does not raise on it.
+            exposure_pct = 0.0
+        else:
+            # Equity gone with the position still on. There is no exposure_pct to report
+            # -- the ratio is unbounded -- and the old `else 0.0` reported the one value
+            # that is certainly wrong, handing the policy a flat-looking account that is
+            # actually holding an underwater position (invariant #3). Fail closed, like
+            # the unknown-status and get_account_balance() paths above.
+            raise ValueError(
+                f"Position worth {position_value} held against non-positive equity "
+                f"({total_balance}). The venue is mid-liquidation or reporting "
+                f"inconsistently; refusing to report this account as flat."
+            )
 
-        if position_size == 0 or current_price == 0 or liquidation_price <= 0:
+        if position_size == 0 or current_price == 0:
             distance_to_liquidation = 1.0
         else:
+            if liquidation_price <= 0:
+                # Cross-margin venues omit the liquidation price (bybit sends liqPrice=""
+                # for unified/cross, OKX liqPx="" for cross) because the whole account
+                # backs the position, so there is no per-position price to publish.
+                # Defaulting to 1.0 reported a 20x long one move away from liquidation as
+                # exactly as safe as a flat spot account (#277). Fall back to the
+                # isolated-margin geometry the offline envs train against. Cross margin
+                # liquidates later than isolated, so this understates the distance -- it
+                # errs toward showing the policy more risk than it has, not less.
+                liquidation_price = isolated_liquidation_price(
+                    position_status.entry_price,
+                    is_long=position_size > 0,
+                    leverage=leverage,
+                )
             if position_size > 0:
                 distance_to_liquidation = (current_price - liquidation_price) / current_price
             else:

--- a/torchtrade/envs/live/shared/futures_live_base.py
+++ b/torchtrade/envs/live/shared/futures_live_base.py
@@ -101,11 +101,18 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
             # clamp to a distance of 0.0, telling the policy a healthy position is AT
             # liquidation on one garbage tick. Checked once, here, rather than at each
             # comparison (#277).
+            # Every venue number this branch reads, not just the ones feeding
+            # distance_to_liquidation: a NaN notional_value is worse than a NaN
+            # liquidation price, because exposure_pct = nan/equity puts NaN straight into
+            # the observation tensor and from there into the policy network.
             for _name, _value in (
                 ("qty", position_status.qty),
                 ("mark_price", position_status.mark_price),
                 ("leverage", position_status.leverage),
                 ("liquidation_price", position_status.liquidation_price),
+                ("notional_value", position_status.notional_value),
+                ("unrealized_pnl_pct", position_status.unrealized_pnl_pct),
+                ("entry_price", position_status.entry_price),
             ):
                 if not math.isfinite(_value):
                     raise ValueError(

--- a/torchtrade/envs/live/shared/futures_live_base.py
+++ b/torchtrade/envs/live/shared/futures_live_base.py
@@ -75,6 +75,15 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
         # missing one means the adapter broke. The default turned that into a silent
         # exposure_pct of 0.0 -- every position reading as flat, forever (#277).
         total_balance = balance["total_margin_balance"]
+        # A NaN equity passes the held-position guard below only because that one is
+        # keyed on direction; on a FLAT account nothing catches it, and the same value
+        # reaches is_bankrupt(), where `nan < threshold * initial` is False -- bankruptcy
+        # silently disabled for the rest of the episode (#277).
+        if not math.isfinite(total_balance):
+            raise ValueError(
+                f"venue reported a non-finite equity ({total_balance}); refusing to "
+                f"derive an account state or a bankruptcy check from it"
+            )
         position_status = status.get("position_status", None)
 
         # Dust is not a position: gating on `is None` let a 1e-12 residual left behind a
@@ -164,9 +173,15 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
                 # Cross-margin venues omit the liquidation price (OKX sends liqPx="" for
                 # cross) because the whole account backs the position, so there is no
                 # per-position price to publish. bybit blanks liqPrice for unified/cross
-                # too, but blanks `leverage` with it, so its adapter yields
-                # POSITION_UNKNOWN and raises before reaching here -- OKX is the venue
-                # that actually exercises this path.
+                # too; it blanks `leverage` with it, which used to make float("") raise
+                # into POSITION_UNKNOWN, but the adapters now fall back to the configured
+                # leverage there, so bybit reaches this path as well.
+                #
+                # That fallback is a real limitation: the leverage feeding the estimate is
+                # the one this env asked for, not one the venue confirmed, and #277's
+                # unfixed half is precisely that set_leverage failures are swallowed. It
+                # is kept because refusing would make OKX and bybit cross accounts unable
+                # to produce an observation at all.
                 # Defaulting to 1.0 reported a 20x long one move away from liquidation as
                 # exactly as safe as a flat spot account (#277).
                 #

--- a/torchtrade/envs/offline/sequential.py
+++ b/torchtrade/envs/offline/sequential.py
@@ -41,6 +41,7 @@ from torchtrade.envs.utils.fractional_sizing import (
     POSITION_TOLERANCE_ABS,
 )
 from torchtrade.envs.core.common_types import MarginType
+from torchtrade.envs.utils.liquidation import isolated_liquidation_price
 
 
 @dataclass
@@ -270,16 +271,12 @@ class SequentialTradingEnv(TorchTradeOfflineEnv):
         if position_size == 0:
             return 0.0
 
-        margin_fraction = 1.0 / self.leverage
-
-        if position_size > 0:
-            # Long position - liquidated if price drops
-            liquidation_price = entry_price * (1 - margin_fraction + self.maintenance_margin_rate)
-        else:
-            # Short position - liquidated if price rises
-            liquidation_price = entry_price * (1 + margin_fraction - self.maintenance_margin_rate)
-
-        return max(0, liquidation_price)
+        return isolated_liquidation_price(
+            entry_price,
+            is_long=position_size > 0,
+            leverage=self.leverage,
+            maintenance_margin_rate=self.maintenance_margin_rate,
+        )
 
     def _check_liquidation(self, ohlcv: dict) -> bool:
         """Check if current position should be liquidated using intrabar OHLCV data.

--- a/torchtrade/envs/offline/sequential.py
+++ b/torchtrade/envs/offline/sequential.py
@@ -41,7 +41,10 @@ from torchtrade.envs.utils.fractional_sizing import (
     POSITION_TOLERANCE_ABS,
 )
 from torchtrade.envs.core.common_types import MarginType
-from torchtrade.envs.utils.liquidation import isolated_liquidation_price
+from torchtrade.envs.utils.liquidation import (
+    DEFAULT_MAINTENANCE_MARGIN_RATE,
+    isolated_liquidation_price,
+)
 
 
 @dataclass
@@ -77,7 +80,7 @@ class SequentialTradingEnvConfig:
     # leverage == 1: Spot mode (no liquidation)
     leverage: int = 1
     margin_type: MarginType = MarginType.ISOLATED
-    maintenance_margin_rate: float = 0.004
+    maintenance_margin_rate: float = DEFAULT_MAINTENANCE_MARGIN_RATE
 
     def __post_init__(self):
         """Validate configuration and normalize timeframes."""
@@ -258,12 +261,13 @@ class SequentialTradingEnv(TorchTradeOfflineEnv):
     def _calculate_liquidation_price(self, entry_price: float, position_size: float) -> float:
         """Calculate liquidation price for a position.
 
-        No liquidation (leverage=1): Always returns 0.0
-        With liquidation (leverage>1): Calculates based on leverage and margin type
+        This is the gating -- no liquidation at leverage 1, none without a position. The
+        arithmetic itself lives in `isolated_liquidation_price`, shared with the live
+        envs' fallback so the two cannot price the same position differently; restating
+        the formula here is how that starts drifting again.
 
-        For ISOLATED margin:
-        - Long: liquidation_price = entry_price * (1 - 1/leverage + maintenance_margin_rate)
-        - Short: liquidation_price = entry_price * (1 + 1/leverage - maintenance_margin_rate)
+        Note it now raises, rather than returning 0.0, on an entry price of 0: a zero
+        liquidation price is indistinguishable downstream from having no position.
         """
         if not self.has_liquidation:
             return 0.0

--- a/torchtrade/envs/offline/vectorized_sequential.py
+++ b/torchtrade/envs/offline/vectorized_sequential.py
@@ -30,6 +30,7 @@ from torchtrade.envs.utils.fractional_sizing import (
 )
 
 from torchtrade.envs.core.common_types import MarginType
+from torchtrade.envs.utils.liquidation import DEFAULT_MAINTENANCE_MARGIN_RATE
 
 # Money, prices and position sizes are tracked in float64 to match the scalar envs' Python
 # floats. In float32 the accumulated relative epsilon, scaled up by leverage, lands on a
@@ -70,7 +71,7 @@ class VectorizedSequentialTradingEnvConfig:
     # Trading parameters
     leverage: int = 1
     margin_type: MarginType = MarginType.ISOLATED
-    maintenance_margin_rate: float = 0.004
+    maintenance_margin_rate: float = DEFAULT_MAINTENANCE_MARGIN_RATE
 
     def __post_init__(self):
         self.execute_on, self.time_frames, self.window_sizes = (

--- a/torchtrade/envs/utils/liquidation.py
+++ b/torchtrade/envs/utils/liquidation.py
@@ -1,0 +1,51 @@
+"""The isolated-margin liquidation price, in one place.
+
+The offline envs have always computed this; the live envs never did -- they read the
+venue's own `liqPrice` and, when the venue omitted it, reported the safest possible
+answer (#277). This module holds the scalar rule so the live fallback and the offline
+env cannot answer the same question differently.
+
+`vectorized_sequential.py` keeps its own tensorised copy of the same arithmetic; that
+one is pinned to the scalar env by the scalar/vectorized equivalence tests, so it
+cannot drift unnoticed. The live path had no such pin, which is why it shares this.
+"""
+
+# Binance/Bybit/OKX/Bitget all publish tiered maintenance margins that start near 0.4%
+# for the smallest notional brackets, which is also the offline envs' config default -- so
+# at the default a policy meets the same liquidation geometry offline and live. The live
+# side has no config knob for this, so an offline env configured with a different rate
+# does NOT have a matching live fallback. Worth a knob only once someone needs one; the
+# 1/leverage term dominates, so plausible rate choices move the estimate by ~0.1%.
+DEFAULT_MAINTENANCE_MARGIN_RATE = 0.004
+
+
+def isolated_liquidation_price(
+    entry_price: float,
+    is_long: bool,
+    leverage: float,
+    maintenance_margin_rate: float = DEFAULT_MAINTENANCE_MARGIN_RATE,
+) -> float:
+    """Price at which an isolated-margin position loses its margin.
+
+    A long is liquidated on the way down and a short on the way up, each after the
+    position has burned through `1/leverage` of its notional less the maintenance
+    buffer the venue keeps back.
+
+    Clamped at zero: above ~1x leverage the long formula goes negative, which is the
+    correct statement that an unlevered long cannot be liquidated, not a price.
+
+    Raises on inputs that cannot produce a price rather than returning one. A venue that
+    reports an open position with leverage 0 or no entry price is the case #277 is about:
+    the caller must not silently receive a number that reads as "safe".
+    """
+    if leverage <= 0:
+        raise ValueError(f"leverage must be positive to price a liquidation, got {leverage}")
+    if entry_price <= 0:
+        raise ValueError(f"entry_price must be positive to price a liquidation, got {entry_price}")
+
+    margin_fraction = 1.0 / leverage
+    if is_long:
+        price = entry_price * (1 - margin_fraction + maintenance_margin_rate)
+    else:
+        price = entry_price * (1 + margin_fraction - maintenance_margin_rate)
+    return max(0.0, price)

--- a/torchtrade/envs/utils/liquidation.py
+++ b/torchtrade/envs/utils/liquidation.py
@@ -47,3 +47,60 @@ def isolated_liquidation_price(
     if is_long:
         return entry_price * (1 - margin_fraction + maintenance_margin_rate)
     return entry_price * (1 + margin_fraction - maintenance_margin_rate)
+
+
+def cross_liquidation_price(
+    position_size: float,
+    mark_price: float,
+    equity: float,
+    maintenance_margin_rate: float = DEFAULT_MAINTENANCE_MARGIN_RATE,
+) -> float:
+    """Price at which the whole account's equity stops covering maintenance margin.
+
+    Under cross margin the position is not backed by its own isolated margin but by the
+    entire account, so the threshold moves with equity. Solving
+    `equity + size*(P - mark) = mmr * |size| * P` for P gives the expression below.
+
+    This is what makes the estimate honest in the case the isolated formula gets wrong:
+    when losses elsewhere have eaten the collateral, equity is already lower and this
+    prices liquidation NEARER than isolated would. When the account is amply funded it
+    prices it further away -- correctly, because it genuinely is.
+
+    Still an approximation: it cannot see other positions' own maintenance requirements or
+    the venue's tiered margin schedule, which is why the caller pairs it with the isolated
+    price and takes whichever is nearer rather than trusting this alone.
+    """
+    if not (mark_price > 0):
+        raise ValueError(f"mark_price must be positive to price a liquidation, got {mark_price}")
+    if not position_size:
+        raise ValueError("a flat position has no liquidation price")
+
+    sign = 1.0 if position_size > 0 else -1.0
+    return (position_size * mark_price - equity) / (position_size * (1 - sign * maintenance_margin_rate))
+
+
+def nearest_liquidation_price(
+    position_size: float,
+    entry_price: float,
+    mark_price: float,
+    equity: float,
+    leverage: float,
+    maintenance_margin_rate: float = DEFAULT_MAINTENANCE_MARGIN_RATE,
+) -> float:
+    """The more urgent of the isolated and cross estimates, for a venue that publishes none.
+
+    Neither estimate dominates the other. Isolated ignores the rest of the account, so it
+    is wrong whenever collateral elsewhere has been consumed; cross ignores other
+    positions' own maintenance requirements and the venue's risk tiers. Taking whichever
+    sits nearer the mark on the losing side is the only combination that cannot overstate
+    the distance -- and overstating it is the fail-open this whole change removes.
+    """
+    isolated = isolated_liquidation_price(
+        entry_price, is_long=position_size > 0, leverage=leverage,
+        maintenance_margin_rate=maintenance_margin_rate,
+    )
+    cross = cross_liquidation_price(
+        position_size, mark_price, equity, maintenance_margin_rate=maintenance_margin_rate,
+    )
+    # A long is liquidated from below, so nearer means higher; a short from above.
+    return max(isolated, cross) if position_size > 0 else min(isolated, cross)

--- a/torchtrade/envs/utils/liquidation.py
+++ b/torchtrade/envs/utils/liquidation.py
@@ -35,8 +35,9 @@ def isolated_liquidation_price(
     the sub-1x case that would price a liquidation below zero cannot arrive.
 
     Written `not (x >= 1)` rather than `x < 1`: NaN compares False to every operator, so
-    the natural spelling lets it through, and `max(0.0, nan)` is 0.0 -- which is exactly
-    the "reads as safe" answer these guards exist to refuse.
+    the natural spelling lets it through and returns a NaN price. The caller then divides
+    it into a NaN distance and clamps that to 0.0 -- reporting a healthy position as AT
+    liquidation. Fail-closed, but silently and wrongly, on one garbage venue tick.
     """
     if not (leverage >= 1):
         raise ValueError(f"leverage must be at least 1 to price a liquidation, got {leverage}")

--- a/torchtrade/envs/utils/liquidation.py
+++ b/torchtrade/envs/utils/liquidation.py
@@ -89,11 +89,23 @@ def nearest_liquidation_price(
 ) -> float:
     """The more urgent of the isolated and cross estimates, for a venue that publishes none.
 
-    Neither estimate dominates the other. Isolated ignores the rest of the account, so it
-    is wrong whenever collateral elsewhere has been consumed; cross ignores other
-    positions' own maintenance requirements and the venue's risk tiers. Taking whichever
-    sits nearer the mark on the losing side is the only combination that cannot overstate
-    the distance -- and overstating it is the fail-open this whole change removes.
+    Neither estimate dominates. Isolated ignores the rest of the account, so it is wrong
+    once collateral elsewhere has been consumed; cross reflects equity but assumes this
+    position is the account's only maintenance obligation. Taking whichever sits nearer
+    the mark is the best available answer from the fields the adapters currently expose.
+
+    It is NOT a guaranteed bound, and must not be described as one. If the account holds
+    another cross position, its maintenance requirement is missing from both estimates and
+    both overstate the room left: a 1-unit long at mark 100 on equity 5 returns ~95.4
+    (4.6% room) where a second position needing 4 of maintenance puts real liquidation at
+    ~99.4 (0.6%). Closing that needs an account-level maintenance figure from
+    `get_account_balance()`, which no adapter parses today -- see #344.
+
+    The same single-position assumption is already baked into `exposure_pct`, the
+    bankruptcy baseline and `_get_portfolio_value`, all of which divide this position by
+    account-wide equity. What this function must not do is claim more certainty than they
+    do. Against the `1.0` it replaces -- maximally wrong for every cross position,
+    always -- it is a strict improvement in every case, which is why it ships.
     """
     isolated = isolated_liquidation_price(
         entry_price, is_long=position_size > 0, leverage=leverage,

--- a/torchtrade/envs/utils/liquidation.py
+++ b/torchtrade/envs/utils/liquidation.py
@@ -5,17 +5,14 @@ venue's own `liqPrice` and, when the venue omitted it, reported the safest possi
 answer (#277). This module holds the scalar rule so the live fallback and the offline
 env cannot answer the same question differently.
 
-`vectorized_sequential.py` keeps its own tensorised copy of the same arithmetic; that
-one is pinned to the scalar env by the scalar/vectorized equivalence tests, so it
-cannot drift unnoticed. The live path had no such pin, which is why it shares this.
+`vectorized_sequential.py` keeps a tensorised copy of the arithmetic, but the equivalence
+tests pin it to the scalar env, so it cannot drift unnoticed. The live path had no such
+pin, which is why it shares this.
 """
 
-# Binance/Bybit/OKX/Bitget all publish tiered maintenance margins that start near 0.4%
-# for the smallest notional brackets, which is also the offline envs' config default -- so
-# at the default a policy meets the same liquidation geometry offline and live. The live
-# side has no config knob for this, so an offline env configured with a different rate
-# does NOT have a matching live fallback. Worth a knob only once someone needs one; the
-# 1/leverage term dominates, so plausible rate choices move the estimate by ~0.1%.
+# Both offline configs default their maintenance_margin_rate to this, so a policy meets
+# the same liquidation geometry offline and live. The live side has no config knob, so an
+# offline env configured off the default has no matching live fallback.
 DEFAULT_MAINTENANCE_MARGIN_RATE = 0.004
 
 
@@ -31,21 +28,22 @@ def isolated_liquidation_price(
     position has burned through `1/leverage` of its notional less the maintenance
     buffer the venue keeps back.
 
-    Clamped at zero: above ~1x leverage the long formula goes negative, which is the
-    correct statement that an unlevered long cannot be liquidated, not a price.
-
     Raises on inputs that cannot produce a price rather than returning one. A venue that
-    reports an open position with leverage 0 or no entry price is the case #277 is about:
-    the caller must not silently receive a number that reads as "safe".
+    reports an open position with no leverage or no entry price is the case #277 is
+    about: the caller must not silently receive a number that reads as "safe". Both
+    callers gate on leverage > 1 before getting here, and both validate leverage >= 1, so
+    the sub-1x case that would price a liquidation below zero cannot arrive.
+
+    Written `not (x >= 1)` rather than `x < 1`: NaN compares False to every operator, so
+    the natural spelling lets it through, and `max(0.0, nan)` is 0.0 -- which is exactly
+    the "reads as safe" answer these guards exist to refuse.
     """
-    if leverage <= 0:
-        raise ValueError(f"leverage must be positive to price a liquidation, got {leverage}")
-    if entry_price <= 0:
+    if not (leverage >= 1):
+        raise ValueError(f"leverage must be at least 1 to price a liquidation, got {leverage}")
+    if not (entry_price > 0):
         raise ValueError(f"entry_price must be positive to price a liquidation, got {entry_price}")
 
     margin_fraction = 1.0 / leverage
     if is_long:
-        price = entry_price * (1 - margin_fraction + maintenance_margin_rate)
-    else:
-        price = entry_price * (1 + margin_fraction - maintenance_margin_rate)
-    return max(0.0, price)
+        return entry_price * (1 - margin_fraction + maintenance_margin_rate)
+    return entry_price * (1 + margin_fraction - maintenance_margin_rate)


### PR DESCRIPTION
Closes part of #277.

> **Scope note.** This started as the two `account_state` defaults #277 names. Eight review rounds later it is a sweep: no live env may read a fabricated, non-finite, or venue-unconfirmed number as a safe one. The PR was retitled to match. Everything the sweep turned up that was *pre-existing* is filed (#343, #344, #345, #347, #348, #349) rather than fixed here.

**The single worst bug was not in the observation at all.** Alpaca sized and submitted a real order from unguarded `cash`, `market_value` and a hand-rolled `float(position_status.qty)`. A NaN makes `delta_qty` NaN; `nan > 0` is `False` so it always falls to the **sell** branch; and in `trade_mode="notional"` a sell is intercepted as `close_position()`. One garbage tick liquidates the position.

**Most findings were in my own fixes.** Round 2's "simplification" reintroduced the bug on NaN. Round 3's `leverage <= 1` gate became a route in. Round 4 found the equity hardening had never landed, because three adapters *fabricate* the value rather than omitting the key. Round 5's finiteness loop covered only the fields I happened to think of. Round 8 found the `+inf` guard fixed one commit earlier still wrong on four lines the same PR authored. Each is recorded in its commit message.

## The bug

Defaults in the shared futures `_get_observation` answered a missing venue field with the safest possible number, so a position the account is actually holding read like no position at all — CLAUDE.md invariant #3, *"a flat account must read flat, AND an open position must read open"*.

| Site | Missing input | Old answer | Why it is wrong |
|---|---|---|---|
| `distance_to_liquidation` | `liquidation_price <= 0` | `1.0` | Same branch as "no position". bybit sends `liqPrice=""` for unified/cross, OKX `liqPx=""` for cross — a 20x long 4% from liquidation read exactly as safe as a flat spot account. |
| `exposure_pct` denominator | `total_margin_balance` key absent | `0` | All four adapters build the key unconditionally, so absence is an adapter bug. The default made every position read 0% exposed, permanently. |
| `exposure_pct` | equity `<= 0` with a position on | `0.0` | An underwater position held against wiped equity reported as flat. |

The venue does not omit `liqPrice` arbitrarily: under cross margin the whole account backs the position, so there is no per-position price to publish. The formula was never the problem — the default was.

## Same default, four more sites

`.get("total_margin_balance", 0)` also sat in `_get_portfolio_value` and in all four per-exchange bankruptcy baselines. Through `is_bankrupt`, which is `current < threshold * initial`, that one default breaks termination in **both** directions:

- as the **baseline**: `initial = 0` makes `current < threshold * 0` never true — the account can be wiped out and the episode trades on
- as the **current value**: `0 < threshold * initial` is true for any funded account — instant false bankruptcy

All five now index the key. A structural guard keeps them indexed.

## The fix

- **Estimate rather than default.** When the venue omits the price, derive it from *both* the isolated geometry and the account's equity, and use whichever sits nearer the mark on the losing side.

  Isolated alone is not the conservative choice it looks like — @CharlieHelps caught this. It sees only this position, so it answers the same number whether the account is flush or nearly empty; once losses elsewhere have eaten the collateral, cross liquidates *earlier* than isolated says and the estimate **overstates** the distance. That is the same fail-open, one level down. Cross alone is no better: it cannot see other positions' maintenance requirements or the venue's risk tiers, and prices a well-funded long at −903. Only the nearer-of-the-two cannot overstate.

  | case (100-notional, 20x) | isolated | cross | used |
  |---|---|---|---|
  | equity = initial margin (5.0) | 95.40 | 95.38 | 95.38 |
  | collateral eaten elsewhere (2.0) | 95.40 | **98.39** | **98.39** |
  | amply funded (1,000,000) | 95.40 | −903.61 | 95.40 |
- **Gated on `leverage == 1`**, matching offline's `has_liquidation`, as its own branch rather than a fall-through — a short at 1x would otherwise compute `(0 - price)/price = -1` and clamp to `0.0`, reporting an unlevered position as *at* liquidation. `== 1` and not `<= 1`, because the loose form handed 0, negative and fractional leverage the maximally-safe answer, and that is reachable: OKX blanks `lever` on cross positions and its adapter substitutes the *config* leverage.
- **Fail closed elsewhere**, matching the unknown-status path already in that function.
- The venue's own `liqPrice` is still used verbatim when present; the fallback is for an absent price, not a second opinion on a published one.

Guards are spelled `not (x > 0)` / `not (x >= 1)` rather than `x <= 0` / `x < 1`. NaN compares False to every operator, so the natural spelling skips the raise and lands on `max(0.0, nan)`, which returns `0.0` — the exact "reads as safe" answer, arrived at silently.

## Why a shared module

The formula already existed twice offline (scalar + tensorised). Those two are pinned to each other by the scalar/vectorized equivalence tests. A third live copy would have had **no such pin** — the shape that produced BUG 1 (three SLTP action-map implementations).

So the scalar rule moves to `envs/utils/liquidation.py`, is shared with `sequential.py`, and owns the `maintenance_margin_rate` default both offline configs now import. `test_live_distance_to_liquidation_agrees_with_the_offline_env` compares `account_state[5]` end to end over leverage 1/2/20 — end to end rather than price-to-price because the gates around the arithmetic are where the two actually diverged.

## The hardening didn't land the first time

Worth stating plainly, because it is the most useful thing in this PR: indexing `total_margin_balance` instead of `.get(..., 0)` **did nothing on three of the four exchanges**. bitget, bybit and okx *fabricate* the value — `.get('total', 0)`, `.get("totalEquity", 0)`, `.get("totalEq") or "0"` — and publish a well-formed `0.0` under the key. So the indexed read never raised, and two commits' worth of comments described a fix that had not happened.

Fixed at the adapter boundary, where the venue field is actually missing. Also: a genuinely empty account still produced a bankruptcy baseline of `0`, and `current < threshold * 0` is never true, so all four envs now refuse to start an episode on non-positive equity.

Two more routes found in the same round:

- **`int()` truncation defeated the `leverage == 1` branch** added one commit earlier. bybit and okx coerced venue leverage with `int(float(...))`, so anything in `[1, 2)` became exactly `1`, took the no-liquidation branch, and reported a levered position as maximally safe — on the exact cross-margin path the fallback exists for. `PositionStatus.leverage` is a float now.
- **NaN skipped every remaining comparison.** A NaN liquidation price passes `<= 0`, misses the fallback, reaches the arithmetic and clamps to distance `0.0` — a healthy 20x position reported as *at* liquidation on one garbage tick. The venue's numbers are now checked for finiteness once.

## And the round after that

- **The finiteness check guarded the fields I was thinking about.** `notional_value` and `unrealized_pnl_pct` are read in the same branch and go straight into `account_state` unchecked — a NaN notional makes `exposure_pct = nan/equity`, putting **NaN into the observation tensor and from there into the policy network**. Worse than the NaN liquidation price fixed the round before, which at least clamped to a number. The test had been parametrized over exactly the three fields already fixed, so it certified the fix rather than the property.
- **`or` is not `.get(key, default)` for a numeric zero.** The previous round's `float(pos.get("leverage") or self.leverage)` silently swaps a venue-reported leverage of `0` for the config value — inventing a liquidation distance from a leverage the venue never confirmed. bitget reads ccxt's unified `leverage`, a *number* not a REST string, so `0` arrives falsy there today. That defect survived the entire mutation run, because the leverage cells construct `PositionStatus` directly and never touch adapter parsing; it has a structural guard now.
- **Alpaca had the identical unguarded bankruptcy baseline** — it inherits the same `_check_termination` and `is_bankrupt` — and the guard added the round before excluded it *by name*, so the one env still carrying the bug was the one the test skipped.
- **`current < threshold * 0` is not "never true"** — it reduces to `current < 0`. The conclusion held, the stated mechanism didn't, in five copies.

## And the one after that

- **Alpaca had none of the guards.** The futures four got the finiteness checks and the held-position raise; the spot env kept `exposure_pct = ... if portfolio_value > 0 else 0.0` and no validation at all. A NaN `unrealized_plpc` goes into the tensor and on into the policy network; margin debt exceeding the position reads a held position as flat. The same shape as the bankruptcy-baseline bug one round earlier, where the guard excluded alpaca *by name*.
- **Equity itself was never checked for finiteness.** The held-position guard is keyed on direction, so a NaN equity on a **flat** account passed silently — and reaches `is_bankrupt()`, where `nan < threshold * initial` is `False`, disabling termination for the rest of the episode.
- **A comment I falsified two commits earlier.** It said bybit blanks `leverage` alongside `liqPrice` so its adapter yields `POSITION_UNKNOWN` before reaching the fallback. True until I stopped `float("")` raising. bybit now reaches it, on a leverage this env *asked for* rather than one the venue confirmed. The fallback stays — refusing would leave OKX and bybit cross accounts unable to produce an observation at all — but the comment says so now and names the dependency on #277's unfixed half.

## Review found three defects, two of them mine

Recorded because the second round earned its keep:

1. **The guards failed open on NaN** — including in a "simplification" I had just accepted, which replaced a three-branch block with `if total_balance <= 0 ... else 0.0`. Not equivalent: NaN equity skipped the raise *and* took the `0.0` arm, reporting a held position as flat.
2. **Live and offline diverged at leverage 1** — the live default. Offline gates on `has_liquidation`; the ungated live fallback priced a 1x long at `mmr*entry` for 0.996 against offline's 1.0.
3. **My parity test could not see it.** It hardcoded `has_liquidation=True` and passed the same rate to both sides, so it compared the arithmetic while the divergence lived in the gates. Rewritten end to end, sourcing the offline rate from the config default.

## Reviewer findings I did not fully take

@CharlieHelps also flagged that the non-positive-equity `ValueError` can strand an open live position, since no `_step` catches observation failures. Half taken: the transient route is closed at the boundary (bitget and four sizing paths coerced a missing equity field to `0`; they now raise where it is diagnosable). The raise itself stays — `_get_observation` already raises `PositionUnknownError` on that same path, and the only non-raising alternative is `exposure_pct = 0.0`, a held position reported as flat. A close/halt fail-safe applies to every existing raise, not just this one, so it is filed as #343.

## Scope I did not take

- **`set_leverage` failures are still swallowed** (part 1 of #277). Verifying applied leverage means a read-back in four executors and touches sizing, so #277 stays open for it. That is also why `account_state[4]` can still flip between `config.leverage` when flat and `position_status.leverage` when open.
- **Behaviour change beyond the issue:** the helper raises on `entry_price <= 0` / `leverage < 1` where offline previously returned `0.0`. A zero liquidation price is indistinguishable downstream from having no position. Follows invariant #4 (raise rather than absorb nonsense); covered by a test on the offline route too.
- **The four per-exchange zero-liq tests** were retargeted, not deleted. They pin things the shared test cannot: the `entry_price` field name across four different `PositionStatus` dataclasses, and config-leverage vs position-leverage (their fixtures differ, 5 vs 10).

## Verification

Every fix is mutation-checked — each mutant is killed by the test written for it:

| Mutant | Tests failed |
|---|---|
| Nearer-of-two → isolated only (Charlie's finding) | 2 |
| Nearer-of-two → cross only | 10 |
| Nearer/further flipped | 12 |
| Gate back to `leverage <= 1` (the OKX route) | 3 |
| Equity raise keyed on notional again | 1 |
| Offline `has_liquidation` forced False | 4 |
| Reintroduce a single-quoted equity default | 1 |
| Fallback uses config leverage, not the position's | 8 |
| Revert the liquidation fallback | 2 |
| Drop the leverage-1 gate | 2 |
| Drop the live distance clamp | 2 |
| Helper guards back to `< 1` / `<= 0` (NaN) | 2 |
| `_get_portfolio_value` default | 2 |
| Exposure guard back to `<= 0` (NaN) | 1 |
| One per-exchange bankruptcy baseline | 1 |
| Drift the shared maintenance rate | 2 |
| Adapter fabricates 0 equity again | 1 |
| Drop the non-finite venue check | 4 |
| One env drops the baseline validation | 1 |
| Restore `int()` leverage truncation | 1 |
| Loop back to 3 fields (NaN into the tensor) | 3 |
| Alpaca baseline guard removed | 1 |
| Leverage back to `or` (numeric 0) | 1 |
| Alpaca finiteness loop removed | 5 |
| Alpaca flat-reading guard removed | 1 |
| Equity finiteness check removed | 2 |

Full `pytest tests/` — **2551 passed, 19 skipped**. The offline extraction is behaviour-neutral.

Sanity check on the estimate: for the test position (entry 50000, mark 50100, 10x) the fallback gives 45200/54800 against the venue-published 45000/55000 in the neighbouring cells — the right neighbourhood, not a placeholder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
