### PR TITLE
fix(binance): round order quantities to the venue's LOT_SIZE step (#271)

### DIFF
--- a/tests/envs/binance/test_futures_order_executor.py
+++ b/tests/envs/binance/test_futures_order_executor.py
@@ -68,7 +68,7 @@ class TestBinanceFuturesOrderClass:
                 "symbol": "BTCUSDT",
                 "filters": [
                     {"filterType": "PRICE_FILTER", "tickSize": "0.10"},
-                    {"filterType": "LOT_SIZE", "stepSize": "0.001"},
+                    {"filterType": "LOT_SIZE", "stepSize": "0.001", "minQty": "0.001"},
                 ],
             }]
         })
@@ -447,12 +447,12 @@ class TestBinanceLotSizeRounding:
 
         filters = [{"filterType": "PRICE_FILTER", "tickSize": "0.10"}]
         if with_lot_size:
-            filters.append({"filterType": "LOT_SIZE", "stepSize": step})
+            filters.append({"filterType": "LOT_SIZE", "stepSize": step, "minQty": step})
         symbols = [{"symbol": symbol, "filters": filters}]
         for other_symbol, other_step in extra_symbols:
             symbols.append({
                 "symbol": other_symbol,
-                "filters": [{"filterType": "LOT_SIZE", "stepSize": other_step}],
+                "filters": [{"filterType": "LOT_SIZE", "stepSize": other_step, "minQty": other_step}],
             })
 
         client = MagicMock()
@@ -501,10 +501,81 @@ class TestBinanceLotSizeRounding:
         assert ex._round_quantity(1.2345) == pytest.approx(1.234)
         assert ex._round_quantity(1.2345, "ETHUSDT") == pytest.approx(1.23)
 
-    def test_missing_lot_size_falls_back_rather_than_crashing(self):
-        """A venue response without LOT_SIZE must not take down the executor; it warns and
-        uses the previous hardcoded precision."""
-        assert self._executor(with_lot_size=False)._round_quantity(0.12345) == pytest.approx(0.123)
+    def test_a_symbol_the_venue_does_not_list_refuses_to_construct(self):
+        """Falling back is bit-identical to the bug being fixed.
+
+        The venue answered and does not list this symbol, so every order would go out on
+        the fallback precision -- and binance, unlike the other three, has no minQty check
+        downstream to catch the result. A futures executor pointed at a spot-only symbol
+        used to log two warnings and then trade against a symbol that does not exist.
+        """
+        with pytest.raises(ValueError, match="no LOT_SIZE"):
+            self._executor(with_lot_size=False)
+
+    def test_a_malformed_sibling_symbol_does_not_discard_the_cache(self):
+        """One bad entry cost the whole parse, including the tick size, and whether it did
+        depended on whether it sat before or after this symbol in the payload."""
+        from torchtrade.envs.live.binance.order_executor import BinanceFuturesOrderClass
+
+        client = MagicMock()
+        client.futures_exchange_info = MagicMock(return_value={"symbols": [
+            {"symbol": "JUNKUSDT", "filters": [{"filterType": "LOT_SIZE"}]},  # no stepSize
+            {"symbol": "BTCUSDT", "filters": [
+                {"filterType": "PRICE_FILTER", "tickSize": "0.10"},
+                {"filterType": "LOT_SIZE", "stepSize": "0.01", "minQty": "0.01"},
+            ]},
+        ]})
+        client.futures_change_leverage = MagicMock(return_value={})
+        client.futures_change_margin_type = MagicMock(return_value={})
+
+        ex = BinanceFuturesOrderClass(
+            symbol="BTCUSDT", trade_mode="quantity", demo=True, leverage=10, client=client
+        )
+        assert ex._tick_size == pytest.approx(0.10)
+        assert ex._round_quantity(0.12345) == pytest.approx(0.12)
+
+    @pytest.mark.parametrize("step_str,expected", [
+        ("0.001", (0.001, 3)),
+        ("1", (1.0, 0)),
+        ("0.00100000", (0.001, 3)),
+        ("1E-8", (1e-8, 8)),
+        ("1e-05", (1e-5, 5)),
+    ], ids=["plain", "whole", "trailing-zeros", "sci-upper", "sci-lower"])
+    def test_step_parsing_survives_scientific_notation(self, step_str, expected):
+        """`"1E-8".split('.')` has no fractional part, so string surgery reported 0
+        decimals and the final rounding then annihilated the quantity. okx carries a
+        comment about being bitten by exactly this."""
+        from torchtrade.envs.live.binance.order_executor import _step_and_decimals
+
+        step, decimals = _step_and_decimals(step_str)
+        assert step == pytest.approx(expected[0])
+        assert decimals == expected[1]
+
+    @pytest.mark.parametrize("step,quantity", [("1", 0.002), ("0.01", 0.004)],
+                             ids=["whole-units", "hundredths"])
+    def test_a_size_that_floors_away_is_refused_not_submitted(self, step, quantity):
+        """Floored to zero, the old code submitted `quantity: 0.0` on all three legs.
+
+        Reachable in every trade_mode -- `quantity` on any symbol whose step is coarser
+        than the configured size, and `fractional`/`notional` whenever a small balance
+        meets a six-figure price. The venue rejects it, but its error names the
+        pre-rounding size, so both log lines point away from the cause.
+        """
+        ex = self._executor(step=step)
+        with pytest.raises(ValueError, match="below the minimum"):
+            ex._format_quantity(quantity)
+
+    @pytest.mark.parametrize("step,quantity,expected", [
+        ("1", 7.123, "7"),          # not "7.0" -- one decimal more than the venue defines
+        ("0.01", 0.12345, "0.12"),
+        ("0.0001", 0.12345, "0.1234"),
+    ], ids=["whole-units", "hundredths", "ten-thousandths"])
+    def test_quantity_is_formatted_to_the_venue_precision(self, step, quantity, expected):
+        """A string, not a float. `str(7.0)` carries a decimal a symbol with
+        quantityPrecision 0 does not define -- the documented shape of binance's -1111
+        `Precision is over the maximum defined for this asset`. okx formats the same way
+        for the same reason."""
+        assert self._executor(step=step)._format_quantity(quantity) == expected
 
     @pytest.mark.parametrize("take_profit,stop_loss", [
         (None, None),
@@ -536,4 +607,4 @@ class TestBinanceLotSizeRounding:
         ]
         assert quantities, "no order carried a quantity"
         for q in quantities:
-            assert q == pytest.approx(0.12), f"order went out at {q}, not the 0.01 step"
+            assert q == "0.12", f"order went out at {q!r}, not the 0.01 step"

--- a/tests/envs/binance/test_futures_order_executor.py
+++ b/tests/envs/binance/test_futures_order_executor.py
@@ -473,7 +473,7 @@ class TestBinanceLotSizeRounding:
     ], ids=["coarser-than-3dp", "whole-units", "finer-than-3dp"])
     def test_quantity_is_floored_to_the_venue_step(self, step, quantity, expected):
         """Each cell is chosen so `round(quantity, 3)` gives a different, invalid answer."""
-        assert self._executor(step=step)._round_quantity(quantity) == pytest.approx(expected)
+        assert self._executor(step=step).round_quantity(quantity) == pytest.approx(expected)
         assert round(quantity, 3) != pytest.approx(expected)
 
     @pytest.mark.parametrize("quantity,step", [(0.29, "0.01"), (0.57, "0.01"), (0.58, "0.01")])
@@ -483,12 +483,12 @@ class TestBinanceLotSizeRounding:
         207 of the first 400 exact multiples of the four common steps land just under an
         integer in binary. Without the epsilon this silently under-sizes a third of them.
         """
-        assert self._executor(step=step)._round_quantity(quantity) == pytest.approx(quantity)
+        assert self._executor(step=step).round_quantity(quantity) == pytest.approx(quantity)
 
     def test_floor_not_nearest(self):
         """Rounding UP can ask for more than the margin covers, and the venue rejects the
         whole order. bybit floors for the same reason."""
-        assert self._executor(step="0.01")._round_quantity(0.199) == pytest.approx(0.19)
+        assert self._executor(step="0.01").round_quantity(0.199) == pytest.approx(0.19)
 
     def test_other_symbols_round_to_their_own_step(self):
         """close_all_positions closes whatever the account holds, not just this symbol.
@@ -498,8 +498,8 @@ class TestBinanceLotSizeRounding:
         """
         ex = self._executor(step="0.001", extra_symbols=[("ETHUSDT", "0.01")])
 
-        assert ex._round_quantity(1.2345) == pytest.approx(1.234)
-        assert ex._round_quantity(1.2345, "ETHUSDT") == pytest.approx(1.23)
+        assert ex.round_quantity(1.2345) == pytest.approx(1.234)
+        assert ex.round_quantity(1.2345, "ETHUSDT") == pytest.approx(1.23)
 
     def test_a_symbol_the_venue_does_not_list_refuses_to_construct(self):
         """Falling back is bit-identical to the bug being fixed.
@@ -532,7 +532,7 @@ class TestBinanceLotSizeRounding:
             symbol="BTCUSDT", trade_mode="quantity", demo=True, leverage=10, client=client
         )
         assert ex._tick_size == pytest.approx(0.10)
