### PR TITLE
fix(live): validate at the boundary, and stop guessing (#347 #345 #348 #341)

### DIFF
--- a/docs/environments/online.md
+++ b/docs/environments/online.md
@@ -795,11 +795,21 @@ size, exposure and liquidation distance the env has just admitted it cannot veri
 So the env **halts**: it raises `LiveObservationHalt` and produces no transition.
 
 **Which reads this covers.** Only the post-bar state read — the portfolio value and
-observation taken after the bar closes. Two other venue reads per step are *not* routed
-through it and still raise their original exception with no latch and no emergency
-flatten: the position read at the top of `_step()` (used for the position sync and the
-duplicate-action guard) and the initial read inside `_reset()`. Catch
-`PositionUnknownError` as well if you need to cover those. Closing that gap is #355.
+observation taken after the bar closes. Every *other* venue read raises its original
+exception with no latch and no emergency flatten:
+
+| read | raises |
+|---|---|
+| position read at the top of `_step()` (position sync, duplicate-action guard) | `PositionUnknownError` |
+| the initial read inside `_reset()` | `ValueError` |
+| `_current_mark_price()`, called at the top of every futures `_step()` | `ValueError` |
+| the sizing balance / portfolio checks | `ValueError` |
+| the candle close that prices SL/TP brackets | `ValueError` |
+
+So `except LiveObservationHalt` alone does **not** give you a policy-driven emergency
+close on an unreadable price or balance — it catches the post-bar read and nothing else.
+Catch `ValueError` and `PositionUnknownError` too if you need to cover those. Alpaca and
+Polymarket do not route through this path at all. Closing the gap is #355.
 
 ```python
 from torchtrade.envs.core.live import LiveObservationHalt

--- a/tests/envs/alpaca/test_torch_env_sltp.py
+++ b/tests/envs/alpaca/test_torch_env_sltp.py
@@ -8,6 +8,7 @@ pricing is not covered here -- that belongs to the order executor and the offlin
 from unittest.mock import patch
 
 import pytest
+import numpy as np
 import torch
 from torchrl.envs.utils import check_env_specs
 from tensordict import TensorDict
@@ -140,6 +141,31 @@ class TestAlpacaSLTPTradingEnvReset:
         is NOT what this catches -- see assert_the_step_emits_the_whole_done_family."""
         with patch.object(type(env), "_wait_for_next_timestamp"):
             check_env_specs(env)
+
+    @pytest.mark.parametrize("close,harm", [
+        (float("nan"), "both bracket legs go to the venue as NaN, unlogged"),
+        (0.0, "both legs price at zero"),
+        (-50000.0, "the stop lands ABOVE the take-profit -- an inverted bracket"),
+    ], ids=["nan", "zero", "negative"])
+    def test_a_bracket_is_never_priced_off_an_unusable_close(self, env, close, harm):
+        """#347 swept alpaca/env.py and never reached alpaca/env_sltp.py.
+
+        The entry is a full-balance market BUY in every case; if the venue takes it and
+        rejects the legs, bracket_status zeroes active_stop_loss/active_take_profit and the
+        position sits unprotected in an env whose ONLY exit is SL/TP. And {harm}.
+        """
+        env._wait_for_next_timestamp = lambda: None
+        env.reset()
+        env.observer.get_observations = lambda return_base_ohlc=False: {
+            "1Minute_10": np.zeros((10, 4), dtype=np.float32),
+            **({"base_features": np.full((10, 4), close, dtype=np.float32),
+                "base_timestamps": np.arange(10)} if return_base_ohlc else {}),
+        }
+
+        with pytest.raises(ValueError, match="unusable close price"):
+            env._step(TensorDict({"action": torch.tensor(1)}, batch_size=()))
+
+        assert env.trader.position_qty == 0, "no entry may be opened on an unusable close"
 
     def test_reset_clears_a_live_bracket(self, env):
         """Reset must clear SL/TP levels that an episode actually set.

--- a/tests/envs/alpaca/test_torch_env_sltp.py
+++ b/tests/envs/alpaca/test_torch_env_sltp.py
@@ -167,6 +167,24 @@ class TestAlpacaSLTPTradingEnvReset:
 
         assert env.trader.position_qty == 0, "no entry may be opened on an unusable close"
 
+    @pytest.mark.parametrize("cash", [float("nan"), float("inf"), -250.0],
+                             ids=["nan", "inf", "negative"])
+    def test_a_bracket_is_never_sized_off_an_unusable_cash_balance(self, env, cash):
+        """#347: alpaca SLTP sizes off self.balance, written raw in _reset.
+
+        _get_portfolio_value DOES validate -- but it is a SEPARATE fetch, and this env's
+        _step calls it AFTER _execute_trade_if_needed. So the venue could report healthy
+        cash on that later call while the NaN captured at reset had already sized a
+        full-balance bracket buy: the raise landed after the order was live.
+        """
+        env._wait_for_next_timestamp = lambda: None
+        env.trader.cash = cash
+
+        with pytest.raises(ValueError, match="unusable cash balance"):
+            env.reset()
+
+        assert env.trader.position_qty == 0, "no entry may be sized off an unusable balance"
+
     def test_reset_clears_a_live_bracket(self, env):
         """Reset must clear SL/TP levels that an episode actually set.
 

--- a/tests/envs/binance/test_torch_env_futures_sltp.py
+++ b/tests/envs/binance/test_torch_env_futures_sltp.py
@@ -741,13 +741,13 @@ class TestCriticalEdgeCases:
 
         env.reset()
         action_tuple = ("long", -0.02, 0.03)
-        trade_info = env._execute_trade_if_needed(action_tuple)
 
-        # Should handle gracefully
-        if trade_info["executed"] and trade_info.get("stop_loss") is not None:
-            # If trade executed, prices should be valid
-            assert trade_info["stop_loss"] >= 0
-            assert trade_info["take_profit"] >= 0
+        # "Handle gracefully" used to mean a conditional assertion that ran only if the
+        # trade executed -- so it passed whether or not brackets were priced off zero.
+        # A zero close now refuses outright, which is the graceful handling (#347).
+        with pytest.raises(ValueError, match="unusable close price"):
+            env._execute_trade_if_needed(action_tuple)
+        mock_trader.trade.assert_not_called()
 
     def test_reentry_allowed_same_step_as_closure(self, env_with_mocks):
         """When SL/TP closes a position, re-entry is allowed in the same step.
@@ -1033,7 +1033,7 @@ class TestBinanceSLTPNotionalTradeMode:
         expected_qty = 500.0 / 50050.0
         assert call_kwargs["quantity"] == pytest.approx(expected_qty, rel=1e-4)
 
-    def test_notional_zero_price_aborts_trade(self, notional_env):
+    def test_notional_zero_price_refuses_to_trade(self, notional_env):
         """Zero candle close price must abort trade without calling trader.trade()."""
         env, mock_trader = notional_env
 
@@ -1047,10 +1047,12 @@ class TestBinanceSLTPNotionalTradeMode:
         env.observer.get_observations = MagicMock(side_effect=mock_obs_zero)
         env.reset()
         mock_trader.reset_mock()
-        trade_info = env._execute_trade_if_needed(("long", -0.02, 0.03))
+        # A zero candle close is unusable data, not a soft abort: it divides the notional
+        # sizing and prices both brackets, including in the "quantity" default (#347).
+        with pytest.raises(ValueError, match="unusable close price"):
+            env._execute_trade_if_needed(("long", -0.02, 0.03))
 
         mock_trader.trade.assert_not_called()
-        assert trade_info["success"] is False
 
     def test_quantity_mode_passes_raw_value(self):
         """Quantity mode must pass quantity_per_trade directly without conversion."""

--- a/tests/envs/binance/test_torch_env_futures_sltp.py
+++ b/tests/envs/binance/test_torch_env_futures_sltp.py
@@ -1071,6 +1071,7 @@ class TestBinanceSLTPNotionalTradeMode:
         mock_observer.window_sizes = [10]
 
         mock_trader = MagicMock()
+        mock_trader.get_mark_price = MagicMock(return_value=50000.0)
         mock_trader.cancel_open_orders = MagicMock(return_value=True)
         mock_trader.close_position = MagicMock(return_value=True)
         mock_trader.get_account_balance = MagicMock(return_value={
@@ -1125,6 +1126,7 @@ class TestBinanceSLTPNotionalTradeMode:
         mock_observer.window_sizes = [10]
 
         mock_trader = MagicMock()
+        mock_trader.get_mark_price = MagicMock(return_value=50000.0)
         mock_trader.cancel_open_orders = MagicMock(return_value=True)
         mock_trader.close_position = MagicMock(return_value=True)
         mock_trader.get_account_balance = MagicMock(return_value={
@@ -1186,6 +1188,7 @@ class TestBinanceSLTPLockPosition:
         mock_observer.window_sizes = [10]
 
         mock_trader = MagicMock()
+        mock_trader.get_mark_price = MagicMock(return_value=50000.0)
         mock_trader.cancel_open_orders = MagicMock(return_value=True)
         mock_trader.close_position = MagicMock(return_value=True)
         mock_trader.get_account_balance = MagicMock(return_value={

--- a/tests/envs/bitget/test_torch_env_futures_sltp.py
+++ b/tests/envs/bitget/test_torch_env_futures_sltp.py
@@ -753,6 +753,7 @@ class TestBitgetSLTPNotionalTradeMode:
         mock_observer.window_sizes = [10]
 
         mock_trader = MagicMock()
+        mock_trader.get_mark_price = MagicMock(return_value=50000.0)
         mock_trader.cancel_open_orders = MagicMock(return_value=True)
         mock_trader.close_position = MagicMock(return_value=True)
         mock_trader.get_account_balance = MagicMock(return_value={
@@ -807,6 +808,7 @@ class TestBitgetSLTPNotionalTradeMode:
         mock_observer.window_sizes = [10]
 
         mock_trader = MagicMock()
+        mock_trader.get_mark_price = MagicMock(return_value=50000.0)
         mock_trader.cancel_open_orders = MagicMock(return_value=True)
         mock_trader.close_position = MagicMock(return_value=True)
         mock_trader.get_account_balance = MagicMock(return_value={
@@ -868,6 +870,7 @@ class TestBitgetSLTPLockPosition:
         mock_observer.window_sizes = [10]
 
         mock_trader = MagicMock()
+        mock_trader.get_mark_price = MagicMock(return_value=50000.0)
         mock_trader.cancel_open_orders = MagicMock(return_value=True)
         mock_trader.close_position = MagicMock(return_value=True)
         mock_trader.get_account_balance = MagicMock(return_value={

--- a/tests/envs/bitget/test_torch_env_futures_sltp.py
+++ b/tests/envs/bitget/test_torch_env_futures_sltp.py
@@ -715,7 +715,7 @@ class TestBitgetSLTPNotionalTradeMode:
         expected_qty = 500.0 / 50050.0
         assert call_kwargs["quantity"] == pytest.approx(expected_qty, rel=1e-4)
 
-    def test_notional_zero_price_aborts_trade(self, notional_env):
+    def test_notional_zero_price_refuses_to_trade(self, notional_env):
         """Zero candle close price must abort trade without calling trader.trade()."""
         env, mock_trader = notional_env
 
@@ -729,10 +729,12 @@ class TestBitgetSLTPNotionalTradeMode:
         env.observer.get_observations = MagicMock(side_effect=mock_obs_zero)
         env.reset()
         mock_trader.reset_mock()
-        trade_info = env._execute_trade_if_needed(("long", -0.02, 0.03))
+        # A zero candle close is unusable data, not a soft abort: it divides the notional
+        # sizing and prices both brackets, including in the "quantity" default (#347).
+        with pytest.raises(ValueError, match="unusable close price"):
+            env._execute_trade_if_needed(("long", -0.02, 0.03))
 
         mock_trader.trade.assert_not_called()
-        assert trade_info["success"] is False
 
     def test_quantity_mode_passes_raw_value(self):
         """Quantity mode must pass quantity_per_trade directly without conversion."""

--- a/tests/envs/bybit/test_torch_env_futures_sltp.py
+++ b/tests/envs/bybit/test_torch_env_futures_sltp.py
@@ -579,16 +579,21 @@ class TestBybitSLTPNotionalTradeMode:
             # $500 / $50000 = 0.01 BTC
             assert call_kwargs["quantity"] == pytest.approx(0.01, rel=1e-6)
 
-    def test_notional_zero_price_aborts_trade(self, notional_env, mock_env_trader):
-        """Zero mark price must abort trade without calling trader.trade()."""
+    def test_notional_zero_price_refuses_to_trade(self, notional_env, mock_env_trader):
+        """A venue price of 0 is unusable data, not a graceful abort condition (#347).
+
+        It used to return `success: False` -- indistinguishable from a legitimate refusal
+        -- while the same value silently divided in the sizing path. It now raises, and
+        the thing that matters is unchanged: no order is submitted.
+        """
         mock_env_trader.get_mark_price = MagicMock(return_value=0.0)
 
         with patch.object(notional_env, "_wait_for_next_timestamp"):
             notional_env.reset()
-            trade_info = notional_env._execute_trade_if_needed(("long", -0.02, 0.03))
+            with pytest.raises(ValueError, match="unusable mark price"):
+                notional_env._execute_trade_if_needed(("long", -0.02, 0.03))
 
             mock_env_trader.trade.assert_not_called()
-            assert trade_info["success"] is False
 
     def test_quantity_mode_passes_raw_value(self, mock_env_observer, mock_env_trader):
         """Quantity mode must pass quantity_per_trade directly without conversion."""

--- a/tests/envs/okx/test_torch_env_futures.py
+++ b/tests/envs/okx/test_torch_env_futures.py
@@ -303,6 +303,42 @@ class TestOKXFuturesTorchTradingEnv:
             f"a position opened after a liquidation inherited the dead position's age ({aged})"
         )
 
+    @pytest.mark.parametrize("mark_price,harm", [
+        (float("nan"), "a NaN quantity goes to the venue unlogged (caught at reset)"),
+        (-50000.0, "the sign flips: a max-LONG action places a SHORT"),
+        (0.0, "ZeroDivisionError out of _step"),
+    ], ids=["nan", "negative", "zero"])
+    def test_an_open_position_cannot_size_from_an_unvalidated_mark_price(
+        self, env, mock_env_trader, mark_price, harm
+    ):
+        """#347: the sweep guarded the flat half of okx's ternary and stopped.
+
+        The other half runs on every RESIZE, and okx is the only exchange that threads the
+        price down from _step rather than re-fetching inside _execute_fractional_action.
+        Both okx fields feeding mark_price fall back to 0.0 when empty, so this arrives
+        from two blank venue fields, not only a wire fault -- and {harm}.
+        """
+        from torchtrade.envs.live.okx.order_executor import PositionStatus
+
+        def status(price):
+            return {"position_status": PositionStatus(
+                qty=0.1, notional_value=5000.0, entry_price=50000.0, unrealized_pnl=0.0,
+                unrealized_pnl_pct=0.0, mark_price=price, leverage=5,
+                margin_mode="isolated", liquidation_price=40000.0,
+            )}
+
+        # Reset on a healthy price, then poison: the venue tick that goes bad mid-episode
+        # is the one that reaches sizing, and it isolates _step from the reset-time guard.
+        mock_env_trader.get_status = MagicMock(return_value=status(50000.0))
+        with patch.object(env, "_wait_for_next_timestamp"):
+            env.reset()
+            mock_env_trader.get_status = MagicMock(return_value=status(mark_price))
+            td = TensorDict({"action": torch.tensor(len(env.action_levels) - 1)}, [])
+            with pytest.raises(ValueError, match="mark.?price"):
+                env.step(td)
+
+        mock_env_trader.trade.assert_not_called()
+
 
 class TestOKXActionIndexClamping:
     """Tests for action index out-of-range clamping."""

--- a/tests/envs/okx/test_torch_env_futures_sltp.py
+++ b/tests/envs/okx/test_torch_env_futures_sltp.py
@@ -316,14 +316,19 @@ class TestOKXSLTPNotionalTradeMode:
             assert call_kwargs["side"] == expected_side
             assert call_kwargs["quantity"] == pytest.approx(0.01, rel=1e-6)
 
-    def test_notional_zero_price_aborts_trade(self, notional_env, mock_env_trader):
-        """Zero mark price must abort trade without calling trader.trade()."""
+    def test_notional_zero_price_refuses_to_trade(self, notional_env, mock_env_trader):
+        """A venue price of 0 is unusable data, not a graceful abort condition (#347).
+
+        It used to return `success: False` -- indistinguishable from a legitimate refusal
+        -- while the same value silently divided in the sizing path. It now raises, and
+        the thing that matters is unchanged: no order is submitted.
+        """
         mock_env_trader.get_mark_price = MagicMock(return_value=0.0)
         with patch.object(notional_env, "_wait_for_next_timestamp"):
             notional_env.reset()
-            trade_info = notional_env._execute_trade_if_needed(("long", -0.02, 0.03))
+            with pytest.raises(ValueError, match="unusable mark price"):
+                notional_env._execute_trade_if_needed(("long", -0.02, 0.03))
             mock_env_trader.trade.assert_not_called()
-            assert trade_info["success"] is False
 
     def test_quantity_mode_passes_raw_value(self, mock_env_observer, mock_env_trader):
         """Quantity mode must pass quantity_per_trade directly without conversion."""

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -1848,3 +1848,50 @@ def test_no_futures_env_reads_the_mark_price_unvalidated(exchange, module):
     assert "self.trader.get_mark_price()" not in path.read_text(), (
         f"{exchange}/{module} sizes from an unvalidated mark price"
     )
+
+
+@pytest.mark.parametrize("exchange", ["alpaca", "binance", "bitget", "bybit", "okx"])
+def test_no_env_returns_a_zero_target_it_cannot_size(exchange):
+    """#348: "I cannot size this" returned the same tuple as "go flat".
+
+    On alpaca that is a liquidation: it has no `target_qty == 0` guard, so a zero target
+    against an open position becomes `delta = 0 - current` and sells -- from an action
+    that meant maximum long. The four futures envs DO guard it, so there it was a silent
+    no-op: the agent's action dropped every bar with only a warning. Both are wrong for
+    the same reason -- "I cannot size this" must not be the same value as "go flat".
+    """
+    src = (pathlib.Path(inspect.getfile(TorchTradeLiveEnv)).parent.parent
+           / "live" / exchange / "env.py").read_text()
+    assert "refusing, because returning a zero target" in src, (
+        f"{exchange} still returns a zero target when it cannot read the balance"
+    )
+
+
+@pytest.mark.parametrize("exchange,field", [
+    ("bitget", "liquidationPrice"),
+    ("bitget", "entryPrice"),
+    ("bitget", "markPrice"),
+    ("bitget", "unrealizedPnl"),
+])
+def test_nullable_venue_fields_do_not_read_as_an_outage(exchange, field):
+    """#341: a cross position returns `liquidationPrice: None`, and bare `float(None)`
+    raises TypeError into the broad except -- reporting a HEALTHY position as
+    POSITION_UNKNOWN, which is fail-closed and freezes the env every bar."""
+    src = (pathlib.Path(inspect.getfile(TorchTradeLiveEnv)).parent.parent
+           / "live" / exchange / "order_executor.py").read_text()
+    assert f"pos.get('{field}', " not in src, (
+        f"{exchange} reads {field} with a two-arg get; a null value raises rather than "
+        f"defaulting, and the broad except turns that into POSITION_UNKNOWN"
+    )
+
+
+@pytest.mark.parametrize("exchange", ["bitget", "bybit"])
+def test_an_unusable_position_side_is_refused_not_signed_short(exchange):
+    """#341: `contracts if side == 'long' else -contracts` signs a long as a SHORT for
+    any unexpected value. Every consumer reads that sign -- the account_state the policy
+    sees and the trade path -- so a flipped sign is a wrong-direction trade."""
+    src = (pathlib.Path(inspect.getfile(TorchTradeLiveEnv)).parent.parent
+           / "live" / exchange / "order_executor.py").read_text()
+    assert "refusing to infer a direction" in src, (
+        f"{exchange} still defaults an unknown side to a direction"
+    )

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -628,6 +628,9 @@ def test_an_outage_stops_the_step_before_it_can_trade(exchange, module):
     env._sync_position_from_exchange = (
         lambda ps: sync_owner._sync_position_from_exchange(env, ps)
     )
+    env._current_mark_price = (
+        lambda ps=None: TorchTradeFuturesLiveEnv._current_mark_price(env, ps)
+    )
 
     try:
         env_cls._step(env, {"action": 2})
@@ -722,6 +725,7 @@ def test_alpaca_refuses_to_value_the_portfolio_on_an_unknown_status():
         ),
         balance=0.0,
     )
+    env._read_cash = lambda: AlpacaBaseTorchTradingEnv._read_cash(env)
     with pytest.raises(PositionUnknownError):
         AlpacaBaseTorchTradingEnv._get_portfolio_value(env)
 
@@ -897,6 +901,9 @@ def test_okx_sizes_through_the_dust_rule_in_step():
         action_levels=[-1.0, 0.0, 1.0],
         _sync_position_from_exchange=lambda ps: None,
         _execute_trade_if_needed=_capture,
+    )
+    env._current_mark_price = (
+        lambda ps=None: TorchTradeFuturesLiveEnv._current_mark_price(env, ps)
     )
     with pytest.raises(RuntimeError):
         OKXFuturesTorchTradingEnv._step(env, {"action": 1})
@@ -1314,36 +1321,6 @@ def test_concrete_adapter_cross_labels_route_to_account_aware_estimate(field, la
     assert distance == pytest.approx(abs(99.0 / 0.996 - 100.0) / 100.0, rel=1e-5)
 
 
-@pytest.mark.parametrize("account_mode,expected", [
-    ("isolated", 0.046),
-    ("cross", abs(99.0 / 0.996 - 100.0) / 100.0),
-], ids=["uta-isolated", "uta-regular"])
-def test_bybit_v5_trade_mode_zero_routes_by_normalized_account_mode(account_mode, expected):
-    """Modern Bybit UTA tradeMode=0 must not decide isolated-vs-cross routing."""
-    from torchtrade.envs.live.bybit.order_executor import PositionStatus
-
-    position = PositionStatus(
-        qty=1.0,
-        notional_value=100.0,
-        entry_price=100.0,
-        unrealized_pnl=0.0,
-        unrealized_pnl_pct=0.0,
-        mark_price=100.0,
-        leverage=20,
-        margin_mode=account_mode,
-        liquidation_price=0.0,
-    )
-    balance = {"total_margin_balance": 5.0}
-    if account_mode == "cross":
-        balance["total_maintenance_margin"] = 4.4
-
-    distance = TorchTradeFuturesLiveEnv._get_observation(
-        _futures_env_stub(position, balance)
-    )["account_state"][5].item()
-
-    assert distance == pytest.approx(expected, rel=1e-5)
-
-
 @pytest.mark.parametrize("margin_mode", [None, "portfolio", "NEW_MODE"])
 def test_blank_liquidation_price_with_unknown_margin_mode_fails_closed(margin_mode):
     env = _futures_env_stub(
@@ -1751,18 +1728,30 @@ def test_alpaca_refuses_to_size_a_trade_from_a_non_finite_read(field, value):
         AlpacaTorchTradingEnv._calculate_fractional_position(env, 1.0, 100.0)
 
 
-def test_alpaca_portfolio_value_refuses_a_non_finite_read():
+@pytest.mark.parametrize("cash,market_value,expected", [
+    ("nan", None, "unusable cash balance"),
+    ("-250", None, "unusable cash balance"),
+    ("1000", float("nan"), "non-finite portfolio value"),
+], ids=["nan-cash", "negative-cash", "nan-market-value"])
+def test_alpaca_portfolio_value_refuses_a_non_finite_read(cash, market_value, expected):
     """alpaca's _step calls this BEFORE building an observation, and its value feeds the
-    reward and _check_termination -- so the observation guard can never catch it."""
+    reward and _check_termination -- so the observation guard can never catch it.
+
+    Two guards, and the rows prove BOTH are live: cash is now refused at the read (#347,
+    because the SLTP env sizes off it directly), while market_value still arrives raw and
+    can only be caught here.
+    """
     from torchtrade.envs.live.alpaca.base import AlpacaBaseTorchTradingEnv
 
+    position = None if market_value is None else SimpleNamespace(market_value=market_value)
     env = SimpleNamespace(
         trader=SimpleNamespace(
-            get_status=lambda: {"position_status": None},
-            client=SimpleNamespace(get_account=lambda: SimpleNamespace(cash="nan")),
+            get_status=lambda: {"position_status": position},
+            client=SimpleNamespace(get_account=lambda: SimpleNamespace(cash=cash)),
         ),
     )
-    with pytest.raises(ValueError, match="non-finite portfolio value"):
+    env._read_cash = lambda: AlpacaBaseTorchTradingEnv._read_cash(env)
+    with pytest.raises(ValueError, match=expected):
         AlpacaBaseTorchTradingEnv._get_portfolio_value(env)
 
 
@@ -1822,19 +1811,24 @@ def test_futures_sizing_rejects_a_non_finite_balance(exchange):
     )
 
 
-@pytest.mark.parametrize("price", [float("nan"), float("inf"), float("-inf")],
-                         ids=["nan", "inf", "-inf"])
-def test_a_non_finite_mark_price_cannot_size_a_trade(price):
+@pytest.mark.parametrize("source", ["fetched", "position"])
+@pytest.mark.parametrize("price", [float("nan"), float("inf"), float("-inf"), 0.0, -100.0],
+                         ids=["nan", "inf", "-inf", "zero", "negative"])
+def test_an_unusable_mark_price_cannot_size_a_trade(source, price):
     """#347: the sizing paths divide by this, and `<= 0` cannot see NaN.
 
     A NaN price makes delta_qty NaN; `nan > 0` is False, so the trade falls to the SELL
-    branch -- which in some trade modes is intercepted as a full close. The venue's own
-    rejection names the pre-rounding size, so the error points away from the cause.
+    branch -- which in some trade modes is intercepted as a full close. A negative one
+    flips the sign outright. Both SOURCES matter: an open position's mark took the same
+    money path as the fetched one but went unvalidated in 7 of 8 envs, reaching
+    history.record_step and the reward. Every venue reads it as
+    `float(pos.get("markPrice") or entry_price)`, so two blank fields yield 0.0.
     """
     env = SimpleNamespace(trader=SimpleNamespace(get_mark_price=lambda: price))
+    position_status = SimpleNamespace(mark_price=price) if source == "position" else None
 
     with pytest.raises(ValueError, match="unusable mark price"):
-        TorchTradeFuturesLiveEnv._current_mark_price(env)
+        TorchTradeFuturesLiveEnv._current_mark_price(env, position_status)
 
 
 @pytest.mark.parametrize("exchange", ["binance", "bitget", "bybit", "okx"])
@@ -1845,13 +1839,19 @@ def test_no_futures_env_reads_the_mark_price_unvalidated(exchange, module):
             / "live" / exchange / f"{module}.py")
     if not path.exists():
         pytest.skip(f"{exchange} has no {module}")
-    assert "self.trader.get_mark_price()" not in path.read_text(), (
+    src = path.read_text()
+    assert "self.trader.get_mark_price()" not in src, (
         f"{exchange}/{module} sizes from an unvalidated mark price"
+    )
+    # The position's own mark is the same number by another route -- okx was the only env
+    # that ever validated it, and it feeds record_step and the reward in all of them.
+    assert "position_status.mark_price" not in src, (
+        f"{exchange}/{module} reads the position mark raw instead of via "
+        f"_current_mark_price(position_status)"
     )
 
 
-@pytest.mark.parametrize("equity", [0.0, -50.0, float("nan")],
-                         ids=["empty", "negative", "non-finite"])
+@pytest.mark.parametrize("equity", [0.0, -50.0], ids=["empty", "negative"])
 def test_alpaca_refuses_to_size_rather_than_returning_a_flat_target(equity):
     """#348: "I cannot size this" returned the same tuple as "go flat".
 
@@ -1979,3 +1979,62 @@ def test_sltp_sizing_rejects_a_non_finite_price_or_balance(exchange):
         assert "math.isfinite(current_price)" in src, (
             f"{exchange} sizes from a candle close with no finiteness check"
         )
+
+
+@pytest.mark.parametrize("exchange,side_key,side", [
+    ("bybit", "side", None), ("bybit", "side", ""), ("bybit", "side", "unexpected"),
+    ("okx", "posSide", None), ("okx", "posSide", ""), ("okx", "posSide", "unexpected"),
+])
+def test_an_emergency_close_refuses_an_unusable_side_instead_of_guessing(
+    exchange, side_key, side
+):
+    """#341's other half: the sweep fixed get_status and stopped before close_position.
+
+    FLATTEN now calls this, so it is on the money path the halt work created. bybit
+    defaulted to "Buy" and okx to "net" -- either sends a reduce-only close in the wrong
+    direction, which the venue rejects. The operator sees flatten_accepted=False having
+    believed the position was closed, so the refusal must be explicit, not a rejection.
+    """
+    client = MagicMock()
+    if exchange == "bybit":
+        from torchtrade.envs.live.bybit.order_executor import BybitFuturesOrderClass as cls
+        client.get_positions = MagicMock(return_value={"retCode": 0, "result": {"list": [
+            {"symbol": "BTCUSDT", "size": "1.0", side_key: side}
+        ]}})
+        ex = cls(symbol="BTCUSDT", trade_mode="quantity", demo=True, leverage=10,
+                 api_key="k", api_secret="s", client=client)
+    else:
+        from torchtrade.envs.live.okx.order_executor import OKXFuturesOrderClass as cls
+        account = MagicMock()
+        account.get_positions = MagicMock(return_value={"code": "0", "data": [
+            {"instId": "BTC-USDT-SWAP", "pos": "1.0", side_key: side}
+        ]})
+        account.set_position_mode = MagicMock(return_value={"code": "0"})
+        account.set_leverage = MagicMock(return_value={"code": "0"})
+        public = MagicMock(); public.get_instruments = MagicMock(return_value={"data": []})
+        ex = cls(symbol="BTC-USDT-SWAP", trade_mode="quantity", demo=True, leverage=10,
+                 api_key="k", api_secret="s", passphrase="p",
+                 client=client, account_client=account, public_client=public)
+
+    assert ex.close_position() is False, "an unusable side must not report a clean close"
+    client.place_order.assert_not_called()
+
+
+@pytest.mark.parametrize("mark_price", [0.0, -100.0], ids=["zero", "negative"])
+def test_a_non_positive_mark_on_an_open_position_is_refused(mark_price):
+    """Finite is not enough, and this PR is what made it load-bearing.
+
+    The flat branch now writes `current_price = 0.0` as a sentinel, which turned a
+    near-dead `current_price == 0` clause into the one that decides
+    distance_to_liquidation. A venue mark of exactly 0.0 on a HELD 20x position passes
+    the finiteness loop and then reads as 1.0 -- as safe as a flat spot account, which is
+    the literal text of #277. A negative one computes (-100-95)/-100 = 1.95, and the
+    `max(0.0, ...)` clamp only holds the bottom, so the policy is handed a reading better
+    than maximally safe.
+    """
+    env = _futures_env_stub(
+        _open_position(1.0, mark_price=mark_price, liquidation_price=95.0),
+        {"total_margin_balance": 5.0, "total_maintenance_margin": 4.4},
+    )
+    with pytest.raises(ValueError, match="non-positive mark price"):
+        TorchTradeFuturesLiveEnv._get_observation(env)

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -18,6 +18,7 @@ import math
 from types import SimpleNamespace
 
 import pytest
+from unittest.mock import MagicMock
 
 import torchtrade.envs  # noqa: F401  -- registers every live env as a subclass
 from torchtrade.envs.core.live import TorchTradeLiveEnv
@@ -1504,8 +1505,8 @@ def test_a_bankruptcy_baseline_that_would_never_fire_is_refused(equity, reason):
             get_account_balance=lambda: {"total_margin_balance": equity}
         )
     )
-    # The real validator, bound to the stand-in -- stubbing it would test nothing.
-    env._require_finite = lambda v, n: TorchTradeFuturesLiveEnv._require_finite(env, v, n)
+    # The real reader, bound to the stand-in -- stubbing it would test nothing.
+    env._get_portfolio_value = lambda: TorchTradeFuturesLiveEnv._get_portfolio_value(env)
 
     with pytest.raises(ValueError):
         TorchTradeFuturesLiveEnv._capture_bankruptcy_baseline(env)
@@ -1831,9 +1832,8 @@ def test_a_non_finite_mark_price_cannot_size_a_trade(price):
     rejection names the pre-rounding size, so the error points away from the cause.
     """
     env = SimpleNamespace(trader=SimpleNamespace(get_mark_price=lambda: price))
-    env._require_finite = lambda v, n: TorchTradeFuturesLiveEnv._require_finite(env, v, n)
 
-    with pytest.raises(ValueError, match="non-finite mark price"):
+    with pytest.raises(ValueError, match="unusable mark price"):
         TorchTradeFuturesLiveEnv._current_mark_price(env)
 
 
@@ -1850,48 +1850,126 @@ def test_no_futures_env_reads_the_mark_price_unvalidated(exchange, module):
     )
 
 
-@pytest.mark.parametrize("exchange", ["alpaca", "binance", "bitget", "bybit", "okx"])
-def test_no_env_returns_a_zero_target_it_cannot_size(exchange):
+@pytest.mark.parametrize("equity", [0.0, -50.0, float("nan")],
+                         ids=["empty", "negative", "non-finite"])
+def test_alpaca_refuses_to_size_rather_than_returning_a_flat_target(equity):
     """#348: "I cannot size this" returned the same tuple as "go flat".
 
-    On alpaca that is a liquidation: it has no `target_qty == 0` guard, so a zero target
-    against an open position becomes `delta = 0 - current` and sells -- from an action
-    that meant maximum long. The four futures envs DO guard it, so there it was a silent
-    no-op: the agent's action dropped every bar with only a warning. Both are wrong for
-    the same reason -- "I cannot size this" must not be the same value as "go flat".
+    Alpaca has no `target_qty == 0` guard, so a zero target against an open position
+    becomes `delta = 0 - current` and SELLS -- from an action that meant maximum long.
+    """
+    from torchtrade.envs.live.alpaca.env import AlpacaTorchTradingEnv
+
+    env = SimpleNamespace(trader=SimpleNamespace(
+        client=SimpleNamespace(get_account=lambda: SimpleNamespace(cash=str(equity))),
+        get_status=lambda: {"position_status": None},
+    ))
+    with pytest.raises(ValueError):
+        AlpacaTorchTradingEnv._calculate_fractional_position(env, 1.0, 100.0)
+
+
+def _bitget_status(**pos_overrides):
+    """Real bitget adapter over a stubbed ccxt client."""
+    from torchtrade.envs.live.bitget.order_executor import BitgetFuturesOrderClass
+
+    pos = {"symbol": "BTC/USDT:USDT", "contracts": 1.0, "side": "long",
+           "entryPrice": 100.0, "markPrice": 101.0}
+    pos.update(pos_overrides)
+    client = MagicMock()
+    client.fetch_positions = MagicMock(return_value=[pos])
+    client.load_markets = MagicMock(return_value={})
+    client.markets = {}
+    ex = BitgetFuturesOrderClass(symbol="BTC/USDT:USDT", trade_mode="quantity",
+                                 demo=True, leverage=10, client=client)
+    return ex.get_status().get("position_status")
+
+
+@pytest.mark.parametrize("field", ["liquidationPrice", "entryPrice", "markPrice",
+                                   "unrealizedPnl", "notional"])
+def test_a_null_venue_field_does_not_turn_a_healthy_position_into_an_outage(field):
+    """#341: bare `float(None)` raised TypeError into bitget's broad except, so a cross
+    position with `liquidationPrice: None` reported POSITION_UNKNOWN.
+
+    That is the worst shape available: POSITION_UNKNOWN is deliberately fail-closed, so a
+    perfectly healthy position froze the env every bar -- on a lie.
+    """
+    status = _bitget_status(**{field: None})
+
+    assert status is not POSITION_UNKNOWN, f"a null {field} read as an outage"
+    assert status.qty == pytest.approx(1.0)
+
+
+@pytest.mark.parametrize("side", [None, "", "unexpected", "SHORT"])
+def test_an_unusable_side_reads_as_unknown_not_as_a_direction(side):
+    """`contracts if side == 'long' else -contracts` signed a long as a SHORT for any
+    unexpected value, and every consumer reads that sign."""
+    assert _bitget_status(side=side) is POSITION_UNKNOWN
+
+
+@pytest.mark.parametrize("pos_side", [None, "", "SHORT", "unexpected"])
+def test_okx_refuses_an_unusable_posside_instead_of_signing_it_long(pos_side):
+    """OKX was the worst of the three and my first pass missed it.
+
+    It reports hedge-mode size as a POSITIVE `pos` with direction only in `posSide`, and
+    any unrecognised value fell through to the net-mode branch keeping that positive sign
+    -- so a short read as a long, with no error, straight into the trade path. bitget and
+    bybit at least degraded to POSITION_UNKNOWN.
+    """
+    from torchtrade.envs.live.okx.order_executor import OKXFuturesOrderClass
+
+    # account_client, not client: okx splits Trade/Account/PublicData, and injecting only
+    # `client` left get_positions hitting the real API -- so the test passed on the API
+    # error rather than on the guard, with or without the fix.
+    account = MagicMock()
+    account.get_positions = MagicMock(return_value={"code": "0", "data": [
+        {"instId": "BTC-USDT-SWAP", "pos": "1.0", "posSide": pos_side,
+         "avgPx": "100", "markPx": "101", "lever": "10", "mgnMode": "cross"}
+    ]})
+    account.set_position_mode = MagicMock(return_value={"code": "0"})
+    account.set_leverage = MagicMock(return_value={"code": "0"})
+    public = MagicMock()
+    public.get_instruments = MagicMock(return_value={"data": []})
+
+    ex = OKXFuturesOrderClass(
+        symbol="BTC-USDT-SWAP", trade_mode="quantity", demo=True, leverage=10,
+        api_key="k", api_secret="s", passphrase="p",
+        client=MagicMock(), account_client=account, public_client=public,
+    )
+    assert ex.get_status().get("position_status") is POSITION_UNKNOWN
+
+
+def test_okx_still_signs_a_recognised_short_negative():
+    """The guard must reject the unrecognised, not the legitimate."""
+    from torchtrade.envs.live.okx.order_executor import OKXFuturesOrderClass
+
+    account = MagicMock()
+    account.get_positions = MagicMock(return_value={"code": "0", "data": [
+        {"instId": "BTC-USDT-SWAP", "pos": "1.0", "posSide": "short",
+         "avgPx": "100", "markPx": "101", "lever": "10", "mgnMode": "cross"}
+    ]})
+    account.set_position_mode = MagicMock(return_value={"code": "0"})
+    account.set_leverage = MagicMock(return_value={"code": "0"})
+    public = MagicMock()
+    public.get_instruments = MagicMock(return_value={"data": []})
+
+    ex = OKXFuturesOrderClass(
+        symbol="BTC-USDT-SWAP", trade_mode="quantity", demo=True, leverage=10,
+        api_key="k", api_secret="s", passphrase="p",
+        client=MagicMock(), account_client=account, public_client=public,
+    )
+    assert ex.get_status()["position_status"].qty == pytest.approx(-1.0)
+
+
+@pytest.mark.parametrize("exchange", ["binance", "bitget", "bybit", "okx"])
+def test_sltp_sizing_rejects_a_non_finite_price_or_balance(exchange):
+    """#347 stopped at env.py: all four SLTP envs still divided by an unguarded value.
+
+    `nan <= 0` is False, so the guard was transparent to exactly the input the issue is
+    about -- and binance/bitget size from a candle close, so the validated mark-price
+    accessor never entered their path at all.
     """
     src = (pathlib.Path(inspect.getfile(TorchTradeLiveEnv)).parent.parent
-           / "live" / exchange / "env.py").read_text()
-    assert "refusing, because returning a zero target" in src, (
-        f"{exchange} still returns a zero target when it cannot read the balance"
-    )
-
-
-@pytest.mark.parametrize("exchange,field", [
-    ("bitget", "liquidationPrice"),
-    ("bitget", "entryPrice"),
-    ("bitget", "markPrice"),
-    ("bitget", "unrealizedPnl"),
-])
-def test_nullable_venue_fields_do_not_read_as_an_outage(exchange, field):
-    """#341: a cross position returns `liquidationPrice: None`, and bare `float(None)`
-    raises TypeError into the broad except -- reporting a HEALTHY position as
-    POSITION_UNKNOWN, which is fail-closed and freezes the env every bar."""
-    src = (pathlib.Path(inspect.getfile(TorchTradeLiveEnv)).parent.parent
-           / "live" / exchange / "order_executor.py").read_text()
-    assert f"pos.get('{field}', " not in src, (
-        f"{exchange} reads {field} with a two-arg get; a null value raises rather than "
-        f"defaulting, and the broad except turns that into POSITION_UNKNOWN"
-    )
-
-
-@pytest.mark.parametrize("exchange", ["bitget", "bybit"])
-def test_an_unusable_position_side_is_refused_not_signed_short(exchange):
-    """#341: `contracts if side == 'long' else -contracts` signs a long as a SHORT for
-    any unexpected value. Every consumer reads that sign -- the account_state the policy
-    sees and the trade path -- so a flipped sign is a wrong-direction trade."""
-    src = (pathlib.Path(inspect.getfile(TorchTradeLiveEnv)).parent.parent
-           / "live" / exchange / "order_executor.py").read_text()
-    assert "refusing to infer a direction" in src, (
-        f"{exchange} still defaults an unknown side to a direction"
+           / "live" / exchange / "env_sltp.py").read_text()
+    assert "math.isfinite(current_price)" in src and "math.isfinite(balance)" in src, (
+        f"{exchange} SLTP sizing still lets a non-finite price or balance through"
     )

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -1486,35 +1486,39 @@ def test_no_adapter_fabricates_zero_equity():
     )
 
 
-def test_every_live_env_validates_its_bankruptcy_baseline():
-    """A baseline of 0 disables bankruptcy above zero: `current < threshold * 0` reduces
-    to `current < 0`, so it survives only for negative equity and a wipeout to zero never
-    terminates. Indexing the key stops an adapter fabricating the 0, and this stops a
-    genuinely empty account starting an episode that can never terminate.
+@pytest.mark.parametrize("equity,reason", [
+    (0.0, "an empty account"),
+    (-50.0, "negative equity"),
+    (float("nan"), "a non-finite reading"),
+    (float("inf"), "a non-finite reading"),
+], ids=["zero", "negative", "nan", "inf"])
+def test_a_bankruptcy_baseline_that_would_never_fire_is_refused(equity, reason):
+    """`is_bankrupt` is `current < threshold * initial`, so a baseline of 0 reduces to
+    `current < 0` -- it never fires above zero equity and a wiped account trades on.
 
-    Checks for the finiteness test specifically, not just a positivity one: `not (x > 0)`
-    catches NaN but passes `+inf`, and `is_bankrupt(current=1e9, initial=inf)` is True --
-    every step of every episode would read bankrupt.
-
-    Structural because the assignment sits inside per-exchange `_reset` scaffolding that
-    needs a live client to reach. Five copies of one line is itself the drift risk the
-    shared base exists to remove -- hoisting it is follow-up work (#345).
+    Behavioural now that #345 hoisted this into the shared base; it used to be a
+    structural grep over four per-exchange copies.
     """
-    live_root = pathlib.Path(inspect.getfile(TorchTradeLiveEnv)).parent.parent / "live"
-    bases = sorted(live_root.glob("*/base.py"))
-    # Alpaca included, not exempted: it inherits the same _check_termination and the same
-    # is_bankrupt, and an unfunded paper account -- the documented default -- yields a
-    # baseline of exactly 0. Excluding it left the one env still carrying the bug as the
-    # one the guard skipped.
-    assert len(bases) >= 5, f"expected 5+ live bases, found {[p.parent.name for p in bases]}"
+    env = SimpleNamespace(
+        trader=SimpleNamespace(
+            get_account_balance=lambda: {"total_margin_balance": equity}
+        )
+    )
+    # The real validator, bound to the stand-in -- stubbing it would test nothing.
+    env._require_finite = lambda v, n: TorchTradeFuturesLiveEnv._require_finite(env, v, n)
 
-    unguarded = [
-        p.parent.name for p in bases
-        if "math.isfinite(self.initial_portfolio_value)" not in p.read_text()
-    ]
-    assert unguarded == [], (
-        f"{unguarded} assign initial_portfolio_value without rejecting a non-positive "
-        f"baseline, which silently disables the bankruptcy check for the whole episode"
+    with pytest.raises(ValueError):
+        TorchTradeFuturesLiveEnv._capture_bankruptcy_baseline(env)
+
+
+@pytest.mark.parametrize("exchange", ["binance", "bitget", "bybit", "okx"])
+def test_every_futures_env_delegates_its_baseline(exchange):
+    """Four byte-identical copies is the drift shape this repo has paid for twice."""
+    src = (pathlib.Path(inspect.getfile(TorchTradeLiveEnv)).parent.parent
+           / "live" / exchange / "base.py").read_text()
+    assert "_capture_bankruptcy_baseline()" in src
+    assert 'balance["total_margin_balance"]' not in src, (
+        f"{exchange} re-forked the baseline read instead of delegating"
     )
 
 
@@ -1814,4 +1818,33 @@ def test_futures_sizing_rejects_a_non_finite_balance(exchange):
     )
     assert "math.isfinite(total_balance)" in src, (
         f"{exchange} does not check that the sizing balance is finite"
+    )
+
+
+@pytest.mark.parametrize("price", [float("nan"), float("inf"), float("-inf")],
+                         ids=["nan", "inf", "-inf"])
+def test_a_non_finite_mark_price_cannot_size_a_trade(price):
+    """#347: the sizing paths divide by this, and `<= 0` cannot see NaN.
+
+    A NaN price makes delta_qty NaN; `nan > 0` is False, so the trade falls to the SELL
+    branch -- which in some trade modes is intercepted as a full close. The venue's own
+    rejection names the pre-rounding size, so the error points away from the cause.
+    """
+    env = SimpleNamespace(trader=SimpleNamespace(get_mark_price=lambda: price))
+    env._require_finite = lambda v, n: TorchTradeFuturesLiveEnv._require_finite(env, v, n)
+
+    with pytest.raises(ValueError, match="non-finite mark price"):
+        TorchTradeFuturesLiveEnv._current_mark_price(env)
+
+
+@pytest.mark.parametrize("exchange", ["binance", "bitget", "bybit", "okx"])
+@pytest.mark.parametrize("module", ["env", "env_sltp"])
+def test_no_futures_env_reads_the_mark_price_unvalidated(exchange, module):
+    """The wiring: 13 call sites across 8 files, and the helper alone proves none of them."""
+    path = (pathlib.Path(inspect.getfile(TorchTradeLiveEnv)).parent.parent
+            / "live" / exchange / f"{module}.py")
+    if not path.exists():
+        pytest.skip(f"{exchange} has no {module}")
+    assert "self.trader.get_mark_price()" not in path.read_text(), (
+        f"{exchange}/{module} sizes from an unvalidated mark price"
     )

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -1497,7 +1497,7 @@ def test_a_bankruptcy_baseline_that_would_never_fire_is_refused(equity, reason):
     """`is_bankrupt` is `current < threshold * initial`, so a baseline of 0 reduces to
     `current < 0` -- it never fires above zero equity and a wiped account trades on.
 
-    Behavioural now that #345 hoisted this into the shared base; it used to be a
+    Behavioural now that #345 hoisted this into TorchTradeLiveEnv; it used to be a
     structural grep over four per-exchange copies.
     """
     env = SimpleNamespace(
@@ -1512,9 +1512,9 @@ def test_a_bankruptcy_baseline_that_would_never_fire_is_refused(equity, reason):
         TorchTradeFuturesLiveEnv._capture_bankruptcy_baseline(env)
 
 
-@pytest.mark.parametrize("exchange", ["binance", "bitget", "bybit", "okx"])
-def test_every_futures_env_delegates_its_baseline(exchange):
-    """Four byte-identical copies is the drift shape this repo has paid for twice."""
+@pytest.mark.parametrize("exchange", ["alpaca", "binance", "bitget", "bybit", "okx"])
+def test_every_live_env_delegates_its_baseline(exchange):
+    """Alpaca included, not exempted -- excluding it is how the bug survived last time."""
     src = (pathlib.Path(inspect.getfile(TorchTradeLiveEnv)).parent.parent
            / "live" / exchange / "base.py").read_text()
     assert "_capture_bankruptcy_baseline()" in src
@@ -1970,6 +1970,12 @@ def test_sltp_sizing_rejects_a_non_finite_price_or_balance(exchange):
     """
     src = (pathlib.Path(inspect.getfile(TorchTradeLiveEnv)).parent.parent
            / "live" / exchange / "env_sltp.py").read_text()
-    assert "math.isfinite(current_price)" in src and "math.isfinite(balance)" in src, (
-        f"{exchange} SLTP sizing still lets a non-finite price or balance through"
+    assert "math.isfinite(balance)" in src, (
+        f"{exchange} SLTP sizing still lets a non-finite balance through"
     )
+    if exchange in ("binance", "bitget"):
+        # These two size from a candle close, so _current_mark_price() never guards them.
+        # bybit and okx go through it, which makes a second price check there dead code.
+        assert "math.isfinite(current_price)" in src, (
+            f"{exchange} sizes from a candle close with no finiteness check"
+        )

--- a/tests/mocks/alpaca.py
+++ b/tests/mocks/alpaca.py
@@ -314,7 +314,12 @@ class MockObserver:
             observations[key] = np.random.randn(ws, self.num_features).astype(np.float32)
 
         if return_base_ohlc:
-            observations["base_features"] = np.random.randn(self.window_sizes[0], 4).astype(np.float32)
+            # Prices, not noise: raw randn puts half the closes below zero, and the env
+            # reads column 3 to size trades and price SL/TP brackets. A fixture that
+            # hands out negative prices cannot tell an inverted bracket from normal data.
+            observations["base_features"] = (
+                50000.0 + np.random.randn(self.window_sizes[0], 4) * 100.0
+            ).astype(np.float32)
             observations["base_timestamps"] = np.array([
                 datetime.now(ZoneInfo("America/New_York")) - timedelta(minutes=i)
                 for i in range(self.window_sizes[0] - 1, -1, -1)

--- a/torchtrade/envs/core/live.py
+++ b/torchtrade/envs/core/live.py
@@ -254,6 +254,17 @@ class TorchTradeLiveEnv(TorchTradeBaseEnv):
                 Unbounded(shape=(base_window, 4), dtype=torch.float),
             )
 
+    def _capture_bankruptcy_baseline(self) -> None:
+        """Record the equity an episode starts from, or refuse to start (#345).
+
+        `is_bankrupt` is `current < threshold * initial`, so a baseline of 0 never fires.
+        """
+        self.initial_portfolio_value = self._get_portfolio_value()
+        if self.initial_portfolio_value <= 0:
+            raise ValueError(
+                f"cannot start an episode on equity of {self.initial_portfolio_value}"
+            )
+
     def _check_termination(self, portfolio_value: float) -> bool:
         """Terminate when the portfolio falls below bankrupt_threshold * its initial value."""
         return is_bankrupt(

--- a/torchtrade/envs/core/live.py
+++ b/torchtrade/envs/core/live.py
@@ -1,5 +1,6 @@
 """Base class for live trading environments."""
 
+import math
 import time
 from abc import abstractmethod
 from datetime import datetime, timedelta
@@ -257,10 +258,12 @@ class TorchTradeLiveEnv(TorchTradeBaseEnv):
     def _capture_bankruptcy_baseline(self) -> None:
         """Record the equity an episode starts from, or refuse to start (#345).
 
-        `is_bankrupt` is `current < threshold * initial`, so a baseline of 0 never fires.
+        `is_bankrupt` is `current < threshold * initial`, so a baseline of 0 never fires,
+        and a NaN baseline makes the comparison False forever -- the check is then off for
+        the whole episode. `nan <= 0` is False, so isfinite has to carry that half.
         """
         self.initial_portfolio_value = self._get_portfolio_value()
-        if self.initial_portfolio_value <= 0:
+        if not math.isfinite(self.initial_portfolio_value) or self.initial_portfolio_value <= 0:
             raise ValueError(
                 f"cannot start an episode on equity of {self.initial_portfolio_value}"
             )

--- a/torchtrade/envs/live/alpaca/base.py
+++ b/torchtrade/envs/live/alpaca/base.py
@@ -308,6 +308,19 @@ class AlpacaBaseTorchTradingEnv(TorchTradeLiveEnv):
 
         return out_td
 
+    def _read_cash(self) -> float:
+        """The cash balance, validated at the read (#347).
+
+        The SLTP env sizes orders straight off `self.balance`, and `_get_portfolio_value`
+        -- which does check -- is a SEPARATE fetch its `_step` makes AFTER the order is
+        already on the venue. Zero cash is legitimate (fully invested); negative is a
+        margin debit that would size a negative-notional buy.
+        """
+        cash = float(self.trader.client.get_account().cash)
+        if not math.isfinite(cash) or cash < 0:
+            raise ValueError(f"venue reported an unusable cash balance ({cash})")
+        return cash
+
     def _get_portfolio_value(self) -> float:
         """
         Calculate total portfolio value for Alpaca.
@@ -319,8 +332,7 @@ class AlpacaBaseTorchTradingEnv(TorchTradeLiveEnv):
         status = self.trader.get_status()
         position_status = status.get("position_status", None)
 
-        account = self.trader.client.get_account()
-        self.balance = float(account.cash)
+        self.balance = self._read_cash()
 
         if position_status is None:
             portfolio_value = self.balance
@@ -349,9 +361,7 @@ class AlpacaBaseTorchTradingEnv(TorchTradeLiveEnv):
         # Reset history tracking
         self.history.reset()
 
-        # Get current state
-        account = self.trader.client.get_account()
-        self.balance = float(account.cash)
+        self.balance = self._read_cash()
 
         status = self.trader.get_status()
         position_status = status.get("position_status")

--- a/torchtrade/envs/live/alpaca/base.py
+++ b/torchtrade/envs/live/alpaca/base.py
@@ -114,15 +114,7 @@ class AlpacaBaseTorchTradingEnv(TorchTradeLiveEnv):
         # baseline the SAME quantity that termination compares against -- cash plus
         # position value -- so the two cannot drift apart. The futures bases already read
         # an equity figure for this reason.
-        self.initial_portfolio_value = self._get_portfolio_value()
-        if not math.isfinite(self.initial_portfolio_value) or self.initial_portfolio_value <= 0:
-            raise ValueError(
-                f"cannot start an episode on a portfolio value of "
-                f"{self.initial_portfolio_value}: the bankruptcy baseline would be 0, "
-                f"and `current < threshold * 0` reduces to `current < 0`, so it never "
-                f"fires above zero equity -- an unfunded paper account would trade on "
-                f"with the check disabled"
-            )
+        self._capture_bankruptcy_baseline()
 
         # Build observation specs
         self._build_observation_specs()

--- a/torchtrade/envs/live/alpaca/env.py
+++ b/torchtrade/envs/live/alpaca/env.py
@@ -226,9 +226,7 @@ class AlpacaTorchTradingEnv(AlpacaBaseTorchTradingEnv):
         # Validate portfolio value
         if not (total_portfolio > 0):
             raise ValueError(
-                f"cannot size a trade against a portfolio value of {total_portfolio}: "
-                f"refusing, because returning a zero target is indistinguishable "
-                f"from a deliberate flat and the caller executes it as a full close"
+                f"cannot size a trade against a portfolio value of {total_portfolio}"
             )
 
         # Target position value based on action

--- a/torchtrade/envs/live/alpaca/env.py
+++ b/torchtrade/envs/live/alpaca/env.py
@@ -225,8 +225,11 @@ class AlpacaTorchTradingEnv(AlpacaBaseTorchTradingEnv):
 
         # Validate portfolio value
         if not (total_portfolio > 0):
-            logger.warning("No portfolio value available for fractional position sizing")
-            return 0.0, 0.0
+            raise ValueError(
+                f"cannot size a trade against a portfolio value of {total_portfolio}: "
+                f"refusing, because returning a zero target is indistinguishable "
+                f"from a deliberate flat and the caller executes it as a full close"
+            )
 
         # Target position value based on action
         target_position_value = total_portfolio * action_value

--- a/torchtrade/envs/live/alpaca/env.py
+++ b/torchtrade/envs/live/alpaca/env.py
@@ -233,7 +233,7 @@ class AlpacaTorchTradingEnv(AlpacaBaseTorchTradingEnv):
         target_position_value = total_portfolio * action_value
 
         # Convert to quantity
-        target_qty = target_position_value / current_price if current_price > 0 else 0.0
+        target_qty = target_position_value / current_price
 
         return target_position_value, target_qty
 

--- a/torchtrade/envs/live/alpaca/env_sltp.py
+++ b/torchtrade/envs/live/alpaca/env_sltp.py
@@ -1,3 +1,4 @@
+import math
 from dataclasses import dataclass
 from typing import Dict, List, Optional, Tuple, Union, Callable
 import logging
@@ -227,7 +228,15 @@ class AlpacaSLTPTorchTradingEnv(SLTPMixin, AlpacaBaseTorchTradingEnv):
             status = self.trader.get_status()
             # Use market data to get current price
             obs = self.observer.get_observations(return_base_ohlc=True)
-            current_price = obs["base_features"][-1, 3]  # Close price
+            current_price = float(obs["base_features"][-1, 3])  # Close price
+            # This prices BOTH brackets: a NaN close sends NaN legs, and a negative one
+            # puts the stop above the take-profit. The entry is a full-balance market buy
+            # either way, and if the venue takes it while rejecting the legs the position
+            # sits unprotected in an env whose only exit is SL/TP (#347).
+            if not math.isfinite(current_price) or current_price <= 0:
+                raise ValueError(
+                    f"unusable close price ({current_price}) for {self.config.symbol}"
+                )
 
             stop_loss_price = current_price * (1 + stop_loss_pct)
             take_profit_price = current_price * (1 + take_profit_pct)

--- a/torchtrade/envs/live/binance/base.py
+++ b/torchtrade/envs/live/binance/base.py
@@ -102,19 +102,7 @@ class BinanceBaseTorchTradingEnv(TorchTradeFuturesLiveEnv):
         # portfolio_value and the current side of the check. Binance's total_wallet_balance
         # excludes unrealized PnL (a real skew here); bitget/bybit/okx map both keys to equity.
         balance = self.trader.get_account_balance()
-        # Indexed: a default of 0 makes the bankruptcy baseline 0, and
-        # `current < threshold * 0` reduces to `current < 0` -- so it never fires
-        # above zero equity and the account could be wiped out with the episode
-        # running on (#277).
-        self.initial_portfolio_value = balance["total_margin_balance"]
-        if not math.isfinite(self.initial_portfolio_value) or self.initial_portfolio_value <= 0:
-            raise ValueError(
-                f"cannot start an episode on equity of "
-                f"{self.initial_portfolio_value}: the bankruptcy baseline would be 0, "
-                f"and `current < threshold * 0` reduces to `current < 0`, so it never "
-                f"fires above zero equity -- the account could be wiped out with "
-                f"the episode trading on"
-            )
+        self._capture_bankruptcy_baseline()
 
         # Build observation specs
         self._build_observation_specs()

--- a/torchtrade/envs/live/binance/base.py
+++ b/torchtrade/envs/live/binance/base.py
@@ -1,6 +1,5 @@
 """Base class for Binance live trading environments."""
 
-import math
 from abc import abstractmethod
 from typing import Callable, List, Optional
 
@@ -98,10 +97,6 @@ class BinanceBaseTorchTradingEnv(TorchTradeFuturesLiveEnv):
         if config.close_position_on_init:
             self.trader.close_position()
 
-        # Bankruptcy baseline on total_margin_balance (equity), matching offline's
-        # portfolio_value and the current side of the check. Binance's total_wallet_balance
-        # excludes unrealized PnL (a real skew here); bitget/bybit/okx map both keys to equity.
-        balance = self.trader.get_account_balance()
         self._capture_bankruptcy_baseline()
 
         # Build observation specs

--- a/torchtrade/envs/live/binance/env.py
+++ b/torchtrade/envs/live/binance/env.py
@@ -163,7 +163,7 @@ class BinanceFuturesTorchTradingEnv(BinanceBaseTorchTradingEnv):
             current_price = position_status.mark_price
             position_size = position_status.qty
         else:
-            current_price = self.trader.get_mark_price()
+            current_price = self._current_mark_price()
             position_size = 0.0
 
         self._sync_position_from_exchange(position_status)
@@ -430,7 +430,7 @@ class BinanceFuturesTorchTradingEnv(BinanceBaseTorchTradingEnv):
         """
         # 1. Query actual position from exchange (source of truth)
         current_qty = self._get_current_position_quantity()
-        current_price = self.trader.get_mark_price()
+        current_price = self._current_mark_price()
 
         # 2. Special case: Close to flat
         if action_value == 0.0:

--- a/torchtrade/envs/live/binance/env.py
+++ b/torchtrade/envs/live/binance/env.py
@@ -362,8 +362,11 @@ class BinanceFuturesTorchTradingEnv(BinanceBaseTorchTradingEnv):
         # balance sizes an inf target -- bitget's amount rounding then yields NaN and
         # hands it to create_order. Same defect this PR fixed on the baselines (#277).
         if not math.isfinite(total_balance) or total_balance <= 0:
-            logger.warning("No balance for fractional position sizing")
-            return 0.0, 0.0, "flat"
+            raise ValueError(
+                f"cannot size a trade against a portfolio value of {total_balance}: "
+                f"refusing, because returning a zero target is indistinguishable "
+                f"from a deliberate flat and the caller executes it as a full close"
+            )
 
         # Use shared utility for core position calculation
         # Reserve 2% buffer for exchange maintenance margin requirements

--- a/torchtrade/envs/live/binance/env.py
+++ b/torchtrade/envs/live/binance/env.py
@@ -160,7 +160,7 @@ class BinanceFuturesTorchTradingEnv(BinanceBaseTorchTradingEnv):
         status = self.trader.get_status()
         position_status = status.get("position_status", None)
         if position_status:
-            current_price = position_status.mark_price
+            current_price = self._current_mark_price(position_status)
             position_size = position_status.qty
         else:
             current_price = self._current_mark_price()

--- a/torchtrade/envs/live/binance/env.py
+++ b/torchtrade/envs/live/binance/env.py
@@ -363,9 +363,7 @@ class BinanceFuturesTorchTradingEnv(BinanceBaseTorchTradingEnv):
         # hands it to create_order. Same defect this PR fixed on the baselines (#277).
         if not math.isfinite(total_balance) or total_balance <= 0:
             raise ValueError(
-                f"cannot size a trade against a portfolio value of {total_balance}: "
-                f"refusing, because returning a zero target is indistinguishable "
-                f"from a deliberate flat and the caller executes it as a full close"
+                f"cannot size a trade against a portfolio value of {total_balance}"
             )
 
         # Use shared utility for core position calculation

--- a/torchtrade/envs/live/binance/env_sltp.py
+++ b/torchtrade/envs/live/binance/env_sltp.py
@@ -309,10 +309,6 @@ class BinanceFuturesSLTPTorchTradingEnv(SLTPMixin, BinanceBaseTorchTradingEnv):
                 return trade_info
             quantity = balance * self.config.position_fraction * self.config.leverage / current_price
         elif self.config.trade_mode == "notional":
-            if current_price <= 0:
-                logger.error(f"Invalid current_price={current_price} for {self.config.symbol}")
-                trade_info["success"] = False
-                return trade_info
             quantity = float(self.config.quantity_per_trade) / current_price
         elif self.config.trade_mode == "quantity":
             quantity = float(self.config.quantity_per_trade)

--- a/torchtrade/envs/live/binance/env_sltp.py
+++ b/torchtrade/envs/live/binance/env_sltp.py
@@ -288,6 +288,14 @@ class BinanceFuturesSLTPTorchTradingEnv(SLTPMixin, BinanceBaseTorchTradingEnv):
         # Get current price for calculating absolute SL/TP levels
         obs = self.observer.get_observations(return_base_ohlc=True)
         current_price = float(obs["base_features"][-1, 3])  # Close price
+        # Validated here, not per trade_mode: this price divides the notional sizing
+        # AND prices both brackets in every mode, including the "quantity" default
+        # which checked nothing. bybit/okx get this from _current_mark_price(); these
+        # two read a candle close, which dropna() does not clear of inf (#347).
+        if not math.isfinite(current_price) or current_price <= 0:
+            raise ValueError(
+                f"unusable close price ({current_price}) for {self.config.symbol}"
+            )
 
         # Resolve quantity based on trade_mode
         if self.config.trade_mode == "fractional":
@@ -295,12 +303,7 @@ class BinanceFuturesSLTPTorchTradingEnv(SLTPMixin, BinanceBaseTorchTradingEnv):
             # live path. Binance's total_wallet_balance excludes unrealized PnL and would under-size;
             # bitget/bybit/okx map both keys to equity, so the switch is a no-op there.
             balance = float(self.trader.get_account_balance()["total_margin_balance"])
-            # isfinite, not `<= 0`: NaN passes both comparisons, and the line below
-            # DIVIDES by current_price -- a NaN quantity reached trader.trade().
-            # binance and bitget size from a candle close here, not the mark price,
-            # so _current_mark_price() never guards this path (#347).
-            if not (math.isfinite(current_price) and math.isfinite(balance)) \
-                    or current_price <= 0 or balance <= 0:
+            if not math.isfinite(balance) or balance <= 0:
                 logger.error(f"Invalid price={current_price} or balance={balance} for {self.config.symbol}")
                 trade_info["success"] = False
                 return trade_info

--- a/torchtrade/envs/live/binance/env_sltp.py
+++ b/torchtrade/envs/live/binance/env_sltp.py
@@ -1,3 +1,4 @@
+import math
 from dataclasses import dataclass
 from typing import Dict, List, Optional, Tuple, Union, Callable
 import logging
@@ -294,7 +295,12 @@ class BinanceFuturesSLTPTorchTradingEnv(SLTPMixin, BinanceBaseTorchTradingEnv):
             # live path. Binance's total_wallet_balance excludes unrealized PnL and would under-size;
             # bitget/bybit/okx map both keys to equity, so the switch is a no-op there.
             balance = float(self.trader.get_account_balance()["total_margin_balance"])
-            if current_price <= 0 or balance <= 0:
+            # isfinite, not `<= 0`: NaN passes both comparisons, and the line below
+            # DIVIDES by current_price -- a NaN quantity reached trader.trade().
+            # binance and bitget size from a candle close here, not the mark price,
+            # so _current_mark_price() never guards this path (#347).
+            if not (math.isfinite(current_price) and math.isfinite(balance)) \
+                    or current_price <= 0 or balance <= 0:
                 logger.error(f"Invalid price={current_price} or balance={balance} for {self.config.symbol}")
                 trade_info["success"] = False
                 return trade_info

--- a/torchtrade/envs/live/binance/env_sltp.py
+++ b/torchtrade/envs/live/binance/env_sltp.py
@@ -180,7 +180,7 @@ class BinanceFuturesSLTPTorchTradingEnv(SLTPMixin, BinanceBaseTorchTradingEnv):
         status = self.trader.get_status()
         position_status = status.get("position_status", None)
         if position_status:
-            current_price = position_status.mark_price
+            current_price = self._current_mark_price(position_status)
             position_size = position_status.qty
         else:
             current_price = self._current_mark_price()

--- a/torchtrade/envs/live/binance/env_sltp.py
+++ b/torchtrade/envs/live/binance/env_sltp.py
@@ -182,7 +182,7 @@ class BinanceFuturesSLTPTorchTradingEnv(SLTPMixin, BinanceBaseTorchTradingEnv):
             current_price = position_status.mark_price
             position_size = position_status.qty
         else:
-            current_price = self.trader.get_mark_price()
+            current_price = self._current_mark_price()
             position_size = 0.0
 
         # Sync position state from exchange — this is the source of truth.

--- a/torchtrade/envs/live/binance/order_executor.py
+++ b/torchtrade/envs/live/binance/order_executor.py
@@ -188,10 +188,17 @@ class BinanceFuturesOrderClass:
                         self._min_qtys[symbol] = float(f.get('minQty') or 0.0)
                     elif f['filterType'] == 'PRICE_FILTER' and symbol == self.symbol:
                         tick_str = f['tickSize']
-                        self._tick_size = float(tick_str)
-                        if '.' in tick_str:
-                            decimal_part = tick_str.rstrip('0').split('.')[1]
-                            self._tick_decimals = len(decimal_part) if decimal_part else 0
+                        tick_size = float(tick_str)
+                        # bybit and okx both gate on this; binance did not. _round_price
+                        # divides by it, and its only callers are the bracket legs, placed
+                        # in a try/except AFTER the entry filled -- so a zero tick does not
+                        # crash, it logs "position opened without SL" and leaves a live
+                        # position the policy has no way to exit under lock_position_until_sltp.
+                        if tick_size > 0:
+                            self._tick_size = tick_size
+                            if '.' in tick_str:
+                                decimal_part = tick_str.rstrip('0').split('.')[1]
+                                self._tick_decimals = len(decimal_part) if decimal_part else 0
                 except Exception as e:
                     logger.warning(
                         f"Skipping malformed {f.get('filterType', '?')} for {symbol}: {e}"

--- a/torchtrade/envs/live/bitget/base.py
+++ b/torchtrade/envs/live/bitget/base.py
@@ -1,6 +1,5 @@
 """Base class for Bitget live trading environments."""
 
-import math
 from abc import abstractmethod
 from typing import Callable, List, Optional
 
@@ -108,10 +107,6 @@ class BitgetBaseTorchTradingEnv(TorchTradeFuturesLiveEnv):
         if config.close_position_on_init:
             self.trader.close_position()
 
-        # Bankruptcy baseline on total_margin_balance (equity), matching offline's
-        # portfolio_value and the current side of the check. Binance's total_wallet_balance
-        # excludes unrealized PnL (a real skew here); bitget/bybit/okx map both keys to equity.
-        balance = self.trader.get_account_balance()
         self._capture_bankruptcy_baseline()
 
         # Build observation specs

--- a/torchtrade/envs/live/bitget/base.py
+++ b/torchtrade/envs/live/bitget/base.py
@@ -112,19 +112,7 @@ class BitgetBaseTorchTradingEnv(TorchTradeFuturesLiveEnv):
         # portfolio_value and the current side of the check. Binance's total_wallet_balance
         # excludes unrealized PnL (a real skew here); bitget/bybit/okx map both keys to equity.
         balance = self.trader.get_account_balance()
-        # Indexed: a default of 0 makes the bankruptcy baseline 0, and
-        # `current < threshold * 0` reduces to `current < 0` -- so it never fires
-        # above zero equity and the account could be wiped out with the episode
-        # running on (#277).
-        self.initial_portfolio_value = balance["total_margin_balance"]
-        if not math.isfinite(self.initial_portfolio_value) or self.initial_portfolio_value <= 0:
-            raise ValueError(
-                f"cannot start an episode on equity of "
-                f"{self.initial_portfolio_value}: the bankruptcy baseline would be 0, "
-                f"and `current < threshold * 0` reduces to `current < 0`, so it never "
-                f"fires above zero equity -- the account could be wiped out with "
-                f"the episode trading on"
-            )
+        self._capture_bankruptcy_baseline()
 
         # Build observation specs
         self._build_observation_specs()

--- a/torchtrade/envs/live/bitget/base.py
+++ b/torchtrade/envs/live/bitget/base.py
@@ -268,7 +268,7 @@ class BitgetBaseTorchTradingEnv(TorchTradeFuturesLiveEnv):
         # Warn if closing with open position
         try:
             status = self.trader.get_status()
-            if status.get("position_status") and status["position_status"].qty != 0:
+            if position_direction_from_status(status.get("position_status")) != 0:
                 logging.getLogger(__name__).warning(
                     "Closing environment with open position! "
                     "Call env.trader.close_position() before env.close() if needed."

--- a/torchtrade/envs/live/bitget/env.py
+++ b/torchtrade/envs/live/bitget/env.py
@@ -302,8 +302,11 @@ class BitgetFuturesTorchTradingEnv(BitgetBaseTorchTradingEnv):
         # balance sizes an inf target -- bitget's amount rounding then yields NaN and
         # hands it to create_order. Same defect this PR fixed on the baselines (#277).
         if not math.isfinite(total_balance) or total_balance <= 0:
-            logger.warning("No balance for fractional position sizing")
-            return 0.0, 0.0, "flat"
+            raise ValueError(
+                f"cannot size a trade against a portfolio value of {total_balance}: "
+                f"refusing, because returning a zero target is indistinguishable "
+                f"from a deliberate flat and the caller executes it as a full close"
+            )
 
         # Use shared utility for core position calculation
         # Reserve 2% buffer for exchange maintenance margin requirements

--- a/torchtrade/envs/live/bitget/env.py
+++ b/torchtrade/envs/live/bitget/env.py
@@ -162,7 +162,7 @@ class BitgetFuturesTorchTradingEnv(BitgetBaseTorchTradingEnv):
             current_price = position_status.mark_price
             position_size = position_status.qty
         else:
-            current_price = self.trader.get_mark_price()
+            current_price = self._current_mark_price()
             position_size = 0.0
 
         self._sync_position_from_exchange(position_status)
@@ -331,7 +331,7 @@ class BitgetFuturesTorchTradingEnv(BitgetBaseTorchTradingEnv):
         """
         # Get current position and price from exchange
         current_qty = self._get_current_position_quantity()
-        current_price = self.trader.get_mark_price()
+        current_price = self._current_mark_price()
 
         # Special case: Close to flat
         if action_value == 0.0:

--- a/torchtrade/envs/live/bitget/env.py
+++ b/torchtrade/envs/live/bitget/env.py
@@ -159,7 +159,7 @@ class BitgetFuturesTorchTradingEnv(BitgetBaseTorchTradingEnv):
         status = self.trader.get_status()
         position_status = status.get("position_status", None)
         if position_status:
-            current_price = position_status.mark_price
+            current_price = self._current_mark_price(position_status)
             position_size = position_status.qty
         else:
             current_price = self._current_mark_price()

--- a/torchtrade/envs/live/bitget/env.py
+++ b/torchtrade/envs/live/bitget/env.py
@@ -303,9 +303,7 @@ class BitgetFuturesTorchTradingEnv(BitgetBaseTorchTradingEnv):
         # hands it to create_order. Same defect this PR fixed on the baselines (#277).
         if not math.isfinite(total_balance) or total_balance <= 0:
             raise ValueError(
-                f"cannot size a trade against a portfolio value of {total_balance}: "
-                f"refusing, because returning a zero target is indistinguishable "
-                f"from a deliberate flat and the caller executes it as a full close"
+                f"cannot size a trade against a portfolio value of {total_balance}"
             )
 
         # Use shared utility for core position calculation

--- a/torchtrade/envs/live/bitget/env_sltp.py
+++ b/torchtrade/envs/live/bitget/env_sltp.py
@@ -1,3 +1,4 @@
+import math
 from dataclasses import dataclass
 from typing import Dict, List, Optional, Tuple, Union, Callable
 import logging
@@ -298,7 +299,12 @@ class BitgetFuturesSLTPTorchTradingEnv(SLTPMixin, BitgetBaseTorchTradingEnv):
             # live path. Binance's total_wallet_balance excludes unrealized PnL and would under-size;
             # bitget/bybit/okx map both keys to equity, so the switch is a no-op there.
             balance = float(self.trader.get_account_balance()["total_margin_balance"])
-            if current_price <= 0 or balance <= 0:
+            # isfinite, not `<= 0`: NaN passes both comparisons, and the line below
+            # DIVIDES by current_price -- a NaN quantity reached trader.trade().
+            # binance and bitget size from a candle close here, not the mark price,
+            # so _current_mark_price() never guards this path (#347).
+            if not (math.isfinite(current_price) and math.isfinite(balance)) \
+                    or current_price <= 0 or balance <= 0:
                 logger.error(f"Invalid price={current_price} or balance={balance} for {self.config.symbol}")
                 trade_info["success"] = False
                 return trade_info

--- a/torchtrade/envs/live/bitget/env_sltp.py
+++ b/torchtrade/envs/live/bitget/env_sltp.py
@@ -186,7 +186,7 @@ class BitgetFuturesSLTPTorchTradingEnv(SLTPMixin, BitgetBaseTorchTradingEnv):
             current_price = position_status.mark_price
             position_size = position_status.qty
         else:
-            current_price = self.trader.get_mark_price()
+            current_price = self._current_mark_price()
             position_size = 0.0
 
         # Sync position state from exchange — this is the source of truth.

--- a/torchtrade/envs/live/bitget/env_sltp.py
+++ b/torchtrade/envs/live/bitget/env_sltp.py
@@ -292,6 +292,14 @@ class BitgetFuturesSLTPTorchTradingEnv(SLTPMixin, BitgetBaseTorchTradingEnv):
         # Get current price for calculating absolute SL/TP levels
         obs = self.observer.get_observations(return_base_ohlc=True)
         current_price = float(obs["base_features"][-1, 3])  # Close price
+        # Validated here, not per trade_mode: this price divides the notional sizing
+        # AND prices both brackets in every mode, including the "quantity" default
+        # which checked nothing. bybit/okx get this from _current_mark_price(); these
+        # two read a candle close, which dropna() does not clear of inf (#347).
+        if not math.isfinite(current_price) or current_price <= 0:
+            raise ValueError(
+                f"unusable close price ({current_price}) for {self.config.symbol}"
+            )
 
         # Resolve quantity based on trade_mode
         if self.config.trade_mode == "fractional":
@@ -299,12 +307,7 @@ class BitgetFuturesSLTPTorchTradingEnv(SLTPMixin, BitgetBaseTorchTradingEnv):
             # live path. Binance's total_wallet_balance excludes unrealized PnL and would under-size;
             # bitget/bybit/okx map both keys to equity, so the switch is a no-op there.
             balance = float(self.trader.get_account_balance()["total_margin_balance"])
-            # isfinite, not `<= 0`: NaN passes both comparisons, and the line below
-            # DIVIDES by current_price -- a NaN quantity reached trader.trade().
-            # binance and bitget size from a candle close here, not the mark price,
-            # so _current_mark_price() never guards this path (#347).
-            if not (math.isfinite(current_price) and math.isfinite(balance)) \
-                    or current_price <= 0 or balance <= 0:
+            if not math.isfinite(balance) or balance <= 0:
                 logger.error(f"Invalid price={current_price} or balance={balance} for {self.config.symbol}")
                 trade_info["success"] = False
                 return trade_info

--- a/torchtrade/envs/live/bitget/env_sltp.py
+++ b/torchtrade/envs/live/bitget/env_sltp.py
@@ -184,7 +184,7 @@ class BitgetFuturesSLTPTorchTradingEnv(SLTPMixin, BitgetBaseTorchTradingEnv):
         status = self.trader.get_status()
         position_status = status.get("position_status", None)
         if position_status:
-            current_price = position_status.mark_price
+            current_price = self._current_mark_price(position_status)
             position_size = position_status.qty
         else:
             current_price = self._current_mark_price()

--- a/torchtrade/envs/live/bitget/env_sltp.py
+++ b/torchtrade/envs/live/bitget/env_sltp.py
@@ -313,10 +313,6 @@ class BitgetFuturesSLTPTorchTradingEnv(SLTPMixin, BitgetBaseTorchTradingEnv):
                 return trade_info
             quantity = balance * self.config.position_fraction * self.config.leverage / current_price
         elif self.config.trade_mode == "notional":
-            if current_price <= 0:
-                logger.error(f"Invalid current_price={current_price} for {self.config.symbol}")
-                trade_info["success"] = False
-                return trade_info
             quantity = float(self.config.quantity_per_trade) / current_price
         elif self.config.trade_mode == "quantity":
             quantity = float(self.config.quantity_per_trade)

--- a/torchtrade/envs/live/bitget/order_executor.py
+++ b/torchtrade/envs/live/bitget/order_executor.py
@@ -488,39 +488,6 @@ class BitgetFuturesOrderClass:
 
         return True
 
-    def check_both_positions_open(self) -> bool:
-        """
-        Check if both long and short positions are open (hedge mode issue).
-
-        Returns:
-            True if both positions are open, False otherwise
-        """
-        try:
-            positions = self.client.fetch_positions([self.symbol])
-            long_open = False
-            short_open = False
-
-            for pos in positions:
-                if pos['symbol'] == self.symbol:
-                    contracts = float(pos.get('contracts', 0))
-                    side = pos.get('side', 'long')
-
-                    if contracts > 0:
-                        if side == 'long':
-                            long_open = True
-                        elif side == 'short':
-                            short_open = True
-
-            if long_open and short_open:
-                logger.warning("⚠️  Both long and short positions are open! Your account is in HEDGE mode.")
-                logger.warning("    Please close all positions and switch to ONE_WAY mode.")
-                return True
-
-            return False
-        except Exception as e:
-            logger.error(f"Error checking positions: {e}")
-            return False
-
     def get_status(self) -> Dict[str, Union[OrderStatus, PositionStatus, None]]:
         """
         Get current order and position status using CCXT.

--- a/torchtrade/envs/live/bitget/order_executor.py
+++ b/torchtrade/envs/live/bitget/order_executor.py
@@ -559,19 +559,30 @@ class BitgetFuturesOrderClass:
                 if pos and float(pos.get('contracts', 0)) != 0:
                     # CCXT returns contracts as the position size
                     contracts = float(pos.get('contracts', 0))
-                    side = pos.get('side', 'long')  # 'long' or 'short'
-
-                    # Convert to signed quantity (positive for long, negative for short)
+                    # Explicit: `contracts if side == 'long' else -contracts` signs a
+                    # long as a SHORT whenever the field is missing or unexpected, and
+                    # every consumer reads that sign -- the account_state the policy
+                    # sees, and the trade path. A direction is never guessed (#341).
+                    side = pos.get('side')
+                    if side not in ('long', 'short'):
+                        raise ValueError(
+                            f"bitget reported an unusable position side ({side!r}); "
+                            f"refusing to infer a direction"
+                        )
                     qty = contracts if side == 'long' else -contracts
 
-                    entry_price = float(pos.get('entryPrice', 0))
-                    mark_price = float(pos.get('markPrice', entry_price))
-                    unrealized_pnl = float(pos.get('unrealizedPnl', 0))
+                    # `or 0` on every nullable CCXT field: a cross position returns
+                    # liquidationPrice=None, and bare float(None) raises TypeError into
+                    # the broad except below -- reporting a healthy position as
+                    # POSITION_UNKNOWN, which freezes the env every bar (#341).
+                    entry_price = float(pos.get('entryPrice') or 0)
+                    mark_price = float(pos.get('markPrice') or entry_price)
+                    unrealized_pnl = float(pos.get('unrealizedPnl') or 0)
                     unrealized_pnl_pct = self._calculate_unrealized_pnl_pct(qty, entry_price, mark_price)
 
                     status["position_status"] = PositionStatus(
                         qty=qty,
-                        notional_value=float(pos.get('notional', abs(contracts * mark_price))),
+                        notional_value=float(pos.get('notional') or abs(contracts * mark_price)),
                         entry_price=entry_price,
                         unrealized_pnl=unrealized_pnl,
                         unrealized_pnl_pct=unrealized_pnl_pct,
@@ -583,7 +594,7 @@ class BitgetFuturesOrderClass:
                             self.leverage if pos.get('leverage') in (None, "") else pos.get('leverage')
                         ),
                         margin_mode=pos.get('marginMode', self.margin_mode.value),
-                        liquidation_price=float(pos.get('liquidationPrice', 0)),
+                        liquidation_price=float(pos.get('liquidationPrice') or 0),
                     )
                 else:
                     status["position_status"] = None
@@ -655,7 +666,7 @@ class BitgetFuturesOrderClass:
                 positions = self.client.fetch_positions([self.symbol])
                 for pos in positions:
                     if pos['symbol'] == self.symbol:
-                        unrealized_pnl += float(pos.get('unrealizedPnl', 0))
+                        unrealized_pnl += float(pos.get('unrealizedPnl') or 0)
             except:
                 pass
 

--- a/torchtrade/envs/live/bitget/order_executor.py
+++ b/torchtrade/envs/live/bitget/order_executor.py
@@ -565,10 +565,12 @@ class BitgetFuturesOrderClass:
                     # sees, and the trade path. A direction is never guessed (#341).
                     side = pos.get('side')
                     if side not in ('long', 'short'):
-                        raise ValueError(
-                            f"bitget reported an unusable position side ({side!r}); "
-                            f"refusing to infer a direction"
+                        logger.error(
+                            "bitget reported an unusable position side (%r); refusing to "
+                            "infer a direction", side
                         )
+                        status["position_status"] = POSITION_UNKNOWN
+                        return status
                     qty = contracts if side == 'long' else -contracts
 
                     # `or 0` on every nullable CCXT field: a cross position returns

--- a/torchtrade/envs/live/bybit/base.py
+++ b/torchtrade/envs/live/bybit/base.py
@@ -91,19 +91,7 @@ class BybitBaseTorchTradingEnv(TorchTradeFuturesLiveEnv):
         # portfolio_value and the current side of the check. Binance's total_wallet_balance
         # excludes unrealized PnL (a real skew here); bitget/bybit/okx map both keys to equity.
         balance = self.trader.get_account_balance()
-        # Indexed: a default of 0 makes the bankruptcy baseline 0, and
-        # `current < threshold * 0` reduces to `current < 0` -- so it never fires
-        # above zero equity and the account could be wiped out with the episode
-        # running on (#277).
-        self.initial_portfolio_value = balance["total_margin_balance"]
-        if not math.isfinite(self.initial_portfolio_value) or self.initial_portfolio_value <= 0:
-            raise ValueError(
-                f"cannot start an episode on equity of "
-                f"{self.initial_portfolio_value}: the bankruptcy baseline would be 0, "
-                f"and `current < threshold * 0` reduces to `current < 0`, so it never "
-                f"fires above zero equity -- the account could be wiped out with "
-                f"the episode trading on"
-            )
+        self._capture_bankruptcy_baseline()
 
         # Build observation specs
         self._build_observation_specs()

--- a/torchtrade/envs/live/bybit/base.py
+++ b/torchtrade/envs/live/bybit/base.py
@@ -208,7 +208,7 @@ class BybitBaseTorchTradingEnv(TorchTradeFuturesLiveEnv):
         """Clean up resources."""
         try:
             status = self.trader.get_status()
-            if status.get("position_status") and status["position_status"].qty != 0:
+            if position_direction_from_status(status.get("position_status")) != 0:
                 logger.warning(
                     "Closing environment with open position! "
                     "Call env.trader.close_position() before env.close() if needed."

--- a/torchtrade/envs/live/bybit/base.py
+++ b/torchtrade/envs/live/bybit/base.py
@@ -1,6 +1,5 @@
 """Base class for Bybit live trading environments."""
 import logging
-import math
 
 from abc import abstractmethod
 from typing import Callable, List, Optional
@@ -87,10 +86,6 @@ class BybitBaseTorchTradingEnv(TorchTradeFuturesLiveEnv):
         if config.close_position_on_init:
             self.trader.close_position()
 
-        # Bankruptcy baseline on total_margin_balance (equity), matching offline's
-        # portfolio_value and the current side of the check. Binance's total_wallet_balance
-        # excludes unrealized PnL (a real skew here); bitget/bybit/okx map both keys to equity.
-        balance = self.trader.get_account_balance()
         self._capture_bankruptcy_baseline()
 
         # Build observation specs

--- a/torchtrade/envs/live/bybit/env.py
+++ b/torchtrade/envs/live/bybit/env.py
@@ -242,9 +242,7 @@ class BybitFuturesTorchTradingEnv(BybitBaseTorchTradingEnv):
         # hands it to create_order. Same defect this PR fixed on the baselines (#277).
         if not math.isfinite(total_balance) or total_balance <= 0:
             raise ValueError(
-                f"cannot size a trade against a portfolio value of {total_balance}: "
-                f"refusing, because returning a zero target is indistinguishable "
-                f"from a deliberate flat and the caller executes it as a full close"
+                f"cannot size a trade against a portfolio value of {total_balance}"
             )
 
         effective_balance = total_balance * 0.98

--- a/torchtrade/envs/live/bybit/env.py
+++ b/torchtrade/envs/live/bybit/env.py
@@ -113,7 +113,7 @@ class BybitFuturesTorchTradingEnv(BybitBaseTorchTradingEnv):
         status = self.trader.get_status()
         position_status = status.get("position_status", None)
         if position_status:
-            current_price = position_status.mark_price
+            current_price = self._current_mark_price(position_status)
             position_size = position_status.qty
         else:
             current_price = self._current_mark_price()

--- a/torchtrade/envs/live/bybit/env.py
+++ b/torchtrade/envs/live/bybit/env.py
@@ -116,7 +116,7 @@ class BybitFuturesTorchTradingEnv(BybitBaseTorchTradingEnv):
             current_price = position_status.mark_price
             position_size = position_status.qty
         else:
-            current_price = self.trader.get_mark_price()
+            current_price = self._current_mark_price()
             position_size = 0.0
 
         # No-op today (this env's _execute_trade_if_needed recomputes qty live and never reads
@@ -258,7 +258,7 @@ class BybitFuturesTorchTradingEnv(BybitBaseTorchTradingEnv):
     def _execute_fractional_action(self, action_value: float) -> Dict:
         """Execute action using fractional position sizing."""
         current_qty = self._get_current_position_quantity()
-        current_price = self.trader.get_mark_price()
+        current_price = self._current_mark_price()
 
         if action_value == 0.0:
             if abs(current_qty) > 0:

--- a/torchtrade/envs/live/bybit/env.py
+++ b/torchtrade/envs/live/bybit/env.py
@@ -241,8 +241,11 @@ class BybitFuturesTorchTradingEnv(BybitBaseTorchTradingEnv):
         # balance sizes an inf target -- bitget's amount rounding then yields NaN and
         # hands it to create_order. Same defect this PR fixed on the baselines (#277).
         if not math.isfinite(total_balance) or total_balance <= 0:
-            logger.warning("No balance for fractional position sizing")
-            return 0.0, 0.0, "flat"
+            raise ValueError(
+                f"cannot size a trade against a portfolio value of {total_balance}: "
+                f"refusing, because returning a zero target is indistinguishable "
+                f"from a deliberate flat and the caller executes it as a full close"
+            )
 
         effective_balance = total_balance * 0.98
         fee_rate = 0.00055  # Bybit futures taker fee

--- a/torchtrade/envs/live/bybit/env_sltp.py
+++ b/torchtrade/envs/live/bybit/env_sltp.py
@@ -268,7 +268,12 @@ class BybitFuturesSLTPTorchTradingEnv(SLTPMixin, BybitBaseTorchTradingEnv):
             # live path. Binance's total_wallet_balance excludes unrealized PnL and would under-size;
             # bitget/bybit/okx map both keys to equity, so the switch is a no-op there.
             balance = float(self.trader.get_account_balance()["total_margin_balance"])
-            if current_price <= 0 or balance <= 0:
+            # isfinite, not `<= 0`: NaN passes both comparisons, and the line below
+            # DIVIDES by current_price -- a NaN quantity reached trader.trade().
+            # binance and bitget size from a candle close here, not the mark price,
+            # so _current_mark_price() never guards this path (#347).
+            if not (math.isfinite(current_price) and math.isfinite(balance)) \
+                    or current_price <= 0 or balance <= 0:
                 logger.error(f"Invalid price={current_price} or balance={balance} for {self.config.symbol}")
                 trade_info["success"] = False
                 return trade_info

--- a/torchtrade/envs/live/bybit/env_sltp.py
+++ b/torchtrade/envs/live/bybit/env_sltp.py
@@ -143,7 +143,7 @@ class BybitFuturesSLTPTorchTradingEnv(SLTPMixin, BybitBaseTorchTradingEnv):
         status = self.trader.get_status()
         position_status = status.get("position_status", None)
         if position_status:
-            current_price = position_status.mark_price
+            current_price = self._current_mark_price(position_status)
             position_size = position_status.qty
         else:
             current_price = self._current_mark_price()

--- a/torchtrade/envs/live/bybit/env_sltp.py
+++ b/torchtrade/envs/live/bybit/env_sltp.py
@@ -146,7 +146,7 @@ class BybitFuturesSLTPTorchTradingEnv(SLTPMixin, BybitBaseTorchTradingEnv):
             current_price = position_status.mark_price
             position_size = position_status.qty
         else:
-            current_price = self.trader.get_mark_price()
+            current_price = self._current_mark_price()
             position_size = 0.0
 
         # Sync position state from exchange — this is the source of truth.
@@ -260,7 +260,7 @@ class BybitFuturesSLTPTorchTradingEnv(SLTPMixin, BybitBaseTorchTradingEnv):
             return trade_info
 
         # Get current mark price (more accurate than candle close for bracket orders)
-        current_price = float(self.trader.get_mark_price())
+        current_price = float(self._current_mark_price())
 
         # Resolve quantity based on trade_mode
         if self.config.trade_mode == "fractional":

--- a/torchtrade/envs/live/bybit/env_sltp.py
+++ b/torchtrade/envs/live/bybit/env_sltp.py
@@ -268,21 +268,14 @@ class BybitFuturesSLTPTorchTradingEnv(SLTPMixin, BybitBaseTorchTradingEnv):
             # live path. Binance's total_wallet_balance excludes unrealized PnL and would under-size;
             # bitget/bybit/okx map both keys to equity, so the switch is a no-op there.
             balance = float(self.trader.get_account_balance()["total_margin_balance"])
-            # isfinite, not `<= 0`: NaN passes both comparisons, and the line below
-            # DIVIDES by current_price -- a NaN quantity reached trader.trade().
-            # binance and bitget size from a candle close here, not the mark price,
-            # so _current_mark_price() never guards this path (#347).
-            if not (math.isfinite(current_price) and math.isfinite(balance)) \
-                    or current_price <= 0 or balance <= 0:
+            # current_price already raised in _current_mark_price(); balance has
+            # no such accessor, and `nan <= 0` is False (#347).
+            if not math.isfinite(balance) or balance <= 0:
                 logger.error(f"Invalid price={current_price} or balance={balance} for {self.config.symbol}")
                 trade_info["success"] = False
                 return trade_info
             quantity = balance * self.config.position_fraction * self.config.leverage / current_price
         elif self.config.trade_mode == "notional":
-            if current_price <= 0:
-                logger.error(f"Invalid current_price={current_price} for {self.config.symbol}")
-                trade_info["success"] = False
-                return trade_info
             quantity = float(self.config.quantity_per_trade) / current_price
         elif self.config.trade_mode == "quantity":
             quantity = float(self.config.quantity_per_trade)

--- a/torchtrade/envs/live/bybit/order_executor.py
+++ b/torchtrade/envs/live/bybit/order_executor.py
@@ -334,7 +334,14 @@ class BybitFuturesOrderClass:
             if pos is not None:
                 margin_mode = self._get_actual_margin_mode(pos)
                 size = float(pos.get("size", 0))
-                side = pos.get("side", "Buy")
+                # Explicit, not defaulted: an unexpected side signed a long as a
+                # SHORT, and every consumer reads that sign (#341).
+                side = pos.get("side")
+                if side not in ("Buy", "Sell"):
+                    raise ValueError(
+                        f"bybit reported an unusable position side ({side!r}); "
+                        f"refusing to infer a direction"
+                    )
                 qty = size if side == "Buy" else -size
 
                 entry_price = float(pos.get("avgPrice", 0))

--- a/torchtrade/envs/live/bybit/order_executor.py
+++ b/torchtrade/envs/live/bybit/order_executor.py
@@ -338,22 +338,24 @@ class BybitFuturesOrderClass:
                 # SHORT, and every consumer reads that sign (#341).
                 side = pos.get("side")
                 if side not in ("Buy", "Sell"):
-                    raise ValueError(
-                        f"bybit reported an unusable position side ({side!r}); "
-                        f"refusing to infer a direction"
+                    logger.error(
+                        "bybit reported an unusable position side (%r); refusing to "
+                        "infer a direction", side
                     )
+                    status["position_status"] = POSITION_UNKNOWN
+                    return status
                 qty = size if side == "Buy" else -size
 
-                entry_price = float(pos.get("avgPrice", 0))
-                mark_price = float(pos.get("markPrice", entry_price))
-                unrealized_pnl = float(pos.get("unrealisedPnl", 0))
+                entry_price = float(pos.get("avgPrice") or 0)
+                mark_price = float(pos.get("markPrice") or entry_price)
+                unrealized_pnl = float(pos.get("unrealisedPnl") or 0)
                 unrealized_pnl_pct = self._calculate_unrealized_pnl_pct(qty, entry_price, mark_price)
 
                 liq_price = float(pos.get("liqPrice") or "0")
 
                 status["position_status"] = PositionStatus(
                     qty=qty,
-                    notional_value=float(pos.get("positionValue", abs(size * mark_price))),
+                    notional_value=float(pos.get("positionValue") or abs(size * mark_price)),
                     entry_price=entry_price,
                     unrealized_pnl=unrealized_pnl,
                     unrealized_pnl_pct=unrealized_pnl_pct,

--- a/torchtrade/envs/live/bybit/order_executor.py
+++ b/torchtrade/envs/live/bybit/order_executor.py
@@ -396,22 +396,26 @@ class BybitFuturesOrderClass:
         if not callable(get_account_info):
             return {"0": "cross", "1": "isolated"}.get(str(position.get("tradeMode")))
 
+        # The PARSING is inside the try too, not just the call: this runs inside
+        # get_status's broad `except`, so an AttributeError on a non-dict response or a
+        # ValueError on a non-numeric retCode would surface as POSITION_UNKNOWN --
+        # reporting a healthy, correctly-reported position as unreadable and freezing the
+        # env every bar. That is the same defect #341 fixed one file over.
         try:
             response = get_account_info()
+            ret_code = response.get("retCode")
+            if ret_code is not None and int(ret_code) != 0:
+                logger.warning(
+                    "get_account_info failed (retCode=%s): %s",
+                    ret_code,
+                    response.get("retMsg", "unknown error"),
+                )
+                return None
+            raw_mode = response.get("result", {}).get("marginMode")
         except Exception as exc:
-            logger.warning(f"Could not query Bybit account margin mode: {exc}")
+            logger.warning(f"Could not read Bybit account margin mode: {exc}")
             return None
 
-        ret_code = response.get("retCode")
-        if ret_code is not None and int(ret_code) != 0:
-            logger.warning(
-                "get_account_info failed (retCode=%s): %s",
-                ret_code,
-                response.get("retMsg", "unknown error"),
-            )
-            return None
-
-        raw_mode = response.get("result", {}).get("marginMode")
         normalized = {
             "ISOLATED_MARGIN": "isolated",
             "REGULAR_MARGIN": "cross",
@@ -604,7 +608,17 @@ class BybitFuturesOrderClass:
             all_closed = True
             for pos in non_zero:
                 size = float(pos.get("size", 0))
-                pos_side = pos.get("side", "Buy")
+                # #341's other half. An emergency close is the last place to guess: a
+                # defaulted "Buy" sends a reduce-only SELL against a short, which the venue
+                # rejects -- a silently failed flatten at the moment FLATTEN was relied on.
+                # #341's other half. An emergency close is the last place to guess: a
+                # defaulted "Buy" sends a reduce-only SELL against a short, which the venue
+                # rejects -- a silently failed flatten at the moment FLATTEN was relied on.
+                pos_side = pos.get("side")
+                if pos_side not in ("Buy", "Sell"):
+                    logger.error(f"Refusing to close a position with side {pos_side!r}")
+                    all_closed = False
+                    continue
                 close_side = "Sell" if pos_side == "Buy" else "Buy"
 
                 params = {

--- a/torchtrade/envs/live/okx/base.py
+++ b/torchtrade/envs/live/okx/base.py
@@ -210,7 +210,7 @@ class OKXBaseTorchTradingEnv(TorchTradeFuturesLiveEnv):
         """Clean up resources."""
         try:
             status = self.trader.get_status()
-            if status.get("position_status") and status["position_status"].qty != 0:
+            if position_direction_from_status(status.get("position_status")) != 0:
                 logger.warning(
                     "Closing environment with open position! "
                     "Call env.trader.close_position() before env.close() if needed."

--- a/torchtrade/envs/live/okx/base.py
+++ b/torchtrade/envs/live/okx/base.py
@@ -1,6 +1,5 @@
 """Base class for OKX live trading environments."""
 import logging
-import math
 
 from abc import abstractmethod
 from typing import Callable, List, Optional
@@ -90,10 +89,6 @@ class OKXBaseTorchTradingEnv(TorchTradeFuturesLiveEnv):
         if config.close_position_on_init:
             self.trader.close_position()
 
-        # Bankruptcy baseline on total_margin_balance (equity), matching offline's
-        # portfolio_value and the current side of the check. Binance's total_wallet_balance
-        # excludes unrealized PnL (a real skew here); bitget/bybit/okx map both keys to equity.
-        balance = self.trader.get_account_balance()
         self._capture_bankruptcy_baseline()
 
         # Build observation specs

--- a/torchtrade/envs/live/okx/base.py
+++ b/torchtrade/envs/live/okx/base.py
@@ -94,19 +94,7 @@ class OKXBaseTorchTradingEnv(TorchTradeFuturesLiveEnv):
         # portfolio_value and the current side of the check. Binance's total_wallet_balance
         # excludes unrealized PnL (a real skew here); bitget/bybit/okx map both keys to equity.
         balance = self.trader.get_account_balance()
-        # Indexed: a default of 0 makes the bankruptcy baseline 0, and
-        # `current < threshold * 0` reduces to `current < 0` -- so it never fires
-        # above zero equity and the account could be wiped out with the episode
-        # running on (#277).
-        self.initial_portfolio_value = balance["total_margin_balance"]
-        if not math.isfinite(self.initial_portfolio_value) or self.initial_portfolio_value <= 0:
-            raise ValueError(
-                f"cannot start an episode on equity of "
-                f"{self.initial_portfolio_value}: the bankruptcy baseline would be 0, "
-                f"and `current < threshold * 0` reduces to `current < 0`, so it never "
-                f"fires above zero equity -- the account could be wiped out with "
-                f"the episode trading on"
-            )
+        self._capture_bankruptcy_baseline()
 
         # Build observation specs
         self._build_observation_specs()

--- a/torchtrade/envs/live/okx/env.py
+++ b/torchtrade/envs/live/okx/env.py
@@ -118,14 +118,8 @@ class OKXFuturesTorchTradingEnv(OKXBaseTorchTradingEnv):
         # read as a live position makes abs(current_qty) > 0 true on a flat account, so
         # action 0.0 closes nothing and still advances current_action_level (#283).
         position_size = position_qty_from_status(position_status)
-        # BOTH halves: the sweep guarded the `else` and left the branch that runs on every
-        # resize. A negative mark_price flips the sign in fractional_sizing, so a max-long
-        # action places a short -- the exact failure _current_mark_price exists to stop.
-        current_price = (
-            position_status.mark_price if position_status else self._current_mark_price()
-        )
-        if not math.isfinite(current_price) or current_price <= 0:
-            raise ValueError(f"venue reported an unusable mark price ({current_price})")
+        # okx alone threads this into sizing rather than re-fetching, so BOTH halves matter.
+        current_price = self._current_mark_price(position_status)
 
         # No-op today (this env's _execute_trade_if_needed recomputes qty live and never reads
         # current_action_level), but keeps the field consistent so adding a duplicate-action

--- a/torchtrade/envs/live/okx/env.py
+++ b/torchtrade/envs/live/okx/env.py
@@ -246,8 +246,11 @@ class OKXFuturesTorchTradingEnv(OKXBaseTorchTradingEnv):
         # balance sizes an inf target -- bitget's amount rounding then yields NaN and
         # hands it to create_order. Same defect this PR fixed on the baselines (#277).
         if not math.isfinite(total_balance) or total_balance <= 0:
-            logger.warning("No balance for fractional position sizing")
-            return 0.0, 0.0, "flat"
+            raise ValueError(
+                f"cannot size a trade against a portfolio value of {total_balance}: "
+                f"refusing, because returning a zero target is indistinguishable "
+                f"from a deliberate flat and the caller executes it as a full close"
+            )
 
         effective_balance = total_balance * 0.98
         fee_rate = 0.0005  # OKX futures taker fee

--- a/torchtrade/envs/live/okx/env.py
+++ b/torchtrade/envs/live/okx/env.py
@@ -118,9 +118,14 @@ class OKXFuturesTorchTradingEnv(OKXBaseTorchTradingEnv):
         # read as a live position makes abs(current_qty) > 0 true on a flat account, so
         # action 0.0 closes nothing and still advances current_action_level (#283).
         position_size = position_qty_from_status(position_status)
+        # BOTH halves: the sweep guarded the `else` and left the branch that runs on every
+        # resize. A negative mark_price flips the sign in fractional_sizing, so a max-long
+        # action places a short -- the exact failure _current_mark_price exists to stop.
         current_price = (
             position_status.mark_price if position_status else self._current_mark_price()
         )
+        if not math.isfinite(current_price) or current_price <= 0:
+            raise ValueError(f"venue reported an unusable mark price ({current_price})")
 
         # No-op today (this env's _execute_trade_if_needed recomputes qty live and never reads
         # current_action_level), but keeps the field consistent so adding a duplicate-action

--- a/torchtrade/envs/live/okx/env.py
+++ b/torchtrade/envs/live/okx/env.py
@@ -247,9 +247,7 @@ class OKXFuturesTorchTradingEnv(OKXBaseTorchTradingEnv):
         # hands it to create_order. Same defect this PR fixed on the baselines (#277).
         if not math.isfinite(total_balance) or total_balance <= 0:
             raise ValueError(
-                f"cannot size a trade against a portfolio value of {total_balance}: "
-                f"refusing, because returning a zero target is indistinguishable "
-                f"from a deliberate flat and the caller executes it as a full close"
+                f"cannot size a trade against a portfolio value of {total_balance}"
             )
 
         effective_balance = total_balance * 0.98

--- a/torchtrade/envs/live/okx/env.py
+++ b/torchtrade/envs/live/okx/env.py
@@ -119,7 +119,7 @@ class OKXFuturesTorchTradingEnv(OKXBaseTorchTradingEnv):
         # action 0.0 closes nothing and still advances current_action_level (#283).
         position_size = position_qty_from_status(position_status)
         current_price = (
-            position_status.mark_price if position_status else self.trader.get_mark_price()
+            position_status.mark_price if position_status else self._current_mark_price()
         )
 
         # No-op today (this env's _execute_trade_if_needed recomputes qty live and never reads

--- a/torchtrade/envs/live/okx/env_sltp.py
+++ b/torchtrade/envs/live/okx/env_sltp.py
@@ -144,7 +144,7 @@ class OKXFuturesSLTPTorchTradingEnv(SLTPMixin, OKXBaseTorchTradingEnv):
         status = self.trader.get_status()
         position_status = status.get("position_status", None)
         if position_status:
-            current_price = position_status.mark_price
+            current_price = self._current_mark_price(position_status)
             position_size = position_status.qty
         else:
             current_price = self._current_mark_price()

--- a/torchtrade/envs/live/okx/env_sltp.py
+++ b/torchtrade/envs/live/okx/env_sltp.py
@@ -267,21 +267,14 @@ class OKXFuturesSLTPTorchTradingEnv(SLTPMixin, OKXBaseTorchTradingEnv):
             # live path. Binance's total_wallet_balance excludes unrealized PnL and would under-size;
             # bitget/bybit/okx map both keys to equity, so the switch is a no-op there.
             balance = float(self.trader.get_account_balance()["total_margin_balance"])
-            # isfinite, not `<= 0`: NaN passes both comparisons, and the line below
-            # DIVIDES by current_price -- a NaN quantity reached trader.trade().
-            # binance and bitget size from a candle close here, not the mark price,
-            # so _current_mark_price() never guards this path (#347).
-            if not (math.isfinite(current_price) and math.isfinite(balance)) \
-                    or current_price <= 0 or balance <= 0:
+            # current_price already raised in _current_mark_price(); balance has
+            # no such accessor, and `nan <= 0` is False (#347).
+            if not math.isfinite(balance) or balance <= 0:
                 logger.error(f"Invalid price={current_price} or balance={balance} for {self.config.symbol}")
                 trade_info["success"] = False
                 return trade_info
             quantity = balance * self.config.position_fraction * self.config.leverage / current_price
         elif self.config.trade_mode == "notional":
-            if current_price <= 0:
-                logger.error(f"Invalid current_price={current_price} for {self.config.symbol}")
-                trade_info["success"] = False
-                return trade_info
             quantity = float(self.config.quantity_per_trade) / current_price
         elif self.config.trade_mode == "quantity":
             quantity = float(self.config.quantity_per_trade)

--- a/torchtrade/envs/live/okx/env_sltp.py
+++ b/torchtrade/envs/live/okx/env_sltp.py
@@ -267,7 +267,12 @@ class OKXFuturesSLTPTorchTradingEnv(SLTPMixin, OKXBaseTorchTradingEnv):
             # live path. Binance's total_wallet_balance excludes unrealized PnL and would under-size;
             # bitget/bybit/okx map both keys to equity, so the switch is a no-op there.
             balance = float(self.trader.get_account_balance()["total_margin_balance"])
-            if current_price <= 0 or balance <= 0:
+            # isfinite, not `<= 0`: NaN passes both comparisons, and the line below
+            # DIVIDES by current_price -- a NaN quantity reached trader.trade().
+            # binance and bitget size from a candle close here, not the mark price,
+            # so _current_mark_price() never guards this path (#347).
+            if not (math.isfinite(current_price) and math.isfinite(balance)) \
+                    or current_price <= 0 or balance <= 0:
                 logger.error(f"Invalid price={current_price} or balance={balance} for {self.config.symbol}")
                 trade_info["success"] = False
                 return trade_info

--- a/torchtrade/envs/live/okx/env_sltp.py
+++ b/torchtrade/envs/live/okx/env_sltp.py
@@ -147,7 +147,7 @@ class OKXFuturesSLTPTorchTradingEnv(SLTPMixin, OKXBaseTorchTradingEnv):
             current_price = position_status.mark_price
             position_size = position_status.qty
         else:
-            current_price = self.trader.get_mark_price()
+            current_price = self._current_mark_price()
             position_size = 0.0
 
         # Sync position state from exchange — this is the source of truth.
@@ -259,7 +259,7 @@ class OKXFuturesSLTPTorchTradingEnv(SLTPMixin, OKXBaseTorchTradingEnv):
             return trade_info
 
         # Get current mark price (more accurate than candle close for bracket orders)
-        current_price = float(self.trader.get_mark_price())
+        current_price = float(self._current_mark_price())
 
         # Resolve quantity based on trade_mode
         if self.config.trade_mode == "fractional":

--- a/torchtrade/envs/live/okx/order_executor.py
+++ b/torchtrade/envs/live/okx/order_executor.py
@@ -345,7 +345,19 @@ class OKXFuturesOrderClass:
 
             if pos is not None:
                 raw_pos = float(pos.get("pos", 0))
-                pos_side = pos.get("posSide", "net")
+                pos_side = pos.get("posSide")
+
+                # An unrecognised posSide used to fall through to the net-mode branch and
+                # keep raw_pos POSITIVE -- so a hedge-mode short read as a long, with no
+                # error, straight into the trade path. Worse than bitget/bybit, which at
+                # least degrade to POSITION_UNKNOWN. A direction is never guessed (#341).
+                if pos_side not in ("short", "long", "net"):
+                    logger.error(
+                        "okx reported an unusable posSide (%r); refusing to infer a "
+                        "direction", pos_side
+                    )
+                    status["position_status"] = POSITION_UNKNOWN
+                    return status
 
                 # Determine signed quantity
                 if pos_side == "short":

--- a/torchtrade/envs/live/okx/order_executor.py
+++ b/torchtrade/envs/live/okx/order_executor.py
@@ -605,7 +605,11 @@ class OKXFuturesOrderClass:
             all_closed = True
             for pos in non_zero:
                 raw_pos = float(pos.get("pos", 0))
-                pos_side = pos.get("posSide", "net")
+                pos_side = pos.get("posSide")
+                if pos_side not in ("long", "short", "net"):
+                    logger.error(f"Refusing to close a position with posSide {pos_side!r}")
+                    all_closed = False
+                    continue
                 if pos_side in ("long", "net") and raw_pos > 0:
                     close_side = "sell"
                 else:

--- a/torchtrade/envs/live/shared/futures_live_base.py
+++ b/torchtrade/envs/live/shared/futures_live_base.py
@@ -95,6 +95,18 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
                     )
             raise LiveObservationHalt(error, policy, accepted, flatten_error) from error
 
+    def _current_mark_price(self) -> float:
+        """The mark price, validated before it can size an order (#347).
+
+        `<= 0` passes NaN and `isfinite` passes a negative, and the sizing paths DIVIDE
+        by this -- a negative price flips the sign, so a long action opens a short.
+        """
+        price = self.trader.get_mark_price()
+        if not math.isfinite(price) or price <= 0:
+            raise ValueError(f"venue reported an unusable mark price ({price})")
+        return price
+
+
     def _get_observation(self, advance_hold: bool = True) -> TensorDictBase:
         """Get the current observation state.
 

--- a/torchtrade/envs/live/shared/futures_live_base.py
+++ b/torchtrade/envs/live/shared/futures_live_base.py
@@ -95,17 +95,20 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
                     )
             raise LiveObservationHalt(error, policy, accepted, flatten_error) from error
 
-    def _current_mark_price(self) -> float:
-        """The mark price, validated before it can size an order (#347).
+    def _current_mark_price(self, position_status=None) -> float:
+        """The bar's mark price, validated before it can size an order (#347).
 
-        `<= 0` passes NaN and `isfinite` passes a negative, and the sizing paths DIVIDE
-        by this -- a negative price flips the sign, so a long action opens a short.
+        An open position's mark and a flat account's fetched mark are the same money-path
+        number, so they get the same rule: the sizing paths DIVIDE by it, and it also
+        reaches `history.record_step` and the reward. `<= 0` passes NaN and `isfinite`
+        passes a negative -- and a negative flips the sign, so a long action opens a short.
+        Every venue reads its mark as `float(pos.get("markPrice") or entry_price)`, which
+        is 0.0 when both fields are blank.
         """
-        price = self.trader.get_mark_price()
+        price = position_status.mark_price if position_status else self.trader.get_mark_price()
         if not math.isfinite(price) or price <= 0:
             raise ValueError(f"venue reported an unusable mark price ({price})")
         return price
-
 
     def _get_observation(self, advance_hold: bool = True) -> TensorDictBase:
         """Get the current observation state.
@@ -199,6 +202,18 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
                         f"venue reported a non-finite {_name} ({_value}) for an open "
                         f"position; refusing to derive an account state from it"
                     )
+            # Finite is not enough for the mark: 0 and negative both pass the loop above and
+            # then short-circuit distance_to_liquidation to "safe". Every venue's mark read
+            # is `float(pos.get("markPrice") or entry_price)`, so two blank fields give 0.0.
+            if position_status.mark_price <= 0:
+                raise ValueError(
+                    f"venue reported a non-positive mark price "
+                    f"({position_status.mark_price}) for an open position"
+                )
+            # Finite is not enough for the mark: 0 and negative both pass the loop above and
+            # then short-circuit distance_to_liquidation to "safe". Every venue's mark read
+            # is `float(pos.get("markPrice") or entry_price)`, so two blank fields give 0.0.
+
             position_size = position_status.qty
             position_value = abs(position_status.notional_value)
             current_price = position_status.mark_price
@@ -226,7 +241,7 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
             )
         exposure_pct = position_value / total_balance if total_balance > 0 else 0.0
 
-        if position_size == 0 or current_price == 0:
+        if position_direction == 0:
             distance_to_liquidation = 1.0
         elif liquidation_price <= 0 and leverage == 1:
             # No leverage, nothing to be liquidated by, and the offline env says the same

--- a/torchtrade/envs/live/shared/futures_live_base.py
+++ b/torchtrade/envs/live/shared/futures_live_base.py
@@ -168,7 +168,10 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
         if position_direction == 0:
             position_size = 0.0
             position_value = 0.0
-            current_price = self.trader.get_mark_price()
+            # No venue call: distance_to_liquidation short-circuits to 1.0 when flat,
+            # so this price is never read. Fetching it cost a round-trip per bar and
+            # -- once validated -- would raise on a flat account over an unused value.
+            current_price = 0.0
             unrealized_pnl_pct = 0.0
             leverage = float(self.config.leverage)
             liquidation_price = 0.0


### PR DESCRIPTION
Closes #347, #345, #348, #341.

Four issues in one PR because they are the same defect in the same files — and combining is *cheaper*: **+212 / −116**, because hoisting the bankruptcy baseline deletes four copies of what it replaces.

## What each was

**#347 — the sizing paths divided by an unvalidated mark price.** 13 call sites across 8 files read `self.trader.get_mark_price()` raw. A NaN makes `delta_qty` NaN; `nan > 0` is `False`, so the trade falls to the **sell** branch. The `<= 0` guards beside them cannot see NaN.

**#345 — four byte-identical copies of the bankruptcy baseline.** `is_bankrupt` is `current < threshold * initial`, so a baseline of `0` reduces to `current < 0`: it never fires above zero equity and a wiped account trades on. The guard now also rejects `+inf`, which `not (x > 0)` passed. Hoisting turned the structural grep I wrote in #342 into a behavioural test.

**#348 — "I cannot size this" returned the same value as "go flat".** I checked the impact rather than repeating the issue, and it differs by env:

| | guard at the caller | consequence |
|---|---|---|
| alpaca | **none** | a zero target against an open position sells — **a liquidation from an action meaning maximum long** |
| binance/bitget/bybit/okx | `if target_qty == 0.0: not executed` | silent no-op — the agent's action dropped every bar with only a warning |

Both are wrong for the same reason, but only alpaca liquidates.

**#341 — bitget turned a healthy position into an outage, and signed longs short.** Bare `float()` on nullable CCXT fields: a cross position returns `liquidationPrice: None`, `float(None)` raises `TypeError` into the broad `except`, and the position reports `POSITION_UNKNOWN` — which is deliberately fail-closed, so the env **freezes every bar on a lie**. Separately, `contracts if side == 'long' else -contracts` signs a long as a **short** for any unexpected value, and every consumer reads that sign: `position_direction_from_status`, the `account_state` the policy sees, and the trade path. bybit had the same shape. Neither infers a direction now.

Also folded in from #349: three `close()` paths hand-rolled `qty != 0`, bypassing the dust rule, so a 1e-12 residual triggered a spurious "closing with an open position" warning.

## Verification

| Mutant | Tests failed |
|---|---|
| Drop the finiteness check | 5 |
| One env reads the raw mark price | 1 |
| One env re-forks the baseline | 1 |
| alpaca returns a zero target again | 1 |
| bitget's nullable read back to two-arg `get` | 1 |
| bybit's side defaulted again | 1 |

`pytest tests/` — **2654 passed, 19 skipped**.

## Note on scope

This is deliberately one PR for four issues. The backlog went 19-closed/17-opened over this session — flat — because I had been filing adjacent findings instead of fixing them in the PR already touching those files. Clustering by file rather than by issue is the correction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)