### PR TITLE
fix(live): include account maintenance in cross liquidation estimates (#344)

### DIFF
--- a/tests/envs/binance/test_futures_order_executor.py
+++ b/tests/envs/binance/test_futures_order_executor.py
@@ -287,6 +287,22 @@ class TestBinanceFuturesOrderClass:
 
         assert balance["total_wallet_balance"] == 1000.0
         assert balance["available_balance"] == 900.0
+        assert balance["total_maintenance_margin"] is None
+
+    @pytest.mark.parametrize("raw,expected", [
+        ("4.4", 4.4),
+        ("0", 0.0),
+        ("", None),
+        (None, None),
+    ])
+    def test_get_account_balance_parses_total_maintenance(
+        self, order_executor, mock_client, raw, expected
+    ):
+        account = mock_client.futures_account.return_value.copy()
+        account["totalMaintMargin"] = raw
+        mock_client.futures_account.return_value = account
+
+        assert order_executor.get_account_balance()["total_maintenance_margin"] == expected
 
     def test_get_mark_price(self, order_executor, mock_client):
         """Test getting mark price."""

--- a/tests/envs/bitget/test_futures_order_executor.py
+++ b/tests/envs/bitget/test_futures_order_executor.py
@@ -242,9 +242,32 @@ class TestBitgetFuturesOrderClass:
         assert "available_balance" in balance
         assert "total_unrealized_profit" in balance
         assert "total_margin_balance" in balance
+        assert balance["total_maintenance_margin"] is None
 
         assert balance["total_wallet_balance"] == 1000.0
         assert balance["available_balance"] == 900.0
+
+    @pytest.mark.parametrize("info,expected", [
+        ([
+            {"marginCoin": "USDC", "assetMode": "union", "unionMm": "99"},
+            {"marginCoin": "USDT", "assetMode": "union", "unionMm": "4.4"},
+        ], 4.4),
+        ([{"marginCoin": "USDT", "assetMode": "union", "unionMm": "0"}], 0.0),
+        ([{
+            "marginCoin": "USDT",
+            "assetMode": "single",
+            "crossedRiskRate": "0.25",
+        }], None),
+        ({"marginCoin": "USDT", "assetMode": "union", "unionMm": "2.5"}, 2.5),
+    ], ids=["list-union", "explicit-zero", "single-unavailable", "mapping-compat"])
+    def test_get_account_balance_parses_union_maintenance(
+        self, order_executor, mock_ccxt_client, info, expected
+    ):
+        raw_balance = mock_ccxt_client.fetch_balance.return_value.copy()
+        raw_balance["info"] = info
+        mock_ccxt_client.fetch_balance.return_value = raw_balance
+
+        assert order_executor.get_account_balance()["total_maintenance_margin"] == expected
 
     def test_get_mark_price(self, order_executor, mock_ccxt_client):
         """Test getting mark price."""

--- a/tests/envs/bybit/conftest.py
+++ b/tests/envs/bybit/conftest.py
@@ -14,6 +14,10 @@ def mock_pybit_client():
     client.set_leverage = MagicMock(return_value={"retCode": 0})
     client.switch_margin_mode = MagicMock(return_value={"retCode": 0})
     client.switch_position_mode = MagicMock(return_value={"retCode": 0})
+    client.get_account_info = MagicMock(return_value={
+        "retCode": 0,
+        "result": {"marginMode": "ISOLATED_MARGIN", "unifiedMarginStatus": 5},
+    })
 
     # Mock order placement
     client.place_order = MagicMock(return_value={

--- a/tests/envs/bybit/test_futures_order_executor.py
+++ b/tests/envs/bybit/test_futures_order_executor.py
@@ -142,6 +142,51 @@ class TestBybitFuturesOrderClass:
         status = order_executor.get_status()
         assert status["position_status"].qty < 0
 
+    @pytest.mark.parametrize("account_mode,expected", [
+        ("ISOLATED_MARGIN", "isolated"),
+        ("REGULAR_MARGIN", "cross"),
+        ("PORTFOLIO_MARGIN", "portfolio"),
+    ])
+    def test_v5_uta_uses_account_info_not_deprecated_trade_mode(
+        self, order_executor, mock_pybit_client, account_mode, expected
+    ):
+        """V5 position tradeMode is always 0; UTA marginMode is authoritative."""
+        position = mock_pybit_client.get_positions.return_value["result"]["list"][0]
+        position["tradeMode"] = "0"
+        position["liqPrice"] = ""
+        mock_pybit_client.get_account_info.return_value = {
+            "retCode": 0,
+            "result": {"marginMode": account_mode, "unifiedMarginStatus": 5},
+        }
+
+        status = order_executor.get_status()["position_status"]
+
+        assert status.margin_mode == expected
+        assert status.liquidation_price == 0.0
+        mock_pybit_client.get_account_info.assert_called_once_with()
+
+    @pytest.mark.parametrize("account_response", [
+        {"retCode": 10001, "retMsg": "unsupported", "result": {}},
+        {"retCode": 0, "result": {"marginMode": ""}},
+        {"retCode": 0, "result": {"marginMode": "NEW_MODE"}},
+    ])
+    def test_supported_account_info_never_falls_back_to_v5_trade_mode_zero(
+        self, order_executor, mock_pybit_client, account_response
+    ):
+        position = mock_pybit_client.get_positions.return_value["result"]["list"][0]
+        position["tradeMode"] = "0"
+        position["liqPrice"] = ""
+        mock_pybit_client.get_account_info.return_value = account_response
+
+        assert order_executor.get_status()["position_status"].margin_mode is None
+
+    def test_legacy_client_without_account_info_uses_position_trade_mode(self, order_executor):
+        """Compatibility is limited to clients that genuinely lack the V5 endpoint."""
+        position = {"tradeMode": "1"}
+        del order_executor.client.get_account_info
+
+        assert order_executor._get_actual_margin_mode(position) == "isolated"
+
     def test_get_account_balance(self, order_executor):
         """Test getting account balance."""
         balance = order_executor.get_account_balance()
@@ -150,6 +195,25 @@ class TestBybitFuturesOrderClass:
         assert balance["available_balance"] == 900.0
         assert "total_unrealized_profit" in balance
         assert "total_margin_balance" in balance
+        assert balance["total_maintenance_margin"] is None
+
+    @pytest.mark.parametrize("raw,expected", [
+        ("4.4", 4.4),
+        ("0", 0.0),
+        ("", None),
+        (None, None),
+    ])
+    def test_get_account_balance_parses_unified_maintenance(
+        self, order_executor, mock_pybit_client, raw, expected
+    ):
+        account = mock_pybit_client.get_wallet_balance.return_value["result"]["list"][0].copy()
+        account["totalMaintenanceMargin"] = raw
+        mock_pybit_client.get_wallet_balance.return_value = {
+            "retCode": 0,
+            "result": {"list": [account]},
+        }
+
+        assert order_executor.get_account_balance()["total_maintenance_margin"] == expected
 
     @pytest.mark.parametrize("position_fixture,expected_side", [
         ("mock_pybit_client", "Sell"),      # Long position -> close with Sell
@@ -426,6 +490,7 @@ class TestBybitFuturesOrderClass:
         mock_pybit_client.get_wallet_balance = MagicMock(side_effect=mock_wallet_balance)
         balance = order_executor.get_account_balance()
         assert balance["total_wallet_balance"] == 500.0
+        assert balance["total_maintenance_margin"] is None
         assert call_count == 2  # Called UNIFIED then CONTRACT
 
     def test_account_balance_both_empty_raises(self, order_executor, mock_pybit_client):

--- a/tests/envs/okx/test_futures_order_executor.py
+++ b/tests/envs/okx/test_futures_order_executor.py
@@ -106,6 +106,24 @@ class TestOKXFuturesOrderClass:
         balance = order_executor.get_account_balance()
         assert balance["total_wallet_balance"] == 1000.0
         assert balance["available_balance"] == 900.0
+        assert balance["total_maintenance_margin"] is None
+
+    @pytest.mark.parametrize("raw,expected", [
+        ("4.4", 4.4),
+        ("0", 0.0),
+        ("", None),
+        (None, None),
+    ])
+    def test_get_account_balance_parses_mmr(
+        self, order_executor, mock_okx_account_client, raw, expected
+    ):
+        account = mock_okx_account_client.get_account_balance.return_value["data"][0].copy()
+        account["mmr"] = raw
+        mock_okx_account_client.get_account_balance.return_value = {
+            "code": "0", "msg": "", "data": [account],
+        }
+
+        assert order_executor.get_account_balance()["total_maintenance_margin"] == expected
 
     @pytest.mark.parametrize("pos_data,expected_side", [
         ({"pos": "0.001", "posSide": "net", "avgPx": "50000.0", "markPx": "50100.0",

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -933,7 +933,7 @@ def _futures_env_stub(position_status, balance, leverage=5):
 
 
 def _open_position(qty, *, entry_price=100.0, mark_price=100.0, leverage=20,
-                   liquidation_price=0.0):
+                   liquidation_price=0.0, margin_mode="isolated"):
     return SimpleNamespace(
         qty=qty,
         notional_value=qty * mark_price,
@@ -942,6 +942,7 @@ def _open_position(qty, *, entry_price=100.0, mark_price=100.0, leverage=20,
         unrealized_pnl_pct=0.0,
         leverage=leverage,
         liquidation_price=liquidation_price,
+        margin_mode=margin_mode,
     )
 
 
@@ -954,10 +955,13 @@ def test_cross_margin_position_without_liq_price_does_not_read_as_flat(qty, expe
 
     `liquidation_price <= 0` then took the same branch as "no position at all" and
     reported 1.0 -- a 20x position four percent from liquidation reading exactly as safe
-    as a flat spot account. Asserts the isolated-margin estimate, not merely "< 1.0", so
-    a fallback that returns any arbitrary smaller number still fails.
+    as a flat spot account. The aggregate equals the focal maintenance here, so the
+    account-aware and single-position cross formulas reduce to the same expected value.
     """
-    env = _futures_env_stub(_open_position(qty), {"total_margin_balance": 1000.0})
+    env = _futures_env_stub(
+        _open_position(qty, margin_mode="cross"),
+        {"total_margin_balance": 1000.0, "total_maintenance_margin": 0.4},
+    )
     obs = TorchTradeFuturesLiveEnv._get_observation(env)
     distance = obs["account_state"][5].item()
 
@@ -1182,7 +1186,8 @@ def test_depleted_collateral_prices_liquidation_nearer_than_isolated(qty, expect
     reintroduced one level down.
     """
     env = _futures_env_stub(
-        _open_position(qty, leverage=20), {"total_margin_balance": 2.0}
+        _open_position(qty, leverage=20, margin_mode="cross"),
+        {"total_margin_balance": 2.0, "total_maintenance_margin": 0.4},
     )
     obs = TorchTradeFuturesLiveEnv._get_observation(env)
     distance = obs["account_state"][5].item()
@@ -1202,7 +1207,8 @@ def test_amply_funded_account_falls_back_to_the_isolated_estimate(qty):
     the isolated bound in exactly that case.
     """
     env = _futures_env_stub(
-        _open_position(qty, leverage=20), {"total_margin_balance": 1_000_000.0}
+        _open_position(qty, leverage=20, margin_mode="cross"),
+        {"total_margin_balance": 1_000_000.0, "total_maintenance_margin": 0.4},
     )
     obs = TorchTradeFuturesLiveEnv._get_observation(env)
 
@@ -1213,13 +1219,149 @@ def test_amply_funded_account_falls_back_to_the_isolated_estimate(qty):
     ({"mark_price": 0.0}, "mark_price must be positive"),
     ({"mark_price": float("nan")}, "mark_price must be positive"),
     ({"position_size": 0.0}, "flat position has no liquidation price"),
-], ids=["zero-mark", "nan-mark", "flat"])
+    ({"equity": 0.0}, "equity must be positive"),
+    ({"total_account_maintenance": float("inf")}, "finite non-negative"),
+    ({"maintenance_margin_rate": 1.0}, "degenerate denominator"),
+], ids=["zero-mark", "nan-mark", "flat", "zero-equity", "infinite-maintenance", "degenerate"])
 def test_cross_estimate_refuses_inputs_it_cannot_price(kwargs, match):
     """Same contract as the isolated helper: never hand back a number that reads as safe."""
-    args = {"position_size": 1.0, "mark_price": 100.0, "equity": 5.0}
+    args = {
+        "position_size": 1.0,
+        "mark_price": 100.0,
+        "equity": 5.0,
+        "total_account_maintenance": 0.4,
+    }
     args.update(kwargs)
     with pytest.raises(ValueError, match=match):
         cross_liquidation_price(**args)
+
+
+@pytest.mark.parametrize("qty,expected_price", [
+    (1.0, 99.0 / 0.996),
+    (-1.0, 101.0 / 1.004),
+], ids=["long", "short"])
+def test_cross_estimate_includes_other_account_maintenance(qty, expected_price):
+    """#344: other obligations move both long and short liquidation nearer the mark."""
+    env = _futures_env_stub(
+        _open_position(qty, margin_mode="cross"),
+        {"total_margin_balance": 5.0, "total_maintenance_margin": 4.4},
+    )
+
+    distance = TorchTradeFuturesLiveEnv._get_observation(env)["account_state"][5].item()
+
+    assert distance == pytest.approx(abs(expected_price - 100.0) / 100.0, rel=1e-5)
+
+
+@pytest.mark.parametrize("qty", [1.0, -1.0], ids=["long", "short"])
+def test_no_other_obligation_matches_single_position_cross_formula(qty):
+    """When aggregate maintenance equals the focal term, #344 reduces to #342."""
+    expected_price = (qty * 100.0 - 5.0) / (qty - 0.004 * abs(qty))
+    actual = cross_liquidation_price(
+        position_size=qty,
+        mark_price=100.0,
+        equity=5.0,
+        total_account_maintenance=0.4,
+    )
+    assert actual == pytest.approx(expected_price)
+
+
+@pytest.mark.parametrize("maintenance", [None, float("nan")], ids=["missing", "nan"])
+def test_cross_position_without_usable_aggregate_maintenance_fails_closed(maintenance):
+    env = _futures_env_stub(
+        _open_position(1.0, margin_mode="cross"),
+        {"total_margin_balance": 5.0, "total_maintenance_margin": maintenance},
+    )
+
+    with pytest.raises(ValueError, match="maintenance"):
+        TorchTradeFuturesLiveEnv._get_observation(env)
+
+
+def test_cross_position_without_aggregate_maintenance_key_fails_closed():
+    env = _futures_env_stub(
+        _open_position(1.0, margin_mode="cross"),
+        {"total_margin_balance": 5.0},
+    )
+
+    with pytest.raises(KeyError, match="total_maintenance_margin"):
+        TorchTradeFuturesLiveEnv._get_observation(env)
+
+
+def test_isolated_missing_liquidation_price_does_not_require_account_maintenance():
+    env = _futures_env_stub(
+        _open_position(1.0, margin_mode="isolated"),
+        {"total_margin_balance": 5.0},
+    )
+    distance = TorchTradeFuturesLiveEnv._get_observation(env)["account_state"][5].item()
+    assert distance == pytest.approx(0.046, rel=1e-5)
+
+
+@pytest.mark.parametrize("field,label", [
+    ("margin_type", "CROSSED"),  # Binance
+    ("margin_mode", "cross"),    # OKX
+    ("margin_mode", "crossed"),  # Bitget
+], ids=["binance", "okx", "bitget"])
+def test_concrete_adapter_cross_labels_route_to_account_aware_estimate(field, label):
+    position = _open_position(1.0)
+    delattr(position, "margin_mode")
+    setattr(position, field, label)
+    env = _futures_env_stub(
+        position,
+        {"total_margin_balance": 5.0, "total_maintenance_margin": 4.4},
+    )
+
+    distance = TorchTradeFuturesLiveEnv._get_observation(env)["account_state"][5].item()
+
+    assert distance == pytest.approx(abs(99.0 / 0.996 - 100.0) / 100.0, rel=1e-5)
+
+
+@pytest.mark.parametrize("account_mode,expected", [
+    ("isolated", 0.046),
+    ("cross", abs(99.0 / 0.996 - 100.0) / 100.0),
+], ids=["uta-isolated", "uta-regular"])
+def test_bybit_v5_trade_mode_zero_routes_by_normalized_account_mode(account_mode, expected):
+    """Modern Bybit UTA tradeMode=0 must not decide isolated-vs-cross routing."""
+    from torchtrade.envs.live.bybit.order_executor import PositionStatus
+
+    position = PositionStatus(
+        qty=1.0,
+        notional_value=100.0,
+        entry_price=100.0,
+        unrealized_pnl=0.0,
+        unrealized_pnl_pct=0.0,
+        mark_price=100.0,
+        leverage=20,
+        margin_mode=account_mode,
+        liquidation_price=0.0,
+    )
+    balance = {"total_margin_balance": 5.0}
+    if account_mode == "cross":
+        balance["total_maintenance_margin"] = 4.4
+
+    distance = TorchTradeFuturesLiveEnv._get_observation(
+        _futures_env_stub(position, balance)
+    )["account_state"][5].item()
+
+    assert distance == pytest.approx(expected, rel=1e-5)
+
+
+@pytest.mark.parametrize("margin_mode", [None, "portfolio", "NEW_MODE"])
+def test_blank_liquidation_price_with_unknown_margin_mode_fails_closed(margin_mode):
+    env = _futures_env_stub(
+        _open_position(1.0, margin_mode=margin_mode),
+        {"total_margin_balance": 5.0, "total_maintenance_margin": 4.4},
+    )
+
+    with pytest.raises(ValueError, match="margin mode"):
+        TorchTradeFuturesLiveEnv._get_observation(env)
+
+
+def test_native_liquidation_price_remains_authoritative_for_cross_positions():
+    env = _futures_env_stub(
+        _open_position(1.0, liquidation_price=98.0, margin_mode="cross"),
+        {"total_margin_balance": 5.0, "total_maintenance_margin": None},
+    )
+    distance = TorchTradeFuturesLiveEnv._get_observation(env)["account_state"][5].item()
+    assert distance == pytest.approx(0.02)
 
 
 @pytest.mark.parametrize("leverage,match", [

--- a/torchtrade/envs/live/binance/order_executor.py
+++ b/torchtrade/envs/live/binance/order_executor.py
@@ -468,11 +468,15 @@ class BinanceFuturesOrderClass:
         """
         try:
             account = self.client.futures_account()
+            maintenance = account.get("totalMaintMargin")
             return {
                 "total_wallet_balance": float(account["totalWalletBalance"]),
                 "available_balance": float(account["availableBalance"]),
                 "total_unrealized_profit": float(account["totalUnrealizedProfit"]),
                 "total_margin_balance": float(account["totalMarginBalance"]),
+                "total_maintenance_margin": (
+                    float(maintenance) if maintenance not in (None, "") else None
+                ),
             }
         except Exception as e:
             logger.error(f"Error getting account balance: {str(e)}")

--- a/torchtrade/envs/live/bitget/order_executor.py
+++ b/torchtrade/envs/live/bitget/order_executor.py
@@ -631,6 +631,24 @@ class BitgetFuturesOrderClass:
             total = float(raw_total)
             free = float(usdt_balance.get('free', 0))
 
+            # Classic futures normally returns one raw account entry per margin coin.
+            # Only union asset mode exposes an account-wide maintenance total. A mapping
+            # is accepted for older fixtures/CCXT response shapes; crossedRiskRate is not
+            # a maintenance amount and must not be relabeled as one.
+            raw_info = balance.get('info')
+            raw_accounts = raw_info if isinstance(raw_info, list) else [raw_info]
+            maintenance = None
+            for raw_account in raw_accounts:
+                if not isinstance(raw_account, dict):
+                    continue
+                margin_coin = str(raw_account.get('marginCoin', 'USDT')).upper()
+                if margin_coin != 'USDT':
+                    continue
+                if raw_account.get('assetMode') == 'union':
+                    union_mm = raw_account.get('unionMm')
+                    maintenance = float(union_mm) if union_mm not in (None, '') else None
+                break
+
             # Unrealized PnL can be calculated from positions
             unrealized_pnl = 0.0
             try:
@@ -646,6 +664,7 @@ class BitgetFuturesOrderClass:
                 "available_balance": free,
                 "total_unrealized_profit": unrealized_pnl,
                 "total_margin_balance": total,
+                "total_maintenance_margin": maintenance,
             }
 
             logger.debug(f"Account balance: total={total:.2f}, available={free:.2f}, pnl={unrealized_pnl:.4f}")

--- a/torchtrade/envs/live/bybit/order_executor.py
+++ b/torchtrade/envs/live/bybit/order_executor.py
@@ -53,7 +53,7 @@ class PositionStatus:
     mark_price: float
     leverage: float  # float, not int: int() truncated 1.5x to 1x, which then took
     # the no-liquidation branch and reported a levered position as safe (#277).
-    margin_mode: str
+    margin_mode: Optional[str]
     liquidation_price: float
 
 
@@ -332,6 +332,7 @@ class BybitFuturesOrderClass:
             pos = non_zero[0] if non_zero else None
 
             if pos is not None:
+                margin_mode = self._get_actual_margin_mode(pos)
                 size = float(pos.get("size", 0))
                 side = pos.get("side", "Buy")
                 qty = size if side == "Buy" else -size
@@ -356,7 +357,7 @@ class BybitFuturesOrderClass:
                     leverage=float(
                         self.leverage if pos.get("leverage") in (None, "") else pos.get("leverage")
                     ),
-                    margin_mode=pos.get("tradeMode", str(self.margin_mode.to_pybit())),
+                    margin_mode=margin_mode,
                     liquidation_price=liq_price,
                 )
             else:
@@ -368,7 +369,50 @@ class BybitFuturesOrderClass:
 
         return status
 
-    def get_account_balance(self) -> Dict[str, float]:
+    def _get_actual_margin_mode(self, position: Dict[str, object]) -> Optional[str]:
+        """Return the account's effective margin mode for liquidation routing.
+
+        Bybit V5 deprecates ``tradeMode`` on position responses and always returns 0,
+        including for isolated UTA accounts. Current pybit clients expose
+        ``get_account_info()``, whose ``marginMode`` is authoritative. A legacy client
+        without that endpoint may still be paired with an older/classic response where
+        position ``tradeMode`` was meaningful, so only that missing-method case retains
+        the old 0/1 fallback.
+
+        A supported account-info endpoint that errors or returns an unknown value is not
+        evidence of either mode. Returning ``None`` lets the shared observation fail
+        closed when Bybit also omits the native liquidation price.
+        """
+        get_account_info = getattr(self.client, "get_account_info", None)
+        if not callable(get_account_info):
+            return {"0": "cross", "1": "isolated"}.get(str(position.get("tradeMode")))
+
+        try:
+            response = get_account_info()
+        except Exception as exc:
+            logger.warning(f"Could not query Bybit account margin mode: {exc}")
+            return None
+
+        ret_code = response.get("retCode")
+        if ret_code is not None and int(ret_code) != 0:
+            logger.warning(
+                "get_account_info failed (retCode=%s): %s",
+                ret_code,
+                response.get("retMsg", "unknown error"),
+            )
+            return None
+
+        raw_mode = response.get("result", {}).get("marginMode")
+        normalized = {
+            "ISOLATED_MARGIN": "isolated",
+            "REGULAR_MARGIN": "cross",
+            "PORTFOLIO_MARGIN": "portfolio",
+        }.get(str(raw_mode).upper())
+        if normalized is None:
+            logger.warning("Bybit returned an unknown account margin mode: %r", raw_mode)
+        return normalized
+
+    def get_account_balance(self) -> Dict[str, Optional[float]]:
         """
         Get futures account balance using pybit.
 
@@ -398,12 +442,16 @@ class BybitFuturesOrderClass:
             available = float(account.get("totalAvailableBalance", 0))
             total_pnl = float(account.get("totalPerpUPL", 0))
             margin_balance = float(account.get("totalMarginBalance", total_equity))
+            maintenance = account.get("totalMaintenanceMargin")
 
             result = {
                 "total_wallet_balance": total_equity,
                 "available_balance": available,
                 "total_unrealized_profit": total_pnl,
                 "total_margin_balance": margin_balance,
+                "total_maintenance_margin": (
+                    float(maintenance) if maintenance not in (None, "") else None
+                ),
             }
 
             logger.debug(f"Account balance: total={total_equity:.2f}, available={available:.2f}, pnl={total_pnl:.4f}")

--- a/torchtrade/envs/live/okx/order_executor.py
+++ b/torchtrade/envs/live/okx/order_executor.py
@@ -426,12 +426,16 @@ class OKXFuturesOrderClass:
                     break
 
             total_pnl = float(account.get("upl") or "0")
+            maintenance = account.get("mmr")
 
             result = {
                 "total_wallet_balance": total_equity,
                 "available_balance": available,
                 "total_unrealized_profit": total_pnl,
                 "total_margin_balance": total_equity,
+                "total_maintenance_margin": (
+                    float(maintenance) if maintenance not in (None, "") else None
+                ),
             }
 
             logger.debug(f"Account balance: total={total_equity:.2f}, available={available:.2f}, pnl={total_pnl:.4f}")

--- a/torchtrade/envs/live/shared/futures_live_base.py
+++ b/torchtrade/envs/live/shared/futures_live_base.py
@@ -20,7 +20,31 @@ from torchtrade.envs.core.state import (
     position_direction_from_status,
     position_qty_from_status,
 )
-from torchtrade.envs.utils.liquidation import nearest_liquidation_price
+from torchtrade.envs.utils.liquidation import (
+    isolated_liquidation_price,
+    nearest_liquidation_price,
+)
+
+
+def _normalized_margin_mode(position_status):
+    """Normalize concrete adapter labels to ``cross``/``isolated`` or unknown.
+
+    Binance exposes ``margin_type`` while the other adapters expose ``margin_mode``.
+    Unknown labels deliberately remain unknown: when the venue also omits a native
+    liquidation price, guessing either route can report a dangerously safe distance.
+    """
+    margin_mode = getattr(
+        position_status,
+        "margin_mode",
+        getattr(position_status, "margin_type", None),
+    )
+    value = getattr(margin_mode, "value", margin_mode)
+    value = str(value).lower()
+    if value in {"0", "cross", "crossed"}:
+        return "cross"
+    if value in {"1", "isolated"}:
+        return "isolated"
+    return None
 
 
 class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
@@ -170,39 +194,48 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
             distance_to_liquidation = 1.0
         else:
             if liquidation_price <= 0:
-                # Cross-margin venues omit the liquidation price (OKX sends liqPx="" for
-                # cross) because the whole account backs the position, so there is no
-                # per-position price to publish. bybit blanks liqPrice for unified/cross
-                # too; it blanks `leverage` with it, which used to make float("") raise
-                # into POSITION_UNKNOWN, but the adapters now fall back to the configured
-                # leverage there, so bybit reaches this path as well.
-                #
-                # That fallback is a real limitation: the leverage feeding the estimate is
-                # the one this env asked for, not one the venue confirmed, and #277's
-                # unfixed half is precisely that set_leverage failures are swallowed. It
-                # is kept because refusing would make OKX and bybit cross accounts unable
-                # to produce an observation at all.
+                # Venues can omit liquidation prices even for real positions: OKX sends
+                # liqPx="" for some cross positions, while Bybit can blank liqPrice when
+                # the estimate falls outside instrument bounds (and always does so in
+                # portfolio margin). Routing therefore depends on the adapter's normalized
+                # actual margin mode, never on the mere absence of the price.
                 # Defaulting to 1.0 reported a 20x long one move away from liquidation as
                 # exactly as safe as a flat spot account (#277).
                 #
-                # Estimated from BOTH the isolated geometry and the account's equity,
-                # taking whichever is nearer. Isolated alone is not the conservative
-                # choice it looks like: it only sees this position, so once losses
-                # elsewhere have eaten the collateral, cross liquidates earlier than
-                # isolated says and the estimate would overstate the distance -- the same
-                # fail-open, reintroduced with extra steps.
-                #
-                # Still not a guaranteed bound: a second cross position's maintenance
-                # requirement is invisible to both estimates and would move liquidation
-                # nearer again (#344). That assumption -- this env owns the account -- is
-                # the same one exposure_pct and the bankruptcy baseline already make.
-                liquidation_price = nearest_liquidation_price(
-                    position_size=position_size,
-                    entry_price=position_status.entry_price,
-                    mark_price=current_price,
-                    equity=total_balance,
-                    leverage=leverage,
-                )
+                margin_mode = _normalized_margin_mode(position_status)
+                if margin_mode == "cross":
+                    # The aggregate is measured at the current mark. The helper subtracts
+                    # the focal position's current maintenance, keeps that focal term
+                    # price-sensitive, and treats the remainder as locally constant.
+                    # Missing aggregate maintenance must fail closed rather than silently
+                    # recreate the single-position assumption from #344.
+                    total_account_maintenance = balance["total_maintenance_margin"]
+                    if total_account_maintenance is None:
+                        raise ValueError(
+                            "Cross-margin liquidation price is unavailable because the "
+                            "venue did not report total account maintenance"
+                        )
+                    liquidation_price = nearest_liquidation_price(
+                        position_size=position_size,
+                        entry_price=position_status.entry_price,
+                        mark_price=current_price,
+                        equity=total_balance,
+                        leverage=leverage,
+                        total_account_maintenance=total_account_maintenance,
+                    )
+                elif margin_mode == "isolated":
+                    # Isolated positions retain their position-only fallback; account-wide
+                    # maintenance does not determine their liquidation threshold.
+                    liquidation_price = isolated_liquidation_price(
+                        position_status.entry_price,
+                        is_long=position_size > 0,
+                        leverage=leverage,
+                    )
+                else:
+                    raise ValueError(
+                        "Liquidation price is unavailable because the venue's actual "
+                        "margin mode is missing or unsupported"
+                    )
             if position_size > 0:
                 distance_to_liquidation = (current_price - liquidation_price) / current_price
             else:

--- a/torchtrade/envs/utils/liquidation.py
+++ b/torchtrade/envs/utils/liquidation.py
@@ -10,6 +10,8 @@ tests pin it to the scalar env, so it cannot drift unnoticed. The live path had 
 pin, which is why it shares this.
 """
 
+import math
+
 # Both offline configs default their maintenance_margin_rate to this, so a policy meets
 # the same liquidation geometry offline and live. The live side has no config knob, so an
 # offline env configured off the default has no matching live fallback.
@@ -54,30 +56,55 @@ def cross_liquidation_price(
     position_size: float,
     mark_price: float,
     equity: float,
+    total_account_maintenance: float,
     maintenance_margin_rate: float = DEFAULT_MAINTENANCE_MARGIN_RATE,
 ) -> float:
     """Price at which the whole account's equity stops covering maintenance margin.
 
-    Under cross margin the position is not backed by its own isolated margin but by the
-    entire account, so the threshold moves with equity. Solving
-    `equity + size*(P - mark) = mmr * |size| * P` for P gives the expression below.
+    The venue's aggregate maintenance is measured at the current mark. Split it into the
+    focal position's current maintenance and everything else, then keep the focal term
+    price-sensitive while treating the remainder as locally constant:
+
+    `other = max(total_maintenance - rate * abs(size) * mark, 0)`
+    `equity + size*(P - mark) = other + rate * abs(size) * P`
 
     This is what makes the estimate honest in the case the isolated formula gets wrong:
     when losses elsewhere have eaten the collateral, equity is already lower and this
     prices liquidation NEARER than isolated would. When the account is amply funded it
     prices it further away -- correctly, because it genuinely is.
 
-    Still an approximation: it cannot see other positions' own maintenance requirements or
-    the venue's tiered margin schedule, which is why the caller pairs it with the isolated
-    price and takes whichever is nearer rather than trusting this alone.
+    This remains a local estimate: other positions also move, risk tiers can change, and
+    portfolio margin is not represented by this linear model.
     """
-    if not (mark_price > 0):
+    if not math.isfinite(mark_price) or not (mark_price > 0):
         raise ValueError(f"mark_price must be positive to price a liquidation, got {mark_price}")
-    if not position_size:
+    if not math.isfinite(position_size) or not position_size:
         raise ValueError("a flat position has no liquidation price")
+    if not math.isfinite(equity) or not (equity > 0):
+        raise ValueError(f"equity must be positive to price a liquidation, got {equity}")
+    if not math.isfinite(total_account_maintenance) or total_account_maintenance < 0:
+        raise ValueError(
+            "total_account_maintenance must be a finite non-negative number, "
+            f"got {total_account_maintenance}"
+        )
+    if not math.isfinite(maintenance_margin_rate) or maintenance_margin_rate < 0:
+        raise ValueError(
+            "maintenance_margin_rate must be a finite non-negative number, "
+            f"got {maintenance_margin_rate}"
+        )
 
-    sign = 1.0 if position_size > 0 else -1.0
-    return (position_size * mark_price - equity) / (position_size * (1 - sign * maintenance_margin_rate))
+    focal_at_mark = maintenance_margin_rate * abs(position_size) * mark_price
+    other_maintenance = max(total_account_maintenance - focal_at_mark, 0.0)
+    denominator = position_size - maintenance_margin_rate * abs(position_size)
+    if not math.isfinite(denominator) or denominator == 0:
+        raise ValueError("cross-margin liquidation equation has a degenerate denominator")
+
+    price = (
+        position_size * mark_price + other_maintenance - equity
+    ) / denominator
+    if not math.isfinite(price):
+        raise ValueError(f"cross-margin liquidation price is non-finite: {price}")
+    return price
 
 
 def nearest_liquidation_price(
@@ -86,34 +113,23 @@ def nearest_liquidation_price(
     mark_price: float,
     equity: float,
     leverage: float,
+    total_account_maintenance: float,
     maintenance_margin_rate: float = DEFAULT_MAINTENANCE_MARGIN_RATE,
 ) -> float:
     """The more urgent of the isolated and cross estimates, for a venue that publishes none.
 
-    Neither estimate dominates. Isolated ignores the rest of the account, so it is wrong
-    once collateral elsewhere has been consumed; cross reflects equity but assumes this
-    position is the account's only maintenance obligation. Taking whichever sits nearer
-    the mark is the best available answer from the fields the adapters currently expose.
-
-    It is NOT a guaranteed bound, and must not be described as one. If the account holds
-    another cross position, its maintenance requirement is missing from both estimates and
-    both overstate the room left: a 1-unit long at mark 100 on equity 5 returns ~95.4
-    (4.6% room) where a second position needing 4 of maintenance puts real liquidation at
-    ~99.4 (0.6%). Closing that needs an account-level maintenance figure from
-    `get_account_balance()`, which no adapter parses today -- see #344.
-
-    The same single-position assumption is already baked into `exposure_pct`, the
-    bankruptcy baseline and `_get_portfolio_value`, all of which divide this position by
-    account-wide equity. What this function must not do is claim more certainty than they
-    do. Against the `1.0` it replaces -- maximally wrong for every cross position,
-    always -- it is a strict improvement in every case, which is why it ships.
+    Neither estimate dominates. The isolated price preserves the venue-independent
+    position geometry, while the cross price incorporates the account's current aggregate
+    maintenance. Taking whichever sits nearer the mark avoids trusting an implausibly far
+    local cross estimate when the account is amply funded.
     """
     isolated = isolated_liquidation_price(
         entry_price, is_long=position_size > 0, leverage=leverage,
         maintenance_margin_rate=maintenance_margin_rate,
     )
     cross = cross_liquidation_price(
-        position_size, mark_price, equity, maintenance_margin_rate=maintenance_margin_rate,
+        position_size, mark_price, equity, total_account_maintenance,
+        maintenance_margin_rate=maintenance_margin_rate,
     )
     # A long is liquidated from below, so nearer means higher; a short from above.
     return max(isolated, cross) if position_size > 0 else min(isolated, cross)


### PR DESCRIPTION
Closes #344. This is @CharlieHelps' work from #350, cherry-picked onto `main` with authorship intact.

#350 was stacked on `fix/live-fail-open-leverage-liq-277`; squash-merging that as #342 deleted the base branch, which auto-closed #350 and left it unreopenable (GitHub refuses to reopen against a deleted base, and refuses to retarget a closed PR). The commit applies cleanly to `main`, so this carries it forward unchanged.

## What it does

When a cross-margin venue omits the liquidation price, the estimate previously assumed this position was the account's only maintenance obligation — so a second position's requirement was invisible and the distance was overstated. It now splits the venue's aggregate maintenance into the focal position's current share and everything else, keeps the focal term price-sensitive and treats the remainder as locally constant.

I reviewed and approved this on #350. Verified again on current `main`:

| scenario (1-unit long, mark 100, equity 5, 20x) | before | this PR |
|---|---|---|
| another position needing 4 of maintenance | 4.6% room | **0.6%** (true value) |
| this position only | 4.6% | 4.6% (unchanged) |
| venue omits the aggregate | estimated anyway | **raises** |
| isolated position, no venue price | cross estimate applied | **isolated formula** |
| unrecognised margin mode | estimated anyway | **raises** |

Two improvements over what it replaces: it routes on the **actual margin mode** rather than on the mere absence of a price — so an isolated position no longer gets a meaningless cross estimate — and it fails closed when the venue won't report aggregate maintenance instead of silently recreating the single-position assumption.

Checks: all four adapters key `total_maintenance_margin`; every `MarginType`/`MarginMode` enum value across binance/bitget/bybit/okx normalises correctly, as do raw venue strings in both cases and bybit's numeric `"0"`/`"1"`; no existing test was removed or weakened.

`pytest tests/` on this branch — **2668 passed, 19 skipped, 0 failures**.

Co-authored-by: CharlieHelps <charlie@charlielabs.ai>