-        assert ex._round_quantity(0.12345) == pytest.approx(0.12)
+        assert ex.round_quantity(0.12345) == pytest.approx(0.12)
 
     @pytest.mark.parametrize("step_str,expected", [
         ("0.001", (0.001, 3)),
@@ -608,3 +608,79 @@ class TestBinanceLotSizeRounding:
         assert quantities, "no order carried a quantity"
         for q in quantities:
             assert q == "0.12", f"order went out at {q!r}, not the 0.01 step"
+
+    def test_a_malformed_lot_size_does_not_take_the_tick_size_with_it(self):
+        """Scoping the try to the SYMBOL made one bad filter abort that symbol's others.
+
+        For the traded symbol that left `_tick_size` None, so SLTP stop prices go out at
+        full float precision, draw binance -1111, and are swallowed by the non-fatal
+        bracket handler -- a position open with no stop loss. LOT_SIZE is listed first
+        here deliberately; the ordering is what decided whether the tick survived.
+        """
+        from torchtrade.envs.live.binance.order_executor import BinanceFuturesOrderClass
+
+        client = MagicMock()
+        client.futures_exchange_info = MagicMock(return_value={"symbols": [{
+            "symbol": "BTCUSDT",
+            "filters": [
+                {"filterType": "LOT_SIZE", "stepSize": "0.01"},   # minQty absent
+                {"filterType": "PRICE_FILTER", "tickSize": "0.10"},
+            ],
+        }]})
+        client.futures_change_leverage = MagicMock(return_value={})
+        client.futures_change_margin_type = MagicMock(return_value={})
+
+        ex = BinanceFuturesOrderClass(
+            symbol="BTCUSDT", trade_mode="quantity", demo=True, leverage=10, client=client
+        )
+        assert ex._tick_size == pytest.approx(0.10)
+        assert ex._round_price(100.16) == pytest.approx(100.2)
+        assert ex.round_quantity(0.12345) == pytest.approx(0.12)
+
+    def test_a_malformed_payload_body_falls_back_rather_than_crashing(self):
+        """A truncated or error-shaped body is a FAILED FETCH, not a config error.
+
+        Reading `['symbols']` outside the try took down __init__ with a bare KeyError --
+        neither the deliberate ValueError nor the fallback, and the ValueError's message
+        even advertises "the payload changed shape" for a case that never reached it.
+        """
+        from torchtrade.envs.live.binance.order_executor import BinanceFuturesOrderClass
+
+        client = MagicMock()
+        client.futures_exchange_info = MagicMock(return_value={"code": -1121, "msg": "Invalid symbol"})
+        client.futures_change_leverage = MagicMock(return_value={})
+        client.futures_change_margin_type = MagicMock(return_value={})
+
+        ex = BinanceFuturesOrderClass(
+            symbol="BTCUSDT", trade_mode="quantity", demo=True, leverage=10, client=client
+        )
+        assert ex.round_quantity(0.12345) == pytest.approx(0.123)
+
+    def test_a_minimum_larger_than_the_step_is_still_enforced(self):
+        """`f['minQty']` raising skips the rest of the LOT_SIZE branch, silently.
+
+        The step is cached on the line above, so construction succeeds and the only
+        casualty is `_min_qtys` -- which leaves `minimum` degrading to `step`. A venue
+        whose minQty exceeds its step (0.01 against 0.001 here) would then accept a 0.005
+        order the venue rejects. Reading the field defensively keeps both.
+        """
+        from torchtrade.envs.live.binance.order_executor import BinanceFuturesOrderClass
+
+        client = MagicMock()
+        client.futures_exchange_info = MagicMock(return_value={"symbols": [{
+            "symbol": "BTCUSDT",
+            "filters": [
+                {"filterType": "PRICE_FILTER", "tickSize": "0.10"},
+                {"filterType": "LOT_SIZE", "stepSize": "0.001", "minQty": "0.01"},
+            ],
+        }]})
+        client.futures_change_leverage = MagicMock(return_value={})
+        client.futures_change_margin_type = MagicMock(return_value={})
+
+        ex = BinanceFuturesOrderClass(
+            symbol="BTCUSDT", trade_mode="quantity", demo=True, leverage=10, client=client
+        )
+        assert ex._min_qtys["BTCUSDT"] == pytest.approx(0.01)
+        with pytest.raises(ValueError, match="below the minimum"):
+            ex._format_quantity(0.005)
+        assert ex._format_quantity(0.012) == "0.012"

--- a/tests/envs/binance/test_futures_order_executor.py
+++ b/tests/envs/binance/test_futures_order_executor.py
@@ -430,3 +430,110 @@ class TestOrderStatusDataclass:
 
         assert order.is_open is False
         assert order.filled_qty == 0.001
+
+
+class TestBinanceLotSizeRounding:
+    """#271: binance never parsed LOT_SIZE, so every quantity went out as round(q, 3).
+
+    Bitget, bybit and okx all fetch the real per-symbol step. Binance was the exception,
+    and any symbol whose step is not exactly three decimals got a silently wrong size --
+    a rejected order, or a mis-sized position. The mock in this file has carried a
+    LOT_SIZE filter since before the wiring existed, and nothing read it.
+    """
+
+    @staticmethod
+    def _executor(step="0.01", symbol="BTCUSDT", extra_symbols=(), with_lot_size=True):
+        from torchtrade.envs.live.binance.order_executor import BinanceFuturesOrderClass
+
+        filters = [{"filterType": "PRICE_FILTER", "tickSize": "0.10"}]
+        if with_lot_size:
+            filters.append({"filterType": "LOT_SIZE", "stepSize": step})
+        symbols = [{"symbol": symbol, "filters": filters}]
+        for other_symbol, other_step in extra_symbols:
+            symbols.append({
+                "symbol": other_symbol,
+                "filters": [{"filterType": "LOT_SIZE", "stepSize": other_step}],
+            })
+
+        client = MagicMock()
+        client.futures_exchange_info = MagicMock(return_value={"symbols": symbols})
+        client.futures_change_leverage = MagicMock(return_value={})
+        client.futures_change_margin_type = MagicMock(return_value={})
+        return BinanceFuturesOrderClass(
+            symbol=symbol, trade_mode="quantity", demo=True, leverage=10, client=client
+        )
+
+    @pytest.mark.parametrize("step,quantity,expected", [
+        # round(q, 3) would give 0.123 -- a size the venue rejects outright.
+        ("0.01", 0.12345, 0.12),
+        # A whole-unit step. round(q, 3) gives 7.123, which is not a multiple of anything.
+        ("1", 7.123, 7.0),
+        # Finer than three decimals: round(q, 3) silently discards the tail.
+        ("0.0001", 0.12345, 0.1234),
+    ], ids=["coarser-than-3dp", "whole-units", "finer-than-3dp"])
+    def test_quantity_is_floored_to_the_venue_step(self, step, quantity, expected):
+        """Each cell is chosen so `round(quantity, 3)` gives a different, invalid answer."""
+        assert self._executor(step=step)._round_quantity(quantity) == pytest.approx(expected)
+        assert round(quantity, 3) != pytest.approx(expected)
+
+    @pytest.mark.parametrize("quantity,step", [(0.29, "0.01"), (0.57, "0.01"), (0.58, "0.01")])
+    def test_an_exact_multiple_is_not_shaved_by_a_whole_step(self, quantity, step):
+        """`0.29 / 0.01` is 28.999999999999996, so a bare floor returns 0.28.
+
+        207 of the first 400 exact multiples of the four common steps land just under an
+        integer in binary. Without the epsilon this silently under-sizes a third of them.
+        """
+        assert self._executor(step=step)._round_quantity(quantity) == pytest.approx(quantity)
+
+    def test_floor_not_nearest(self):
+        """Rounding UP can ask for more than the margin covers, and the venue rejects the
+        whole order. bybit floors for the same reason."""
+        assert self._executor(step="0.01")._round_quantity(0.199) == pytest.approx(0.19)
+
+    def test_other_symbols_round_to_their_own_step(self):
+        """close_all_positions closes whatever the account holds, not just this symbol.
+
+        Rounding ETHUSDT's quantity with BTCUSDT's step is the same class of bug this
+        fixes, so the cache is keyed by symbol rather than holding one step.
+        """
+        ex = self._executor(step="0.001", extra_symbols=[("ETHUSDT", "0.01")])
+
+        assert ex._round_quantity(1.2345) == pytest.approx(1.234)
+        assert ex._round_quantity(1.2345, "ETHUSDT") == pytest.approx(1.23)
+
+    def test_missing_lot_size_falls_back_rather_than_crashing(self):
+        """A venue response without LOT_SIZE must not take down the executor; it warns and
+        uses the previous hardcoded precision."""
+        assert self._executor(with_lot_size=False)._round_quantity(0.12345) == pytest.approx(0.123)
+
+    @pytest.mark.parametrize("take_profit,stop_loss", [
+        (None, None),
+        (60000.0, 40000.0),
+    ], ids=["plain", "with-brackets"])
+    def test_submitted_orders_carry_the_step_rounded_quantity(self, take_profit, stop_loss):
+        """The wiring, not the helper.
+
+        Reverting all five call sites to `round(quantity, 3)` left every other cell in this
+        class green -- they exercise `_round_quantity` directly and say nothing about
+        whether an order ever reaches it. That is the same shape as the LOT_SIZE mock this
+        file carried for a year without a reader.
+
+        The bracket variant is here because the TP/SL legs are separate call sites from the
+        main order and were rounded separately.
+        """
+        ex = self._executor(step="0.01")
+        ex.client.futures_create_order = MagicMock(return_value={"orderId": 1, "status": "NEW"})
+
+        assert ex.trade(
+            side="buy", quantity=0.12345, order_type="market",
+            take_profit=take_profit, stop_loss=stop_loss,
+        )
+
+        quantities = [
+            call.kwargs["quantity"]
+            for call in ex.client.futures_create_order.call_args_list
+            if "quantity" in call.kwargs
+        ]
+        assert quantities, "no order carried a quantity"
+        for q in quantities:
+            assert q == pytest.approx(0.12), f"order went out at {q}, not the 0.01 step"

--- a/tests/envs/binance/test_futures_order_executor.py
+++ b/tests/envs/binance/test_futures_order_executor.py
@@ -684,3 +684,49 @@ class TestBinanceLotSizeRounding:
         with pytest.raises(ValueError, match="below the minimum"):
             ex._format_quantity(0.005)
         assert ex._format_quantity(0.012) == "0.012"
+
+    @pytest.mark.parametrize("residual", [0.0009, 0.0006, 0.0004],
+                             ids=["just-under", "half", "quarter"])
+    def test_a_sub_step_residual_is_still_closable(self, residual):
+        """The minimum gate is an OPENS argument, and wiring it into closes removed a
+        close that main performed.
+
+        A reduceOnly order is clamped by the venue to the actual position, so one at the
+        minimum DOES fill. Sub-step residuals are real -- partial fill of a close, ADL, a
+        liquidation remnant, a venue step change -- and `binance/base.py` discards
+        `close_position()`'s return on reset, so a refusal starts the episode against a
+        position the env believes it closed.
+        """
+        ex = self._executor(step="0.001")
+        assert ex._format_quantity(residual, reduce_only=True) == "0.001"
+        with pytest.raises(ValueError, match="below the minimum"):
+            ex._format_quantity(residual)          # opening is still refused
+
+    @pytest.mark.parametrize("quantity,step,expected", [
+        (-7.5, "1", -7.0),        # math.floor gives -8.0: MORE than the caller sized
+        (-0.295, "0.01", -0.29),
+        (0.295, "0.01", 0.29),
+    ], ids=["negative-whole", "negative-fractional", "positive-control"])
+    def test_rounding_moves_toward_zero_for_either_sign(self, quantity, step, expected):
+        """`math.floor` moves a negative AWAY from zero, so the public helper returned more
+        than was asked for -- the one thing its docstring promises not to do. No live call
+        site passes a negative today; it is public API with no stated precondition."""
+        assert self._executor(step=step).round_quantity(quantity) == pytest.approx(expected)
+
+    @pytest.mark.parametrize("quantity", [19000.01, 19000.028, 19000.046])
+    def test_a_large_exact_multiple_survives_repeated_rounding(self, quantity):
+        """A fixed 1e-9 tolerance stops covering the binary error once quantity/step
+        passes ~1e7, and this PR applies the rounding two or three times to one number:
+        env sizing, then the delta, then _format_quantity.
+
+        These are exact multiples of the 0.001 step. Under a fixed tolerance 19000.01
+        becomes 19000.009 on the first application and 19000.008 on the second -- a step
+        lost per pass. main could not do this: it floored once, then rounded to NEAREST.
+        """
+        ex = self._executor(step="0.001")
+        once = ex.round_quantity(quantity)
+        # abs=, not the default relative tolerance: pytest.approx defaults to rel=1e-6,
+        # which at a quantity of 19000 is 0.019 -- nineteen times the step this is meant
+        # to detect. The first version of this assertion could not fail.
+        assert once == pytest.approx(quantity, abs=1e-9), "shaved a step off an exact multiple"
+        assert ex.round_quantity(once) == pytest.approx(quantity, abs=1e-9), "not idempotent"

--- a/tests/envs/binance/test_futures_order_executor.py
+++ b/tests/envs/binance/test_futures_order_executor.py
@@ -433,30 +433,30 @@ class TestOrderStatusDataclass:
 
 
 class TestBinanceLotSizeRounding:
-    """#271: binance never parsed LOT_SIZE, so every quantity went out as round(q, 3).
-
-    Bitget, bybit and okx all fetch the real per-symbol step. Binance was the exception,
-    and any symbol whose step is not exactly three decimals got a silently wrong size --
-    a rejected order, or a mis-sized position. The mock in this file has carried a
-    LOT_SIZE filter since before the wiring existed, and nothing read it.
+    """#271: binance parsed only PRICE_FILTER, so every quantity went out as
+    `round(quantity, 3)` and any symbol whose step is not three decimals got a silently
+    wrong size. The LOT_SIZE mock in this file predates any code that read it.
     """
 
     @staticmethod
-    def _executor(step="0.01", symbol="BTCUSDT", extra_symbols=(), with_lot_size=True):
+    def _executor(step="0.01", min_qty=None, symbol="BTCUSDT", extra_symbols=(),
+                  with_lot_size=True, filters=None, exchange_info=None):
         from torchtrade.envs.live.binance.order_executor import BinanceFuturesOrderClass
 
-        filters = [{"filterType": "PRICE_FILTER", "tickSize": "0.10"}]
-        if with_lot_size:
-            filters.append({"filterType": "LOT_SIZE", "stepSize": step, "minQty": step})
+        if filters is None:
+            filters = [{"filterType": "PRICE_FILTER", "tickSize": "0.10"}]
+            if with_lot_size:
+                filters.append({"filterType": "LOT_SIZE", "stepSize": step,
+                                "minQty": min_qty or step})
         symbols = [{"symbol": symbol, "filters": filters}]
         for other_symbol, other_step in extra_symbols:
-            symbols.append({
-                "symbol": other_symbol,
-                "filters": [{"filterType": "LOT_SIZE", "stepSize": other_step, "minQty": other_step}],
-            })
+            symbols.append({"symbol": other_symbol, "filters": [
+                {"filterType": "LOT_SIZE", "stepSize": other_step, "minQty": other_step}]})
 
         client = MagicMock()
-        client.futures_exchange_info = MagicMock(return_value={"symbols": symbols})
+        client.futures_exchange_info = MagicMock(
+            return_value=exchange_info if exchange_info is not None else {"symbols": symbols}
+        )
         client.futures_change_leverage = MagicMock(return_value={})
         client.futures_change_margin_type = MagicMock(return_value={})
         return BinanceFuturesOrderClass(
@@ -464,269 +464,125 @@ class TestBinanceLotSizeRounding:
         )
 
     @pytest.mark.parametrize("step,quantity,expected", [
-        # round(q, 3) would give 0.123 -- a size the venue rejects outright.
+        # round(q, 3) gives a different, venue-invalid answer for each of these.
         ("0.01", 0.12345, 0.12),
-        # A whole-unit step. round(q, 3) gives 7.123, which is not a multiple of anything.
         ("1", 7.123, 7.0),
-        # Finer than three decimals: round(q, 3) silently discards the tail.
         ("0.0001", 0.12345, 0.1234),
-    ], ids=["coarser-than-3dp", "whole-units", "finer-than-3dp"])
-    def test_quantity_is_floored_to_the_venue_step(self, step, quantity, expected):
-        """Each cell is chosen so `round(quantity, 3)` gives a different, invalid answer."""
-        assert self._executor(step=step).round_quantity(quantity) == pytest.approx(expected)
-        assert round(quantity, 3) != pytest.approx(expected)
+        ("0.01", 0.199, 0.19),          # floor, not nearest: rounding up can exceed margin
+        # Exact multiples: 0.29/0.01 is 28.999999999999996, so a bare floor shaves a step.
+        ("0.01", 0.29, 0.29),
+        ("0.01", 0.57, 0.57),
+        # Above a ratio of ~1e7 a FIXED tolerance stops covering the binary error, and this
+        # value is rounded two or three times on its way to an order.
+        ("0.001", 19000.01, 19000.01),
+        ("0.001", 19000.028, 19000.028),
+        # Toward zero, not down: math.floor sends a negative AWAY from zero, i.e. to MORE
+        # than the caller sized.
+        ("1", -7.5, -7.0),
+        ("0.01", -0.295, -0.29),
+    ])
+    def test_quantity_is_floored_toward_zero_to_the_venue_step(self, step, quantity, expected):
+        ex = self._executor(step=step)
+        # abs=, not the default rel=1e-6, which at 19000 is 0.019 -- nineteen times the
+        # step these cells exist to detect.
+        assert ex.round_quantity(quantity) == pytest.approx(expected, abs=1e-9)
+        # Idempotent: the value is rounded again downstream.
+        assert ex.round_quantity(ex.round_quantity(quantity)) == pytest.approx(expected, abs=1e-9)
 
-    @pytest.mark.parametrize("quantity,step", [(0.29, "0.01"), (0.57, "0.01"), (0.58, "0.01")])
-    def test_an_exact_multiple_is_not_shaved_by_a_whole_step(self, quantity, step):
-        """`0.29 / 0.01` is 28.999999999999996, so a bare floor returns 0.28.
+    @pytest.mark.parametrize("step,quantity,expected", [
+        ("1", 7.123, "7"),              # not "7.0": one decimal more than the venue defines
+        ("0.01", 0.12345, "0.12"),
+        ("0.0001", 0.12345, "0.1234"),
+    ])
+    def test_quantity_is_formatted_to_the_venue_precision(self, step, quantity, expected):
+        """A string: `str(7.0)` carries a decimal a quantityPrecision-0 symbol does not
+        define, which binance rejects with -1111."""
+        assert self._executor(step=step)._format_quantity(quantity) == expected
 
-        207 of the first 400 exact multiples of the four common steps land just under an
-        integer in binary. Without the epsilon this silently under-sizes a third of them.
+    @pytest.mark.parametrize("step,min_qty,quantity,closable", [
+        ("1", None, 0.002, "1"),          # step coarser than the size
+        ("0.01", None, 0.004, "0.01"),
+        ("0.001", "0.01", 0.005, "0.010"),  # minQty above the step; precision follows the step
+        ("0.001", None, 0.0009, "0.001"), # sub-step residual
+        ("0.001", None, 0.0006, "0.001"),
+    ])
+    def test_a_size_below_the_minimum_is_refused_to_open_but_closable(
+        self, step, min_qty, quantity, closable
+    ):
+        """Floored to zero, the old code submitted `quantity: 0.0` on all three legs.
+
+        A reduceOnly order is clamped by the venue to the actual position, so one at the
+        minimum DOES fill -- refusing there stranded sub-step residuals (partial fill of a
+        close, ADL, liquidation remnant), and base.py discards close_position()'s return
+        on reset, so the episode starts against a position the env believes it closed.
         """
-        assert self._executor(step=step).round_quantity(quantity) == pytest.approx(quantity)
+        ex = self._executor(step=step, min_qty=min_qty)
+        with pytest.raises(ValueError, match="below the minimum"):
+            ex._format_quantity(quantity)
+        assert ex._format_quantity(quantity, reduce_only=True) == closable
 
-    def test_floor_not_nearest(self):
-        """Rounding UP can ask for more than the margin covers, and the venue rejects the
-        whole order. bybit floors for the same reason."""
-        assert self._executor(step="0.01").round_quantity(0.199) == pytest.approx(0.19)
+    @pytest.mark.parametrize("step_str,expected", [
+        ("0.001", (0.001, 3)), ("1", (1.0, 0)), ("0.00100000", (0.001, 3)),
+        ("1E-8", (1e-8, 8)), ("1e-05", (1e-5, 5)),
+    ])
+    def test_step_parsing_survives_scientific_notation(self, step_str, expected):
+        """`"1E-8".split('.')` has no fractional part, so string surgery reported 0
+        decimals and the final rounding annihilated the quantity."""
+        from torchtrade.envs.live.binance.order_executor import _step_and_decimals
 
-    def test_other_symbols_round_to_their_own_step(self):
-        """close_all_positions closes whatever the account holds, not just this symbol.
+        assert _step_and_decimals(step_str) == pytest.approx(expected)
 
-        Rounding ETHUSDT's quantity with BTCUSDT's step is the same class of bug this
-        fixes, so the cache is keyed by symbol rather than holding one step.
-        """
+    def test_each_symbol_rounds_to_its_own_step(self):
+        """close_all_positions closes whatever the account holds, so the cache is keyed by
+        symbol rather than holding one step."""
         ex = self._executor(step="0.001", extra_symbols=[("ETHUSDT", "0.01")])
 
         assert ex.round_quantity(1.2345) == pytest.approx(1.234)
         assert ex.round_quantity(1.2345, "ETHUSDT") == pytest.approx(1.23)
 
-    def test_a_symbol_the_venue_does_not_list_refuses_to_construct(self):
-        """Falling back is bit-identical to the bug being fixed.
-
-        The venue answered and does not list this symbol, so every order would go out on
-        the fallback precision -- and binance, unlike the other three, has no minQty check
-        downstream to catch the result. A futures executor pointed at a spot-only symbol
-        used to log two warnings and then trade against a symbol that does not exist.
-        """
-        with pytest.raises(ValueError, match="no LOT_SIZE"):
-            self._executor(with_lot_size=False)
-
-    def test_a_malformed_sibling_symbol_does_not_discard_the_cache(self):
-        """One bad entry cost the whole parse, including the tick size, and whether it did
-        depended on whether it sat before or after this symbol in the payload."""
-        from torchtrade.envs.live.binance.order_executor import BinanceFuturesOrderClass
-
-        client = MagicMock()
-        client.futures_exchange_info = MagicMock(return_value={"symbols": [
-            {"symbol": "JUNKUSDT", "filters": [{"filterType": "LOT_SIZE"}]},  # no stepSize
-            {"symbol": "BTCUSDT", "filters": [
-                {"filterType": "PRICE_FILTER", "tickSize": "0.10"},
-                {"filterType": "LOT_SIZE", "stepSize": "0.01", "minQty": "0.01"},
-            ]},
-        ]})
-        client.futures_change_leverage = MagicMock(return_value={})
-        client.futures_change_margin_type = MagicMock(return_value={})
-
-        ex = BinanceFuturesOrderClass(
-            symbol="BTCUSDT", trade_mode="quantity", demo=True, leverage=10, client=client
-        )
-        assert ex._tick_size == pytest.approx(0.10)
-        assert ex.round_quantity(0.12345) == pytest.approx(0.12)
-
-    @pytest.mark.parametrize("step_str,expected", [
-        ("0.001", (0.001, 3)),
-        ("1", (1.0, 0)),
-        ("0.00100000", (0.001, 3)),
-        ("1E-8", (1e-8, 8)),
-        ("1e-05", (1e-5, 5)),
-    ], ids=["plain", "whole", "trailing-zeros", "sci-upper", "sci-lower"])
-    def test_step_parsing_survives_scientific_notation(self, step_str, expected):
-        """`"1E-8".split('.')` has no fractional part, so string surgery reported 0
-        decimals and the final rounding then annihilated the quantity. okx carries a
-        comment about being bitten by exactly this."""
-        from torchtrade.envs.live.binance.order_executor import _step_and_decimals
-
-        step, decimals = _step_and_decimals(step_str)
-        assert step == pytest.approx(expected[0])
-        assert decimals == expected[1]
-
-    @pytest.mark.parametrize("step,quantity", [("1", 0.002), ("0.01", 0.004)],
-                             ids=["whole-units", "hundredths"])
-    def test_a_size_that_floors_away_is_refused_not_submitted(self, step, quantity):
-        """Floored to zero, the old code submitted `quantity: 0.0` on all three legs.
-
-        Reachable in every trade_mode -- `quantity` on any symbol whose step is coarser
-        than the configured size, and `fractional`/`notional` whenever a small balance
-        meets a six-figure price. The venue rejects it, but its error names the
-        pre-rounding size, so both log lines point away from the cause.
-        """
-        ex = self._executor(step=step)
-        with pytest.raises(ValueError, match="below the minimum"):
-            ex._format_quantity(quantity)
-
-    @pytest.mark.parametrize("step,quantity,expected", [
-        ("1", 7.123, "7"),          # not "7.0" -- one decimal more than the venue defines
-        ("0.01", 0.12345, "0.12"),
-        ("0.0001", 0.12345, "0.1234"),
-    ], ids=["whole-units", "hundredths", "ten-thousandths"])
-    def test_quantity_is_formatted_to_the_venue_precision(self, step, quantity, expected):
-        """A string, not a float. `str(7.0)` carries a decimal a symbol with
-        quantityPrecision 0 does not define -- the documented shape of binance's -1111
-        `Precision is over the maximum defined for this asset`. okx formats the same way
-        for the same reason."""
-        assert self._executor(step=step)._format_quantity(quantity) == expected
-
-    @pytest.mark.parametrize("take_profit,stop_loss", [
-        (None, None),
-        (60000.0, 40000.0),
-    ], ids=["plain", "with-brackets"])
+    @pytest.mark.parametrize("take_profit,stop_loss", [(None, None), (60000.0, 40000.0)],
+                             ids=["plain", "with-brackets"])
     def test_submitted_orders_carry_the_step_rounded_quantity(self, take_profit, stop_loss):
-        """The wiring, not the helper.
-
-        Reverting all five call sites to `round(quantity, 3)` left every other cell in this
-        class green -- they exercise `_round_quantity` directly and say nothing about
-        whether an order ever reaches it. That is the same shape as the LOT_SIZE mock this
-        file carried for a year without a reader.
-
-        The bracket variant is here because the TP/SL legs are separate call sites from the
-        main order and were rounded separately.
+        """The wiring, not the helper: reverting all five call sites to `round(quantity, 3)`
+        left every helper-level cell green -- the same shape as the LOT_SIZE mock this file
+        carried unread. The bracket legs are separately-rounded call sites.
         """
         ex = self._executor(step="0.01")
         ex.client.futures_create_order = MagicMock(return_value={"orderId": 1, "status": "NEW"})
 
-        assert ex.trade(
-            side="buy", quantity=0.12345, order_type="market",
-            take_profit=take_profit, stop_loss=stop_loss,
-        )
+        assert ex.trade(side="buy", quantity=0.12345, order_type="market",
+                        take_profit=take_profit, stop_loss=stop_loss)
 
-        quantities = [
-            call.kwargs["quantity"]
-            for call in ex.client.futures_create_order.call_args_list
-            if "quantity" in call.kwargs
-        ]
-        assert quantities, "no order carried a quantity"
-        for q in quantities:
-            assert q == "0.12", f"order went out at {q!r}, not the 0.01 step"
+        quantities = [c.kwargs["quantity"] for c in ex.client.futures_create_order.call_args_list
+                      if "quantity" in c.kwargs]
+        assert quantities and all(q == "0.12" for q in quantities), quantities
 
-    def test_a_malformed_lot_size_does_not_take_the_tick_size_with_it(self):
-        """Scoping the try to the SYMBOL made one bad filter abort that symbol's others.
+    def test_a_symbol_the_venue_does_not_list_refuses_to_construct(self):
+        """Falling back is bit-identical to the bug being fixed, and binance has no minQty
+        check downstream to catch the result."""
+        with pytest.raises(ValueError, match="no LOT_SIZE"):
+            self._executor(with_lot_size=False)
 
-        For the traded symbol that left `_tick_size` None, so SLTP stop prices go out at
-        full float precision, draw binance -1111, and are swallowed by the non-fatal
-        bracket handler -- a position open with no stop loss. LOT_SIZE is listed first
-        here deliberately; the ordering is what decided whether the tick survived.
-        """
-        from torchtrade.envs.live.binance.order_executor import BinanceFuturesOrderClass
+    @pytest.mark.parametrize("symbols", [
+        # A malformed SIBLING must not discard the cache...
+        [{"symbol": "JUNKUSDT", "filters": [{"filterType": "LOT_SIZE"}]},
+         {"symbol": "BTCUSDT", "filters": [
+             {"filterType": "PRICE_FILTER", "tickSize": "0.10"},
+             {"filterType": "LOT_SIZE", "stepSize": "0.01", "minQty": "0.01"}]}],
+        # ...nor may a malformed LOT_SIZE cost the TRADED symbol its PRICE_FILTER, which
+        # would send SLTP stop prices out unrounded (-1111, swallowed: no stop loss).
+        [{"symbol": "BTCUSDT", "filters": [
+            {"filterType": "LOT_SIZE", "stepSize": "0.01"},
+            {"filterType": "PRICE_FILTER", "tickSize": "0.10"}]}],
+    ], ids=["malformed-sibling", "malformed-own-lot-size"])
+    def test_one_bad_filter_does_not_discard_the_rest(self, symbols):
+        ex = self._executor(exchange_info={"symbols": symbols})
 
-        client = MagicMock()
-        client.futures_exchange_info = MagicMock(return_value={"symbols": [{
-            "symbol": "BTCUSDT",
-            "filters": [
-                {"filterType": "LOT_SIZE", "stepSize": "0.01"},   # minQty absent
-                {"filterType": "PRICE_FILTER", "tickSize": "0.10"},
-            ],
-        }]})
-        client.futures_change_leverage = MagicMock(return_value={})
-        client.futures_change_margin_type = MagicMock(return_value={})
-
-        ex = BinanceFuturesOrderClass(
-            symbol="BTCUSDT", trade_mode="quantity", demo=True, leverage=10, client=client
-        )
         assert ex._tick_size == pytest.approx(0.10)
-        assert ex._round_price(100.16) == pytest.approx(100.2)
         assert ex.round_quantity(0.12345) == pytest.approx(0.12)
 
     def test_a_malformed_payload_body_falls_back_rather_than_crashing(self):
-        """A truncated or error-shaped body is a FAILED FETCH, not a config error.
-
-        Reading `['symbols']` outside the try took down __init__ with a bare KeyError --
-        neither the deliberate ValueError nor the fallback, and the ValueError's message
-        even advertises "the payload changed shape" for a case that never reached it.
-        """
-        from torchtrade.envs.live.binance.order_executor import BinanceFuturesOrderClass
-
-        client = MagicMock()
-        client.futures_exchange_info = MagicMock(return_value={"code": -1121, "msg": "Invalid symbol"})
-        client.futures_change_leverage = MagicMock(return_value={})
-        client.futures_change_margin_type = MagicMock(return_value={})
-
-        ex = BinanceFuturesOrderClass(
-            symbol="BTCUSDT", trade_mode="quantity", demo=True, leverage=10, client=client
-        )
+        """A truncated or error-shaped body is a FAILED FETCH, not a config error -- reading
+        ['symbols'] outside the try took down __init__ with a bare KeyError."""
+        ex = self._executor(exchange_info={"code": -1121, "msg": "Invalid symbol"})
         assert ex.round_quantity(0.12345) == pytest.approx(0.123)
-
-    def test_a_minimum_larger_than_the_step_is_still_enforced(self):
-        """`f['minQty']` raising skips the rest of the LOT_SIZE branch, silently.
-
-        The step is cached on the line above, so construction succeeds and the only
-        casualty is `_min_qtys` -- which leaves `minimum` degrading to `step`. A venue
-        whose minQty exceeds its step (0.01 against 0.001 here) would then accept a 0.005
-        order the venue rejects. Reading the field defensively keeps both.
-        """
-        from torchtrade.envs.live.binance.order_executor import BinanceFuturesOrderClass
-
-        client = MagicMock()
-        client.futures_exchange_info = MagicMock(return_value={"symbols": [{
-            "symbol": "BTCUSDT",
-            "filters": [
-                {"filterType": "PRICE_FILTER", "tickSize": "0.10"},
-                {"filterType": "LOT_SIZE", "stepSize": "0.001", "minQty": "0.01"},
-            ],
-        }]})
-        client.futures_change_leverage = MagicMock(return_value={})
-        client.futures_change_margin_type = MagicMock(return_value={})
-
-        ex = BinanceFuturesOrderClass(
-            symbol="BTCUSDT", trade_mode="quantity", demo=True, leverage=10, client=client
-        )
-        assert ex._min_qtys["BTCUSDT"] == pytest.approx(0.01)
-        with pytest.raises(ValueError, match="below the minimum"):
-            ex._format_quantity(0.005)
-        assert ex._format_quantity(0.012) == "0.012"
-
-    @pytest.mark.parametrize("residual", [0.0009, 0.0006, 0.0004],
-                             ids=["just-under", "half", "quarter"])
-    def test_a_sub_step_residual_is_still_closable(self, residual):
-        """The minimum gate is an OPENS argument, and wiring it into closes removed a
-        close that main performed.
-
-        A reduceOnly order is clamped by the venue to the actual position, so one at the
-        minimum DOES fill. Sub-step residuals are real -- partial fill of a close, ADL, a
-        liquidation remnant, a venue step change -- and `binance/base.py` discards
-        `close_position()`'s return on reset, so a refusal starts the episode against a
-        position the env believes it closed.
-        """
-        ex = self._executor(step="0.001")
-        assert ex._format_quantity(residual, reduce_only=True) == "0.001"
-        with pytest.raises(ValueError, match="below the minimum"):
-            ex._format_quantity(residual)          # opening is still refused
-
-    @pytest.mark.parametrize("quantity,step,expected", [
-        (-7.5, "1", -7.0),        # math.floor gives -8.0: MORE than the caller sized
-        (-0.295, "0.01", -0.29),
-        (0.295, "0.01", 0.29),
-    ], ids=["negative-whole", "negative-fractional", "positive-control"])
-    def test_rounding_moves_toward_zero_for_either_sign(self, quantity, step, expected):
-        """`math.floor` moves a negative AWAY from zero, so the public helper returned more
-        than was asked for -- the one thing its docstring promises not to do. No live call
-        site passes a negative today; it is public API with no stated precondition."""
-        assert self._executor(step=step).round_quantity(quantity) == pytest.approx(expected)
-
-    @pytest.mark.parametrize("quantity", [19000.01, 19000.028, 19000.046])
-    def test_a_large_exact_multiple_survives_repeated_rounding(self, quantity):
-        """A fixed 1e-9 tolerance stops covering the binary error once quantity/step
-        passes ~1e7, and this PR applies the rounding two or three times to one number:
-        env sizing, then the delta, then _format_quantity.
-
-        These are exact multiples of the 0.001 step. Under a fixed tolerance 19000.01
-        becomes 19000.009 on the first application and 19000.008 on the second -- a step
-        lost per pass. main could not do this: it floored once, then rounded to NEAREST.
-        """
-        ex = self._executor(step="0.001")
-        once = ex.round_quantity(quantity)
-        # abs=, not the default relative tolerance: pytest.approx defaults to rel=1e-6,
-        # which at a quantity of 19000 is 0.019 -- nineteen times the step this is meant
-        # to detect. The first version of this assertion could not fail.
-        assert once == pytest.approx(quantity, abs=1e-9), "shaved a step off an exact multiple"
-        assert ex.round_quantity(once) == pytest.approx(quantity, abs=1e-9), "not idempotent"

--- a/tests/envs/binance/test_torch_env_futures.py
+++ b/tests/envs/binance/test_torch_env_futures.py
@@ -4,6 +4,7 @@ import pytest
 import torch
 from torchrl.envs.utils import check_env_specs
 import numpy as np
+import math
 from unittest.mock import MagicMock, patch
 from tensordict import TensorDict
 
@@ -42,6 +43,12 @@ class TestBinanceFuturesTorchTradingEnv:
         trader = MagicMock()
 
         # Mock methods
+        # Models the executor's lot-size rounding, which the env now delegates to rather
+        # than re-querying futures_exchange_info() per sizing decision (#271). A bare
+        # MagicMock returns a MagicMock and every comparison downstream raises.
+        trader.round_quantity = MagicMock(
+            side_effect=lambda q, symbol=None: math.floor(q / 0.001 + 1e-9) * 0.001
+        )
         trader.cancel_open_orders = MagicMock(return_value=True)
         trader.close_position = MagicMock(return_value=True)
         trader.close_all_positions = MagicMock(return_value={})
@@ -208,6 +215,24 @@ class TestBinanceFuturesTorchTradingEnv:
             assert "reward" in next_td["next"].keys()
             assert "done" in next_td["next"].keys()
             assert "account_state" in next_td["next"].keys()
+
+    def test_sizing_delegates_rounding_to_the_executor(self, env, mock_trader):
+        """#271: the env carried a SECOND LOT_SIZE parser with the bug this PR fixes.
+
+        It re-queried futures_exchange_info() per sizing decision and floored with a bare
+        `int(qty / step) * step` -- no epsilon, so 0.29 became 0.28, exactly what
+        test_an_exact_multiple_is_not_shaved_by_a_whole_step exists to prevent. Fixing the
+        executor could not reach it: the env discarded the step before calling trade().
+
+        Asserts the delegation rather than the arithmetic. With two owners of lot-size
+        knowledge the arithmetic can be right in one and wrong in the other, which is
+        exactly how this survived a PR that fixed the other one.
+        """
+        mock_trader.round_quantity.reset_mock()
+        env._calculate_fractional_position(1.0, 50000.0)
+        assert mock_trader.round_quantity.called, (
+            "env sized without going through the executor's lot-size rounding"
+        )
 
     def test_step_long_action(self, env, mock_trader):
         """Test step with long action."""
@@ -544,6 +569,12 @@ class TestBinanceFractionalPositionResizing:
     @pytest.fixture
     def mock_trader(self):
         trader = MagicMock()
+        # Models the executor's lot-size rounding, which the env now delegates to rather
+        # than re-querying futures_exchange_info() per sizing decision (#271). A bare
+        # MagicMock returns a MagicMock and every comparison downstream raises.
+        trader.round_quantity = MagicMock(
+            side_effect=lambda q, symbol=None: math.floor(q / 0.001 + 1e-9) * 0.001
+        )
         trader.cancel_open_orders = MagicMock(return_value=True)
         trader.close_position = MagicMock(return_value=True)
         trader.close_all_positions = MagicMock(return_value={})
@@ -619,6 +650,11 @@ class TestMultipleSteps:
         mock_observer.window_sizes = [10]
 
         mock_trader = MagicMock()
+        # Models the executor's lot-size rounding (#271); a bare MagicMock
+        # returns a MagicMock and comparisons downstream raise.
+        mock_trader.round_quantity = MagicMock(
+            side_effect=lambda q, symbol=None: math.floor(q / 0.001 + 1e-9) * 0.001
+        )
         mock_trader.cancel_open_orders = MagicMock(return_value=True)
         mock_trader.close_position = MagicMock(return_value=True)
         mock_trader.get_account_balance = MagicMock(return_value={
@@ -689,6 +725,12 @@ class TestBinanceInitCleanup:
     @pytest.fixture
     def mock_trader(self):
         trader = MagicMock()
+        # Models the executor's lot-size rounding, which the env now delegates to rather
+        # than re-querying futures_exchange_info() per sizing decision (#271). A bare
+        # MagicMock returns a MagicMock and every comparison downstream raises.
+        trader.round_quantity = MagicMock(
+            side_effect=lambda q, symbol=None: math.floor(q / 0.001 + 1e-9) * 0.001
+        )
         trader.cancel_open_orders = MagicMock(return_value=True)
         trader.close_position = MagicMock(return_value=True)
         trader.get_account_balance = MagicMock(return_value={
@@ -808,3 +850,4 @@ class TestWithReplayData:
                     break
 
             assert executor.current_price > 0
+

--- a/tests/envs/replay/test_order_executor.py
+++ b/tests/envs/replay/test_order_executor.py
@@ -1,0 +1,21 @@
+"""Tests for ReplayOrderExecutor's trader-interface obligations."""
+
+import pytest
+
+
+def test_replay_rounds_quantities_to_the_grid_it_has_always_used():
+    """#271 made `round_quantity` part of the trader interface, and returning the quantity
+    untouched silently moved every existing backtest's numbers.
+
+    Before this, binance's env reached `futures_exchange_info()` through a trader with no
+    `client`; the AttributeError fell through to a default filter set with stepSize 0.001.
+    An accident of the error path, but it is what recorded backtests were run against --
+    so it is preserved deliberately rather than changed silently. Leaving replay ungridded
+    would also have WIDENED the live/replay divergence in a PR meant to narrow it.
+    """
+    from torchtrade.envs.replay.order_executor import ReplayOrderExecutor, REPLAY_QTY_STEP
+
+    assert REPLAY_QTY_STEP == 0.001
+    assert ReplayOrderExecutor.round_quantity(None, 0.9796155) == pytest.approx(0.979)
+    # And the same exact-multiple hazard the live executor guards against.
+    assert ReplayOrderExecutor.round_quantity(None, 0.29) == pytest.approx(0.29)

--- a/tests/envs/test_live_trade_state.py
+++ b/tests/envs/test_live_trade_state.py
@@ -9,6 +9,7 @@ permanent local state desynchronization from the exchange.
 """
 
 from __future__ import annotations
+import math
 
 from unittest.mock import patch
 
@@ -49,6 +50,14 @@ class MockTrader:
         self.close_should_fail = False
         self.close_should_raise = False
         self.trades_executed = []
+
+    def round_quantity(self, quantity, symbol=None):
+        """Part of the trader interface the live envs size through (#271).
+
+        A 0.001 step, which is what binance uses for BTCUSDT -- the point here is that the
+        env delegates rather than carrying its own LOT_SIZE parser, not the step itself.
+        """
+        return math.floor(quantity / 0.001 + 1e-9) * 0.001
 
     def get_status(self):
         if self.position_qty != 0:

--- a/torchtrade/envs/live/binance/env.py
+++ b/torchtrade/envs/live/binance/env.py
@@ -309,14 +309,6 @@ class BinanceFuturesTorchTradingEnv(BinanceBaseTorchTradingEnv):
                 ]
             }
 
-    def _get_step_size(self) -> float:
-        """Get the step size (lot size) for the trading symbol."""
-        symbol_info = self._get_symbol_info()
-        for filter_item in symbol_info.get('filters', []):
-            if filter_item['filterType'] == 'LOT_SIZE':
-                return float(filter_item['stepSize'])
-        return 0.001  # Default fallback
-
     def _get_min_notional(self) -> float:
         """Get the minimum notional value for orders."""
         symbol_info = self._get_symbol_info()
@@ -396,11 +388,11 @@ class BinanceFuturesTorchTradingEnv(BinanceBaseTorchTradingEnv):
             )
             return 0.0, 0.0, "flat"
 
-        # Floor to exchange step size (never exceed available margin)
-        position_qty = abs(position_size)
-        step_size = self._get_step_size()
-        if step_size > 0:
-            position_qty = int(position_qty / step_size) * step_size
+        # Floor through the executor, which caches the venue's step and carries the
+        # epsilon. This used to re-query futures_exchange_info() per sizing decision and
+        # floor with a bare int(), which shaves a whole step off exact multiples --
+        # 0.29 -> 0.28 (#271). One owner of lot-size knowledge, not two.
+        position_qty = self.trader.round_quantity(abs(position_size))
 
         # Apply direction
         direction = 1 if position_size > 0 else -1
@@ -447,13 +439,10 @@ class BinanceFuturesTorchTradingEnv(BinanceBaseTorchTradingEnv):
         delta = target_qty - current_qty
 
         # 6. Check if delta is significant enough to trade
-        step_size = self._get_step_size()
-        if abs(delta) < step_size:
-            return self._create_trade_info(executed=False)  # Already close enough
-
-        # 7. Floor delta to step size (never exceed available margin)
         sign = 1 if delta > 0 else -1
-        delta = int(abs(delta) / step_size) * step_size * sign
+        delta = self.trader.round_quantity(abs(delta)) * sign
+        if delta == 0:
+            return self._create_trade_info(executed=False)  # Already close enough
 
         # 8. Check delta notional meets exchange minimum
         delta_notional = abs(delta) * current_price

--- a/torchtrade/envs/live/binance/order_executor.py
+++ b/torchtrade/envs/live/binance/order_executor.py
@@ -177,34 +177,42 @@ class BinanceFuturesOrderClass:
         symbol's step would be its own bug.
         """
         try:
-            info = self.client.futures_exchange_info()
+            symbols = self.client.futures_exchange_info()['symbols']
         except Exception as e:
-            # Transient: fall back and warn. A symbol the venue does not list is a config
-            # error and raises below; a fetch that did not happen is not.
+            # Transient, and a truncated or error-shaped body counts: a fetch that did not
+            # produce a payload is not a config error. A symbol the venue DID answer about
+            # and does not list is, and raises below. Reading ['symbols'] inside this try
+            # is deliberate -- outside it, a malformed body took down __init__ with a bare
+            # KeyError instead of either branch.
             logger.warning(f"Could not fetch symbol filters for {self.symbol}: {e}")
             return
 
-        for s in info['symbols']:
-            # Per symbol, so one malformed entry costs one step rather than the whole
-            # cache. Sweeping every symbol inside a single try meant an unrelated delisted
-            # entry could discard the tick size too -- and whether it did depended on
-            # whether it appeared before or after this symbol in the payload.
-            try:
-                for f in s['filters']:
+        for s in symbols:
+            symbol = s.get('symbol', '?')
+            # Per FILTER, not per symbol: scoped to the symbol, a LOT_SIZE short of a
+            # field aborted that symbol's remaining filters -- including its PRICE_FILTER.
+            # For the traded symbol that left _tick_size None, which sends SLTP stop prices
+            # out at full float precision, draws -1111, and is swallowed by the non-fatal
+            # bracket handler: a position open with no stop loss.
+            for f in s.get('filters', []):
+                try:
                     if f['filterType'] == 'LOT_SIZE':
-                        self._qty_steps[s['symbol']] = _step_and_decimals(f['stepSize'])
-                        self._min_qtys[s['symbol']] = float(f['minQty'])
-                    elif f['filterType'] == 'PRICE_FILTER' and s['symbol'] == self.symbol:
+                        self._qty_steps[symbol] = _step_and_decimals(f['stepSize'])
+                        # Optional: absent means "no explicit minimum", not "unusable".
+                        self._min_qtys[symbol] = float(f.get('minQty') or 0.0)
+                    elif f['filterType'] == 'PRICE_FILTER' and symbol == self.symbol:
                         tick_str = f['tickSize']
                         self._tick_size = float(tick_str)
                         # Derive decimal places from tick string for clean formatting
                         if '.' in tick_str:
                             decimal_part = tick_str.rstrip('0').split('.')[1]
                             self._tick_decimals = len(decimal_part) if decimal_part else 0
-            except Exception as e:
-                # Names the offending symbol: the first version logged only self.symbol,
-                # which is never the one at fault and sends the reader the wrong way.
-                logger.warning(f"Skipping malformed filters for {s.get('symbol', '?')}: {e}")
+                except Exception as e:
+                    # Names the offending symbol AND filter: the first version logged only
+                    # self.symbol, which is never the one at fault.
+                    logger.warning(
+                        f"Skipping malformed {f.get('filterType', '?')} for {symbol}: {e}"
+                    )
 
         if self._tick_size is None:
             logger.warning(f"No PRICE_FILTER found for {self.symbol}, prices will not be rounded")
@@ -230,7 +238,7 @@ class BinanceFuturesOrderClass:
             return round(rounded, self._tick_decimals)
         return price
 
-    def _round_quantity(self, quantity: float, symbol: Optional[str] = None) -> float:
+    def round_quantity(self, quantity: float, symbol: Optional[str] = None) -> float:
         """Floor a quantity to the symbol's LOT_SIZE step.
 
         Floor rather than round to nearest: rounding up asks for more than the caller
@@ -262,8 +270,17 @@ class BinanceFuturesOrderClass:
         the venue reject an order whose own error message points at the pre-rounding size.
         """
         key = symbol or self.symbol
+        if key not in self._qty_steps:
+            # Only reachable for a foreign symbol via close_all_positions -- self.symbol
+            # is guaranteed present or construction raised. Said out loud, because this is
+            # the same fallback precision the PR calls bit-identical to the bug, and
+            # without a line here the only diagnosis is binance's own -1111.
+            logger.warning(
+                f"No LOT_SIZE cached for {key}; sizing on fallback precision "
+                f"{_FALLBACK_QTY_STEP_PAIR}, which the venue may reject"
+            )
         step, decimals = self._qty_steps.get(key, _FALLBACK_QTY_STEP_PAIR)
-        rounded = self._round_quantity(quantity, key)
+        rounded = self.round_quantity(quantity, key)
         minimum = max(self._min_qtys.get(key, 0.0), step)
         if rounded < minimum:
             raise ValueError(
@@ -549,7 +566,10 @@ class BinanceFuturesOrderClass:
                 order_params["positionSide"] = position_side
 
             self.client.futures_create_order(**order_params)
-            logger.info(f"Position closed: {qty} {side}")
+            # The submitted size, not the requested one: this PR exists because the
+            # two differ, so a log naming the request is a log naming a number that
+            # was never sent.
+            logger.info(f"Position closed: {order_params['quantity']} {side}")
             return True
 
         except Exception as e:

--- a/torchtrade/envs/live/binance/order_executor.py
+++ b/torchtrade/envs/live/binance/order_executor.py
@@ -163,72 +163,48 @@ class BinanceFuturesOrderClass:
             logger.warning(f"Could not setup futures account: {e}")
 
     def _fetch_symbol_filters(self):
-        """Cache tick size and LOT_SIZE step from Binance exchange info.
+        """Cache the tick size and every symbol's LOT_SIZE step and minQty (#271).
 
-        Only PRICE_FILTER was read before, so every order quantity went out as
-        `round(quantity, 3)` and any symbol whose step is not exactly three decimals got a
-        silently wrong size -- a rejected order, or a mis-sized position (#271). Bitget,
-        bybit and okx all fetch a real step from the venue; binance was the one that did
-        not. This is not full parity with them: they also cache minQty, and until this
-        change binance had neither.
-
-        Steps are kept for EVERY symbol, not just this one, because close_all_positions
-        closes whatever the account holds -- rounding another symbol's quantity with this
-        symbol's step would be its own bug.
+        Every symbol, not just this one: close_all_positions closes whatever the account
+        holds, and another symbol's quantity must not be rounded with this symbol's step.
         """
         try:
             symbols = self.client.futures_exchange_info()['symbols']
         except Exception as e:
-            # Transient, and a truncated or error-shaped body counts: a fetch that did not
-            # produce a payload is not a config error. A symbol the venue DID answer about
-            # and does not list is, and raises below. Reading ['symbols'] inside this try
-            # is deliberate -- outside it, a malformed body took down __init__ with a bare
-            # KeyError instead of either branch.
+            # No payload is a transient failure; a payload that omits this symbol is a
+            # config error and raises below.
             logger.warning(f"Could not fetch symbol filters for {self.symbol}: {e}")
             return
 
         for s in symbols:
             symbol = s.get('symbol', '?')
-            # Per FILTER, not per symbol: scoped to the symbol, a LOT_SIZE short of a
-            # field aborted that symbol's remaining filters -- including its PRICE_FILTER.
-            # For the traded symbol that left _tick_size None, which sends SLTP stop prices
-            # out at full float precision, draws -1111, and is swallowed by the non-fatal
-            # bracket handler: a position open with no stop loss.
+            # Scoped per FILTER: a malformed LOT_SIZE must not cost this symbol its
+            # PRICE_FILTER, which would send SLTP stop prices out unrounded.
             for f in s.get('filters', []):
                 try:
                     if f['filterType'] == 'LOT_SIZE':
                         self._qty_steps[symbol] = _step_and_decimals(f['stepSize'])
-                        # Optional: absent means "no explicit minimum", not "unusable".
                         self._min_qtys[symbol] = float(f.get('minQty') or 0.0)
                     elif f['filterType'] == 'PRICE_FILTER' and symbol == self.symbol:
                         tick_str = f['tickSize']
                         self._tick_size = float(tick_str)
-                        # Derive decimal places from tick string for clean formatting
                         if '.' in tick_str:
                             decimal_part = tick_str.rstrip('0').split('.')[1]
                             self._tick_decimals = len(decimal_part) if decimal_part else 0
                 except Exception as e:
-                    # Names the offending symbol AND filter: the first version logged only
-                    # self.symbol, which is never the one at fault.
                     logger.warning(
                         f"Skipping malformed {f.get('filterType', '?')} for {symbol}: {e}"
                     )
 
         if self._tick_size is None:
             logger.warning(f"No PRICE_FILTER found for {self.symbol}, prices will not be rounded")
-        else:
-            logger.info(f"Tick size for {self.symbol}: {self._tick_size} ({self._tick_decimals} decimals)")
 
-        # Fail closed: the venue answered and does not list this symbol, so every order
-        # would go out on the fallback precision -- which is bit-identical to the bug this
-        # fixes, and binance is the one exchange with no min_qty net downstream to catch
-        # the result. A futures executor pointed at a spot-only symbol used to log two
-        # warnings and then trade happily against a symbol that does not exist.
+        # Fail closed: the fallback precision is the bug this fixes, and binance has no
+        # minQty check downstream to catch the result.
         if self.symbol not in self._qty_steps:
             raise ValueError(
-                f"binance returned no LOT_SIZE for {self.symbol}: it is not a futures "
-                f"symbol on this venue, or the payload changed shape. Refusing to size "
-                f"orders on fallback precision."
+                f"binance returned no LOT_SIZE for {self.symbol}: not a futures symbol on "
+                f"this venue, or the payload changed shape."
             )
 
     def _round_price(self, price: float) -> float:
@@ -239,77 +215,50 @@ class BinanceFuturesOrderClass:
         return price
 
     def round_quantity(self, quantity: float, symbol: Optional[str] = None) -> float:
-        """Floor a quantity to the symbol's LOT_SIZE step.
+        """Floor a quantity toward zero to the symbol's LOT_SIZE step.
 
-        Floor rather than round to nearest: rounding up asks for more than the caller
-        sized, which can exceed the margin available and get the whole order rejected.
-        (bybit floors too, but in `bybit/env.py`'s sizing rather than in its executor --
-        so this is the same reasoning, not the same code.)
+        Floor, not round-to-nearest: rounding up asks for more than the caller sized and
+        can exceed the available margin. Toward zero rather than down, so a negative is
+        not floored to MORE than was asked.
+
+        The tolerance is relative because quantity/step lands just under an integer for
+        many exact multiples (0.29/0.01 is 28.999999999999996), and a fixed one stops
+        covering that above a ratio of ~1e7 -- where repeated rounding would shave a step.
         """
         step, decimals = self._qty_steps.get(symbol or self.symbol, _FALLBACK_QTY_STEP_PAIR)
         if step <= 0:
             return quantity
-
-        # Toward zero, not down: math.floor moves a negative AWAY from zero, so -7.5 at
-        # step 1 returned -8.0 -- more than the caller sized, the one thing the docstring
-        # promises not to do. Both env call sites pass abs(), but this is public API.
         sign = -1.0 if quantity < 0 else 1.0
         ratio = abs(quantity) / step
-
-        # The tolerance is not decoration: quantity/step lands just under an integer for
-        # plenty of exact multiples in binary (0.29/0.01 is 28.999999999999996), and a bare
-        # floor would shave a whole step off a valid size. Relative, because a fixed 1e-9
-        # stops covering the binary error once the ratio passes ~1e7 -- and this value is
-        # rounded two or three times on its way to an order.
-        tolerance = max(1e-9, ratio * 1e-12)
-        return sign * round(math.floor(ratio + tolerance) * step, decimals)
+        return sign * round(math.floor(ratio + max(1e-9, ratio * 1e-12)) * step, decimals)
 
     def _format_quantity(
         self, quantity: float, symbol: Optional[str] = None, reduce_only: bool = False
     ) -> str:
-        """The venue-precision string for an order, or raise if the size rounds away.
+        """The venue-precision string for an order.
 
-        A string, not a float: `str(7.0)` carries a decimal a symbol with
-        quantityPrecision 0 does not define, which is the documented shape of binance's
-        `-1111 Precision is over the maximum defined for this asset`. okx formats the same
-        way for the same reason.
+        A string because `str(7.0)` carries a decimal a quantityPrecision-0 symbol does
+        not define, which binance rejects with -1111.
 
-        Raises below the venue minimum rather than submitting the floored value. That
-        value is 0 whenever the request is under one step -- reachable on any symbol whose
-        step is coarser than the configured size, and routinely in the fractional and
-        notional modes when a small balance meets a six-figure price. The old
-        `round(q, 3)` did it too; the difference is that this says so instead of letting
-        the venue reject an order whose own error message points at the pre-rounding size.
+        Below the venue minimum, an opening order raises rather than submitting the
+        floored value -- which is 0 whenever the request is under one step. A reduceOnly
+        order clamps up instead: the venue caps it at the actual position, so it fills and
+        closes a sub-step residual that would otherwise be stranded.
         """
         key = symbol or self.symbol
         if key not in self._qty_steps:
-            # Only reachable for a foreign symbol via close_all_positions -- self.symbol
-            # is guaranteed present or construction raised. Said out loud, because this is
-            # the same fallback precision the PR calls bit-identical to the bug, and
-            # without a line here the only diagnosis is binance's own -1111.
-            logger.warning(
-                f"No LOT_SIZE cached for {key}; sizing on fallback precision "
-                f"{_FALLBACK_QTY_STEP_PAIR}, which the venue may reject"
-            )
+            logger.warning(f"No LOT_SIZE cached for {key}; using fallback precision")
         step, decimals = self._qty_steps.get(key, _FALLBACK_QTY_STEP_PAIR)
         rounded = self.round_quantity(quantity, key)
         minimum = max(self._min_qtys.get(key, 0.0), step)
+
         if rounded < minimum:
-            if reduce_only:
-                # A reduceOnly order is clamped by the venue to the actual position, so one
-                # at the minimum DOES fill and closes it. Refusing here removed a close
-                # that used to happen: a sub-step residual (partial fill, ADL, liquidation
-                # remnant, a venue step change) stayed open, and base.py discards
-                # close_position()'s return on reset -- so the episode starts against a
-                # position the env believes it closed. The minimum gate is an opens
-                # argument and belongs only on the opens path.
-                rounded = minimum
-            else:
+            if not reduce_only:
                 raise ValueError(
-                    f"{key}: a quantity of {quantity} floors to {rounded} at the venue "
-                    f"step {step}, below the minimum {minimum}. Refusing to submit an "
-                    f"order that cannot fill."
+                    f"{key}: {quantity} floors to {rounded} at step {step}, below the "
+                    f"minimum {minimum}. Refusing to submit an order that cannot fill."
                 )
+            rounded = minimum
         return f"{rounded:.{decimals}f}"
 
     def trade(

--- a/torchtrade/envs/live/binance/order_executor.py
+++ b/torchtrade/envs/live/binance/order_executor.py
@@ -1,6 +1,7 @@
 import logging
 from dataclasses import dataclass
 from enum import Enum
+import math
 from typing import Dict, List, Optional, Union
 import warnings
 import os
@@ -13,6 +14,20 @@ from torchtrade.envs.core.state import POSITION_UNKNOWN
 load_dotenv()
 
 logger = logging.getLogger(__name__)
+
+
+_FALLBACK_QTY_STEP = 0.001
+_FALLBACK_QTY_STEP_PAIR = (_FALLBACK_QTY_STEP, 3)
+
+
+def _step_and_decimals(step_str: str):
+    """(step, decimals) from a LOT_SIZE stepSize string such as "0.001" or "1"."""
+    step = float(step_str)
+    decimals = 0
+    if '.' in step_str:
+        fractional = step_str.rstrip('0').split('.')[1]
+        decimals = len(fractional)
+    return step, decimals
 
 
 class PositionSide(Enum):
@@ -97,6 +112,9 @@ class BinanceFuturesOrderClass:
         self.last_order_id = None
 
         self._tick_size: Optional[float] = None
+        # symbol -> (step, decimals). Every symbol, not just this one: see
+        # _fetch_symbol_filters -- close_all_positions closes whatever the account holds.
+        self._qty_steps: Dict[str, tuple] = {}
         self._tick_decimals: int = 0
 
         # Initialize client
@@ -115,7 +133,7 @@ class BinanceFuturesOrderClass:
 
         # Setup futures account and fetch price precision
         self._setup_futures_account()
-        self._fetch_price_precision()
+        self._fetch_symbol_filters()
 
     def _setup_futures_account(self):
         """Configure futures account settings."""
@@ -140,25 +158,42 @@ class BinanceFuturesOrderClass:
         except Exception as e:
             logger.warning(f"Could not setup futures account: {e}")
 
-    def _fetch_price_precision(self):
-        """Fetch and cache tick size from Binance exchange info."""
+    def _fetch_symbol_filters(self):
+        """Cache tick size and LOT_SIZE step from Binance exchange info.
+
+        Only PRICE_FILTER was read before, so every order quantity went out as
+        `round(quantity, 3)` and any symbol whose step is not exactly three decimals got a
+        silently wrong size -- a rejected order, or a mis-sized position (#271). Bitget,
+        bybit and okx all fetch the real per-symbol step; binance was the one that did not.
+
+        Steps are kept for EVERY symbol, not just this one, because close_all_positions
+        closes whatever the account holds -- rounding another symbol's quantity with this
+        symbol's step would be its own bug.
+        """
         try:
             info = self.client.futures_exchange_info()
             for s in info['symbols']:
-                if s['symbol'] == self.symbol:
-                    for f in s['filters']:
-                        if f['filterType'] == 'PRICE_FILTER':
-                            tick_str = f['tickSize']
-                            self._tick_size = float(tick_str)
-                            # Derive decimal places from tick string for clean formatting
-                            if '.' in tick_str:
-                                decimal_part = tick_str.rstrip('0').split('.')[1]
-                                self._tick_decimals = len(decimal_part) if decimal_part else 0
-                            logger.info(f"Tick size for {self.symbol}: {self._tick_size} ({self._tick_decimals} decimals)")
-                            return
-            logger.warning(f"No PRICE_FILTER found for {self.symbol}, prices will not be rounded")
+                for f in s['filters']:
+                    if f['filterType'] == 'LOT_SIZE':
+                        self._qty_steps[s['symbol']] = _step_and_decimals(f['stepSize'])
+                    elif f['filterType'] == 'PRICE_FILTER' and s['symbol'] == self.symbol:
+                        tick_str = f['tickSize']
+                        self._tick_size = float(tick_str)
+                        # Derive decimal places from tick string for clean formatting
+                        if '.' in tick_str:
+                            decimal_part = tick_str.rstrip('0').split('.')[1]
+                            self._tick_decimals = len(decimal_part) if decimal_part else 0
+            if self._tick_size is None:
+                logger.warning(f"No PRICE_FILTER found for {self.symbol}, prices will not be rounded")
+            else:
+                logger.info(f"Tick size for {self.symbol}: {self._tick_size} ({self._tick_decimals} decimals)")
+            if self.symbol not in self._qty_steps:
+                logger.warning(
+                    f"No LOT_SIZE found for {self.symbol}, quantities fall back to "
+                    f"{_FALLBACK_QTY_STEP}"
+                )
         except Exception as e:
-            logger.warning(f"Could not fetch tick size for {self.symbol}: {e}")
+            logger.warning(f"Could not fetch symbol filters for {self.symbol}: {e}")
 
     def _round_price(self, price: float) -> float:
         """Round a price to the nearest tick size."""
@@ -166,6 +201,20 @@ class BinanceFuturesOrderClass:
             rounded = round(price / self._tick_size) * self._tick_size
             return round(rounded, self._tick_decimals)
         return price
+
+    def _round_quantity(self, quantity: float, symbol: Optional[str] = None) -> float:
+        """Floor a quantity to the symbol's LOT_SIZE step.
+
+        Floor rather than round-to-nearest, matching bybit: rounding up can ask for more
+        than the available margin covers, and the exchange rejects the whole order.
+        """
+        step, decimals = self._qty_steps.get(symbol or self.symbol, _FALLBACK_QTY_STEP_PAIR)
+        if step <= 0:
+            return quantity
+        # The epsilon is not decoration: quantity/step lands just under an integer for
+        # plenty of exact multiples in binary (0.29/0.01 is 28.999999999999996), and a bare
+        # floor would then shave a whole step off a perfectly valid size.
+        return round(math.floor(quantity / step + 1e-9) * step, decimals)
 
     def trade(
         self,
@@ -213,7 +262,7 @@ class BinanceFuturesOrderClass:
                 "symbol": self.symbol,
                 "side": side,
                 "type": binance_order_type,
-                "quantity": round(quantity, 3),
+                "quantity": self._round_quantity(quantity),
             }
 
             # Add position side for hedge mode
@@ -258,7 +307,7 @@ class BinanceFuturesOrderClass:
                     "side": "SELL" if side == "BUY" else "BUY",
                     "type": "TAKE_PROFIT_MARKET",
                     "stopPrice": self._round_price(take_profit),
-                    "quantity": round(quantity, 3),
+                    "quantity": self._round_quantity(quantity),
                     "reduceOnly": "true",
                 }
                 if position_side != "BOTH":
@@ -275,7 +324,7 @@ class BinanceFuturesOrderClass:
                     "side": "SELL" if side == "BUY" else "BUY",
                     "type": "STOP_MARKET",
                     "stopPrice": self._round_price(stop_loss),
-                    "quantity": round(quantity, 3),
+                    "quantity": self._round_quantity(quantity),
                     "reduceOnly": "true",
                 }
                 if position_side != "BOTH":
@@ -435,7 +484,7 @@ class BinanceFuturesOrderClass:
                 "symbol": self.symbol,
                 "side": side,
                 "type": "MARKET",
-                "quantity": round(qty, 3),
+                "quantity": self._round_quantity(qty),
                 "reduceOnly": "true",
             }
 
@@ -466,7 +515,7 @@ class BinanceFuturesOrderClass:
                             symbol=symbol,
                             side=side,
                             type="MARKET",
-                            quantity=round(abs(qty), 3),
+                            quantity=self._round_quantity(abs(qty), symbol),
                             reduceOnly="true",
                         )
                         results[symbol] = True

--- a/torchtrade/envs/live/binance/order_executor.py
+++ b/torchtrade/envs/live/binance/order_executor.py
@@ -2,6 +2,7 @@ import logging
 from dataclasses import dataclass
 from enum import Enum
 import math
+from decimal import Decimal
 from typing import Dict, List, Optional, Union
 import warnings
 import os
@@ -21,13 +22,15 @@ _FALLBACK_QTY_STEP_PAIR = (_FALLBACK_QTY_STEP, 3)
 
 
 def _step_and_decimals(step_str: str):
-    """(step, decimals) from a LOT_SIZE stepSize string such as "0.001" or "1"."""
-    step = float(step_str)
-    decimals = 0
-    if '.' in step_str:
-        fractional = step_str.rstrip('0').split('.')[1]
-        decimals = len(fractional)
-    return step, decimals
+    """(step, decimals) from a LOT_SIZE stepSize string such as "0.001" or "1".
+
+    Through Decimal rather than string surgery: `"1E-8".split('.')` yields no fractional
+    part, so the naive version reported 0 decimals and the final rounding then annihilated
+    the quantity. Binance sends fixed-point today, but okx's _format_size carries a comment
+    about being bitten by exactly this, so it is not a hypothetical.
+    """
+    d = Decimal(step_str).normalize()
+    return float(d), max(0, -d.as_tuple().exponent)
 
 
 class PositionSide(Enum):
@@ -115,6 +118,7 @@ class BinanceFuturesOrderClass:
         # symbol -> (step, decimals). Every symbol, not just this one: see
         # _fetch_symbol_filters -- close_all_positions closes whatever the account holds.
         self._qty_steps: Dict[str, tuple] = {}
+        self._min_qtys: Dict[str, float] = {}
         self._tick_decimals: int = 0
 
         # Initialize client
@@ -164,7 +168,9 @@ class BinanceFuturesOrderClass:
         Only PRICE_FILTER was read before, so every order quantity went out as
         `round(quantity, 3)` and any symbol whose step is not exactly three decimals got a
         silently wrong size -- a rejected order, or a mis-sized position (#271). Bitget,
-        bybit and okx all fetch the real per-symbol step; binance was the one that did not.
+        bybit and okx all fetch a real step from the venue; binance was the one that did
+        not. This is not full parity with them: they also cache minQty, and until this
+        change binance had neither.
 
         Steps are kept for EVERY symbol, not just this one, because close_all_positions
         closes whatever the account holds -- rounding another symbol's quantity with this
@@ -172,10 +178,22 @@ class BinanceFuturesOrderClass:
         """
         try:
             info = self.client.futures_exchange_info()
-            for s in info['symbols']:
+        except Exception as e:
+            # Transient: fall back and warn. A symbol the venue does not list is a config
+            # error and raises below; a fetch that did not happen is not.
+            logger.warning(f"Could not fetch symbol filters for {self.symbol}: {e}")
+            return
+
+        for s in info['symbols']:
+            # Per symbol, so one malformed entry costs one step rather than the whole
+            # cache. Sweeping every symbol inside a single try meant an unrelated delisted
+            # entry could discard the tick size too -- and whether it did depended on
+            # whether it appeared before or after this symbol in the payload.
+            try:
                 for f in s['filters']:
                     if f['filterType'] == 'LOT_SIZE':
                         self._qty_steps[s['symbol']] = _step_and_decimals(f['stepSize'])
+                        self._min_qtys[s['symbol']] = float(f['minQty'])
                     elif f['filterType'] == 'PRICE_FILTER' and s['symbol'] == self.symbol:
                         tick_str = f['tickSize']
                         self._tick_size = float(tick_str)
@@ -183,17 +201,27 @@ class BinanceFuturesOrderClass:
                         if '.' in tick_str:
                             decimal_part = tick_str.rstrip('0').split('.')[1]
                             self._tick_decimals = len(decimal_part) if decimal_part else 0
-            if self._tick_size is None:
-                logger.warning(f"No PRICE_FILTER found for {self.symbol}, prices will not be rounded")
-            else:
-                logger.info(f"Tick size for {self.symbol}: {self._tick_size} ({self._tick_decimals} decimals)")
-            if self.symbol not in self._qty_steps:
-                logger.warning(
-                    f"No LOT_SIZE found for {self.symbol}, quantities fall back to "
-                    f"{_FALLBACK_QTY_STEP}"
-                )
-        except Exception as e:
-            logger.warning(f"Could not fetch symbol filters for {self.symbol}: {e}")
+            except Exception as e:
+                # Names the offending symbol: the first version logged only self.symbol,
+                # which is never the one at fault and sends the reader the wrong way.
+                logger.warning(f"Skipping malformed filters for {s.get('symbol', '?')}: {e}")
+
+        if self._tick_size is None:
+            logger.warning(f"No PRICE_FILTER found for {self.symbol}, prices will not be rounded")
+        else:
+            logger.info(f"Tick size for {self.symbol}: {self._tick_size} ({self._tick_decimals} decimals)")
+
+        # Fail closed: the venue answered and does not list this symbol, so every order
+        # would go out on the fallback precision -- which is bit-identical to the bug this
+        # fixes, and binance is the one exchange with no min_qty net downstream to catch
+        # the result. A futures executor pointed at a spot-only symbol used to log two
+        # warnings and then trade happily against a symbol that does not exist.
+        if self.symbol not in self._qty_steps:
+            raise ValueError(
+                f"binance returned no LOT_SIZE for {self.symbol}: it is not a futures "
+                f"symbol on this venue, or the payload changed shape. Refusing to size "
+                f"orders on fallback precision."
+            )
 
     def _round_price(self, price: float) -> float:
         """Round a price to the nearest tick size."""
@@ -205,8 +233,10 @@ class BinanceFuturesOrderClass:
     def _round_quantity(self, quantity: float, symbol: Optional[str] = None) -> float:
         """Floor a quantity to the symbol's LOT_SIZE step.
 
-        Floor rather than round-to-nearest, matching bybit: rounding up can ask for more
-        than the available margin covers, and the exchange rejects the whole order.
+        Floor rather than round to nearest: rounding up asks for more than the caller
+        sized, which can exceed the margin available and get the whole order rejected.
+        (bybit floors too, but in `bybit/env.py`'s sizing rather than in its executor --
+        so this is the same reasoning, not the same code.)
         """
         step, decimals = self._qty_steps.get(symbol or self.symbol, _FALLBACK_QTY_STEP_PAIR)
         if step <= 0:
@@ -215,6 +245,33 @@ class BinanceFuturesOrderClass:
         # plenty of exact multiples in binary (0.29/0.01 is 28.999999999999996), and a bare
         # floor would then shave a whole step off a perfectly valid size.
         return round(math.floor(quantity / step + 1e-9) * step, decimals)
+
+    def _format_quantity(self, quantity: float, symbol: Optional[str] = None) -> str:
+        """The venue-precision string for an order, or raise if the size rounds away.
+
+        A string, not a float: `str(7.0)` carries a decimal a symbol with
+        quantityPrecision 0 does not define, which is the documented shape of binance's
+        `-1111 Precision is over the maximum defined for this asset`. okx formats the same
+        way for the same reason.
+
+        Raises below the venue minimum rather than submitting the floored value. That
+        value is 0 whenever the request is under one step -- reachable on any symbol whose
+        step is coarser than the configured size, and routinely in the fractional and
+        notional modes when a small balance meets a six-figure price. The old
+        `round(q, 3)` did it too; the difference is that this says so instead of letting
+        the venue reject an order whose own error message points at the pre-rounding size.
+        """
+        key = symbol or self.symbol
+        step, decimals = self._qty_steps.get(key, _FALLBACK_QTY_STEP_PAIR)
+        rounded = self._round_quantity(quantity, key)
+        minimum = max(self._min_qtys.get(key, 0.0), step)
+        if rounded < minimum:
+            raise ValueError(
+                f"{key}: a quantity of {quantity} floors to {rounded} at the venue step "
+                f"{step}, below the minimum {minimum}. Refusing to submit an order that "
+                f"cannot fill."
+            )
+        return f"{rounded:.{decimals}f}"
 
     def trade(
         self,
@@ -262,7 +319,7 @@ class BinanceFuturesOrderClass:
                 "symbol": self.symbol,
                 "side": side,
                 "type": binance_order_type,
-                "quantity": self._round_quantity(quantity),
+                "quantity": self._format_quantity(quantity),
             }
 
             # Add position side for hedge mode
@@ -307,7 +364,7 @@ class BinanceFuturesOrderClass:
                     "side": "SELL" if side == "BUY" else "BUY",
                     "type": "TAKE_PROFIT_MARKET",
                     "stopPrice": self._round_price(take_profit),
-                    "quantity": self._round_quantity(quantity),
+                    "quantity": self._format_quantity(quantity),
                     "reduceOnly": "true",
                 }
                 if position_side != "BOTH":
@@ -324,7 +381,7 @@ class BinanceFuturesOrderClass:
                     "side": "SELL" if side == "BUY" else "BUY",
                     "type": "STOP_MARKET",
                     "stopPrice": self._round_price(stop_loss),
-                    "quantity": self._round_quantity(quantity),
+                    "quantity": self._format_quantity(quantity),
                     "reduceOnly": "true",
                 }
                 if position_side != "BOTH":
@@ -484,7 +541,7 @@ class BinanceFuturesOrderClass:
                 "symbol": self.symbol,
                 "side": side,
                 "type": "MARKET",
-                "quantity": self._round_quantity(qty),
+                "quantity": self._format_quantity(qty),
                 "reduceOnly": "true",
             }
 
@@ -515,7 +572,7 @@ class BinanceFuturesOrderClass:
                             symbol=symbol,
                             side=side,
                             type="MARKET",
-                            quantity=self._round_quantity(abs(qty), symbol),
+                            quantity=self._format_quantity(abs(qty), symbol),
                             reduceOnly="true",
                         )
                         results[symbol] = True

--- a/torchtrade/envs/live/binance/order_executor.py
+++ b/torchtrade/envs/live/binance/order_executor.py
@@ -249,12 +249,24 @@ class BinanceFuturesOrderClass:
         step, decimals = self._qty_steps.get(symbol or self.symbol, _FALLBACK_QTY_STEP_PAIR)
         if step <= 0:
             return quantity
-        # The epsilon is not decoration: quantity/step lands just under an integer for
-        # plenty of exact multiples in binary (0.29/0.01 is 28.999999999999996), and a bare
-        # floor would then shave a whole step off a perfectly valid size.
-        return round(math.floor(quantity / step + 1e-9) * step, decimals)
 
-    def _format_quantity(self, quantity: float, symbol: Optional[str] = None) -> str:
+        # Toward zero, not down: math.floor moves a negative AWAY from zero, so -7.5 at
+        # step 1 returned -8.0 -- more than the caller sized, the one thing the docstring
+        # promises not to do. Both env call sites pass abs(), but this is public API.
+        sign = -1.0 if quantity < 0 else 1.0
+        ratio = abs(quantity) / step
+
+        # The tolerance is not decoration: quantity/step lands just under an integer for
+        # plenty of exact multiples in binary (0.29/0.01 is 28.999999999999996), and a bare
+        # floor would shave a whole step off a valid size. Relative, because a fixed 1e-9
+        # stops covering the binary error once the ratio passes ~1e7 -- and this value is
+        # rounded two or three times on its way to an order.
+        tolerance = max(1e-9, ratio * 1e-12)
+        return sign * round(math.floor(ratio + tolerance) * step, decimals)
+
+    def _format_quantity(
+        self, quantity: float, symbol: Optional[str] = None, reduce_only: bool = False
+    ) -> str:
         """The venue-precision string for an order, or raise if the size rounds away.
 
         A string, not a float: `str(7.0)` carries a decimal a symbol with
@@ -283,11 +295,21 @@ class BinanceFuturesOrderClass:
         rounded = self.round_quantity(quantity, key)
         minimum = max(self._min_qtys.get(key, 0.0), step)
         if rounded < minimum:
-            raise ValueError(
-                f"{key}: a quantity of {quantity} floors to {rounded} at the venue step "
-                f"{step}, below the minimum {minimum}. Refusing to submit an order that "
-                f"cannot fill."
-            )
+            if reduce_only:
+                # A reduceOnly order is clamped by the venue to the actual position, so one
+                # at the minimum DOES fill and closes it. Refusing here removed a close
+                # that used to happen: a sub-step residual (partial fill, ADL, liquidation
+                # remnant, a venue step change) stayed open, and base.py discards
+                # close_position()'s return on reset -- so the episode starts against a
+                # position the env believes it closed. The minimum gate is an opens
+                # argument and belongs only on the opens path.
+                rounded = minimum
+            else:
+                raise ValueError(
+                    f"{key}: a quantity of {quantity} floors to {rounded} at the venue "
+                    f"step {step}, below the minimum {minimum}. Refusing to submit an "
+                    f"order that cannot fill."
+                )
         return f"{rounded:.{decimals}f}"
 
     def trade(
@@ -558,7 +580,7 @@ class BinanceFuturesOrderClass:
                 "symbol": self.symbol,
                 "side": side,
                 "type": "MARKET",
-                "quantity": self._format_quantity(qty),
+                "quantity": self._format_quantity(qty, reduce_only=True),
                 "reduceOnly": "true",
             }
 
@@ -592,7 +614,7 @@ class BinanceFuturesOrderClass:
                             symbol=symbol,
                             side=side,
                             type="MARKET",
-                            quantity=self._format_quantity(abs(qty), symbol),
+                            quantity=self._format_quantity(abs(qty), symbol, reduce_only=True),
                             reduceOnly="true",
                         )
                         results[symbol] = True

--- a/torchtrade/envs/replay/order_executor.py
+++ b/torchtrade/envs/replay/order_executor.py
@@ -247,6 +247,17 @@ class ReplayOrderExecutor:
             "total_margin_balance": total,
         }
 
+    def round_quantity(self, quantity: float, symbol: Optional[str] = None) -> float:
+        """Part of the trader interface the live envs size through (#271).
+
+        Replay has no venue to query for a LOT_SIZE step, and inventing one would make a
+        backtest disagree with the exchange it is standing in for in a second, invisible
+        way. So it imposes no lot-size constraint and says so here, rather than the live
+        env discovering the method is missing mid-episode. That divergence from live is
+        part of what #278 tracks.
+        """
+        return quantity
+
     def get_mark_price(self) -> float:
         """Get current mark price (latest close)."""
         return self.current_price

--- a/torchtrade/envs/replay/order_executor.py
+++ b/torchtrade/envs/replay/order_executor.py
@@ -1,6 +1,7 @@
 """Replay order executor for simulated trading with historical data."""
 
 import logging
+import math
 from dataclasses import dataclass
 from typing import Dict, Optional
 
@@ -21,6 +22,10 @@ class PositionStatus:
     margin_type: str    # Binance-compatible
     margin_mode: str    # Bybit-compatible
     liquidation_price: float
+
+
+# The grid replay has effectively used all along -- see round_quantity (#271).
+REPLAY_QTY_STEP = 0.001
 
 
 class ReplayOrderExecutor:
@@ -250,13 +255,24 @@ class ReplayOrderExecutor:
     def round_quantity(self, quantity: float, symbol: Optional[str] = None) -> float:
         """Part of the trader interface the live envs size through (#271).
 
-        Replay has no venue to query for a LOT_SIZE step, and inventing one would make a
-        backtest disagree with the exchange it is standing in for in a second, invisible
-        way. So it imposes no lot-size constraint and says so here, rather than the live
-        env discovering the method is missing mid-episode. That divergence from live is
-        part of what #278 tracks.
+        Replay has no venue to query, so it floors to a fixed default grid. Returning the
+        quantity untouched looked cleaner and was wrong twice over: it silently moved
+        every existing backtest's numbers, and it put replay on NO grid while the same
+        change put live on the venue's real one -- widening the live/replay divergence
+        that #278 tracks, in a PR whose point is to narrow it.
+
+        The grid is the one replay already used. Before this, binance's env reached
+        `futures_exchange_info()` through a trader that has no `client`, and the resulting
+        AttributeError fell through to a default filter set whose stepSize is 0.001. That
+        was an accident of the error path, but it is what every recorded backtest was run
+        against, so it is preserved deliberately rather than changed silently.
         """
-        return quantity
+        step = REPLAY_QTY_STEP
+        # Same tolerance reasoning as the live executor: a bare floor shaves a whole step
+        # off exact multiples that land just under an integer in binary.
+        ratio = abs(quantity) / step
+        sign = -1.0 if quantity < 0 else 1.0
+        return sign * round(math.floor(ratio + max(1e-9, ratio * 1e-12)) * step, 3)
 
     def get_mark_price(self) -> float:
         """Get current mark price (latest close)."""


### PR DESCRIPTION
Closes #271.

## The bug

`_fetch_price_precision` parsed `PRICE_FILTER` and stopped, so every order quantity went out as a hardcoded `round(quantity, 3)` — five call sites. Any symbol whose step is not exactly three decimals got a silently wrong size: a rejected order, or a mis-sized position.

Bitget, bybit and okx all fetch the real per-symbol step. Binance was the one exception, which is why #271 calls it "the same bug class as the already-fixed bitget lot-size bug — the fix was never applied to binance."

The mock in `tests/envs/binance/test_futures_order_executor.py:71` has carried a `LOT_SIZE` filter since before any production code read it. It does now.

## Two things the obvious implementation gets wrong

**A bare floor shaves exact multiples.** `0.29 / 0.01` is `28.999999999999996` in binary, so `math.floor` returns `0.28` — a whole step lost on a perfectly valid size. Measured: **207 of the first 400 exact multiples** of the four common steps (`0.0001`, `0.001`, `0.01`, `0.1`, `1`) land just under an integer. The epsilon is load-bearing, not defensive decoration.

**Steps are cached per symbol, not one per executor.** `close_all_positions` closes whatever the account holds, not just `self.symbol` — rounding ETHUSDT's quantity with BTCUSDT's step would be this same bug wearing a different hat. `futures_exchange_info()` returns every symbol anyway, so keying the cache costs nothing.

Floors rather than rounds to nearest, matching bybit: rounding **up** can ask for more than the available margin covers, and the venue rejects the whole order.

Renamed `_fetch_price_precision` → `_fetch_symbol_filters`, since "price precision" stopped describing what it does.

## What review found after the first commit

**The issue was not actually fixed by the executor change.** `binance/env.py` carried a *second* LOT_SIZE parser — re-querying `futures_exchange_info()` on every sizing decision and flooring with a bare `int(qty / step) * step`. No epsilon, so `0.29 → 0.28`: exactly what this PR's own test forbids, still live in the fractional path, and unreachable from the executor because the env discarded the step before calling `trade()`. Both sizing paths now delegate to the executor and the duplicate parser is deleted — one owner of lot-size knowledge, not two.

That made `round_quantity` part of the trader interface, which surfaced a genuine integration gap: `ReplayOrderExecutor` acts as a trader and didn't implement it, so binance-in-replay would have failed at runtime. It returns the quantity unchanged — replay has no venue to query, and inventing a step would make a backtest disagree with the exchange it stands in for in a second, invisible way (#278).

**Two regressions from my own first fix pass:**

- Scoping the `try` to the *symbol* meant one bad filter aborted that symbol's remaining filters — including its `PRICE_FILTER`. On the traded symbol that left `_tick_size` `None`, so SLTP stop prices go out at full float precision, draw `-1111`, and are swallowed by the non-fatal bracket handler: **a position open with no stop loss**. Construction didn't even raise, because the step was cached on the line before the failure. Scoped per *filter* now.
- Narrowing the `try` moved `info['symbols']` outside it, so a truncated or error-shaped body took down `__init__` with a bare `KeyError` — neither the fallback nor the deliberate `ValueError`, whose message advertises "the payload changed shape" for a case that couldn't reach it.

Also: the foreign-symbol fallback in `close_all_positions` was silent, and `close_position` logged the *requested* size rather than the submitted one — in a PR whose entire subject is that the two differ.

## Verification

Mutation-checked:

| Mutant | Tests failed |
|---|---|
| Stop parsing `LOT_SIZE` | 5 |
| Revert the five call sites to `round(quantity, 3)` | 2 |
| Drop the epsilon (shaves exact multiples) | 3 |
| Round-to-nearest instead of floor | 1 |
| Ignore the per-symbol argument | 1 |
| Unknown symbol falls back instead of raising | 1 |
| Zero-size guard removed | 2 |
| Float instead of venue-precision string | 5 |
| Scientific notation back to string surgery | 2 |
| minQty never cached | 1 |
| The env's own bare-int floor | 1 |
| `['symbols']` read outside the try | 1 |

**The first version of these tests was the bug itself, again.** They exercised `_round_quantity` directly and nothing else — reverting all five call sites to `round(quantity, 3)` left every one of them green. That is exactly the shape of the unread `LOT_SIZE` mock this PR is fixing: a fixture for wiring that was never asserted. There is now a cell checking what an order actually carries, including the TP/SL legs, which are separately-rounded call sites.

`pytest tests/` — **2528 passed, 19 skipped**.

Worth noting: `pytest tests/envs/binance` was green while the **full suite had 6 failures** — mocks in `tests/envs/test_live_trade_state.py` didn't model the widened trader interface. A scoped run would have missed it.

## Scope and one unverified claim

`get_lot_size()` is still not added for parity with bybit/bitget/okx — `round_quantity()` is the capability the env actually needs, and an unused accessor is dead code. Cross-exchange parity gaps are tracked in #289.

**Unverified:** that binance rejects `"7.0"` with `-1111` on a `quantityPrecision: 0` symbol. I could not reach the live API. The string formatting is defensible regardless — `str(7.0)` carries a decimal such a symbol does not define, and okx formats the same way with an explicit comment about it — but the rejection itself is reasoned, not observed. One testnet order on a step-1 symbol would settle it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
