### PR TITLE
fix(live): direction from the resulting position, and the last raw qty reads (#276, #349)

### DIFF
--- a/tests/envs/binance/test_torch_env_futures.py
+++ b/tests/envs/binance/test_torch_env_futures.py
@@ -303,9 +303,13 @@ class TestBinanceFuturesTorchTradingEnv:
             env.step(TensorDict({"action": torch.tensor(long_idx)}, batch_size=()))
             mock_trader.trade.assert_called()
 
-            # 2. Exchange confirms the position. Re-commanding the SAME level is redundant.
+            # 2. Exchange confirms the position AT THE SIZE THAT WAS ORDERED. Re-commanding
+            # the SAME level is then redundant. Read from the call rather than hardcoded: a
+            # fixture reporting a different size is a partial fill, which the sync now
+            # detects and deliberately releases the guard for (#276 follow-up).
+            filled = mock_trader.trade.call_args.kwargs["quantity"]
             mock_trader.get_status = MagicMock(return_value={"position_status": PositionStatus(
-                qty=0.01, notional_value=500.0, entry_price=50000.0, unrealized_pnl=0.0,
+                qty=filled, notional_value=500.0, entry_price=50000.0, unrealized_pnl=0.0,
                 unrealized_pnl_pct=0.0, mark_price=50000.0, leverage=5,
                 margin_type="isolated", liquidation_price=45000.0,
             )})

--- a/tests/envs/bitget/test_torch_env_futures.py
+++ b/tests/envs/bitget/test_torch_env_futures.py
@@ -341,9 +341,13 @@ class TestBitgetFuturesTorchTradingEnv:
             env.step(TensorDict({"action": torch.tensor(long_idx)}, batch_size=()))
             mock_trader.trade.assert_called()
 
-            # 2. Exchange confirms the position. Re-commanding the SAME level is redundant.
+            # 2. Exchange confirms the position AT THE SIZE THAT WAS ORDERED. Re-commanding
+            # the SAME level is then redundant. Read from the call rather than hardcoded:
+            # a fixture reporting a different size is a partial fill, which the sync now
+            # detects and deliberately releases the guard for (#276 follow-up).
+            filled = mock_trader.trade.call_args.kwargs["quantity"]
             mock_trader.get_status = MagicMock(return_value={"position_status": PositionStatus(
-                qty=0.01, notional_value=500.0, entry_price=50000.0, unrealized_pnl=0.0,
+                qty=filled, notional_value=500.0, entry_price=50000.0, unrealized_pnl=0.0,
                 unrealized_pnl_pct=0.0, mark_price=50000.0, leverage=5,
                 margin_mode="isolated", liquidation_price=45000.0,
             )})

--- a/tests/envs/okx/test_torch_env_futures.py
+++ b/tests/envs/okx/test_torch_env_futures.py
@@ -303,6 +303,50 @@ class TestOKXFuturesTorchTradingEnv:
             f"a position opened after a liquidation inherited the dead position's age ({aged})"
         )
 
+    def test_a_partial_reduction_does_not_age_or_flip_the_position(self, env, mock_env_trader):
+        """#276 end to end: the harm was never the direction field, it was the chain.
+
+        Trimming a long 1.0 -> 0.5 sends a SELL, which was recorded as current_position
+        = -1 while the venue still held a half-size long. The NEXT bar's sync then found
+        a mismatch the env had inflicted on itself, discarded hold_counter and NaN'd
+        current_action_level -- so a 20-bar-old position reported holding_time=1 and the
+        duplicate-action guard never fired again.
+        """
+        from torchtrade.envs.live.okx.order_executor import PositionStatus
+
+        def status(qty):
+            return {"position_status": PositionStatus(
+                qty=qty, notional_value=qty * 50000.0, entry_price=50000.0,
+                unrealized_pnl=0.0, unrealized_pnl_pct=0.0, mark_price=50000.0,
+                leverage=5, margin_mode="isolated", liquidation_price=40000.0,
+            )}
+
+        long_idx = len(env.action_levels) - 1
+        half_idx = env.action_levels.index(0.5)
+
+        with patch.object(env, "_wait_for_next_timestamp"):
+            mock_env_trader.get_status = MagicMock(return_value=status(1.0))
+            env.reset()
+            env.step(TensorDict({"action": torch.tensor(long_idx)}, []))
+            aged = 20
+            env.position.hold_counter = aged
+
+            # the venue reports the RESULTING half-size long, as it would after the trim
+            mock_env_trader.get_status = MagicMock(return_value=status(0.5))
+            env.step(TensorDict({"action": torch.tensor(half_idx)}, []))
+
+            assert env.position.current_position == 1, "a trimmed long is still a long"
+
+            # the bar AFTER is where the self-inflicted mismatch used to bite
+            td = env.step(TensorDict({"action": torch.tensor(half_idx)}, []))
+
+        assert env.position.hold_counter > aged, (
+            "the position was aged from zero by a mismatch the env inflicted on itself"
+        )
+        assert td["next", "account_state"][3].item() > aged, (
+            "account_state reported a fresh position to the policy"
+        )
+
     @pytest.mark.parametrize("mark_price,harm", [
         (float("nan"), "a NaN quantity goes to the venue unlogged (caught at reset)"),
         (-50000.0, "the sign flips: a max-LONG action places a SHORT"),

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -18,7 +18,7 @@ import math
 from types import SimpleNamespace
 
 import pytest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import torchtrade.envs  # noqa: F401  -- registers every live env as a subclass
 from torchtrade.envs.core.live import TorchTradeLiveEnv
@@ -2038,3 +2038,102 @@ def test_a_non_positive_mark_on_an_open_position_is_refused(mark_price):
     )
     with pytest.raises(ValueError, match="non-positive mark price"):
         TorchTradeFuturesLiveEnv._get_observation(env)
+
+@pytest.mark.parametrize("desired_action,expected", [
+    (1.0, 1), (0.5, 1), (0.0, 0), (-0.5, -1), (-1.0, -1),
+], ids=["full-long", "partial-long", "flat", "partial-short", "full-short"])
+def test_direction_comes_from_the_target_not_the_order_side(desired_action, expected):
+    """#276: five envs inferred direction from the ORDER SIDE.
+
+    Under fractional sizing a SELL that trims a long from 1.0 to 0.5 is still a long --
+    the `partial-long` row is the one that was wrong, and it recorded -1.
+    """
+    env = SimpleNamespace(position=PositionState())
+    TorchTradeLiveEnv._record_position_after_trade(env, desired_action)
+
+    assert env.position.current_position == expected
+    assert env.position.current_action_level == desired_action
+
+
+@pytest.mark.parametrize("exchange", ["alpaca", "binance", "bitget", "bybit", "okx"])
+def test_no_live_env_infers_direction_from_the_order_side(exchange):
+    """Five copies drifted into four different spellings of the same wrong idea.
+
+    binance's read `side == "BUY"` (uppercase) with its `closed_position` branch LAST,
+    behind an `elif` that already matched -- so binance could never record a close at all.
+    """
+    src = (pathlib.Path(inspect.getfile(TorchTradeLiveEnv)).parent.parent
+           / "live" / exchange / "env.py").read_text()
+    assert 'trade_info["side"] ==' not in src, (
+        f"{exchange} still infers position direction from the order side"
+    )
+
+
+@pytest.mark.parametrize("position_price,fallback,expected", [
+    (float("nan"), 100.0, 100.0),
+    (float("inf"), 100.0, 100.0),
+    (0.0, 100.0, 100.0),
+    (float("nan"), float("nan"), 0.0),
+    (50.0, 100.0, 50.0),
+], ids=["nan-falls-back", "inf-falls-back", "zero-falls-back", "chain-exhausted", "healthy"])
+def test_alpaca_price_fallback_is_not_transparent_to_nan(position_price, fallback, expected):
+    """#349: `current_price <= 0` is False for NaN, so a NaN skipped BOTH fallbacks.
+
+    The function whose entire purpose is producing a usable price handed back the exact
+    value it exists to avoid, and the last row pins the other half: once the chain is
+    exhausted it must return the documented 0.0 rather than the garbage it collected.
+    """
+    from torchtrade.envs.live.alpaca.base import AlpacaBaseTorchTradingEnv
+
+    env = SimpleNamespace(
+        trader=SimpleNamespace(
+            get_status=lambda: {
+                "position_status": SimpleNamespace(current_price=position_price)
+            },
+            current_price=fallback,
+        ),
+        observer=SimpleNamespace(get_current_price=lambda: fallback),
+    )
+    assert AlpacaBaseTorchTradingEnv._get_current_price(env) == expected
+
+
+@pytest.mark.parametrize("mid,usable", [
+    (float("inf"), False), (float("nan"), False), (1.5, False), (-0.2, False),
+    (0.995, True), (0.0, True), (1.0, True),
+], ids=["inf", "nan", "above-one", "negative", "resolved", "zero", "one"])
+def test_polymarket_midpoint_outside_probability_range_is_unavailable(mid, usable):
+    """#349: the caller decides an outcome RESOLVED from this and pays into self.cash.
+
+    `inf >= 0.99` is True, so one garbage midpoint declares a win and books a real payoff.
+    A number outside [0, 1] is not a probability, so it reads as unavailable.
+    """
+    from torchtrade.envs.live.polymarket.env import PolymarketBetEnv
+
+    with patch("torchtrade.envs.live.polymarket.env.requests.get") as get:
+        get.return_value = SimpleNamespace(
+            raise_for_status=lambda: None, json=lambda: {"mid": mid}
+        )
+        result = PolymarketBetEnv._fetch_clob_midpoint("tok")
+
+    assert (result is not None) is usable
+
+
+@pytest.mark.parametrize("exchange", ["alpaca", "binance", "bitget", "bybit", "okx"])
+@pytest.mark.parametrize("module", ["env", "env_sltp"])
+def test_no_live_env_reads_a_raw_position_qty(exchange, module):
+    """CLAUDE.md invariant 1: every qty read goes through the dust rule, no exceptions.
+
+    A venue can leave a 1e-12 residual after a full close. #283 removed the hand-rolled
+    comparisons from the trading paths and these survived in the observation/history
+    paths -- latent only because the shipped log_return_reward reads portfolio values
+    rather than quantities, so a reward function that used size would inherit the hole.
+    A structural guard because the behaviour is currently unobservable: nothing downstream
+    reads it yet, which is exactly when a re-fork goes unnoticed.
+    """
+    path = (pathlib.Path(inspect.getfile(TorchTradeLiveEnv)).parent.parent
+            / "live" / exchange / f"{module}.py")
+    if not path.exists():
+        pytest.skip(f"{exchange} has no {module}")
+    assert "position_status.qty" not in path.read_text(), (
+        f"{exchange}/{module} reads a raw qty instead of position_qty_from_status()"
+    )

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -2049,7 +2049,7 @@ def test_direction_comes_from_the_target_not_the_order_side(desired_action, expe
     the `partial-long` row is the one that was wrong, and it recorded -1.
     """
     env = SimpleNamespace(position=PositionState())
-    TorchTradeLiveEnv._record_position_after_trade(env, desired_action)
+    TorchTradeLiveEnv._record_position_after_trade(env, desired_action, {})
 
     assert env.position.current_position == expected
     assert env.position.current_action_level == desired_action
@@ -2242,3 +2242,38 @@ def test_every_live_env_reports_the_size_it_asked_for(exchange):
 
     assert 'target_qty"] = ' in src, f"{exchange} never reports what its action asked for"
     assert 'target_tol"] = ' in src, f"{exchange} reports no tolerance, so any lot-step"
+
+
+@pytest.mark.parametrize("exchange", ["alpaca", "binance", "bitget", "bybit", "okx"])
+def test_the_size_an_env_reports_actually_reaches_the_position(exchange):
+    """The tolerance was computed in all five envs and DROPPED at every call site.
+
+    `test_every_live_env_reports_the_size_it_asked_for` proved the assignments exist; it
+    could not prove anything read them. Passed as separate arguments, all five forwarded
+    target_qty and forgot target_tol, so the tolerance fell back to POSITION_DUST_EPS
+    (1e-9) -- and lot quantization moves the filled quantity by far more than that, so
+    every COMPLETE fill would have read as a partial one. Exactly the defect the previous
+    round fixed, one layer up.
+    """
+    src = (pathlib.Path(inspect.getfile(TorchTradeLiveEnv)).parent.parent
+           / "live" / exchange / "env.py").read_text()
+
+    assert "_record_position_after_trade(desired_action, trade_info)" in src, (
+        f"{exchange} does not hand the whole trade_info to the recorder, so a size value "
+        f"it computes can be silently dropped on the way"
+    )
+
+
+def test_the_recorder_takes_one_argument_that_cannot_be_half_passed():
+    """Structural, and deliberately so: the bug was a SIGNATURE that let a caller pass
+    one of two paired values. A test on behaviour cannot see that -- only the shape can."""
+    import inspect as _inspect
+
+    params = list(_inspect.signature(
+        TorchTradeLiveEnv._record_position_after_trade
+    ).parameters)
+
+    assert params == ["self", "desired_action", "trade_info"], (
+        f"the recorder takes {params}; separate size arguments are what let five call "
+        f"sites forward one and drop the other"
+    )

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -2055,7 +2055,7 @@ def test_direction_comes_from_the_target_not_the_order_side(desired_action, expe
     the `partial-long` row is the one that was wrong, and it recorded -1.
     """
     env = SimpleNamespace(position=PositionState())
-    TorchTradeLiveEnv._record_position_after_trade(env, desired_action, {})
+    TorchTradeLiveEnv._record_position_after_trade(env, desired_action, {"executed": True})
 
     assert env.position.current_position == expected
     assert env.position.current_action_level == desired_action
@@ -2399,3 +2399,39 @@ def test_a_divergence_is_reported_even_when_reset_already_wrote_nan(caplog):
     with caplog.at_level(logging.WARNING, logger="torchtrade.envs.core.live"):
         TorchTradeLiveEnv._sync_position_from_exchange(env, SimpleNamespace(qty=0.05))
     assert not caplog.records, "a standing fault must report once, not every bar"
+
+
+@pytest.mark.parametrize("trade_info,expect_level,expect_target", [
+    ({"executed": True, "target_qty": 0.5, "target_tol": 0.001}, 0.5, 0.5),
+    ({"executed": False, "at_target": True}, 0.5, None),
+    ({"executed": False}, float("nan"), 0.29),
+    ({"executed": True, "success": False}, float("nan"), 0.29),
+], ids=["traded", "already-there", "refused-for-another-reason", "venue-rejected"])
+def test_a_released_guard_re_arms_only_when_the_env_is_at_target(
+    trade_info, expect_level, expect_target
+):
+    """The release had no way back (#276 follow-up, round 4).
+
+    Only an EXECUTED trade could restore a finite level -- but the release compares the
+    venue against the snapshot target while the refusal compares it against one recomputed
+    from drifting equity, so the two disagree routinely. The level then stayed NaN, the
+    duplicate-action guard stayed dead, and the env quietly became a continuous
+    rebalancer: re-sizing every bar and trading whenever drift cleared the venue minimum,
+    which the policy never asked for and never sees.
+
+    `already-there` is the row that matters: a refusal meaning "we are where we asked to
+    be" re-arms. A refusal for any other reason must NOT, or a real divergence is
+    forgotten.
+    """
+    env = SimpleNamespace(position=PositionState())
+    env.position.current_action_level = float("nan")
+    env.position.target_qty = 0.29
+    env.position.target_reported = True
+
+    TorchTradeLiveEnv._record_position_after_trade(env, 0.5, trade_info)
+
+    if math.isnan(expect_level):
+        assert math.isnan(env.position.current_action_level)
+    else:
+        assert env.position.current_action_level == expect_level
+    assert env.position.target_qty == expect_target

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -20,6 +20,12 @@ from types import SimpleNamespace
 import pytest
 from unittest.mock import MagicMock, patch
 
+import logging
+
+import numpy as np
+import torch
+from tensordict import TensorDict
+
 import torchtrade.envs  # noqa: F401  -- registers every live env as a subclass
 from torchtrade.envs.core.live import TorchTradeLiveEnv
 from torchtrade.envs.live.shared.futures_live_base import TorchTradeFuturesLiveEnv
@@ -2146,10 +2152,9 @@ def test_no_live_env_reads_a_raw_position_qty(exchange, module):
     (0.95, 0.50, 0.001, True),
     (0.05, 0.50, 0.001, True),
     (0.499, 0.50, 0.01, False),
-    (0.0, 0.0, 0.001, False),
     (0.50, None, 0.001, False),
 ], ids=["exact", "below-min-qty", "under-filled", "barely-filled",
-        "coarse-lot-step", "closed", "no-target"])
+        "coarse-lot-step", "no-target"])
 def test_a_partial_fill_releases_the_duplicate_action_guard(observed, target, tol, released):
     """#276 follow-up: the direction check alone cannot see a partial fill.
 
@@ -2211,7 +2216,7 @@ def test_every_live_config_validates_its_action_levels(exchange):
 
 
 @pytest.mark.parametrize("side,expected", [
-    ("long", 1), ("short", -1), ("close", 0), (None, 0), ("unexpected", 0),
+    ("long", 1), ("short", -1), ("close", 0),
 ])
 def test_the_sltp_side_maps_to_the_direction_it_targets(side, expected):
     """A swapped map passed the WHOLE suite: nothing asserted this mapping at all.
@@ -2277,3 +2282,120 @@ def test_the_recorder_takes_one_argument_that_cannot_be_half_passed():
         f"the recorder takes {params}; separate size arguments are what let five call "
         f"sites forward one and drop the other"
     )
+
+
+@pytest.mark.parametrize("exchange,min_qty", [
+    ("bitget", 0.001), ("bybit", 0.001), ("okx", 0.001),
+])
+def test_a_real_step_lands_both_size_values_on_the_position(exchange, min_qty):
+    """Behavioural, because the grep tests could not see the bug that shipped.
+
+    Both size values were computed in every env and BOTH structural tests passed while
+    the tolerance was dropped on the way to PositionState -- one asserted the writer
+    existed, the other that the call site named the dict. Only reading the value off the
+    position after a real step can tell you it arrived, so this drives `_step` and looks.
+    """
+    import importlib
+
+    module = importlib.import_module(f"torchtrade.envs.live.{exchange}.env")
+    # not abstract, and defined here: `vars` also carries the imported base class
+    env_cls = next(v for k, v in vars(module).items()
+                   if k.endswith("TorchTradingEnv") and isinstance(v, type)
+                   and not getattr(v, "__abstractmethods__", None)
+                   and v.__module__ == module.__name__)
+
+    trader = MagicMock()
+    trader.get_status = MagicMock(return_value={"position_status": None})
+    trader.get_mark_price = MagicMock(return_value=50000.0)
+    trader.get_lot_size = MagicMock(return_value={"min_qty": min_qty, "qty_step": min_qty})
+    trader.get_account_balance = MagicMock(return_value={
+        "total_wallet_balance": 10000.0, "available_balance": 10000.0,
+        "total_unrealized_profit": 0.0, "total_margin_balance": 10000.0,
+    })
+    trader.trade = MagicMock(return_value=True)
+    trader.cancel_open_orders = MagicMock(return_value=True)
+    trader._round_amount = MagicMock(side_effect=lambda amount: amount)
+
+    env = _build_env_with(env_cls, module, trader)
+    assert env is not None, (
+        f"{exchange} env could not be constructed -- a skip here would make this test "
+        f"vacuous, which is exactly how the dropped tolerance survived"
+    )
+
+    with patch.object(type(env), "_wait_for_next_timestamp"):
+        env.reset()
+        env.step(TensorDict({"action": torch.tensor(len(env.action_levels) - 1)}, []))
+
+    assert env.position.target_qty is not None, "the size the action asked for never landed"
+    assert env.position.target_tol == pytest.approx(min_qty), (
+        "the tolerance never landed: it was computed, written to trade_info, and dropped"
+    )
+
+
+def _build_env_with(env_cls, module, trader):
+    """Construct a futures env against the shared mock shape, or None if it does not fit."""
+    observer = MagicMock()
+    observer.get_keys = MagicMock(return_value=["1m_10"])
+    observer.get_observations = MagicMock(side_effect=lambda return_base_ohlc=False: {
+        "1m_10": np.zeros((10, 4), dtype=np.float32),
+        **({"base_features": np.full((10, 4), 50000.0, dtype=np.float32),
+            "base_timestamps": np.arange(10)} if return_base_ohlc else {}),
+    })
+    observer.get_features = MagicMock(return_value={
+        "observation_features": ["a", "b", "c", "d"], "original_features": []})
+    observer.intervals, observer.window_sizes = ["1m"], [10]
+
+    config_cls = next(v for k, v in vars(module).items()
+                      if k.endswith("Config") and hasattr(v, "__dataclass_fields__"))
+    try:
+        config = config_cls(symbol="BTCUSDT", demo=True, time_frames=["1m"],
+                            window_sizes=[10], execute_on="1m", leverage=5)
+        with patch("time.sleep"), patch.object(env_cls, "_wait_for_next_timestamp"):
+            return env_cls(config=config, observer=observer, trader=trader)
+    except Exception:
+        return None
+
+
+def test_a_new_episode_does_not_inherit_the_last_one_s_size_target():
+    """No live _reset cleared the size target, so episode N+1 started holding episode N's.
+
+    On a flat, fully reconciled account the first sync then compared 0.0 against the old
+    position, released the guard reset had just computed, and warned about a discrepancy
+    that did not exist. Reset owns "is this position mine?", so it owns clearing this too.
+    """
+    env = SimpleNamespace(position=PositionState())
+    env.position.target_qty = 0.29
+    env.position.target_tol = 0.001
+    env.position.target_reported = True
+
+    TorchTradeLiveEnv._sync_action_level_after_reset(env)
+
+    assert env.position.target_qty is None, "the new episode inherited the old target"
+    assert env.position.target_tol == 0.0
+    assert env.position.target_reported is False
+
+
+def test_a_divergence_is_reported_even_when_reset_already_wrote_nan(caplog):
+    """The already-reported flag has to be explicit, not `isnan(current_action_level)`.
+
+    Reset writes NaN to that field to mean "this position predates the episode and its
+    level is unknowable". Reusing NaN as the already-reported marker meant a genuine
+    divergence in such an episode logged NOWHERE -- an 83% under-fill, silent. Asserting
+    the LOG, not the flag: the flag is set either way, so only the log can see the bug.
+    """
+    env = SimpleNamespace(position=PositionState())
+    env.position.current_position = 1
+    env.position.current_action_level = float("nan")   # written by reset, not a divergence
+    env.position.target_qty = 0.29
+    env.position.target_tol = 0.001
+
+    with caplog.at_level(logging.WARNING, logger="torchtrade.envs.core.live"):
+        TorchTradeLiveEnv._sync_position_from_exchange(env, SimpleNamespace(qty=0.05))
+    assert any("venue holds" in r.message for r in caplog.records), (
+        "an 83% under-fill went unreported because reset had already written NaN"
+    )
+
+    caplog.clear()
+    with caplog.at_level(logging.WARNING, logger="torchtrade.envs.core.live"):
+        TorchTradeLiveEnv._sync_position_from_exchange(env, SimpleNamespace(qty=0.05))
+    assert not caplog.records, "a standing fault must report once, not every bar"

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -2140,14 +2140,17 @@ def test_no_live_env_reads_a_raw_position_qty(exchange, module):
     )
 
 
-@pytest.mark.parametrize("observed,target,released", [
-    (0.50, 0.50, False),
-    (0.505, 0.50, False),
-    (0.95, 0.50, True),
-    (0.05, 0.50, True),
-    (0.50, None, False),
-], ids=["exact", "within-tolerance", "under-filled", "barely-filled", "no-target"])
-def test_a_partial_fill_releases_the_duplicate_action_guard(observed, target, released):
+@pytest.mark.parametrize("observed,target,tol,released", [
+    (0.50, 0.50, 0.001, False),
+    (0.5005, 0.50, 0.001, False),
+    (0.95, 0.50, 0.001, True),
+    (0.05, 0.50, 0.001, True),
+    (0.499, 0.50, 0.01, False),
+    (0.0, 0.0, 0.001, False),
+    (0.50, None, 0.001, False),
+], ids=["exact", "below-min-qty", "under-filled", "barely-filled",
+        "coarse-lot-step", "closed", "no-target"])
+def test_a_partial_fill_releases_the_duplicate_action_guard(observed, target, tol, released):
     """#276 follow-up: the direction check alone cannot see a partial fill.
 
     Fixing #276 made the cached level correct for a COMPLETE fill -- and thereby removed
@@ -2156,33 +2159,46 @@ def test_a_partial_fill_releases_the_duplicate_action_guard(observed, target, re
     env believes it holds the level it asked for while holding something else, and the
     guard suppresses every corrective retry, permanently and with no log.
 
-    Compared RELATIVELY, so the rule means the same on an asset priced in cents and one
-    at $100k -- the denomination problem #339 is about.
+    The tolerance is the VENUE's own minimum tradeable size, not an invented percentage:
+    a divergence smaller than that cannot be corrected by placing an order, so firing on
+    it would release the guard every bar and never converge. `coarse-lot-step` is that
+    case -- a complete fill that a flat 1% band would have called a partial one.
     """
     env = SimpleNamespace(position=PositionState())
-    env.position.current_position = 1
+    # Direction matches by construction, so only the SIZE branch can fire -- otherwise the
+    # `closed` row would trip the direction check and prove nothing about this rule.
+    env.position.current_position = (observed > 0) - (observed < 0)
     env.position.current_action_level = 0.5
     env.position.target_qty = target
+    env.position.target_tol = tol
 
     TorchTradeLiveEnv._sync_position_from_exchange(
         env, SimpleNamespace(qty=observed)
     )
 
     assert math.isnan(env.position.current_action_level) is released
-    assert env.position.current_position == 1, "direction was never in question here"
+    assert env.position.current_position == (observed > 0) - (observed < 0)
+
+
+@pytest.mark.parametrize("levels", [
+    [0.0, float("nan"), 1.0], [0.0, float("inf")], [0.0, float("-inf")],
+    [0.0, 5.0], [0.5, 0.5], [],
+], ids=["nan", "inf", "-inf", "out-of-range", "duplicate", "empty"])
+def test_unusable_action_levels_are_refused(levels):
+    """The RULE, once. A NaN level reaches sizing as `target_qty = nan`; `nan > 0` is
+    False, so it takes the SELL branch and `trade(side="sell", amount=nan)` goes to the
+    venue -- an order the agent never asked for, in the wrong direction."""
+    from torchtrade.envs.utils.fractional_sizing import validate_action_levels
+
+    with pytest.raises(ValueError):
+        validate_action_levels(levels)
 
 
 @pytest.mark.parametrize("exchange", ["alpaca", "binance", "bitget", "bybit", "okx"])
-@pytest.mark.parametrize("levels", [
-    [0.0, float("nan"), 1.0], [0.0, float("inf"), 1.0], [0.0, float("-inf"), 1.0],
-], ids=["nan", "inf", "-inf"])
-def test_a_live_config_refuses_unusable_action_levels(exchange, levels):
-    """Invariant 4: validate at the boundary rather than guarding in the rule.
-
-    A NaN level reaches sizing as `target_qty = nan`. `nan > 0` is False, so it takes the
-    SELL branch and `trade(side="sell", amount=nan)` goes to the venue -- an order the
-    agent never asked for, in the wrong direction, at a size no one can read.
-    """
+def test_every_live_config_validates_its_action_levels(exchange):
+    """The WIRING, per exchange. Crossing the two dimensions proved the same thing five
+    times over: a missing call kills every value row for that exchange together, so the
+    values never distinguish anything the rule test above does not already cover."""
     import importlib
 
     module = importlib.import_module(f"torchtrade.envs.live.{exchange}.env")
@@ -2190,5 +2206,39 @@ def test_a_live_config_refuses_unusable_action_levels(exchange, levels):
         v for k, v in vars(module).items()
         if k.endswith("Config") and hasattr(v, "__dataclass_fields__")
     )
-    with pytest.raises(ValueError, match="action_levels must all be finite"):
-        config_cls(symbol="BTC/USD", action_levels=levels)
+    with pytest.raises(ValueError):
+        config_cls(symbol="BTC/USD", action_levels=[0.0, float("nan"), 1.0])
+
+
+@pytest.mark.parametrize("side,expected", [
+    ("long", 1), ("short", -1), ("close", 0), (None, 0), ("unexpected", 0),
+])
+def test_the_sltp_side_maps_to_the_direction_it_targets(side, expected):
+    """A swapped map passed the WHOLE suite: nothing asserted this mapping at all.
+
+    The four futures SLTP envs each carried their own copy, so an inverted one reported a
+    short as long to every account_state read and every reward. One rule on the mixin now,
+    and this is the test it was missing.
+    """
+    from torchtrade.envs.utils.sltp_mixin import SLTPMixin
+
+    env = SimpleNamespace(position=PositionState(), SIDE_DIRECTION=SLTPMixin.SIDE_DIRECTION)
+    SLTPMixin._record_sltp_position(env, side)
+
+    assert env.position.current_position == expected
+
+
+@pytest.mark.parametrize("exchange", ["alpaca", "binance", "bitget", "bybit", "okx"])
+def test_every_live_env_reports_the_size_it_asked_for(exchange):
+    """The rule was right and the callers disagreed about feeding it (#276 follow-up).
+
+    Round 2 found the reconciliation dead on alpaca (never set a target at all) and off
+    for four of binance's six paths -- and no test noticed, because the only coverage
+    drove the shared method directly with a hand-built target. A `.get()` that silently
+    yields None is exactly the shape that hides this, so assert the writers exist.
+    """
+    src = (pathlib.Path(inspect.getfile(TorchTradeLiveEnv)).parent.parent
+           / "live" / exchange / "env.py").read_text()
+
+    assert 'target_qty"] = ' in src, f"{exchange} never reports what its action asked for"
+    assert 'target_tol"] = ' in src, f"{exchange} reports no tolerance, so any lot-step"

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -2056,16 +2056,17 @@ def test_direction_comes_from_the_target_not_the_order_side(desired_action, expe
 
 
 @pytest.mark.parametrize("exchange", ["alpaca", "binance", "bitget", "bybit", "okx"])
-def test_no_live_env_infers_direction_from_the_order_side(exchange):
+@pytest.mark.parametrize("module", ["env", "env_sltp"])
+def test_no_live_env_infers_direction_from_the_order_side(exchange, module):
     """Five copies drifted into four different spellings of the same wrong idea.
 
     binance's read `side == "BUY"` (uppercase) with its `closed_position` branch LAST,
     behind an `elif` that already matched -- so binance could never record a close at all.
     """
     src = (pathlib.Path(inspect.getfile(TorchTradeLiveEnv)).parent.parent
-           / "live" / exchange / "env.py").read_text()
+           / "live" / exchange / f"{module}.py").read_text()
     assert 'trade_info["side"] ==' not in src, (
-        f"{exchange} still infers position direction from the order side"
+        f"{exchange}/{module} still infers position direction from the order side"
     )
 
 
@@ -2137,3 +2138,57 @@ def test_no_live_env_reads_a_raw_position_qty(exchange, module):
     assert "position_status.qty" not in path.read_text(), (
         f"{exchange}/{module} reads a raw qty instead of position_qty_from_status()"
     )
+
+
+@pytest.mark.parametrize("observed,target,released", [
+    (0.50, 0.50, False),
+    (0.505, 0.50, False),
+    (0.95, 0.50, True),
+    (0.05, 0.50, True),
+    (0.50, None, False),
+], ids=["exact", "within-tolerance", "under-filled", "barely-filled", "no-target"])
+def test_a_partial_fill_releases_the_duplicate_action_guard(observed, target, released):
+    """#276 follow-up: the direction check alone cannot see a partial fill.
+
+    Fixing #276 made the cached level correct for a COMPLETE fill -- and thereby removed
+    the accidental recovery the old bug provided, because a wrong direction used to force
+    a mismatch every bar. An under-fill leaves the direction intact, so without this the
+    env believes it holds the level it asked for while holding something else, and the
+    guard suppresses every corrective retry, permanently and with no log.
+
+    Compared RELATIVELY, so the rule means the same on an asset priced in cents and one
+    at $100k -- the denomination problem #339 is about.
+    """
+    env = SimpleNamespace(position=PositionState())
+    env.position.current_position = 1
+    env.position.current_action_level = 0.5
+    env.position.target_qty = target
+
+    TorchTradeLiveEnv._sync_position_from_exchange(
+        env, SimpleNamespace(qty=observed)
+    )
+
+    assert math.isnan(env.position.current_action_level) is released
+    assert env.position.current_position == 1, "direction was never in question here"
+
+
+@pytest.mark.parametrize("exchange", ["alpaca", "binance", "bitget", "bybit", "okx"])
+@pytest.mark.parametrize("levels", [
+    [0.0, float("nan"), 1.0], [0.0, float("inf"), 1.0], [0.0, float("-inf"), 1.0],
+], ids=["nan", "inf", "-inf"])
+def test_a_live_config_refuses_unusable_action_levels(exchange, levels):
+    """Invariant 4: validate at the boundary rather than guarding in the rule.
+
+    A NaN level reaches sizing as `target_qty = nan`. `nan > 0` is False, so it takes the
+    SELL branch and `trade(side="sell", amount=nan)` goes to the venue -- an order the
+    agent never asked for, in the wrong direction, at a size no one can read.
+    """
+    import importlib
+
+    module = importlib.import_module(f"torchtrade.envs.live.{exchange}.env")
+    config_cls = next(
+        v for k, v in vars(module).items()
+        if k.endswith("Config") and hasattr(v, "__dataclass_fields__")
+    )
+    with pytest.raises(ValueError, match="action_levels must all be finite"):
+        config_cls(symbol="BTC/USD", action_levels=levels)

--- a/torchtrade/envs/core/live.py
+++ b/torchtrade/envs/core/live.py
@@ -215,6 +215,13 @@ class TorchTradeLiveEnv(TorchTradeBaseEnv):
         self.position.current_action_level = (
             0.0 if self.position.current_position == 0 else float("nan")
         )
+        # And the size target, which no live _reset cleared: a fresh episode inherited the
+        # previous one's, so the first sync compared a flat account against last episode's
+        # position and released the guard it had just computed -- warning about a
+        # discrepancy that did not exist.
+        self.position.target_qty = None
+        self.position.target_tol = 0.0
+        self.position.target_reported = False
 
     def _sync_position_from_exchange(self, position_status) -> None:
         """Overwrite the cached position with what the exchange actually holds.
@@ -238,8 +245,9 @@ class TorchTradeLiveEnv(TorchTradeBaseEnv):
         Size is reconciled as well as direction. A partial fill leaves the DIRECTION
         intact, so the check above cannot see it -- the env would believe it holds the
         level it asked for while holding something else, and the guard would suppress
-        every corrective retry, permanently and silently. Compared RELATIVELY, so the rule
-        means the same thing on an asset priced in cents and one priced at $100k.
+        every corrective retry, permanently and silently. The tolerance is the venue's own
+        minimum tradeable size, carried on the trade: below that there is no order that
+        could correct the difference, so firing on it would never converge.
 
         An unknown status raises rather than syncing to the 0 an unreachable exchange
         would produce. In practice _step raises earlier, on its own status read.
@@ -250,19 +258,22 @@ class TorchTradeLiveEnv(TorchTradeBaseEnv):
             self.position.current_action_level = 0.0 if observed == 0 else float("nan")
             self.position.hold_counter = 0
             self.position.target_qty = None
+            self.position.target_tol = 0.0
+            self.position.target_reported = False
         elif self.position.target_qty is not None and (
             abs(position_qty_from_status(position_status) - self.position.target_qty)
             >= max(self.position.target_tol, POSITION_DUST_EPS)
         ):
-            # Logged on the TRANSITION only -- the NaN level is its own already-reported
-            # flag. Clearing target_qty instead would turn a standing fault into a
-            # one-shot notice, and a divergence too small to trade away never re-arms.
-            if not math.isnan(self.position.current_action_level):
+            # An explicit flag, not `isnan(level)`: reset writes NaN to mean "this position
+            # predates the episode and its level is unknowable", so reusing NaN as the
+            # already-reported marker silenced every divergence in such an episode.
+            if not self.position.target_reported:
                 logger.warning(
                     "venue holds %s but the last action asked for %s; releasing the "
                     "duplicate-action guard so the agent can correct it",
                     position_qty_from_status(position_status), self.position.target_qty,
                 )
+            self.position.target_reported = True
             self.position.current_action_level = float("nan")
 
         self.position.current_position = observed
@@ -295,7 +306,7 @@ class TorchTradeLiveEnv(TorchTradeBaseEnv):
                 f"cannot start an episode on equity of {self.initial_portfolio_value}"
             )
 
-    def _record_position_after_trade(self, desired_action: float, trade_info=None) -> None:
+    def _record_position_after_trade(self, desired_action: float, trade_info: dict) -> None:
         """Record the position the trade RESULTED in, not the side that was sent (#276).
 
         Under fractional sizing a SELL that only trims a long leaves a long; recording it
@@ -306,11 +317,15 @@ class TorchTradeLiveEnv(TorchTradeBaseEnv):
         leaving it 0.0 so the next bar called every COMPLETE fill a divergence. One
         argument cannot be half-passed.
         """
-        trade_info = trade_info or {}
+        tol = trade_info.get("target_tol") or 0.0
         self.position.current_position = (desired_action > 0) - (desired_action < 0)
         self.position.current_action_level = desired_action
         self.position.target_qty = trade_info.get("target_qty")
-        self.position.target_tol = trade_info.get("target_tol") or 0.0
+        # A venue reporting min_qty as NaN would make max(nan, eps) NaN, and `x >= nan` is
+        # False -- the check would be off with nothing to show for it. CCXT reports 0 here
+        # routinely, which is why this falls back rather than raising.
+        self.position.target_tol = tol if math.isfinite(tol) and tol > 0 else 0.0
+        self.position.target_reported = False
 
     def _check_termination(self, portfolio_value: float) -> bool:
         """Terminate when the portfolio falls below bankrupt_threshold * its initial value."""

--- a/torchtrade/envs/core/live.py
+++ b/torchtrade/envs/core/live.py
@@ -295,21 +295,22 @@ class TorchTradeLiveEnv(TorchTradeBaseEnv):
                 f"cannot start an episode on equity of {self.initial_portfolio_value}"
             )
 
-    def _record_position_after_trade(
-        self, desired_action: float, target_qty=None, target_tol: float = 0.0
-    ) -> None:
+    def _record_position_after_trade(self, desired_action: float, trade_info=None) -> None:
         """Record the position the trade RESULTED in, not the side that was sent (#276).
 
         Under fractional sizing a SELL that only trims a long leaves a long; recording it
         as a short makes the next bar's sync see a mismatch the env inflicted on itself.
 
-        `target_qty` is what the action asked for and `target_tol` the smallest divergence
-        worth acting on, so the next bar can tell a partial fill from a complete one.
+        Takes the whole `trade_info` rather than the two size values separately: passed
+        separately, all five call sites forwarded the target and dropped the tolerance,
+        leaving it 0.0 so the next bar called every COMPLETE fill a divergence. One
+        argument cannot be half-passed.
         """
+        trade_info = trade_info or {}
         self.position.current_position = (desired_action > 0) - (desired_action < 0)
         self.position.current_action_level = desired_action
-        self.position.target_qty = target_qty
-        self.position.target_tol = target_tol
+        self.position.target_qty = trade_info.get("target_qty")
+        self.position.target_tol = trade_info.get("target_tol") or 0.0
 
     def _check_termination(self, portfolio_value: float) -> bool:
         """Terminate when the portfolio falls below bankrupt_threshold * its initial value."""

--- a/torchtrade/envs/core/live.py
+++ b/torchtrade/envs/core/live.py
@@ -317,6 +317,19 @@ class TorchTradeLiveEnv(TorchTradeBaseEnv):
         leaving it 0.0 so the next bar called every COMPLETE fill a divergence. One
         argument cannot be half-passed.
         """
+        if not trade_info.get("executed") or trade_info.get("success") is False:
+            # A refusal that means "we are already there" must RE-ARM the guard. Without
+            # it, a release latches: the release compares against the snapshot target, the
+            # refusal against one recomputed from drifting equity, so the two disagree and
+            # nothing ever restores a finite level -- the env then re-sizes every bar and
+            # trades whenever drift clears the venue minimum, unrequested and unlogged.
+            if trade_info.get("at_target"):
+                self.position.current_action_level = desired_action
+                self.position.target_qty = None
+                self.position.target_tol = 0.0
+                self.position.target_reported = False
+            return
+
         tol = trade_info.get("target_tol") or 0.0
         self.position.current_position = (desired_action > 0) - (desired_action < 0)
         self.position.current_action_level = desired_action

--- a/torchtrade/envs/core/live.py
+++ b/torchtrade/envs/core/live.py
@@ -16,28 +16,13 @@ from torchtrade.envs.core.base import TorchTradeBaseEnv
 from torchtrade.envs.core.state import (
     PositionState,
     position_direction_from_status,
+    POSITION_DUST_EPS,
     position_qty_from_status,
 )
 from torchtrade.envs.utils.termination import is_bankrupt
 
 
 logger = logging.getLogger(__name__)
-
-# A fill within this fraction of the requested size counts as the size that was asked for.
-# Relative, so it means the same thing on an asset priced in cents and one at $100k --
-# unlike a base-unit constant (#339).
-FILL_REL_TOL = 0.01
-
-
-def validate_action_levels(action_levels) -> None:
-    """Refuse a config whose levels cannot size an order (invariant 4: at the boundary).
-
-    A NaN level reaches sizing as `target_qty = nan`; `nan > 0` is False, so it takes the
-    SELL branch and puts `amount=nan` on the venue. Guarding it downstream would only make
-    the nonsense quieter -- the config is where it is wrong.
-    """
-    if not all(math.isfinite(level) for level in action_levels):
-        raise ValueError(f"action_levels must all be finite, got {action_levels}")
 
 
 class ObservationFailurePolicy(str, Enum):
@@ -265,18 +250,20 @@ class TorchTradeLiveEnv(TorchTradeBaseEnv):
             self.position.current_action_level = 0.0 if observed == 0 else float("nan")
             self.position.hold_counter = 0
             self.position.target_qty = None
-        elif self.position.target_qty is not None and not math.isclose(
-            position_qty_from_status(position_status),
-            self.position.target_qty,
-            rel_tol=FILL_REL_TOL,
+        elif self.position.target_qty is not None and (
+            abs(position_qty_from_status(position_status) - self.position.target_qty)
+            >= max(self.position.target_tol, POSITION_DUST_EPS)
         ):
-            logger.warning(
-                "venue holds %s but the last action asked for %s; releasing the "
-                "duplicate-action guard so the agent can correct it",
-                position_qty_from_status(position_status), self.position.target_qty,
-            )
+            # Logged on the TRANSITION only -- the NaN level is its own already-reported
+            # flag. Clearing target_qty instead would turn a standing fault into a
+            # one-shot notice, and a divergence too small to trade away never re-arms.
+            if not math.isnan(self.position.current_action_level):
+                logger.warning(
+                    "venue holds %s but the last action asked for %s; releasing the "
+                    "duplicate-action guard so the agent can correct it",
+                    position_qty_from_status(position_status), self.position.target_qty,
+                )
             self.position.current_action_level = float("nan")
-            self.position.target_qty = None
 
         self.position.current_position = observed
 
@@ -308,18 +295,21 @@ class TorchTradeLiveEnv(TorchTradeBaseEnv):
                 f"cannot start an episode on equity of {self.initial_portfolio_value}"
             )
 
-    def _record_position_after_trade(self, desired_action: float, target_qty=None) -> None:
+    def _record_position_after_trade(
+        self, desired_action: float, target_qty=None, target_tol: float = 0.0
+    ) -> None:
         """Record the position the trade RESULTED in, not the side that was sent (#276).
 
         Under fractional sizing a SELL that only trims a long leaves a long; recording it
         as a short makes the next bar's sync see a mismatch the env inflicted on itself.
 
-        `target_qty` is what the action asked for, so the next bar can tell a partial fill
-        from a complete one -- see `_sync_position_from_exchange`.
+        `target_qty` is what the action asked for and `target_tol` the smallest divergence
+        worth acting on, so the next bar can tell a partial fill from a complete one.
         """
         self.position.current_position = (desired_action > 0) - (desired_action < 0)
         self.position.current_action_level = desired_action
         self.position.target_qty = target_qty
+        self.position.target_tol = target_tol
 
     def _check_termination(self, portfolio_value: float) -> bool:
         """Terminate when the portfolio falls below bankrupt_threshold * its initial value."""

--- a/torchtrade/envs/core/live.py
+++ b/torchtrade/envs/core/live.py
@@ -268,6 +268,19 @@ class TorchTradeLiveEnv(TorchTradeBaseEnv):
                 f"cannot start an episode on equity of {self.initial_portfolio_value}"
             )
 
+    def _record_position_after_trade(self, desired_action: float) -> None:
+        """Direction comes from the RESULTING position, never from the order side (#276).
+
+        Under fractional sizing a SELL that merely trims a long leaves a long. Recording
+        it as a short makes the NEXT bar's sync detect a mismatch the env inflicted on
+        itself, which discards hold_counter and NaNs current_action_level -- so
+        account_state reports holding_time=1 for a 22-bar-old position and the
+        duplicate-action guard never fires again. The target level's sign is the
+        resulting direction.
+        """
+        self.position.current_position = (desired_action > 0) - (desired_action < 0)
+        self.position.current_action_level = desired_action
+
     def _check_termination(self, portfolio_value: float) -> bool:
         """Terminate when the portfolio falls below bankrupt_threshold * its initial value."""
         return is_bankrupt(

--- a/torchtrade/envs/core/live.py
+++ b/torchtrade/envs/core/live.py
@@ -1,5 +1,6 @@
 """Base class for live trading environments."""
 
+import logging
 import math
 import time
 from abc import abstractmethod
@@ -12,8 +13,31 @@ from tensordict import TensorDictBase
 from torchrl.data import Unbounded
 
 from torchtrade.envs.core.base import TorchTradeBaseEnv
-from torchtrade.envs.core.state import PositionState, position_direction_from_status
+from torchtrade.envs.core.state import (
+    PositionState,
+    position_direction_from_status,
+    position_qty_from_status,
+)
 from torchtrade.envs.utils.termination import is_bankrupt
+
+
+logger = logging.getLogger(__name__)
+
+# A fill within this fraction of the requested size counts as the size that was asked for.
+# Relative, so it means the same thing on an asset priced in cents and one at $100k --
+# unlike a base-unit constant (#339).
+FILL_REL_TOL = 0.01
+
+
+def validate_action_levels(action_levels) -> None:
+    """Refuse a config whose levels cannot size an order (invariant 4: at the boundary).
+
+    A NaN level reaches sizing as `target_qty = nan`; `nan > 0` is False, so it takes the
+    SELL branch and puts `amount=nan` on the venue. Guarding it downstream would only make
+    the nonsense quieter -- the config is where it is wrong.
+    """
+    if not all(math.isfinite(level) for level in action_levels):
+        raise ValueError(f"action_levels must all be finite, got {action_levels}")
 
 
 class ObservationFailurePolicy(str, Enum):
@@ -226,8 +250,11 @@ class TorchTradeLiveEnv(TorchTradeBaseEnv):
         THIS same step, the new position must start from zero rather than inherit the dead
         one's age.
 
-        Only the direction is reconciled, not the size: a PARTIAL external close leaves the
-        direction intact and is still invisible to the guard. Pre-existing, not fixed here.
+        Size is reconciled as well as direction. A partial fill leaves the DIRECTION
+        intact, so the check above cannot see it -- the env would believe it holds the
+        level it asked for while holding something else, and the guard would suppress
+        every corrective retry, permanently and silently. Compared RELATIVELY, so the rule
+        means the same thing on an asset priced in cents and one priced at $100k.
 
         An unknown status raises rather than syncing to the 0 an unreachable exchange
         would produce. In practice _step raises earlier, on its own status read.
@@ -237,6 +264,19 @@ class TorchTradeLiveEnv(TorchTradeBaseEnv):
         if observed != self.position.current_position:
             self.position.current_action_level = 0.0 if observed == 0 else float("nan")
             self.position.hold_counter = 0
+            self.position.target_qty = None
+        elif self.position.target_qty is not None and not math.isclose(
+            position_qty_from_status(position_status),
+            self.position.target_qty,
+            rel_tol=FILL_REL_TOL,
+        ):
+            logger.warning(
+                "venue holds %s but the last action asked for %s; releasing the "
+                "duplicate-action guard so the agent can correct it",
+                position_qty_from_status(position_status), self.position.target_qty,
+            )
+            self.position.current_action_level = float("nan")
+            self.position.target_qty = None
 
         self.position.current_position = observed
 
@@ -268,18 +308,18 @@ class TorchTradeLiveEnv(TorchTradeBaseEnv):
                 f"cannot start an episode on equity of {self.initial_portfolio_value}"
             )
 
-    def _record_position_after_trade(self, desired_action: float) -> None:
-        """Direction comes from the RESULTING position, never from the order side (#276).
+    def _record_position_after_trade(self, desired_action: float, target_qty=None) -> None:
+        """Record the position the trade RESULTED in, not the side that was sent (#276).
 
-        Under fractional sizing a SELL that merely trims a long leaves a long. Recording
-        it as a short makes the NEXT bar's sync detect a mismatch the env inflicted on
-        itself, which discards hold_counter and NaNs current_action_level -- so
-        account_state reports holding_time=1 for a 22-bar-old position and the
-        duplicate-action guard never fires again. The target level's sign is the
-        resulting direction.
+        Under fractional sizing a SELL that only trims a long leaves a long; recording it
+        as a short makes the next bar's sync see a mismatch the env inflicted on itself.
+
+        `target_qty` is what the action asked for, so the next bar can tell a partial fill
+        from a complete one -- see `_sync_position_from_exchange`.
         """
         self.position.current_position = (desired_action > 0) - (desired_action < 0)
         self.position.current_action_level = desired_action
+        self.position.target_qty = target_qty
 
     def _check_termination(self, portfolio_value: float) -> bool:
         """Terminate when the portfolio falls below bankrupt_threshold * its initial value."""

--- a/torchtrade/envs/core/state.py
+++ b/torchtrade/envs/core/state.py
@@ -2,7 +2,7 @@
 
 import math
 from dataclasses import asdict, dataclass, field, fields
-from typing import Dict, List, Union
+from typing import Dict, List, Optional, Union
 
 
 # Quantities at or below this are dust, not a position. Exchanges can leave a float residual
@@ -172,6 +172,9 @@ class PositionState:
     hold_counter: int = 0
     hold_direction: float = 0.0
     current_action_level: float = 0.0
+    # The quantity the last accepted action asked for, so a partial fill can be told from
+    # a complete one. None when the env has not traded, or the path cannot report a target.
+    target_qty: Optional[float] = None
 
     def reset(self):
         """Reset all position state to initial values."""

--- a/torchtrade/envs/core/state.py
+++ b/torchtrade/envs/core/state.py
@@ -177,6 +177,9 @@ class PositionState:
     # cannot be corrected by placing an order. None when the env has not traded.
     target_qty: Optional[float] = None
     target_tol: float = 0.0
+    # Whether the current divergence has been logged, so a standing fault reports once
+    # without borrowing NaN, which already means something else on current_action_level.
+    target_reported: bool = False
 
     def reset(self):
         """Reset all position state to initial values."""

--- a/torchtrade/envs/core/state.py
+++ b/torchtrade/envs/core/state.py
@@ -172,9 +172,11 @@ class PositionState:
     hold_counter: int = 0
     hold_direction: float = 0.0
     current_action_level: float = 0.0
-    # The quantity the last accepted action asked for, so a partial fill can be told from
-    # a complete one. None when the env has not traded, or the path cannot report a target.
+    # What the last accepted action asked for, and the smallest divergence from it worth
+    # acting on -- the venue's own minimum tradeable size, because anything below that
+    # cannot be corrected by placing an order. None when the env has not traded.
     target_qty: Optional[float] = None
+    target_tol: float = 0.0
 
     def reset(self):
         """Reset all position state to initial values."""

--- a/torchtrade/envs/live/alpaca/base.py
+++ b/torchtrade/envs/live/alpaca/base.py
@@ -456,10 +456,8 @@ class AlpacaBaseTorchTradingEnv(TorchTradeLiveEnv):
 
         current_price = position_status.current_price if position_status else 0.0
 
-        # The chain advances on USABLE, not on `<= 0` (#349). NaN compares False to every
-        # operator, so `nan <= 0` skipped both fallbacks and returned the NaN as the
-        # answer; `inf > 0` skipped them and then had nothing left. Either way the
-        # function whose whole job is producing a usable price returned one that is not.
+        # Advance on USABLE, not `<= 0` (#349): NaN compares False to every operator, so
+        # `nan <= 0` skipped both fallbacks and returned the NaN as the price.
         def usable(price):
             return math.isfinite(price) and price > 0
 
@@ -468,11 +466,19 @@ class AlpacaBaseTorchTradingEnv(TorchTradeLiveEnv):
 
         if not usable(current_price):
             try:
-                current_price = self.observer.get_current_price()
-                logger.info(f"Fetched current price from market data: {current_price}")
+                fetched = self.observer.get_current_price()
+                if usable(fetched):
+                    # Logged AFTER validating: this said "Fetched current price: nan" and
+                    # then threw it away, so the only trace claimed the fetch worked.
+                    logger.info(f"Fetched current price from market data: {fetched}")
+                current_price = fetched
             except Exception as e:
                 logger.warning(f"Could not fetch current price: {e}")
 
-        # Chain exhausted: 0.0 is this function's documented "unavailable", and every
-        # caller already guards it. Handing back the garbage would defeat the point.
-        return current_price if usable(current_price) else 0.0
+        if not usable(current_price):
+            logger.error(
+                f"No usable price: every source in the chain failed "
+                f"(last value {current_price}); reporting unavailable"
+            )
+            return 0.0
+        return current_price

--- a/torchtrade/envs/live/alpaca/base.py
+++ b/torchtrade/envs/live/alpaca/base.py
@@ -456,16 +456,23 @@ class AlpacaBaseTorchTradingEnv(TorchTradeLiveEnv):
 
         current_price = position_status.current_price if position_status else 0.0
 
-        # Fallback 1: trader's current_price attribute (for mocks)
-        if current_price <= 0 and hasattr(self.trader, 'current_price'):
+        # The chain advances on USABLE, not on `<= 0` (#349). NaN compares False to every
+        # operator, so `nan <= 0` skipped both fallbacks and returned the NaN as the
+        # answer; `inf > 0` skipped them and then had nothing left. Either way the
+        # function whose whole job is producing a usable price returned one that is not.
+        def usable(price):
+            return math.isfinite(price) and price > 0
+
+        if not usable(current_price) and hasattr(self.trader, 'current_price'):
             current_price = self.trader.current_price
 
-        # Fallback 2: fetch from market data
-        if current_price <= 0:
+        if not usable(current_price):
             try:
                 current_price = self.observer.get_current_price()
                 logger.info(f"Fetched current price from market data: {current_price}")
             except Exception as e:
                 logger.warning(f"Could not fetch current price: {e}")
 
-        return current_price
+        # Chain exhausted: 0.0 is this function's documented "unavailable", and every
+        # caller already guards it. Handing back the garbage would defeat the point.
+        return current_price if usable(current_price) else 0.0

--- a/torchtrade/envs/live/alpaca/env.py
+++ b/torchtrade/envs/live/alpaca/env.py
@@ -300,8 +300,7 @@ class AlpacaTorchTradingEnv(AlpacaBaseTorchTradingEnv):
         try:
             success = self.trader.trade(side=side, amount=amount, order_type="market")
             # Set here, not per-branch: alpaca reported no target at all, so the
-            # partial-fill check was dead on this env. min_trade_value is the smallest
-            # divergence alpaca will act on, so it is the tolerance.
+            # partial-fill check was dead on this env.
             trade_info["target_qty"] = target_qty
             trade_info["target_tol"] = min_trade_value / current_price
             trade_info.update({

--- a/torchtrade/envs/live/alpaca/env.py
+++ b/torchtrade/envs/live/alpaca/env.py
@@ -6,6 +6,7 @@ import math
 import torch
 
 logger = logging.getLogger(__name__)
+from torchtrade.envs.core.live import validate_action_levels
 from torchtrade.envs.utils.timeframe import TimeFrame, TimeFrameUnit
 from torchtrade.envs.live.alpaca.utils import normalize_alpaca_timeframe_config
 from torchtrade.envs.live.alpaca.observation import AlpacaObservationClass
@@ -38,6 +39,9 @@ class AlpacaTradingEnvConfig:
         # Build default action levels for fractional mode
         if self.action_levels is None:
             self.action_levels = [0.0, 0.5, 1.0]  # Long-only fractional
+
+        validate_action_levels(self.action_levels)
+
 
 class AlpacaTorchTradingEnv(AlpacaBaseTorchTradingEnv):
     """
@@ -127,7 +131,7 @@ class AlpacaTorchTradingEnv(AlpacaBaseTorchTradingEnv):
         trade_info = self._execute_trade_if_needed(desired_action)
 
         if trade_info["executed"] and trade_info.get("success") is not False:
-            self._record_position_after_trade(desired_action)
+            self._record_position_after_trade(desired_action, trade_info.get("target_qty"))
 
         # Wait for next time step
         self._wait_for_next_timestamp()

--- a/torchtrade/envs/live/alpaca/env.py
+++ b/torchtrade/envs/live/alpaca/env.py
@@ -6,7 +6,7 @@ import math
 import torch
 
 logger = logging.getLogger(__name__)
-from torchtrade.envs.core.live import validate_action_levels
+from torchtrade.envs.utils.fractional_sizing import validate_action_levels
 from torchtrade.envs.utils.timeframe import TimeFrame, TimeFrameUnit
 from torchtrade.envs.live.alpaca.utils import normalize_alpaca_timeframe_config
 from torchtrade.envs.live.alpaca.observation import AlpacaObservationClass
@@ -299,6 +299,11 @@ class AlpacaTorchTradingEnv(AlpacaBaseTorchTradingEnv):
         # Execute trade
         try:
             success = self.trader.trade(side=side, amount=amount, order_type="market")
+            # Set here, not per-branch: alpaca reported no target at all, so the
+            # partial-fill check was dead on this env. min_trade_value is the smallest
+            # divergence alpaca will act on, so it is the tolerance.
+            trade_info["target_qty"] = target_qty
+            trade_info["target_tol"] = min_trade_value / current_price
             trade_info.update({
                 "executed": True,
                 "amount": amount,
@@ -315,31 +320,9 @@ class AlpacaTorchTradingEnv(AlpacaBaseTorchTradingEnv):
         return trade_info
 
     def _calculate_trade_amount(self, side: str) -> float:
-        """Calculate the dollar amount to trade (not used in fractional mode)."""
+        """Required: the base declares this abstract. Fractional mode sizes in
+        _execute_fractional_action instead, so reaching here is a wiring error."""
         raise NotImplementedError("_calculate_trade_amount is not used in fractional mode")
-
-    def _create_info_dict(self, portfolio_value: float, trade_info: Dict, action_value: float) -> Dict:
-        """Create info dictionary for debugging."""
-        portfolio_return = ((portfolio_value - self.initial_portfolio_value) / 
-                        self.initial_portfolio_value)
-
-        account = self.trader.client.get_account()
-        cash = float(account.cash)
-        position_status = self.trader.get_status().get("position_status", None)
-        
-        return {
-            "portfolio_value": portfolio_value,
-            "portfolio_return": portfolio_return,
-            "cash": cash,
-            "position_qty": position_qty_from_status(position_status),
-            "position_market_value": position_status.market_value if position_status else 0,
-            "trade_executed": trade_info["executed"],
-            "trade_amount": trade_info["amount"],
-            "trade_success": trade_info["success"],
-            "trade_side": trade_info["side"],
-            "action": action_value,
-            "trade_mode": self.trader.trade_mode,
-        }
 
 
 if __name__ == "__main__":

--- a/torchtrade/envs/live/alpaca/env.py
+++ b/torchtrade/envs/live/alpaca/env.py
@@ -121,14 +121,13 @@ class AlpacaTorchTradingEnv(AlpacaBaseTorchTradingEnv):
         self._sync_position_from_exchange(position_status)
         # From the exchange, as every other live env does: self.position.position_size is
         # never populated on the alpaca envs (#290). Size held ENTERING the bar.
-        position_size = position_status.qty if position_status else 0.0
+        position_size = position_qty_from_status(position_status)
 
         # Calculate and execute trade if needed
         trade_info = self._execute_trade_if_needed(desired_action)
 
         if trade_info["executed"] and trade_info.get("success") is not False:
-            self.position.current_position = 1 if trade_info["side"] == "buy" else 0
-            self.position.current_action_level = desired_action
+            self._record_position_after_trade(desired_action)
 
         # Wait for next time step
         self._wait_for_next_timestamp()
@@ -328,7 +327,7 @@ class AlpacaTorchTradingEnv(AlpacaBaseTorchTradingEnv):
             "portfolio_value": portfolio_value,
             "portfolio_return": portfolio_return,
             "cash": cash,
-            "position_qty": position_status.qty if position_status else 0,
+            "position_qty": position_qty_from_status(position_status),
             "position_market_value": position_status.market_value if position_status else 0,
             "trade_executed": trade_info["executed"],
             "trade_amount": trade_info["amount"],

--- a/torchtrade/envs/live/alpaca/env.py
+++ b/torchtrade/envs/live/alpaca/env.py
@@ -130,8 +130,7 @@ class AlpacaTorchTradingEnv(AlpacaBaseTorchTradingEnv):
         # Calculate and execute trade if needed
         trade_info = self._execute_trade_if_needed(desired_action)
 
-        if trade_info["executed"] and trade_info.get("success") is not False:
-            self._record_position_after_trade(desired_action, trade_info)
+        self._record_position_after_trade(desired_action, trade_info)
 
         # Wait for next time step
         self._wait_for_next_timestamp()
@@ -278,7 +277,8 @@ class AlpacaTorchTradingEnv(AlpacaBaseTorchTradingEnv):
         delta_value = abs(delta_qty * current_price)
 
         if delta_value < min_trade_value:
-            # Already at target position (within tolerance)
+            # Already at target: say so, so the guard can re-arm (#276 follow-up)
+            trade_info["at_target"] = True
             return trade_info
 
         # Determine trade side and amount

--- a/torchtrade/envs/live/alpaca/env.py
+++ b/torchtrade/envs/live/alpaca/env.py
@@ -131,7 +131,7 @@ class AlpacaTorchTradingEnv(AlpacaBaseTorchTradingEnv):
         trade_info = self._execute_trade_if_needed(desired_action)
 
         if trade_info["executed"] and trade_info.get("success") is not False:
-            self._record_position_after_trade(desired_action, trade_info.get("target_qty"))
+            self._record_position_after_trade(desired_action, trade_info)
 
         # Wait for next time step
         self._wait_for_next_timestamp()

--- a/torchtrade/envs/live/alpaca/env.py
+++ b/torchtrade/envs/live/alpaca/env.py
@@ -299,8 +299,7 @@ class AlpacaTorchTradingEnv(AlpacaBaseTorchTradingEnv):
         # Execute trade
         try:
             success = self.trader.trade(side=side, amount=amount, order_type="market")
-            # Set here, not per-branch: alpaca reported no target at all, so the
-            # partial-fill check was dead on this env.
+            # Set once here rather than per-branch, so no branch can skip it.
             trade_info["target_qty"] = target_qty
             trade_info["target_tol"] = min_trade_value / current_price
             trade_info.update({

--- a/torchtrade/envs/live/alpaca/env_sltp.py
+++ b/torchtrade/envs/live/alpaca/env_sltp.py
@@ -164,10 +164,9 @@ class AlpacaSLTPTorchTradingEnv(SLTPMixin, AlpacaBaseTorchTradingEnv):
         # Eagerly update position from trade result so the rest of this step
         # sees the new state without waiting for the next sync cycle.
         if trade_info["executed"] and trade_info.get("success") is not False:
-            # From the ACTION, not the order side (#276). Alpaca's map drops the side
-            # (long-only spot), so a bracket tuple targets a long and the close action's
-            # (None, None) targets flat.
-            self.position.current_position = 1 if action_tuple[0] is not None else 0
+            # Alpaca's action map drops the side (long-only spot), so a bracket tuple
+            # targets a long and the close action's (None, None) targets flat.
+            self._record_sltp_position("long" if action_tuple[0] is not None else None)
 
         # Wait for next time step
         self._wait_for_next_timestamp()

--- a/torchtrade/envs/live/alpaca/env_sltp.py
+++ b/torchtrade/envs/live/alpaca/env_sltp.py
@@ -6,6 +6,7 @@ import logging
 import torch
 
 logger = logging.getLogger(__name__)
+from torchtrade.envs.core.state import position_qty_from_status
 from torchtrade.envs.utils.timeframe import TimeFrame, TimeFrameUnit
 from torchtrade.envs.live.alpaca.utils import normalize_alpaca_timeframe_config
 from torchtrade.envs.live.alpaca.observation import AlpacaObservationClass
@@ -144,7 +145,7 @@ class AlpacaSLTPTorchTradingEnv(SLTPMixin, AlpacaBaseTorchTradingEnv):
         # From the exchange, as every other live env does: the alpaca envs never populate
         # self.position.position_size, so reading it recorded a flat history forever
         # (#290). This is the size held ENTERING the bar, matching bybit.
-        position_size = position_status.qty if position_status else 0.0
+        position_size = position_qty_from_status(position_status)
 
         # Sync position state from exchange — this is the source of truth.
         # Detects SL/TP closures AND fixes state drift from failed bracket orders.

--- a/torchtrade/envs/live/alpaca/env_sltp.py
+++ b/torchtrade/envs/live/alpaca/env_sltp.py
@@ -164,7 +164,10 @@ class AlpacaSLTPTorchTradingEnv(SLTPMixin, AlpacaBaseTorchTradingEnv):
         # Eagerly update position from trade result so the rest of this step
         # sees the new state without waiting for the next sync cycle.
         if trade_info["executed"] and trade_info.get("success") is not False:
-            self.position.current_position = 1 if trade_info["side"] == "buy" else 0
+            # From the ACTION, not the order side (#276). Alpaca's map drops the side
+            # (long-only spot), so a bracket tuple targets a long and the close action's
+            # (None, None) targets flat.
+            self.position.current_position = 1 if action_tuple[0] is not None else 0
 
         # Wait for next time step
         self._wait_for_next_timestamp()

--- a/torchtrade/envs/live/binance/env.py
+++ b/torchtrade/envs/live/binance/env.py
@@ -9,7 +9,6 @@ logger = logging.getLogger(__name__)
 from tensordict import TensorDict, TensorDictBase
 from torchrl.data import Categorical
 
-from torchtrade.envs.core.live import validate_action_levels
 from torchtrade.envs.core.state import position_qty_from_status
 from torchtrade.envs.utils.timeframe import TimeFrame
 from torchtrade.envs.core.live import (
@@ -22,6 +21,7 @@ from torchtrade.envs.live.binance.order_executor import (
 )
 from torchtrade.envs.live.binance.base import BinanceBaseTorchTradingEnv
 from torchtrade.envs.utils.fractional_sizing import (
+    validate_action_levels,
     build_default_action_levels,
     calculate_fractional_position,
     PositionCalculationParams,
@@ -163,8 +163,6 @@ class BinanceFuturesTorchTradingEnv(BinanceBaseTorchTradingEnv):
         # Get current price and position from trader status (avoids redundant observation call)
         status = self.trader.get_status()
         position_status = status.get("position_status", None)
-        # Both callees already handle None, and the mark read stays FIRST so an unknown
-        # status still raises PositionUnknownError with the price message it always did.
         current_price = self._current_mark_price(position_status)
         position_size = position_qty_from_status(position_status)
 
@@ -254,7 +252,6 @@ class BinanceFuturesTorchTradingEnv(BinanceBaseTorchTradingEnv):
             return self._create_trade_info(executed=False, success=False)
 
         return self._create_trade_info(
-            target_qty=0.0,
             executed=True,
             quantity=abs(current_qty),
             side="CLOSE",
@@ -479,20 +476,20 @@ class BinanceFuturesTorchTradingEnv(BinanceBaseTorchTradingEnv):
                 return close_info
 
             # Open new position in opposite direction
-            side = "BUY" if target_qty > 0 else "SELL"
-            info = self._execute_market_order(side, abs(target_qty))
-            info["target_qty"] = target_qty
-            return info
-
+            side, amount = ("BUY" if target_qty > 0 else "SELL"), abs(target_qty)
         elif delta > 0:
-            # Increasing position (or opening long from flat)
-            return self._execute_market_order("BUY", abs(delta))
-
+            side, amount = "BUY", abs(delta)          # increase, or open long from flat
         elif delta < 0:
-            # Decreasing position (or opening short from flat)
-            return self._execute_market_order("SELL", abs(delta))
+            side, amount = "SELL", abs(delta)         # decrease, or open short from flat
+        else:
+            return self._create_trade_info(executed=False)
 
-        return self._create_trade_info(executed=False)
+        # One exit, so a fourth branch cannot silently skip the target and disable the
+        # partial-fill check: three of these four used to (#276 follow-up).
+        info = self._execute_market_order(side, amount)
+        info["target_qty"] = target_qty
+        info["target_tol"] = min_notional / current_price
+        return info
 
     def _execute_trade_if_needed(self, desired_action: float) -> Dict:
         """

--- a/torchtrade/envs/live/binance/env.py
+++ b/torchtrade/envs/live/binance/env.py
@@ -9,6 +9,7 @@ logger = logging.getLogger(__name__)
 from tensordict import TensorDict, TensorDictBase
 from torchrl.data import Categorical
 
+from torchtrade.envs.core.state import position_qty_from_status
 from torchtrade.envs.utils.timeframe import TimeFrame
 from torchtrade.envs.core.live import (
     ObservationFailurePolicy,
@@ -161,7 +162,7 @@ class BinanceFuturesTorchTradingEnv(BinanceBaseTorchTradingEnv):
         position_status = status.get("position_status", None)
         if position_status:
             current_price = self._current_mark_price(position_status)
-            position_size = position_status.qty
+            position_size = position_qty_from_status(position_status)
         else:
             current_price = self._current_mark_price()
             position_size = 0.0
@@ -178,13 +179,7 @@ class BinanceFuturesTorchTradingEnv(BinanceBaseTorchTradingEnv):
         trade_info = self._execute_trade_if_needed(desired_action)
 
         if trade_info["executed"] and trade_info.get("success") is not False:
-            if trade_info["side"] == "BUY":
-                self.position.current_position = 1
-            elif trade_info["side"] == "SELL":
-                self.position.current_position = -1
-            elif trade_info["closed_position"]:
-                self.position.current_position = 0
-            self.position.current_action_level = desired_action
+            self._record_position_after_trade(desired_action)
 
         # Wait for next time step
         self._wait_for_next_timestamp()

--- a/torchtrade/envs/live/binance/env.py
+++ b/torchtrade/envs/live/binance/env.py
@@ -178,7 +178,7 @@ class BinanceFuturesTorchTradingEnv(BinanceBaseTorchTradingEnv):
         trade_info = self._execute_trade_if_needed(desired_action)
 
         if trade_info["executed"] and trade_info.get("success") is not False:
-            self._record_position_after_trade(desired_action, trade_info.get("target_qty"))
+            self._record_position_after_trade(desired_action, trade_info)
 
         # Wait for next time step
         self._wait_for_next_timestamp()

--- a/torchtrade/envs/live/binance/env.py
+++ b/torchtrade/envs/live/binance/env.py
@@ -484,8 +484,7 @@ class BinanceFuturesTorchTradingEnv(BinanceBaseTorchTradingEnv):
         else:
             return self._create_trade_info(executed=False)
 
-        # One exit, so a fourth branch cannot silently skip the target and disable the
-        # partial-fill check: three of these four used to (#276 follow-up).
+        # One exit, so a new branch cannot skip the target and disable the check.
         info = self._execute_market_order(side, amount)
         info["target_qty"] = target_qty
         info["target_tol"] = min_notional / current_price

--- a/torchtrade/envs/live/binance/env.py
+++ b/torchtrade/envs/live/binance/env.py
@@ -9,6 +9,7 @@ logger = logging.getLogger(__name__)
 from tensordict import TensorDict, TensorDictBase
 from torchrl.data import Categorical
 
+from torchtrade.envs.core.live import validate_action_levels
 from torchtrade.envs.core.state import position_qty_from_status
 from torchtrade.envs.utils.timeframe import TimeFrame
 from torchtrade.envs.core.live import (
@@ -75,6 +76,8 @@ class BinanceFuturesTradingEnvConfig:
             self.action_levels = build_default_action_levels(
                 allow_short=True  # Futures allow short positions
             )
+
+        validate_action_levels(self.action_levels)
 
 
 class BinanceFuturesTorchTradingEnv(BinanceBaseTorchTradingEnv):
@@ -160,12 +163,10 @@ class BinanceFuturesTorchTradingEnv(BinanceBaseTorchTradingEnv):
         # Get current price and position from trader status (avoids redundant observation call)
         status = self.trader.get_status()
         position_status = status.get("position_status", None)
-        if position_status:
-            current_price = self._current_mark_price(position_status)
-            position_size = position_qty_from_status(position_status)
-        else:
-            current_price = self._current_mark_price()
-            position_size = 0.0
+        # Both callees already handle None, and the mark read stays FIRST so an unknown
+        # status still raises PositionUnknownError with the price message it always did.
+        current_price = self._current_mark_price(position_status)
+        position_size = position_qty_from_status(position_status)
 
         self._sync_position_from_exchange(position_status)
 
@@ -179,7 +180,7 @@ class BinanceFuturesTorchTradingEnv(BinanceBaseTorchTradingEnv):
         trade_info = self._execute_trade_if_needed(desired_action)
 
         if trade_info["executed"] and trade_info.get("success") is not False:
-            self._record_position_after_trade(desired_action)
+            self._record_position_after_trade(desired_action, trade_info.get("target_qty"))
 
         # Wait for next time step
         self._wait_for_next_timestamp()
@@ -253,6 +254,7 @@ class BinanceFuturesTorchTradingEnv(BinanceBaseTorchTradingEnv):
             return self._create_trade_info(executed=False, success=False)
 
         return self._create_trade_info(
+            target_qty=0.0,
             executed=True,
             quantity=abs(current_qty),
             side="CLOSE",
@@ -478,7 +480,9 @@ class BinanceFuturesTorchTradingEnv(BinanceBaseTorchTradingEnv):
 
             # Open new position in opposite direction
             side = "BUY" if target_qty > 0 else "SELL"
-            return self._execute_market_order(side, abs(target_qty))
+            info = self._execute_market_order(side, abs(target_qty))
+            info["target_qty"] = target_qty
+            return info
 
         elif delta > 0:
             # Increasing position (or opening long from flat)

--- a/torchtrade/envs/live/binance/env.py
+++ b/torchtrade/envs/live/binance/env.py
@@ -177,8 +177,7 @@ class BinanceFuturesTorchTradingEnv(BinanceBaseTorchTradingEnv):
         # Execute trade
         trade_info = self._execute_trade_if_needed(desired_action)
 
-        if trade_info["executed"] and trade_info.get("success") is not False:
-            self._record_position_after_trade(desired_action, trade_info)
+        self._record_position_after_trade(desired_action, trade_info)
 
         # Wait for next time step
         self._wait_for_next_timestamp()
@@ -455,7 +454,7 @@ class BinanceFuturesTorchTradingEnv(BinanceBaseTorchTradingEnv):
         delta_notional = abs(delta) * current_price
         min_notional = self._get_min_notional()
         if delta_notional < min_notional:
-            return self._create_trade_info(executed=False)  # Delta too small for exchange
+            return self._create_trade_info(executed=False, at_target=True)  # Delta too small for exchange
 
         # 9. Determine trade direction and execute
         if (current_qty > 0 and target_qty < 0) or (current_qty < 0 and target_qty > 0):

--- a/torchtrade/envs/live/binance/env_sltp.py
+++ b/torchtrade/envs/live/binance/env_sltp.py
@@ -9,6 +9,7 @@ logger = logging.getLogger(__name__)
 from tensordict import TensorDictBase
 from torchrl.data import Categorical
 
+from torchtrade.envs.core.state import position_qty_from_status
 from torchtrade.envs.utils.timeframe import TimeFrame
 from torchtrade.envs.live.binance.observation import BinanceObservationClass
 from torchtrade.envs.live.binance.order_executor import (
@@ -181,7 +182,7 @@ class BinanceFuturesSLTPTorchTradingEnv(SLTPMixin, BinanceBaseTorchTradingEnv):
         position_status = status.get("position_status", None)
         if position_status:
             current_price = self._current_mark_price(position_status)
-            position_size = position_status.qty
+            position_size = position_qty_from_status(position_status)
         else:
             current_price = self._current_mark_price()
             position_size = 0.0

--- a/torchtrade/envs/live/binance/env_sltp.py
+++ b/torchtrade/envs/live/binance/env_sltp.py
@@ -180,12 +180,10 @@ class BinanceFuturesSLTPTorchTradingEnv(SLTPMixin, BinanceBaseTorchTradingEnv):
         # Get current price and position from trader status (avoids redundant observation call)
         status = self.trader.get_status()
         position_status = status.get("position_status", None)
-        if position_status:
-            current_price = self._current_mark_price(position_status)
-            position_size = position_qty_from_status(position_status)
-        else:
-            current_price = self._current_mark_price()
-            position_size = 0.0
+        # Both callees already handle None, and the mark read stays FIRST so an unknown
+        # status still raises PositionUnknownError with the price message it always did.
+        current_price = self._current_mark_price(position_status)
+        position_size = position_qty_from_status(position_status)
 
         # Sync position state from exchange — this is the source of truth.
         # Detects SL/TP closures AND fixes state drift from failed bracket orders.
@@ -204,12 +202,11 @@ class BinanceFuturesSLTPTorchTradingEnv(SLTPMixin, BinanceBaseTorchTradingEnv):
         # Eagerly update position from trade result so the rest of this step
         # sees the new state without waiting for the next sync cycle.
         if trade_info["executed"] and trade_info.get("success") is not False:
-            if trade_info["side"] == "BUY":
-                self.position.current_position = 1  # Long
-            elif trade_info["side"] == "SELL":
-                self.position.current_position = -1  # Short
-            elif trade_info["closed_position"]:
-                self.position.current_position = 0  # Closed
+            # The TARGET side from the action, never the order side (#276): the same
+            # self-inflicted-mismatch chain applies here. binance and bitget also had
+            # their closed branch behind an elif that always matched first, so an SLTP
+            # close could never be recorded at all.
+            self.position.current_position = {"long": 1, "short": -1}.get(action_tuple[0], 0)
 
         # Wait for next time step
         self._wait_for_next_timestamp()

--- a/torchtrade/envs/live/binance/env_sltp.py
+++ b/torchtrade/envs/live/binance/env_sltp.py
@@ -180,8 +180,6 @@ class BinanceFuturesSLTPTorchTradingEnv(SLTPMixin, BinanceBaseTorchTradingEnv):
         # Get current price and position from trader status (avoids redundant observation call)
         status = self.trader.get_status()
         position_status = status.get("position_status", None)
-        # Both callees already handle None, and the mark read stays FIRST so an unknown
-        # status still raises PositionUnknownError with the price message it always did.
         current_price = self._current_mark_price(position_status)
         position_size = position_qty_from_status(position_status)
 
@@ -202,11 +200,7 @@ class BinanceFuturesSLTPTorchTradingEnv(SLTPMixin, BinanceBaseTorchTradingEnv):
         # Eagerly update position from trade result so the rest of this step
         # sees the new state without waiting for the next sync cycle.
         if trade_info["executed"] and trade_info.get("success") is not False:
-            # The TARGET side from the action, never the order side (#276): the same
-            # self-inflicted-mismatch chain applies here. binance and bitget also had
-            # their closed branch behind an elif that always matched first, so an SLTP
-            # close could never be recorded at all.
-            self.position.current_position = {"long": 1, "short": -1}.get(action_tuple[0], 0)
+            self._record_sltp_position(action_tuple[0])
 
         # Wait for next time step
         self._wait_for_next_timestamp()
@@ -279,8 +273,7 @@ class BinanceFuturesSLTPTorchTradingEnv(SLTPMixin, BinanceBaseTorchTradingEnv):
             return trade_info
 
         # Check if already in same position (ignore duplicate actions)
-        position_map = {"long": 1, "short": -1}
-        if side in position_map and self.position.current_position == position_map[side]:
+        if side in self.SIDE_DIRECTION and self.position.current_position == self.SIDE_DIRECTION[side]:
             return trade_info  # Already in this position, ignore duplicate action
 
         # Get current price for calculating absolute SL/TP levels

--- a/torchtrade/envs/live/bitget/env.py
+++ b/torchtrade/envs/live/bitget/env.py
@@ -7,6 +7,7 @@ import torch
 from tensordict import TensorDictBase
 from torchrl.data import Categorical
 
+from torchtrade.envs.core.state import position_qty_from_status
 from torchtrade.envs.live.bitget.observation import BitgetObservationClass
 from torchtrade.envs.live.bitget.order_executor import (
     BitgetFuturesOrderClass,
@@ -160,7 +161,7 @@ class BitgetFuturesTorchTradingEnv(BitgetBaseTorchTradingEnv):
         position_status = status.get("position_status", None)
         if position_status:
             current_price = self._current_mark_price(position_status)
-            position_size = position_status.qty
+            position_size = position_qty_from_status(position_status)
         else:
             current_price = self._current_mark_price()
             position_size = 0.0
@@ -177,13 +178,7 @@ class BitgetFuturesTorchTradingEnv(BitgetBaseTorchTradingEnv):
         trade_info = self._execute_trade_if_needed(desired_action)
 
         if trade_info["executed"] and trade_info.get("success") is not False:
-            if trade_info["side"] == "buy":
-                self.position.current_position = 1  # Long
-            elif trade_info["side"] == "sell" and trade_info.get("closed_position"):
-                self.position.current_position = 0  # Closed
-            elif trade_info["side"] == "sell":
-                self.position.current_position = -1  # Short
-            self.position.current_action_level = desired_action
+            self._record_position_after_trade(desired_action)
 
         # Wait for next time step
         self._wait_for_next_timestamp()

--- a/torchtrade/envs/live/bitget/env.py
+++ b/torchtrade/envs/live/bitget/env.py
@@ -7,7 +7,6 @@ import torch
 from tensordict import TensorDictBase
 from torchrl.data import Categorical
 
-from torchtrade.envs.core.live import validate_action_levels
 from torchtrade.envs.core.state import position_qty_from_status
 from torchtrade.envs.live.bitget.observation import BitgetObservationClass
 from torchtrade.envs.live.bitget.order_executor import (
@@ -20,6 +19,7 @@ from torchtrade.envs.core.live import (
     ObservationFailurePolicy,
 )
 from torchtrade.envs.utils.fractional_sizing import (
+    validate_action_levels,
     calculate_fractional_position,
     PositionCalculationParams,
 )
@@ -162,8 +162,6 @@ class BitgetFuturesTorchTradingEnv(BitgetBaseTorchTradingEnv):
         # Get current price and position from trader status (avoids redundant observation call)
         status = self.trader.get_status()
         position_status = status.get("position_status", None)
-        # Both callees already handle None, and the mark read stays FIRST so an unknown
-        # status still raises PositionUnknownError with the price message it always did.
         current_price = self._current_mark_price(position_status)
         position_size = position_qty_from_status(position_status)
 
@@ -258,7 +256,6 @@ class BitgetFuturesTorchTradingEnv(BitgetBaseTorchTradingEnv):
             self.position.current_position = 0
 
         return self._create_trade_info(
-            target_qty=0.0,
             executed=True,
             quantity=abs(current_qty),
             side=side,
@@ -361,6 +358,7 @@ class BitgetFuturesTorchTradingEnv(BitgetBaseTorchTradingEnv):
         # Execute market order
         info = self._execute_market_order(side, amount)
         info["target_qty"] = target_qty
+        info["target_tol"] = min_qty
         return info
 
     def _execute_trade_if_needed(self, desired_action: float) -> Dict:

--- a/torchtrade/envs/live/bitget/env.py
+++ b/torchtrade/envs/live/bitget/env.py
@@ -7,6 +7,7 @@ import torch
 from tensordict import TensorDictBase
 from torchrl.data import Categorical
 
+from torchtrade.envs.core.live import validate_action_levels
 from torchtrade.envs.core.state import position_qty_from_status
 from torchtrade.envs.live.bitget.observation import BitgetObservationClass
 from torchtrade.envs.live.bitget.order_executor import (
@@ -73,6 +74,8 @@ class BitgetFuturesTradingEnvConfig:
         # Build default action levels for fractional mode
         if self.action_levels is None:
             self.action_levels = [-1.0, -0.5, 0.0, 0.5, 1.0]  # Standard fractional with long/short
+
+        validate_action_levels(self.action_levels)
 
 
 class BitgetFuturesTorchTradingEnv(BitgetBaseTorchTradingEnv):
@@ -159,12 +162,10 @@ class BitgetFuturesTorchTradingEnv(BitgetBaseTorchTradingEnv):
         # Get current price and position from trader status (avoids redundant observation call)
         status = self.trader.get_status()
         position_status = status.get("position_status", None)
-        if position_status:
-            current_price = self._current_mark_price(position_status)
-            position_size = position_qty_from_status(position_status)
-        else:
-            current_price = self._current_mark_price()
-            position_size = 0.0
+        # Both callees already handle None, and the mark read stays FIRST so an unknown
+        # status still raises PositionUnknownError with the price message it always did.
+        current_price = self._current_mark_price(position_status)
+        position_size = position_qty_from_status(position_status)
 
         self._sync_position_from_exchange(position_status)
 
@@ -178,7 +179,7 @@ class BitgetFuturesTorchTradingEnv(BitgetBaseTorchTradingEnv):
         trade_info = self._execute_trade_if_needed(desired_action)
 
         if trade_info["executed"] and trade_info.get("success") is not False:
-            self._record_position_after_trade(desired_action)
+            self._record_position_after_trade(desired_action, trade_info.get("target_qty"))
 
         # Wait for next time step
         self._wait_for_next_timestamp()
@@ -257,6 +258,7 @@ class BitgetFuturesTorchTradingEnv(BitgetBaseTorchTradingEnv):
             self.position.current_position = 0
 
         return self._create_trade_info(
+            target_qty=0.0,
             executed=True,
             quantity=abs(current_qty),
             side=side,
@@ -357,7 +359,9 @@ class BitgetFuturesTorchTradingEnv(BitgetBaseTorchTradingEnv):
             return self._create_trade_info(executed=False)
 
         # Execute market order
-        return self._execute_market_order(side, amount)
+        info = self._execute_market_order(side, amount)
+        info["target_qty"] = target_qty
+        return info
 
     def _execute_trade_if_needed(self, desired_action: float) -> Dict:
         """Execute trade based on desired action value.

--- a/torchtrade/envs/live/bitget/env.py
+++ b/torchtrade/envs/live/bitget/env.py
@@ -176,8 +176,7 @@ class BitgetFuturesTorchTradingEnv(BitgetBaseTorchTradingEnv):
         # Calculate and execute trade if needed
         trade_info = self._execute_trade_if_needed(desired_action)
 
-        if trade_info["executed"] and trade_info.get("success") is not False:
-            self._record_position_after_trade(desired_action, trade_info)
+        self._record_position_after_trade(desired_action, trade_info)
 
         # Wait for next time step
         self._wait_for_next_timestamp()
@@ -346,14 +345,14 @@ class BitgetFuturesTorchTradingEnv(BitgetBaseTorchTradingEnv):
 
         if abs(delta_qty) < min_qty:
             # Already at target (delta below the minimum tradeable size)
-            return self._create_trade_info(executed=False)
+            return self._create_trade_info(executed=False, at_target=True)
 
         side = "buy" if delta_qty > 0 else "sell"
         # Floor to the exchange lot step (CCXT truncates -> never exceeds margin)
         amount = self.trader._round_amount(abs(delta_qty))
 
         if amount < min_qty:
-            return self._create_trade_info(executed=False)
+            return self._create_trade_info(executed=False, at_target=True)
 
         # Execute market order
         info = self._execute_market_order(side, amount)

--- a/torchtrade/envs/live/bitget/env.py
+++ b/torchtrade/envs/live/bitget/env.py
@@ -177,7 +177,7 @@ class BitgetFuturesTorchTradingEnv(BitgetBaseTorchTradingEnv):
         trade_info = self._execute_trade_if_needed(desired_action)
 
         if trade_info["executed"] and trade_info.get("success") is not False:
-            self._record_position_after_trade(desired_action, trade_info.get("target_qty"))
+            self._record_position_after_trade(desired_action, trade_info)
 
         # Wait for next time step
         self._wait_for_next_timestamp()

--- a/torchtrade/envs/live/bitget/env_sltp.py
+++ b/torchtrade/envs/live/bitget/env_sltp.py
@@ -9,6 +9,7 @@ logger = logging.getLogger(__name__)
 from tensordict import TensorDictBase
 from torchrl.data import Categorical
 
+from torchtrade.envs.core.state import position_qty_from_status
 from torchtrade.envs.live.bitget.observation import BitgetObservationClass
 from torchtrade.envs.live.bitget.order_executor import (
     BitgetFuturesOrderClass,
@@ -185,7 +186,7 @@ class BitgetFuturesSLTPTorchTradingEnv(SLTPMixin, BitgetBaseTorchTradingEnv):
         position_status = status.get("position_status", None)
         if position_status:
             current_price = self._current_mark_price(position_status)
-            position_size = position_status.qty
+            position_size = position_qty_from_status(position_status)
         else:
             current_price = self._current_mark_price()
             position_size = 0.0

--- a/torchtrade/envs/live/bitget/env_sltp.py
+++ b/torchtrade/envs/live/bitget/env_sltp.py
@@ -184,12 +184,10 @@ class BitgetFuturesSLTPTorchTradingEnv(SLTPMixin, BitgetBaseTorchTradingEnv):
         # Get current price and position from trader status (avoids redundant observation call)
         status = self.trader.get_status()
         position_status = status.get("position_status", None)
-        if position_status:
-            current_price = self._current_mark_price(position_status)
-            position_size = position_qty_from_status(position_status)
-        else:
-            current_price = self._current_mark_price()
-            position_size = 0.0
+        # Both callees already handle None, and the mark read stays FIRST so an unknown
+        # status still raises PositionUnknownError with the price message it always did.
+        current_price = self._current_mark_price(position_status)
+        position_size = position_qty_from_status(position_status)
 
         # Sync position state from exchange — this is the source of truth.
         # Detects SL/TP closures AND fixes state drift from failed bracket orders.
@@ -208,12 +206,11 @@ class BitgetFuturesSLTPTorchTradingEnv(SLTPMixin, BitgetBaseTorchTradingEnv):
         # Eagerly update position from trade result so the rest of this step
         # sees the new state without waiting for the next sync cycle.
         if trade_info["executed"] and trade_info.get("success") is not False:
-            if trade_info["side"] == "buy":
-                self.position.current_position = 1  # Long
-            elif trade_info["side"] == "sell":
-                self.position.current_position = -1  # Short
-            elif trade_info.get("closed_position"):
-                self.position.current_position = 0  # Closed
+            # The TARGET side from the action, never the order side (#276): the same
+            # self-inflicted-mismatch chain applies here. binance and bitget also had
+            # their closed branch behind an elif that always matched first, so an SLTP
+            # close could never be recorded at all.
+            self.position.current_position = {"long": 1, "short": -1}.get(action_tuple[0], 0)
 
         # Wait for next time step
         self._wait_for_next_timestamp()

--- a/torchtrade/envs/live/bitget/env_sltp.py
+++ b/torchtrade/envs/live/bitget/env_sltp.py
@@ -184,8 +184,6 @@ class BitgetFuturesSLTPTorchTradingEnv(SLTPMixin, BitgetBaseTorchTradingEnv):
         # Get current price and position from trader status (avoids redundant observation call)
         status = self.trader.get_status()
         position_status = status.get("position_status", None)
-        # Both callees already handle None, and the mark read stays FIRST so an unknown
-        # status still raises PositionUnknownError with the price message it always did.
         current_price = self._current_mark_price(position_status)
         position_size = position_qty_from_status(position_status)
 
@@ -206,11 +204,7 @@ class BitgetFuturesSLTPTorchTradingEnv(SLTPMixin, BitgetBaseTorchTradingEnv):
         # Eagerly update position from trade result so the rest of this step
         # sees the new state without waiting for the next sync cycle.
         if trade_info["executed"] and trade_info.get("success") is not False:
-            # The TARGET side from the action, never the order side (#276): the same
-            # self-inflicted-mismatch chain applies here. binance and bitget also had
-            # their closed branch behind an elif that always matched first, so an SLTP
-            # close could never be recorded at all.
-            self.position.current_position = {"long": 1, "short": -1}.get(action_tuple[0], 0)
+            self._record_sltp_position(action_tuple[0])
 
         # Wait for next time step
         self._wait_for_next_timestamp()
@@ -283,8 +277,7 @@ class BitgetFuturesSLTPTorchTradingEnv(SLTPMixin, BitgetBaseTorchTradingEnv):
             return trade_info
 
         # Check if already in same position (ignore duplicate actions)
-        position_map = {"long": 1, "short": -1}
-        if side in position_map and self.position.current_position == position_map[side]:
+        if side in self.SIDE_DIRECTION and self.position.current_position == self.SIDE_DIRECTION[side]:
             return trade_info  # Already in this position, ignore duplicate action
 
         # Get current price for calculating absolute SL/TP levels

--- a/torchtrade/envs/live/bybit/env.py
+++ b/torchtrade/envs/live/bybit/env.py
@@ -8,6 +8,7 @@ import torch
 from tensordict import TensorDictBase
 from torchrl.data import Categorical
 
+from torchtrade.envs.core.state import position_qty_from_status
 from torchtrade.envs.live.bybit.observation import BybitObservationClass
 from torchtrade.envs.live.bybit.order_executor import (
     BybitFuturesOrderClass,
@@ -114,7 +115,7 @@ class BybitFuturesTorchTradingEnv(BybitBaseTorchTradingEnv):
         position_status = status.get("position_status", None)
         if position_status:
             current_price = self._current_mark_price(position_status)
-            position_size = position_status.qty
+            position_size = position_qty_from_status(position_status)
         else:
             current_price = self._current_mark_price()
             position_size = 0.0
@@ -141,13 +142,7 @@ class BybitFuturesTorchTradingEnv(BybitBaseTorchTradingEnv):
         trade_info = self._execute_trade_if_needed(desired_action)
 
         if trade_info["executed"] and trade_info.get("success") is not False:
-            if trade_info["side"] == "buy":
-                self.position.current_position = 1
-            elif trade_info["side"] == "sell" and trade_info.get("closed_position"):
-                self.position.current_position = 0
-            elif trade_info["side"] == "sell":
-                self.position.current_position = -1
-            self.position.current_action_level = desired_action
+            self._record_position_after_trade(desired_action)
 
         self._wait_for_next_timestamp()
 

--- a/torchtrade/envs/live/bybit/env.py
+++ b/torchtrade/envs/live/bybit/env.py
@@ -140,8 +140,7 @@ class BybitFuturesTorchTradingEnv(BybitBaseTorchTradingEnv):
 
         trade_info = self._execute_trade_if_needed(desired_action)
 
-        if trade_info["executed"] and trade_info.get("success") is not False:
-            self._record_position_after_trade(desired_action, trade_info)
+        self._record_position_after_trade(desired_action, trade_info)
 
         self._wait_for_next_timestamp()
 
@@ -268,7 +267,7 @@ class BybitFuturesTorchTradingEnv(BybitBaseTorchTradingEnv):
         qty_step = lot_size["qty_step"]
 
         if abs(delta_qty) < min_qty:
-            return self._create_trade_info(executed=False)
+            return self._create_trade_info(executed=False, at_target=True)
 
         side = "buy" if delta_qty > 0 else "sell"
         # Use round() to avoid float artifacts (e.g., 0.003000000000003)
@@ -276,7 +275,7 @@ class BybitFuturesTorchTradingEnv(BybitBaseTorchTradingEnv):
         amount = round(int(abs(delta_qty) / qty_step) * qty_step, step_decimals)
 
         if amount < min_qty:
-            return self._create_trade_info(executed=False)
+            return self._create_trade_info(executed=False, at_target=True)
 
         info = self._execute_market_order(side, amount)
         info["target_qty"] = target_qty

--- a/torchtrade/envs/live/bybit/env.py
+++ b/torchtrade/envs/live/bybit/env.py
@@ -8,7 +8,6 @@ import torch
 from tensordict import TensorDictBase
 from torchrl.data import Categorical
 
-from torchtrade.envs.core.live import validate_action_levels
 from torchtrade.envs.core.state import position_qty_from_status
 from torchtrade.envs.live.bybit.observation import BybitObservationClass
 from torchtrade.envs.live.bybit.order_executor import (
@@ -21,6 +20,7 @@ from torchtrade.envs.core.live import (
     ObservationFailurePolicy,
 )
 from torchtrade.envs.utils.fractional_sizing import (
+    validate_action_levels,
     calculate_fractional_position,
     PositionCalculationParams,
 )
@@ -116,8 +116,6 @@ class BybitFuturesTorchTradingEnv(BybitBaseTorchTradingEnv):
         """Execute one environment step."""
         status = self.trader.get_status()
         position_status = status.get("position_status", None)
-        # Both callees already handle None, and the mark read stays FIRST so an unknown
-        # status still raises PositionUnknownError with the price message it always did.
         current_price = self._current_mark_price(position_status)
         position_size = position_qty_from_status(position_status)
 
@@ -215,7 +213,6 @@ class BybitFuturesTorchTradingEnv(BybitBaseTorchTradingEnv):
             self.position.current_position = 0
 
         return self._create_trade_info(
-            target_qty=0.0,
             executed=True,
             quantity=abs(current_qty),
             side=side,
@@ -283,6 +280,7 @@ class BybitFuturesTorchTradingEnv(BybitBaseTorchTradingEnv):
 
         info = self._execute_market_order(side, amount)
         info["target_qty"] = target_qty
+        info["target_tol"] = lot_size["min_qty"]
         return info
 
     def _execute_trade_if_needed(self, desired_action: float) -> Dict:

--- a/torchtrade/envs/live/bybit/env.py
+++ b/torchtrade/envs/live/bybit/env.py
@@ -8,6 +8,7 @@ import torch
 from tensordict import TensorDictBase
 from torchrl.data import Categorical
 
+from torchtrade.envs.core.live import validate_action_levels
 from torchtrade.envs.core.state import position_qty_from_status
 from torchtrade.envs.live.bybit.observation import BybitObservationClass
 from torchtrade.envs.live.bybit.order_executor import (
@@ -69,6 +70,8 @@ class BybitFuturesTradingEnvConfig:
         if self.action_levels is None:
             self.action_levels = [-1.0, -0.5, 0.0, 0.5, 1.0]
 
+        validate_action_levels(self.action_levels)
+
 
 class BybitFuturesTorchTradingEnv(BybitBaseTorchTradingEnv):
     """
@@ -113,12 +116,10 @@ class BybitFuturesTorchTradingEnv(BybitBaseTorchTradingEnv):
         """Execute one environment step."""
         status = self.trader.get_status()
         position_status = status.get("position_status", None)
-        if position_status:
-            current_price = self._current_mark_price(position_status)
-            position_size = position_qty_from_status(position_status)
-        else:
-            current_price = self._current_mark_price()
-            position_size = 0.0
+        # Both callees already handle None, and the mark read stays FIRST so an unknown
+        # status still raises PositionUnknownError with the price message it always did.
+        current_price = self._current_mark_price(position_status)
+        position_size = position_qty_from_status(position_status)
 
         # No-op today (this env's _execute_trade_if_needed recomputes qty live and never reads
         # current_action_level), but keeps the field consistent so adding a duplicate-action
@@ -142,7 +143,7 @@ class BybitFuturesTorchTradingEnv(BybitBaseTorchTradingEnv):
         trade_info = self._execute_trade_if_needed(desired_action)
 
         if trade_info["executed"] and trade_info.get("success") is not False:
-            self._record_position_after_trade(desired_action)
+            self._record_position_after_trade(desired_action, trade_info.get("target_qty"))
 
         self._wait_for_next_timestamp()
 
@@ -214,6 +215,7 @@ class BybitFuturesTorchTradingEnv(BybitBaseTorchTradingEnv):
             self.position.current_position = 0
 
         return self._create_trade_info(
+            target_qty=0.0,
             executed=True,
             quantity=abs(current_qty),
             side=side,
@@ -279,7 +281,9 @@ class BybitFuturesTorchTradingEnv(BybitBaseTorchTradingEnv):
         if amount < min_qty:
             return self._create_trade_info(executed=False)
 
-        return self._execute_market_order(side, amount)
+        info = self._execute_market_order(side, amount)
+        info["target_qty"] = target_qty
+        return info
 
     def _execute_trade_if_needed(self, desired_action: float) -> Dict:
         """Execute trade based on desired action value."""

--- a/torchtrade/envs/live/bybit/env.py
+++ b/torchtrade/envs/live/bybit/env.py
@@ -141,7 +141,7 @@ class BybitFuturesTorchTradingEnv(BybitBaseTorchTradingEnv):
         trade_info = self._execute_trade_if_needed(desired_action)
 
         if trade_info["executed"] and trade_info.get("success") is not False:
-            self._record_position_after_trade(desired_action, trade_info.get("target_qty"))
+            self._record_position_after_trade(desired_action, trade_info)
 
         self._wait_for_next_timestamp()
 

--- a/torchtrade/envs/live/bybit/env_sltp.py
+++ b/torchtrade/envs/live/bybit/env_sltp.py
@@ -143,8 +143,6 @@ class BybitFuturesSLTPTorchTradingEnv(SLTPMixin, BybitBaseTorchTradingEnv):
         """Execute one environment step."""
         status = self.trader.get_status()
         position_status = status.get("position_status", None)
-        # Both callees already handle None, and the mark read stays FIRST so an unknown
-        # status still raises PositionUnknownError with the price message it always did.
         current_price = self._current_mark_price(position_status)
         position_size = position_qty_from_status(position_status)
 
@@ -173,11 +171,7 @@ class BybitFuturesSLTPTorchTradingEnv(SLTPMixin, BybitBaseTorchTradingEnv):
         # Eagerly update position from trade result so the rest of this step
         # sees the new state without waiting for the next sync cycle.
         if trade_info["executed"] and trade_info.get("success") is not False:
-            # The TARGET side from the action, never the order side (#276): the same
-            # self-inflicted-mismatch chain applies here. binance and bitget also had
-            # their closed branch behind an elif that always matched first, so an SLTP
-            # close could never be recorded at all.
-            self.position.current_position = {"long": 1, "short": -1}.get(action_tuple[0], 0)
+            self._record_sltp_position(action_tuple[0])
 
         self._wait_for_next_timestamp()
 
@@ -253,8 +247,7 @@ class BybitFuturesSLTPTorchTradingEnv(SLTPMixin, BybitBaseTorchTradingEnv):
             return trade_info
 
         # Check if already in same position
-        position_map = {"long": 1, "short": -1}
-        if side in position_map and self.position.current_position == position_map[side]:
+        if side in self.SIDE_DIRECTION and self.position.current_position == self.SIDE_DIRECTION[side]:
             return trade_info
 
         # Get current mark price (more accurate than candle close for bracket orders)

--- a/torchtrade/envs/live/bybit/env_sltp.py
+++ b/torchtrade/envs/live/bybit/env_sltp.py
@@ -8,6 +8,7 @@ import torch
 from tensordict import TensorDictBase
 from torchrl.data import Categorical
 
+from torchtrade.envs.core.state import position_qty_from_status
 from torchtrade.envs.live.bybit.observation import BybitObservationClass
 from torchtrade.envs.live.bybit.order_executor import (
     BybitFuturesOrderClass,
@@ -144,7 +145,7 @@ class BybitFuturesSLTPTorchTradingEnv(SLTPMixin, BybitBaseTorchTradingEnv):
         position_status = status.get("position_status", None)
         if position_status:
             current_price = self._current_mark_price(position_status)
-            position_size = position_status.qty
+            position_size = position_qty_from_status(position_status)
         else:
             current_price = self._current_mark_price()
             position_size = 0.0

--- a/torchtrade/envs/live/bybit/env_sltp.py
+++ b/torchtrade/envs/live/bybit/env_sltp.py
@@ -143,12 +143,10 @@ class BybitFuturesSLTPTorchTradingEnv(SLTPMixin, BybitBaseTorchTradingEnv):
         """Execute one environment step."""
         status = self.trader.get_status()
         position_status = status.get("position_status", None)
-        if position_status:
-            current_price = self._current_mark_price(position_status)
-            position_size = position_qty_from_status(position_status)
-        else:
-            current_price = self._current_mark_price()
-            position_size = 0.0
+        # Both callees already handle None, and the mark read stays FIRST so an unknown
+        # status still raises PositionUnknownError with the price message it always did.
+        current_price = self._current_mark_price(position_status)
+        position_size = position_qty_from_status(position_status)
 
         # Sync position state from exchange — this is the source of truth.
         # Detects SL/TP closures AND fixes state drift from failed bracket orders.
@@ -175,12 +173,11 @@ class BybitFuturesSLTPTorchTradingEnv(SLTPMixin, BybitBaseTorchTradingEnv):
         # Eagerly update position from trade result so the rest of this step
         # sees the new state without waiting for the next sync cycle.
         if trade_info["executed"] and trade_info.get("success") is not False:
-            if trade_info.get("closed_position"):
-                self.position.current_position = 0
-            elif trade_info["side"] == "buy":
-                self.position.current_position = 1
-            elif trade_info["side"] == "sell":
-                self.position.current_position = -1
+            # The TARGET side from the action, never the order side (#276): the same
+            # self-inflicted-mismatch chain applies here. binance and bitget also had
+            # their closed branch behind an elif that always matched first, so an SLTP
+            # close could never be recorded at all.
+            self.position.current_position = {"long": 1, "short": -1}.get(action_tuple[0], 0)
 
         self._wait_for_next_timestamp()
 

--- a/torchtrade/envs/live/okx/env.py
+++ b/torchtrade/envs/live/okx/env.py
@@ -147,8 +147,7 @@ class OKXFuturesTorchTradingEnv(OKXBaseTorchTradingEnv):
             desired_action, current_qty=position_size, current_price=current_price,
         )
 
-        if trade_info["executed"] and trade_info.get("success") is not False:
-            self._record_position_after_trade(desired_action, trade_info)
+        self._record_position_after_trade(desired_action, trade_info)
 
         self._wait_for_next_timestamp()
 
@@ -271,7 +270,7 @@ class OKXFuturesTorchTradingEnv(OKXBaseTorchTradingEnv):
 
         lot_size = self.trader.get_lot_size()
         if abs(delta_qty) < lot_size["min_qty"]:
-            return self._create_trade_info(executed=False)
+            return self._create_trade_info(executed=False, at_target=True)
 
         side = "buy" if delta_qty > 0 else "sell"
         # _format_size() in trade() handles lot-step quantization

--- a/torchtrade/envs/live/okx/env.py
+++ b/torchtrade/envs/live/okx/env.py
@@ -70,6 +70,7 @@ class OKXFuturesTradingEnvConfig:
         if self.action_levels is None:
             self.action_levels = [-1.0, -0.5, 0.0, 0.5, 1.0]
 
+        validate_action_levels(self.action_levels)
 
 
 class OKXFuturesTorchTradingEnv(OKXBaseTorchTradingEnv):

--- a/torchtrade/envs/live/okx/env.py
+++ b/torchtrade/envs/live/okx/env.py
@@ -70,7 +70,6 @@ class OKXFuturesTradingEnvConfig:
         if self.action_levels is None:
             self.action_levels = [-1.0, -0.5, 0.0, 0.5, 1.0]
 
-        validate_action_levels(self.action_levels)
 
 
 class OKXFuturesTorchTradingEnv(OKXBaseTorchTradingEnv):
@@ -148,7 +147,7 @@ class OKXFuturesTorchTradingEnv(OKXBaseTorchTradingEnv):
         )
 
         if trade_info["executed"] and trade_info.get("success") is not False:
-            self._record_position_after_trade(desired_action, trade_info.get("target_qty"))
+            self._record_position_after_trade(desired_action, trade_info)
 
         self._wait_for_next_timestamp()
 

--- a/torchtrade/envs/live/okx/env.py
+++ b/torchtrade/envs/live/okx/env.py
@@ -8,6 +8,7 @@ import torch
 from tensordict import TensorDictBase
 from torchrl.data import Categorical
 
+from torchtrade.envs.core.live import validate_action_levels
 from torchtrade.envs.live.okx.observation import OKXObservationClass
 from torchtrade.envs.live.okx.order_executor import (
     OKXFuturesOrderClass,
@@ -68,6 +69,8 @@ class OKXFuturesTradingEnvConfig:
 
         if self.action_levels is None:
             self.action_levels = [-1.0, -0.5, 0.0, 0.5, 1.0]
+
+        validate_action_levels(self.action_levels)
 
 
 class OKXFuturesTorchTradingEnv(OKXBaseTorchTradingEnv):
@@ -145,7 +148,7 @@ class OKXFuturesTorchTradingEnv(OKXBaseTorchTradingEnv):
         )
 
         if trade_info["executed"] and trade_info.get("success") is not False:
-            self._record_position_after_trade(desired_action)
+            self._record_position_after_trade(desired_action, trade_info.get("target_qty"))
 
         self._wait_for_next_timestamp()
 
@@ -217,6 +220,7 @@ class OKXFuturesTorchTradingEnv(OKXBaseTorchTradingEnv):
             self.position.current_position = 0
 
         return self._create_trade_info(
+            target_qty=0.0,
             executed=True,
             quantity=abs(current_qty),
             side=side,
@@ -272,7 +276,9 @@ class OKXFuturesTorchTradingEnv(OKXBaseTorchTradingEnv):
 
         side = "buy" if delta_qty > 0 else "sell"
         # _format_size() in trade() handles lot-step quantization
-        return self._execute_market_order(side, abs(delta_qty))
+        info = self._execute_market_order(side, abs(delta_qty))
+        info["target_qty"] = target_qty
+        return info
 
     def _execute_trade_if_needed(
         self, desired_action: float, *, current_qty: float = 0.0, current_price: float = 0.0,

--- a/torchtrade/envs/live/okx/env.py
+++ b/torchtrade/envs/live/okx/env.py
@@ -114,7 +114,7 @@ class OKXFuturesTorchTradingEnv(OKXBaseTorchTradingEnv):
         """Execute one environment step."""
         status = self.trader.get_status()
         position_status = status.get("position_status", None)
-        # Size through the canonical rule, not `position_status.qty` raw: a dust residual
+        # Size through the canonical rule, not the raw venue qty: a dust residual
         # read as a live position makes abs(current_qty) > 0 true on a flat account, so
         # action 0.0 closes nothing and still advances current_action_level (#283).
         position_size = position_qty_from_status(position_status)
@@ -145,13 +145,7 @@ class OKXFuturesTorchTradingEnv(OKXBaseTorchTradingEnv):
         )
 
         if trade_info["executed"] and trade_info.get("success") is not False:
-            if trade_info.get("closed_position"):
-                self.position.current_position = 0
-            elif trade_info["side"] == "buy":
-                self.position.current_position = 1
-            elif trade_info["side"] == "sell":
-                self.position.current_position = -1
-            self.position.current_action_level = desired_action
+            self._record_position_after_trade(desired_action)
 
         self._wait_for_next_timestamp()
 

--- a/torchtrade/envs/live/okx/env.py
+++ b/torchtrade/envs/live/okx/env.py
@@ -8,7 +8,6 @@ import torch
 from tensordict import TensorDictBase
 from torchrl.data import Categorical
 
-from torchtrade.envs.core.live import validate_action_levels
 from torchtrade.envs.live.okx.observation import OKXObservationClass
 from torchtrade.envs.live.okx.order_executor import (
     OKXFuturesOrderClass,
@@ -21,6 +20,7 @@ from torchtrade.envs.core.live import (
     ObservationFailurePolicy,
 )
 from torchtrade.envs.utils.fractional_sizing import (
+    validate_action_levels,
     calculate_fractional_position,
     PositionCalculationParams,
 )
@@ -220,7 +220,6 @@ class OKXFuturesTorchTradingEnv(OKXBaseTorchTradingEnv):
             self.position.current_position = 0
 
         return self._create_trade_info(
-            target_qty=0.0,
             executed=True,
             quantity=abs(current_qty),
             side=side,
@@ -278,6 +277,7 @@ class OKXFuturesTorchTradingEnv(OKXBaseTorchTradingEnv):
         # _format_size() in trade() handles lot-step quantization
         info = self._execute_market_order(side, abs(delta_qty))
         info["target_qty"] = target_qty
+        info["target_tol"] = lot_size["min_qty"]
         return info
 
     def _execute_trade_if_needed(

--- a/torchtrade/envs/live/okx/env_sltp.py
+++ b/torchtrade/envs/live/okx/env_sltp.py
@@ -144,12 +144,10 @@ class OKXFuturesSLTPTorchTradingEnv(SLTPMixin, OKXBaseTorchTradingEnv):
         """Execute one environment step."""
         status = self.trader.get_status()
         position_status = status.get("position_status", None)
-        if position_status:
-            current_price = self._current_mark_price(position_status)
-            position_size = position_qty_from_status(position_status)
-        else:
-            current_price = self._current_mark_price()
-            position_size = 0.0
+        # Both callees already handle None, and the mark read stays FIRST so an unknown
+        # status still raises PositionUnknownError with the price message it always did.
+        current_price = self._current_mark_price(position_status)
+        position_size = position_qty_from_status(position_status)
 
         # Sync position state from exchange — this is the source of truth.
         position_closed = self._sync_position_from_exchange(position_status)
@@ -174,12 +172,11 @@ class OKXFuturesSLTPTorchTradingEnv(SLTPMixin, OKXBaseTorchTradingEnv):
 
         # Eagerly update position from trade result
         if trade_info["executed"] and trade_info.get("success") is not False:
-            if trade_info.get("closed_position"):
-                self.position.current_position = 0
-            elif trade_info["side"] == "buy":
-                self.position.current_position = 1
-            elif trade_info["side"] == "sell":
-                self.position.current_position = -1
+            # The TARGET side from the action, never the order side (#276): the same
+            # self-inflicted-mismatch chain applies here. binance and bitget also had
+            # their closed branch behind an elif that always matched first, so an SLTP
+            # close could never be recorded at all.
+            self.position.current_position = {"long": 1, "short": -1}.get(action_tuple[0], 0)
 
         self._wait_for_next_timestamp()
 

--- a/torchtrade/envs/live/okx/env_sltp.py
+++ b/torchtrade/envs/live/okx/env_sltp.py
@@ -8,6 +8,7 @@ import torch
 from tensordict import TensorDictBase
 from torchrl.data import Categorical
 
+from torchtrade.envs.core.state import position_qty_from_status
 from torchtrade.envs.live.okx.observation import OKXObservationClass
 from torchtrade.envs.live.okx.order_executor import (
     OKXFuturesOrderClass,
@@ -145,7 +146,7 @@ class OKXFuturesSLTPTorchTradingEnv(SLTPMixin, OKXBaseTorchTradingEnv):
         position_status = status.get("position_status", None)
         if position_status:
             current_price = self._current_mark_price(position_status)
-            position_size = position_status.qty
+            position_size = position_qty_from_status(position_status)
         else:
             current_price = self._current_mark_price()
             position_size = 0.0

--- a/torchtrade/envs/live/okx/env_sltp.py
+++ b/torchtrade/envs/live/okx/env_sltp.py
@@ -144,8 +144,6 @@ class OKXFuturesSLTPTorchTradingEnv(SLTPMixin, OKXBaseTorchTradingEnv):
         """Execute one environment step."""
         status = self.trader.get_status()
         position_status = status.get("position_status", None)
-        # Both callees already handle None, and the mark read stays FIRST so an unknown
-        # status still raises PositionUnknownError with the price message it always did.
         current_price = self._current_mark_price(position_status)
         position_size = position_qty_from_status(position_status)
 
@@ -172,11 +170,7 @@ class OKXFuturesSLTPTorchTradingEnv(SLTPMixin, OKXBaseTorchTradingEnv):
 
         # Eagerly update position from trade result
         if trade_info["executed"] and trade_info.get("success") is not False:
-            # The TARGET side from the action, never the order side (#276): the same
-            # self-inflicted-mismatch chain applies here. binance and bitget also had
-            # their closed branch behind an elif that always matched first, so an SLTP
-            # close could never be recorded at all.
-            self.position.current_position = {"long": 1, "short": -1}.get(action_tuple[0], 0)
+            self._record_sltp_position(action_tuple[0])
 
         self._wait_for_next_timestamp()
 
@@ -252,8 +246,7 @@ class OKXFuturesSLTPTorchTradingEnv(SLTPMixin, OKXBaseTorchTradingEnv):
             return trade_info
 
         # Check if already in same position
-        position_map = {"long": 1, "short": -1}
-        if side in position_map and self.position.current_position == position_map[side]:
+        if side in self.SIDE_DIRECTION and self.position.current_position == self.SIDE_DIRECTION[side]:
             return trade_info
 
         # Get current mark price (more accurate than candle close for bracket orders)

--- a/torchtrade/envs/live/polymarket/env.py
+++ b/torchtrade/envs/live/polymarket/env.py
@@ -454,9 +454,8 @@ class PolymarketBetEnv(EnvBase):
     def _fetch_clob_midpoint(token_id: str) -> Optional[float]:
         """One-shot CLOB midpoint query for a single outcome token.
 
-        Validated at the read (#349): the caller decides an outcome is RESOLVED from this
-        and pays out into `self.cash`, and `+inf >= 0.99` is True. A probability outside
-        [0, 1] is not a midpoint, so it reads as "unavailable" rather than as a result.
+        Rejects a midpoint outside [0, 1] (#349): the caller reads RESOLVED off this and
+        pays into `self.cash`, and `+inf >= 0.99` is True.
         """
         resp = requests.get(
             f"{CLOB_API_BASE}/midpoint",
@@ -469,7 +468,12 @@ class PolymarketBetEnv(EnvBase):
         if mid is None:
             return None
         mid = float(mid)
-        return mid if 0.0 <= mid <= 1.0 else None
+        if not 0.0 <= mid <= 1.0:
+            # Named, because the caller maps None to "unresolved" and then blames a
+            # TIMEOUT in its warning -- pointing at the wrong subsystem entirely.
+            logger.error(f"CLOB midpoint for {token_id} outside [0, 1]: {mid!r}")
+            return None
+        return mid
 
     @staticmethod
     def _compute_payoff(

--- a/torchtrade/envs/live/polymarket/env.py
+++ b/torchtrade/envs/live/polymarket/env.py
@@ -452,7 +452,12 @@ class PolymarketBetEnv(EnvBase):
 
     @staticmethod
     def _fetch_clob_midpoint(token_id: str) -> Optional[float]:
-        """One-shot CLOB midpoint query for a single outcome token."""
+        """One-shot CLOB midpoint query for a single outcome token.
+
+        Validated at the read (#349): the caller decides an outcome is RESOLVED from this
+        and pays out into `self.cash`, and `+inf >= 0.99` is True. A probability outside
+        [0, 1] is not a midpoint, so it reads as "unavailable" rather than as a result.
+        """
         resp = requests.get(
             f"{CLOB_API_BASE}/midpoint",
             params={"token_id": token_id},
@@ -461,7 +466,10 @@ class PolymarketBetEnv(EnvBase):
         resp.raise_for_status()
         body = resp.json()
         mid = body.get("mid")
-        return float(mid) if mid is not None else None
+        if mid is None:
+            return None
+        mid = float(mid)
+        return mid if 0.0 <= mid <= 1.0 else None
 
     @staticmethod
     def _compute_payoff(

--- a/torchtrade/envs/live/shared/futures_live_base.py
+++ b/torchtrade/envs/live/shared/futures_live_base.py
@@ -105,6 +105,8 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
         Every venue reads its mark as `float(pos.get("markPrice") or entry_price)`, which
         is 0.0 when both fields are blank.
         """
+        # Handles None itself, so callers pass the status straight through; keep this read
+        # ahead of any qty read so an unknown status still raises with the price message.
         price = position_status.mark_price if position_status else self.trader.get_mark_price()
         if not math.isfinite(price) or price <= 0:
             raise ValueError(f"venue reported an unusable mark price ({price})")

--- a/torchtrade/envs/live/shared/futures_live_base.py
+++ b/torchtrade/envs/live/shared/futures_live_base.py
@@ -105,8 +105,6 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
         Every venue reads its mark as `float(pos.get("markPrice") or entry_price)`, which
         is 0.0 when both fields are blank.
         """
-        # Handles None itself, so callers pass the status straight through; keep this read
-        # ahead of any qty read so an unknown status still raises with the price message.
         price = position_status.mark_price if position_status else self.trader.get_mark_price()
         if not math.isfinite(price) or price <= 0:
             raise ValueError(f"venue reported an unusable mark price ({price})")
@@ -212,9 +210,6 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
                     f"venue reported a non-positive mark price "
                     f"({position_status.mark_price}) for an open position"
                 )
-            # Finite is not enough for the mark: 0 and negative both pass the loop above and
-            # then short-circuit distance_to_liquidation to "safe". Every venue's mark read
-            # is `float(pos.get("markPrice") or entry_price)`, so two blank fields give 0.0.
 
             position_size = position_status.qty
             position_value = abs(position_status.notional_value)

--- a/torchtrade/envs/utils/sltp_mixin.py
+++ b/torchtrade/envs/utils/sltp_mixin.py
@@ -20,6 +20,18 @@ class SLTPMixin:
         - self.active_take_profit: float (current TP price)
     """
 
+    # The direction each SLTP side targets. Also used by the duplicate-action check
+    # further down each env, which is why it lives in one place.
+    SIDE_DIRECTION = {"long": 1, "short": -1}
+
+    def _record_sltp_position(self, side) -> None:
+        """The position the ACTION targets, never the order side (#276).
+
+        binance and bitget had their close branch behind an elif that always matched
+        first, so an SLTP close could never be recorded at all.
+        """
+        self.position.current_position = self.SIDE_DIRECTION.get(side, 0)
+
     def _sync_position_from_exchange(self, position_status) -> bool:
         """Sync internal position state from exchange and detect SL/TP closures.
 

--- a/torchtrade/envs/utils/sltp_mixin.py
+++ b/torchtrade/envs/utils/sltp_mixin.py
@@ -25,11 +25,7 @@ class SLTPMixin:
     SIDE_DIRECTION = {"long": 1, "short": -1}
 
     def _record_sltp_position(self, side) -> None:
-        """The position the ACTION targets, never the order side (#276).
-
-        binance and bitget had their close branch behind an elif that always matched
-        first, so an SLTP close could never be recorded at all.
-        """
+        """The position the ACTION targets, never the order side (#276)."""
         self.position.current_position = self.SIDE_DIRECTION.get(side, 0)
 
     def _sync_position_from_exchange(self, position_status) -> bool:


### PR DESCRIPTION
Closes #276. Closes #349.

## #276 — direction inferred from the order side

Five live envs set `current_position` from `trade_info["side"]`. Under fractional sizing a SELL that trims a long from 1.0 to 0.5 **leaves a long**, but was recorded as `-1`.

The damage is the chain, not the field: the next bar's `_sync_position_from_exchange` finds a mismatch the env inflicted on itself, discards `hold_counter` and NaNs `current_action_level`. So `account_state[3]` reports `holding_time=1` for a 20-bar-old position, and the duplicate-action guard is permanently defeated — every repeat of `0.5` re-trades.

The five copies had drifted into four spellings. Binance's was worse than the rest: uppercase `"BUY"`/`"SELL"` with its `closed_position` branch **last**, behind an `elif` that always matched first — so binance could never record a close at all.

Now one `_record_position_after_trade` on `TorchTradeLiveEnv`, taking the sign of the target level, plus a structural guard so no exchange re-forks it.

**Nothing failed when I changed this across five envs.** The behaviour had no test. It has one now, end to end.

## #349 — the leftovers

| item | what it did |
|---|---|
| `alpaca/base._get_current_price` | advanced its fallback chain on `<= 0`, which NaN passes — so a NaN skipped **both** fallbacks and was returned by the function that exists to avoid exactly that. `inf` failed the other way: satisfied `> 0`, skipped the fallbacks, left nothing. Now advances on *usable*, and an exhausted chain returns its documented `0.0`. |
| `polymarket._fetch_clob_midpoint` | returned `float(mid)` unchecked while the caller decides an outcome is RESOLVED from it and pays into `self.cash` — and `inf >= 0.99` is True. Outside `[0, 1]` now reads as unavailable. |
| raw `position_status.qty` | bypassed the dust rule. The issue catalogued five sites; **the structural guard found five more the moment it existed** — including one in okx whose own comment quoted the forbidden pattern while doing the right thing. |

The qty item is latent today (`log_return_reward` reads portfolio values, not quantities). That is precisely when a re-fork goes unnoticed, which is why it is a guard rather than a behavioural test.

## Not in this PR

**#339** turns out to touch the **offline** envs, not live — only `sequential.py` and `vectorized_sequential.py` consume `POSITION_TOLERANCE_ABS`. Changing a sizing threshold there is a behavioural change to the highest-priority environments and a scalar/vectorized parity surface. It gets its own PR rather than riding along in a live-env change.

## Verification

Every fix mutation-tested individually — including the one that revealed `#349.4` had zero coverage before the guard existed.

Full suite: **2788 passed, 19 skipped**. Diff: 15 files, +203/−49.

🤖 Generated with [Claude Code](https://claude.com/claude-code)