### PR TITLE
fix(live): make the venue confirm the leverage before sizing against it (#277)

### DIFF
--- a/docs/environments/online.md
+++ b/docs/environments/online.md
@@ -42,6 +42,16 @@ Non-SLTP environments use `action_levels` for fractional position sizing — sam
 
 Live environments use a **query-first pattern**: they query the actual exchange position (source of truth), calculate the target based on the action, round to exchange constraints (lot size, min notional), and trade only the delta.
 
+!!! warning "Leverage is verified against the exchange at construction"
+    Futures environments refuse to start if the exchange will not apply the configured
+    `leverage` — a rejected request, or an applied value that differs from the one asked
+    for. Both would otherwise size every position against leverage the account does not
+    have, and make `account_state[4]` report the configured value while flat but the
+    exchange's value once a position is open.
+
+    An exchange that is *already* at the requested leverage reports that as an error;
+    that case is recognised and is not a failure.
+
 !!! warning "Timeframe Format - Critical for Model Compatibility"
     Always use canonical timeframe forms:
 

--- a/docs/environments/online.md
+++ b/docs/environments/online.md
@@ -51,7 +51,9 @@ Live environments use a **query-first pattern**: they query the actual exchange 
 
     A successful construction guarantees **leverage only**. Margin mode is still
     best-effort, and Bybit's set-leverage response carries no leverage, so on Bybit an
-    accepted-but-clamped value is not detected.
+    accepted-but-clamped value is not detected. Passing your own `trader=` skips the
+    handshake entirely — the environment still sizes from `config.leverage`, so an
+    injected executor must already be at that leverage.
 
 !!! warning "Timeframe Format - Critical for Model Compatibility"
     Always use canonical timeframe forms:

--- a/docs/environments/online.md
+++ b/docs/environments/online.md
@@ -43,14 +43,15 @@ Non-SLTP environments use `action_levels` for fractional position sizing — sam
 Live environments use a **query-first pattern**: they query the actual exchange position (source of truth), calculate the target based on the action, round to exchange constraints (lot size, min notional), and trade only the delta.
 
 !!! warning "Leverage is verified against the exchange at construction"
-    Futures environments refuse to start if the exchange will not apply the configured
-    `leverage` — a rejected request, or an applied value that differs from the one asked
-    for. Both would otherwise size every position against leverage the account does not
-    have, and make `account_state[4]` report the configured value while flat but the
-    exchange's value once a position is open.
+    Futures environments refuse to start if the exchange rejects the configured
+    `leverage`, or reports applying a different one. Either would otherwise size every
+    position against leverage the account does not have, and make `account_state[4]`
+    report the configured value while flat but the exchange's value once a position is
+    open.
 
-    An exchange that is *already* at the requested leverage reports that as an error;
-    that case is recognised and is not a failure.
+    A successful construction guarantees **leverage only**. Margin mode is still
+    best-effort, and Bybit's set-leverage response carries no leverage, so on Bybit an
+    accepted-but-clamped value is not detected.
 
 !!! warning "Timeframe Format - Critical for Model Compatibility"
     Always use canonical timeframe forms:

--- a/tests/envs/binance/test_futures_order_executor.py
+++ b/tests/envs/binance/test_futures_order_executor.py
@@ -450,7 +450,9 @@ class TestBinanceLotSizeRounding:
         client.futures_exchange_info = MagicMock(
             return_value=exchange_info if exchange_info is not None else {"symbols": symbols}
         )
-        client.futures_change_leverage = MagicMock(return_value={})
+        client.futures_change_leverage = MagicMock(
+            side_effect=lambda symbol, leverage, **k: {"leverage": leverage}
+        )
         client.futures_change_margin_type = MagicMock(return_value={})
         return BinanceFuturesOrderClass(
             symbol=symbol, trade_mode="quantity", demo=True, leverage=10, client=client

--- a/tests/envs/binance/test_futures_order_executor.py
+++ b/tests/envs/binance/test_futures_order_executor.py
@@ -13,7 +13,11 @@ class TestBinanceFuturesOrderClass:
         client = MagicMock()
 
         # Mock futures methods
-        client.futures_change_leverage = MagicMock(return_value={"leverage": 10})
+        # Echoes the request, as binance does -- it returns the leverage it actually
+        # applied, which is how a silent per-notional cap gets caught (#277).
+        client.futures_change_leverage = MagicMock(
+            side_effect=lambda symbol, leverage, **k: {"leverage": leverage}
+        )
         client.futures_change_margin_type = MagicMock(return_value={})
 
         client.futures_create_order = MagicMock(return_value={

--- a/tests/envs/binance/test_futures_order_executor.py
+++ b/tests/envs/binance/test_futures_order_executor.py
@@ -347,13 +347,6 @@ class TestBinanceFuturesOrderClass:
         assert success is True
         mock_client.futures_cancel_all_open_orders.assert_called_once()
 
-    def test_set_leverage(self, order_executor, mock_client):
-        """Test changing leverage."""
-        success = order_executor.set_leverage(20)
-
-        assert success is True
-        assert order_executor.leverage == 20
-
     def test_reduce_only_order(self, order_executor, mock_client):
         """Test reduce only order."""
         success = order_executor.trade(

--- a/tests/envs/bitget/conftest.py
+++ b/tests/envs/bitget/conftest.py
@@ -10,11 +10,15 @@ def mock_ccxt_client():
     client = MagicMock()
 
     # Mock account configuration methods
-    # Echoes the requested leverage, as the venue does. A constant 10 made every
-    # executor built at another leverage look like a venue that had refused (#277).
-    client.set_leverage = MagicMock(
-        side_effect=lambda leverage, *a, **k: {"leverage": leverage}
-    )
+    # Echoes the requested leverage in bitget's real body shape (#277). A constant 10
+    # made every executor built at another leverage look like a refusal, and a
+    # top-level "leverage" key -- which ccxt never returns -- made the check inert.
+    client.set_leverage = MagicMock(side_effect=lambda leverage, *a, **k: {
+        "code": "00000", "msg": "success",
+        "data": {"symbol": "BTCUSDT", "marginCoin": "USDT",
+                 "longLeverage": str(leverage), "shortLeverage": str(leverage),
+                 "crossMarginLeverage": str(leverage), "marginMode": "isolated"},
+    })
     client.set_margin_mode = MagicMock(return_value={"marginMode": "isolated"})
     client.set_position_mode = MagicMock(return_value={"posMode": "one_way_mode"})
 

--- a/tests/envs/bitget/conftest.py
+++ b/tests/envs/bitget/conftest.py
@@ -10,7 +10,11 @@ def mock_ccxt_client():
     client = MagicMock()
 
     # Mock account configuration methods
-    client.set_leverage = MagicMock(return_value={"leverage": 10})
+    # Echoes the requested leverage, as the venue does. A constant 10 made every
+    # executor built at another leverage look like a venue that had refused (#277).
+    client.set_leverage = MagicMock(
+        side_effect=lambda leverage, *a, **k: {"leverage": leverage}
+    )
     client.set_margin_mode = MagicMock(return_value={"marginMode": "isolated"})
     client.set_position_mode = MagicMock(return_value={"posMode": "one_way_mode"})
 

--- a/tests/envs/bitget/test_futures_order_executor.py
+++ b/tests/envs/bitget/test_futures_order_executor.py
@@ -311,14 +311,6 @@ class TestBitgetFuturesOrderClass:
         # Should call cancel for each order
         assert mock_ccxt_client.cancel_order.call_count == 2
 
-    def test_set_leverage(self, order_executor, mock_ccxt_client):
-        """Test changing leverage."""
-        success = order_executor.set_leverage(20)
-
-        assert success is True
-        assert order_executor.leverage == 20
-        mock_ccxt_client.set_leverage.assert_called()
-
     def test_set_margin_mode(self, order_executor, mock_ccxt_client):
         """Test changing margin mode."""
         from torchtrade.envs.live.bitget.order_executor import MarginMode

--- a/tests/envs/bybit/test_futures_order_executor.py
+++ b/tests/envs/bybit/test_futures_order_executor.py
@@ -284,22 +284,8 @@ class TestBybitFuturesOrderClass:
         assert call_kwargs["category"] == "linear"
         assert call_kwargs["symbol"] == "BTCUSDT"
 
-    @pytest.mark.parametrize("ret_code,expected_success,expected_leverage", [
-        (0, True, 20),       # Success: leverage updated
-        (110043, False, 10), # Rejected: leverage stays at original (10)
-    ], ids=["success", "rejected"])
-    def test_set_leverage_validates_retcode(self, order_executor, mock_pybit_client, ret_code, expected_success, expected_leverage):
-        """set_leverage must validate retCode and only update local state on success."""
-        mock_pybit_client.set_leverage = MagicMock(return_value={
-            "retCode": ret_code,
-            "retMsg": "OK" if ret_code == 0 else "Leverage not modified",
-        })
-        result = order_executor.set_leverage(20)
-        assert result is expected_success
-        assert order_executor.leverage == expected_leverage
-
     @pytest.mark.parametrize("ret_code,expected_success,expect_mode_changed", [
-        (0, True, True),       # Success: mode updated
+        (0, True, True),        # Success: mode updated
         (110026, False, False), # Rejected: mode stays at original
     ], ids=["success", "rejected"])
     def test_set_margin_mode_validates_retcode(self, order_executor, mock_pybit_client, ret_code, expected_success, expect_mode_changed):

--- a/tests/envs/okx/conftest.py
+++ b/tests/envs/okx/conftest.py
@@ -33,7 +33,10 @@ def mock_okx_account_client():
 
     # Mock account configuration
     client.set_position_mode = MagicMock(return_value={"code": "0", "msg": ""})
-    client.set_leverage = MagicMock(return_value={"code": "0", "msg": "", "data": [{}]})
+    # `lever` present: an entry without it no longer confirms anything (#277).
+    client.set_leverage = MagicMock(
+        side_effect=lambda instId=None, lever=None, **k: {
+            "code": "0", "msg": "", "data": [{"lever": lever}]})
 
     # Mock position information
     client.get_positions = MagicMock(return_value={

--- a/tests/envs/okx/test_futures_order_executor.py
+++ b/tests/envs/okx/test_futures_order_executor.py
@@ -146,19 +146,6 @@ class TestOKXFuturesOrderClass:
             assert call_kwargs["side"] == expected_side
             assert call_kwargs["reduceOnly"] is True
 
-    @pytest.mark.parametrize("code,expected_success,expected_leverage", [
-        ("0", True, 20),
-        ("51101", False, 10),
-    ], ids=["success", "rejected"])
-    def test_set_leverage_validates_code(self, order_executor, mock_okx_account_client, code, expected_success, expected_leverage):
-        """set_leverage must validate code and only update local state on success."""
-        mock_okx_account_client.set_leverage = MagicMock(return_value={
-            "code": code, "msg": "", "data": [{}],
-        })
-        result = order_executor.set_leverage(20)
-        assert result is expected_success
-        assert order_executor.leverage == expected_leverage
-
     @pytest.mark.parametrize("code,expected_success,expect_mode_changed", [
         ("0", True, True),
         ("51101", False, False),

--- a/tests/envs/test_leverage_boundary.py
+++ b/tests/envs/test_leverage_boundary.py
@@ -78,7 +78,17 @@ EXCHANGES = ["binance", "bitget", "bybit", "okx"]
 # which is what makes the refusal path below the one that has to hold on all four.
 _ECHO = {
     "binance": lambda applied: {"leverage": applied},
-    "bitget": lambda applied: {"leverage": applied},
+    # ccxt returns bitget's raw body: the applied leverage lives per side under `data`,
+    # and there is no top-level `leverage` key. Shaping this to the code instead of the
+    # venue is what made an inert check look verified.
+    "bitget": lambda applied: {
+        "code": "00000", "msg": "success", "requestTime": 1700864711517,
+        "data": {
+            "symbol": "BTCUSDT", "marginCoin": "USDT",
+            "longLeverage": str(applied), "shortLeverage": str(applied),
+            "crossMarginLeverage": str(applied), "marginMode": "isolated",
+        },
+    },
     "okx": lambda applied: {"code": "0", "data": [{"lever": str(applied)}]},
 }
 
@@ -140,3 +150,14 @@ def test_a_venue_that_confirms_the_request_constructs(exchange):
     """The other half of the check: a matching echo must not be read as a mismatch."""
     echo = _ECHO[exchange]
     assert _build(exchange, 20, lambda *a, **k: echo(20)).leverage == 20
+
+
+@pytest.mark.parametrize("exchange", EXCHANGES)
+def test_a_response_the_echo_cannot_be_read_from_stops_construction(exchange):
+    """These executors advertise `client=` injection, so the shape is not guaranteed.
+
+    A shim returning None on a 200 used to erase the whole verification with no
+    diagnostic -- the check silently skipped and construction reported success.
+    """
+    with pytest.raises(TypeError, match="not a dict"):
+        _build(exchange, 20, lambda *a, **k: None)

--- a/tests/envs/test_leverage_boundary.py
+++ b/tests/envs/test_leverage_boundary.py
@@ -214,3 +214,57 @@ def test_bitget_confirms_nothing_on_the_unified_account_route():
     """The unified route answers `"data": "success"` -- a string, carrying no leverage."""
     with pytest.raises(ValueError, match="confirmed no leverage"):
         _build("bitget", 20, lambda *a, **k: {"code": "00000", "data": "success"})
+
+
+@pytest.mark.parametrize("exchange", ["bitget", "bybit"])
+def test_the_margin_mode_is_applied_before_the_leverage_it_can_overwrite(exchange):
+    """Verifying leverage first confirms a number that stops being true one call later.
+
+    bitget stores leverage per margin mode, so a leverage verified under isolated says
+    nothing about the account once it switches to crossed. bybit is worse: its
+    switch_margin_mode carries buyLeverage and sellLeverage, and it is tolerated with a
+    warning, so it can silently undo the verified set.
+
+    Order is asserted directly because neither effect is observable from construction --
+    both leave a *successful* build holding a leverage nobody checked.
+    """
+    calls = []
+
+    def record(name, result):
+        def call(*a, **k):
+            calls.append(name)
+            return result
+        return call
+
+    if exchange == "bitget":
+        from torchtrade.envs.live.bitget.order_executor import BitgetFuturesOrderClass
+        BitgetFuturesOrderClass(
+            symbol="BTCUSDT", trade_mode="quantity", demo=True, leverage=20,
+            client=SimpleNamespace(
+                set_leverage=record("leverage", {"code": "00000", "data": {
+                    "longLeverage": "20", "shortLeverage": "20",
+                    "crossMarginLeverage": "20", "marginMode": "isolated"}}),
+                set_margin_mode=record("margin_mode", {}),
+                set_position_mode=_boom, load_markets=_boom, markets={},
+                fetch_positions=_boom,
+            ),
+        )
+    else:
+        from torchtrade.envs.live.bybit.order_executor import (
+            BybitFuturesOrderClass, MarginMode, PositionMode,
+        )
+        BybitFuturesOrderClass(
+            symbol="BTCUSDT", trade_mode="quantity", demo=True, leverage=20,
+            margin_mode=MarginMode.ISOLATED, position_mode=PositionMode.ONE_WAY,
+            api_key="k", api_secret="s",
+            client=SimpleNamespace(
+                set_leverage=record("leverage", {"retCode": 0}),
+                switch_margin_mode=record("margin_mode", {"retCode": 0}),
+                switch_position_mode=_boom, get_instruments_info=_boom, get_positions=_boom,
+            ),
+        )
+
+    assert calls.index("margin_mode") < calls.index("leverage"), (
+        f"{exchange} verified leverage before setting the margin mode that can change "
+        f"it; call order was {calls}"
+    )

--- a/tests/envs/test_leverage_boundary.py
+++ b/tests/envs/test_leverage_boundary.py
@@ -1,0 +1,142 @@
+"""The venue must confirm the leverage before the env sizes anything against it (#277).
+
+Every exchange used to wrap its set-leverage call in `except Exception: warning`, so a
+rejection left `self.leverage` at the configured value and the env went on sizing
+positions against leverage the account did not have -- and reporting that value as
+`account_state[4]` while flat, while reporting the venue's real one once a position
+opened. Same element, two numbers, no trade in between.
+
+These build REAL order executors, because the defect lived in each executor's
+`_setup_futures_account`; a fake trader would prove nothing about it.
+"""
+import pytest
+from types import SimpleNamespace
+
+
+def _boom(*a, **k):
+    raise ConnectionError("unused in these tests")
+
+
+def _build(exchange, leverage, set_leverage):
+    """Construct a real order executor whose leverage call is `set_leverage`.
+
+    Every other venue call raises: each is already wrapped in its own tolerant handler,
+    so construction reaching the end proves the leverage path alone decided the outcome.
+    """
+    if exchange == "binance":
+        from torchtrade.envs.live.binance.order_executor import BinanceFuturesOrderClass
+        return BinanceFuturesOrderClass(
+            symbol="BTCUSDT", trade_mode="quantity", demo=True, leverage=leverage,
+            client=SimpleNamespace(
+                futures_change_leverage=set_leverage, futures_change_margin_type=_boom,
+                futures_exchange_info=_boom, futures_position_information=_boom,
+            ),
+        )
+    if exchange == "bitget":
+        from torchtrade.envs.live.bitget.order_executor import BitgetFuturesOrderClass
+        return BitgetFuturesOrderClass(
+            symbol="BTCUSDT", trade_mode="quantity", demo=True, leverage=leverage,
+            client=SimpleNamespace(
+                set_leverage=set_leverage, set_position_mode=_boom, set_margin_mode=_boom,
+                load_markets=_boom, markets={}, fetch_positions=_boom,
+            ),
+        )
+    if exchange == "bybit":
+        from torchtrade.envs.live.bybit.order_executor import (
+            BybitFuturesOrderClass, MarginMode, PositionMode,
+        )
+        return BybitFuturesOrderClass(
+            symbol="BTCUSDT", trade_mode="quantity", demo=True, leverage=leverage,
+            margin_mode=MarginMode.ISOLATED, position_mode=PositionMode.ONE_WAY,
+            api_key="k", api_secret="s",
+            client=SimpleNamespace(
+                set_leverage=set_leverage, switch_position_mode=_boom,
+                switch_margin_mode=_boom, get_instruments_info=_boom, get_positions=_boom,
+            ),
+        )
+    if exchange == "okx":
+        from torchtrade.envs.live.okx.order_executor import (
+            OKXFuturesOrderClass, MarginMode, PositionMode,
+        )
+        return OKXFuturesOrderClass(
+            symbol="BTC-USDT-SWAP", trade_mode="quantity", demo=True, leverage=leverage,
+            margin_mode=MarginMode.ISOLATED, position_mode=PositionMode.NET,
+            api_key="k", api_secret="s", passphrase="p",
+            client=SimpleNamespace(),
+            account_client=SimpleNamespace(
+                set_leverage=set_leverage, set_position_mode=_boom, get_positions=_boom,
+            ),
+            public_client=SimpleNamespace(get_instruments=_boom),
+        )
+    raise AssertionError(f"unhandled exchange {exchange}")
+
+
+EXCHANGES = ["binance", "bitget", "bybit", "okx"]
+
+# How each venue states the leverage it actually applied. bybit is absent because its
+# set-leverage response carries no leverage field -- it can only be checked for refusal,
+# which is what makes the refusal path below the one that has to hold on all four.
+_ECHO = {
+    "binance": lambda applied: {"leverage": applied},
+    "bitget": lambda applied: {"leverage": applied},
+    "okx": lambda applied: {"code": "0", "data": [{"lever": str(applied)}]},
+}
+
+
+@pytest.mark.parametrize("exchange", EXCHANGES)
+def test_a_refused_leverage_stops_construction(exchange):
+    """The headline defect: the refusal was logged at warning and trading continued."""
+    def refuse(*a, **k):
+        raise ConnectionError("venue refused the leverage")
+
+    with pytest.raises(ConnectionError):
+        _build(exchange, 20, refuse)
+
+
+@pytest.mark.parametrize("exchange", EXCHANGES)
+def test_leverage_the_venue_already_had_is_not_a_refusal(exchange):
+    """Every venue reports "already at this value" as an API error.
+
+    Without this carve-out the fix above would refuse to construct on every rerun
+    against an account already configured -- which is the reason the original blanket
+    `except Exception` was there, and why removing it needs this case to stay green.
+    """
+    def already(*a, **k):
+        raise RuntimeError("ErrCode: 110043 leverage not modified")
+
+    assert _build(exchange, 20, already).leverage == 20
+
+
+@pytest.mark.parametrize("exchange", sorted(_ECHO))
+def test_a_venue_that_applies_a_different_leverage_is_refused(exchange):
+    """Accepting the call is not applying the request.
+
+    Binance caps leverage per notional bracket, so "accepted" can still mean the account
+    sits at a lower leverage than the one every position size is computed from.
+    """
+    echo = _ECHO[exchange]
+    with pytest.raises(ValueError, match="but the venue applied"):
+        _build(exchange, 20, lambda *a, **k: echo(5))
+
+
+# The two venues that report a refusal as a status code in an otherwise-successful
+# response rather than by raising. Both adapters check codes this way everywhere else.
+_REJECTION_CODE = {
+    "bybit": {"retCode": 110045, "retMsg": "risk limit exceeded"},
+    "okx": {"code": "51004", "msg": "leverage exceeds the risk limit"},
+}
+
+
+@pytest.mark.parametrize("exchange", sorted(_REJECTION_CODE))
+def test_a_refusal_reported_as_a_status_code_stops_construction(exchange):
+    """A refusal need not arrive as an exception; these venues return one in the body."""
+    rejection = _REJECTION_CODE[exchange]
+    with pytest.raises(ValueError, match="refused"):
+        _build(exchange, 20, lambda *a, **k: rejection)
+
+
+@pytest.mark.parametrize("exchange", sorted(_ECHO))
+def test_a_venue_that_confirms_the_request_constructs(exchange):
+    """The other half of the check: a matching echo must not be read as a mismatch."""
+    echo = _ECHO[exchange]
+    assert _build(exchange, 20, lambda *a, **k: echo(20)).leverage == 20

--- a/tests/envs/test_leverage_boundary.py
+++ b/tests/envs/test_leverage_boundary.py
@@ -161,3 +161,56 @@ def test_a_response_the_echo_cannot_be_read_from_stops_construction(exchange):
     """
     with pytest.raises(TypeError, match="not a dict"):
         _build(exchange, 20, lambda *a, **k: None)
+
+
+def test_bitget_reads_the_leverage_of_the_margin_mode_actually_in_force():
+    """bitget stores leverage per margin mode, and the body reports all of them.
+
+    The side fields agree with the request here and only the cross field disagrees, so
+    this passes if and only if the crossed body selects `crossMarginLeverage`. Every
+    other fixture in the repo is isolated, which left this branch executing in no test
+    at all -- the same shape of gap that let the first version of the check ship inert.
+    """
+    crossed = {
+        "code": "00000",
+        "data": {
+            "symbol": "BTCUSDT", "marginCoin": "USDT",
+            "longLeverage": "20", "shortLeverage": "20",
+            "crossMarginLeverage": "5", "marginMode": "crossed",
+        },
+    }
+    with pytest.raises(ValueError, match="but the venue applied"):
+        _build("bitget", 20, lambda *a, **k: crossed)
+
+
+# A response the venue DID return, whose leverage field is missing or renamed. Distinct
+# from a non-dict response: the call looks entirely successful.
+_ECHO_MISSING = {
+    "binance": {"symbol": "BTCUSDT", "maxNotionalValue": "1000"},
+    "bitget": {"code": "00000", "data": {"symbol": "BTCUSDT", "marginMode": "isolated"}},
+    "okx": {"code": "0", "data": [{"instId": "BTC-USDT-SWAP"}]},
+}
+
+
+@pytest.mark.parametrize("exchange", sorted(_ECHO_MISSING))
+def test_a_venue_that_reports_no_leverage_confirms_nothing(exchange):
+    """Absent is not "close enough".
+
+    Reading a key that does not exist, finding None and returning happy is exactly how
+    the first version of this check shipped inert on bitget. A renamed or dropped field
+    has to fail loudly, or the check silently stops checking and the suite stays green.
+    """
+    with pytest.raises(ValueError, match="did not report"):
+        _build(exchange, 20, lambda *a, **k: _ECHO_MISSING[exchange])
+
+
+def test_okx_confirms_nothing_when_it_returns_no_entries():
+    """An empty data list is a failure to confirm, not a pass."""
+    with pytest.raises(ValueError, match="confirmed no leverage"):
+        _build("okx", 20, lambda *a, **k: {"code": "0", "data": []})
+
+
+def test_bitget_confirms_nothing_on_the_unified_account_route():
+    """The unified route answers `"data": "success"` -- a string, carrying no leverage."""
+    with pytest.raises(ValueError, match="confirmed no leverage"):
+        _build("bitget", 20, lambda *a, **k: {"code": "00000", "data": "success"})

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -484,23 +484,23 @@ assert len(_SIZING_ENVS) == 4, f"expected 4 envs that size from a live query, go
 _FAILING_FETCH_EXCHANGES = ["binance", "bitget", "bybit", "okx", "alpaca"]
 
 
-def _leverage_echo(client, exchange, leverage=10):
-    """Make an injected mock answer the leverage handshake as its venue does (#277).
+# Each venue's real set-leverage body at 10x. An executor refuses to construct without
+# one (#277): a response the echo cannot be read from confirms nothing, and skipping
+# silently is the fail-open the check exists to close.
+_LEVERAGE_BODIES = {
+    "bybit": {"retCode": 0},
+    "okx": {"code": "0", "data": [{"lever": "10"}]},
+    "bitget": {"code": "00000", "data": {
+        "longLeverage": "10", "shortLeverage": "10",
+        "crossMarginLeverage": "10", "marginMode": "isolated"}},
+    "binance": {"leverage": 10},
+}
 
-    Without this the executor refuses to construct: a client that returns something
-    other than a dict cannot confirm the leverage, and skipping silently is the very
-    fail-open the check exists to close.
-    """
-    bodies = {
-        "bybit": {"retCode": 0},
-        "okx": {"code": "0", "data": [{"lever": str(leverage)}]},
-        "bitget": {"code": "00000", "data": {
-            "longLeverage": str(leverage), "shortLeverage": str(leverage),
-            "crossMarginLeverage": str(leverage), "marginMode": "isolated"}},
-        "binance": {"leverage": leverage},
-    }
+
+def _leverage_echo(client, exchange):
+    """Make an injected mock answer the leverage handshake as its venue does (#277)."""
     setter = "futures_change_leverage" if exchange == "binance" else "set_leverage"
-    setattr(client, setter, MagicMock(return_value=bodies[exchange]))
+    setattr(client, setter, MagicMock(return_value=_LEVERAGE_BODIES[exchange]))
     return client
 
 def _executor_with_failing_position_fetch(exchange):
@@ -508,23 +508,18 @@ def _executor_with_failing_position_fetch(exchange):
     def boom(*a, **k):
         raise ConnectionError("simulated outage")
 
-    # The outage under test is the POSITION FETCH. Leverage has to be settable or the
-    # executor refuses to construct (#277) and the test would never reach the fetch --
-    # so these echo the requested leverage the way a healthy venue does.
-    def ok_leverage(*a, **k):
-        return {"leverage": 10, "code": "0", "retCode": 0, "data": [{"lever": "10"}]}
 
     if exchange == "binance":
         from torchtrade.envs.live.binance.order_executor import BinanceFuturesOrderClass
         client = SimpleNamespace(futures_position_information=boom, futures_exchange_info=boom,
-                                 futures_change_leverage=ok_leverage, futures_change_margin_type=boom)
+                                 futures_change_leverage=lambda *a, **k: _LEVERAGE_BODIES[exchange], futures_change_margin_type=boom)
         return BinanceFuturesOrderClass(
             symbol="BTCUSDT", trade_mode="quantity", demo=True, leverage=10, client=client
         )
     if exchange == "bitget":
         from torchtrade.envs.live.bitget.order_executor import BitgetFuturesOrderClass
         client = SimpleNamespace(fetch_positions=boom, load_markets=boom, markets={},
-                                 set_leverage=ok_leverage, set_position_mode=boom,
+                                 set_leverage=lambda *a, **k: _LEVERAGE_BODIES[exchange], set_position_mode=boom,
                                  set_margin_mode=boom)
         return BitgetFuturesOrderClass(
             symbol="BTCUSDT", trade_mode="quantity", demo=True, leverage=10, client=client
@@ -534,7 +529,7 @@ def _executor_with_failing_position_fetch(exchange):
             BybitFuturesOrderClass, MarginMode, PositionMode,
         )
         client = SimpleNamespace(get_positions=boom, get_instruments_info=boom,
-                                 set_leverage=ok_leverage, switch_position_mode=boom,
+                                 set_leverage=lambda *a, **k: _LEVERAGE_BODIES[exchange], switch_position_mode=boom,
                                  switch_margin_mode=boom)
         return BybitFuturesOrderClass(
             symbol="BTCUSDT", trade_mode="quantity", demo=True, leverage=10,
@@ -550,7 +545,7 @@ def _executor_with_failing_position_fetch(exchange):
             margin_mode=MarginMode.ISOLATED, position_mode=PositionMode.NET,
             api_key="k", api_secret="s", passphrase="p",
             client=SimpleNamespace(),
-            account_client=SimpleNamespace(get_positions=boom, set_leverage=ok_leverage,
+            account_client=SimpleNamespace(get_positions=boom, set_leverage=lambda *a, **k: _LEVERAGE_BODIES[exchange],
                                            set_position_mode=boom),
             public_client=SimpleNamespace(get_instruments=boom),
         )
@@ -1978,13 +1973,13 @@ def test_okx_refuses_an_unusable_posside_instead_of_signing_it_long(pos_side):
     # account_client, not client: okx splits Trade/Account/PublicData, and injecting only
     # `client` left get_positions hitting the real API -- so the test passed on the API
     # error rather than on the guard, with or without the fix.
-    account = _leverage_echo(MagicMock(), "okx")
+    account = MagicMock()
     account.get_positions = MagicMock(return_value={"code": "0", "data": [
         {"instId": "BTC-USDT-SWAP", "pos": "1.0", "posSide": pos_side,
          "avgPx": "100", "markPx": "101", "lever": "10", "mgnMode": "cross"}
     ]})
     account.set_position_mode = MagicMock(return_value={"code": "0"})
-    account.set_leverage = MagicMock(return_value={"code": "0"})
+    account.set_leverage = MagicMock(return_value=_LEVERAGE_BODIES["okx"])
     public = MagicMock()
     public.get_instruments = MagicMock(return_value={"data": []})
 
@@ -2000,13 +1995,13 @@ def test_okx_still_signs_a_recognised_short_negative():
     """The guard must reject the unrecognised, not the legitimate."""
     from torchtrade.envs.live.okx.order_executor import OKXFuturesOrderClass
 
-    account = _leverage_echo(MagicMock(), "okx")
+    account = MagicMock()
     account.get_positions = MagicMock(return_value={"code": "0", "data": [
         {"instId": "BTC-USDT-SWAP", "pos": "1.0", "posSide": "short",
          "avgPx": "100", "markPx": "101", "lever": "10", "mgnMode": "cross"}
     ]})
     account.set_position_mode = MagicMock(return_value={"code": "0"})
-    account.set_leverage = MagicMock(return_value={"code": "0"})
+    account.set_leverage = MagicMock(return_value=_LEVERAGE_BODIES["okx"])
     public = MagicMock()
     public.get_instruments = MagicMock(return_value={"data": []})
 
@@ -2063,12 +2058,12 @@ def test_an_emergency_close_refuses_an_unusable_side_instead_of_guessing(
                  api_key="k", api_secret="s", client=client)
     else:
         from torchtrade.envs.live.okx.order_executor import OKXFuturesOrderClass as cls
-        account = _leverage_echo(MagicMock(), "okx")
+        account = MagicMock()
         account.get_positions = MagicMock(return_value={"code": "0", "data": [
             {"instId": "BTC-USDT-SWAP", "pos": "1.0", side_key: side}
         ]})
         account.set_position_mode = MagicMock(return_value={"code": "0"})
-        account.set_leverage = MagicMock(return_value={"code": "0"})
+        account.set_leverage = MagicMock(return_value=_LEVERAGE_BODIES["okx"])
         public = MagicMock(); public.get_instruments = MagicMock(return_value={"data": []})
         ex = cls(symbol="BTC-USDT-SWAP", trade_mode="quantity", demo=True, leverage=10,
                  api_key="k", api_secret="s", passphrase="p",

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -489,15 +489,24 @@ def _executor_with_failing_position_fetch(exchange):
     def boom(*a, **k):
         raise ConnectionError("simulated outage")
 
+    # The outage under test is the POSITION FETCH. Leverage has to be settable or the
+    # executor refuses to construct (#277) and the test would never reach the fetch --
+    # so these echo the requested leverage the way a healthy venue does.
+    def ok_leverage(*a, **k):
+        return {"leverage": 10, "code": "0", "retCode": 0, "data": [{"lever": "10"}]}
+
     if exchange == "binance":
         from torchtrade.envs.live.binance.order_executor import BinanceFuturesOrderClass
-        client = SimpleNamespace(futures_position_information=boom, futures_exchange_info=boom)
+        client = SimpleNamespace(futures_position_information=boom, futures_exchange_info=boom,
+                                 futures_change_leverage=ok_leverage, futures_change_margin_type=boom)
         return BinanceFuturesOrderClass(
             symbol="BTCUSDT", trade_mode="quantity", demo=True, leverage=10, client=client
         )
     if exchange == "bitget":
         from torchtrade.envs.live.bitget.order_executor import BitgetFuturesOrderClass
-        client = SimpleNamespace(fetch_positions=boom, load_markets=boom, markets={})
+        client = SimpleNamespace(fetch_positions=boom, load_markets=boom, markets={},
+                                 set_leverage=ok_leverage, set_position_mode=boom,
+                                 set_margin_mode=boom)
         return BitgetFuturesOrderClass(
             symbol="BTCUSDT", trade_mode="quantity", demo=True, leverage=10, client=client
         )
@@ -505,7 +514,9 @@ def _executor_with_failing_position_fetch(exchange):
         from torchtrade.envs.live.bybit.order_executor import (
             BybitFuturesOrderClass, MarginMode, PositionMode,
         )
-        client = SimpleNamespace(get_positions=boom, get_instruments_info=boom)
+        client = SimpleNamespace(get_positions=boom, get_instruments_info=boom,
+                                 set_leverage=ok_leverage, switch_position_mode=boom,
+                                 switch_margin_mode=boom)
         return BybitFuturesOrderClass(
             symbol="BTCUSDT", trade_mode="quantity", demo=True, leverage=10,
             margin_mode=MarginMode.ISOLATED, position_mode=PositionMode.ONE_WAY,
@@ -520,7 +531,8 @@ def _executor_with_failing_position_fetch(exchange):
             margin_mode=MarginMode.ISOLATED, position_mode=PositionMode.NET,
             api_key="k", api_secret="s", passphrase="p",
             client=SimpleNamespace(),
-            account_client=SimpleNamespace(get_positions=boom, set_leverage=boom),
+            account_client=SimpleNamespace(get_positions=boom, set_leverage=ok_leverage,
+                                           set_position_mode=boom),
             public_client=SimpleNamespace(get_instruments=boom),
         )
     if exchange == "alpaca":

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -497,12 +497,6 @@ _LEVERAGE_BODIES = {
 }
 
 
-def _leverage_echo(client, exchange):
-    """Make an injected mock answer the leverage handshake as its venue does (#277)."""
-    setter = "futures_change_leverage" if exchange == "binance" else "set_leverage"
-    setattr(client, setter, MagicMock(return_value=_LEVERAGE_BODIES[exchange]))
-    return client
-
 def _executor_with_failing_position_fetch(exchange):
     """Build a real order executor whose position fetch raises, as in an outage."""
     def boom(*a, **k):
@@ -1928,7 +1922,8 @@ def _bitget_status(**pos_overrides):
     pos = {"symbol": "BTC/USDT:USDT", "contracts": 1.0, "side": "long",
            "entryPrice": 100.0, "markPrice": 101.0}
     pos.update(pos_overrides)
-    client = _leverage_echo(MagicMock(), "bitget")
+    client = MagicMock()
+    client.set_leverage = MagicMock(return_value=_LEVERAGE_BODIES["bitget"])
     client.fetch_positions = MagicMock(return_value=[pos])
     client.load_markets = MagicMock(return_value={})
     client.markets = {}
@@ -2048,7 +2043,8 @@ def test_an_emergency_close_refuses_an_unusable_side_instead_of_guessing(
     direction, which the venue rejects. The operator sees flatten_accepted=False having
     believed the position was closed, so the refusal must be explicit, not a rejection.
     """
-    client = _leverage_echo(MagicMock(), exchange)
+    client = MagicMock()
+    client.set_leverage = MagicMock(return_value=_LEVERAGE_BODIES[exchange])
     if exchange == "bybit":
         from torchtrade.envs.live.bybit.order_executor import BybitFuturesOrderClass as cls
         client.get_positions = MagicMock(return_value={"retCode": 0, "result": {"list": [

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -484,6 +484,25 @@ assert len(_SIZING_ENVS) == 4, f"expected 4 envs that size from a live query, go
 _FAILING_FETCH_EXCHANGES = ["binance", "bitget", "bybit", "okx", "alpaca"]
 
 
+def _leverage_echo(client, exchange, leverage=10):
+    """Make an injected mock answer the leverage handshake as its venue does (#277).
+
+    Without this the executor refuses to construct: a client that returns something
+    other than a dict cannot confirm the leverage, and skipping silently is the very
+    fail-open the check exists to close.
+    """
+    bodies = {
+        "bybit": {"retCode": 0},
+        "okx": {"code": "0", "data": [{"lever": str(leverage)}]},
+        "bitget": {"code": "00000", "data": {
+            "longLeverage": str(leverage), "shortLeverage": str(leverage),
+            "crossMarginLeverage": str(leverage), "marginMode": "isolated"}},
+        "binance": {"leverage": leverage},
+    }
+    setter = "futures_change_leverage" if exchange == "binance" else "set_leverage"
+    setattr(client, setter, MagicMock(return_value=bodies[exchange]))
+    return client
+
 def _executor_with_failing_position_fetch(exchange):
     """Build a real order executor whose position fetch raises, as in an outage."""
     def boom(*a, **k):
@@ -1582,8 +1601,8 @@ def test_no_adapter_swaps_a_venue_reported_zero_leverage_for_the_config():
     Scope, stated so this is not mistaken for more than it is: a MISSING or BLANK venue
     leverage still falls back to the config value, deliberately, because refusing would
     leave OKX and bybit cross accounts unable to produce an observation at all. That
-    fallback is only as good as set_leverage having worked, which #277's unfixed half is
-    about. What this forbids is the silent case -- a leverage the venue did report, as 0,
+    fallback is only as good as set_leverage having worked, which #277 now verifies at
+    construction. What this forbids is the silent case -- a leverage the venue did report, as 0,
     being swapped for a different number.
     """
     live_root = pathlib.Path(inspect.getfile(TorchTradeLiveEnv)).parent.parent / "live"
@@ -1914,7 +1933,7 @@ def _bitget_status(**pos_overrides):
     pos = {"symbol": "BTC/USDT:USDT", "contracts": 1.0, "side": "long",
            "entryPrice": 100.0, "markPrice": 101.0}
     pos.update(pos_overrides)
-    client = MagicMock()
+    client = _leverage_echo(MagicMock(), "bitget")
     client.fetch_positions = MagicMock(return_value=[pos])
     client.load_markets = MagicMock(return_value={})
     client.markets = {}
@@ -1959,7 +1978,7 @@ def test_okx_refuses_an_unusable_posside_instead_of_signing_it_long(pos_side):
     # account_client, not client: okx splits Trade/Account/PublicData, and injecting only
     # `client` left get_positions hitting the real API -- so the test passed on the API
     # error rather than on the guard, with or without the fix.
-    account = MagicMock()
+    account = _leverage_echo(MagicMock(), "okx")
     account.get_positions = MagicMock(return_value={"code": "0", "data": [
         {"instId": "BTC-USDT-SWAP", "pos": "1.0", "posSide": pos_side,
          "avgPx": "100", "markPx": "101", "lever": "10", "mgnMode": "cross"}
@@ -1981,7 +2000,7 @@ def test_okx_still_signs_a_recognised_short_negative():
     """The guard must reject the unrecognised, not the legitimate."""
     from torchtrade.envs.live.okx.order_executor import OKXFuturesOrderClass
 
-    account = MagicMock()
+    account = _leverage_echo(MagicMock(), "okx")
     account.get_positions = MagicMock(return_value={"code": "0", "data": [
         {"instId": "BTC-USDT-SWAP", "pos": "1.0", "posSide": "short",
          "avgPx": "100", "markPx": "101", "lever": "10", "mgnMode": "cross"}
@@ -2034,7 +2053,7 @@ def test_an_emergency_close_refuses_an_unusable_side_instead_of_guessing(
     direction, which the venue rejects. The operator sees flatten_accepted=False having
     believed the position was closed, so the refusal must be explicit, not a rejection.
     """
-    client = MagicMock()
+    client = _leverage_echo(MagicMock(), exchange)
     if exchange == "bybit":
         from torchtrade.envs.live.bybit.order_executor import BybitFuturesOrderClass as cls
         client.get_positions = MagicMock(return_value={"retCode": 0, "result": {"list": [
@@ -2044,7 +2063,7 @@ def test_an_emergency_close_refuses_an_unusable_side_instead_of_guessing(
                  api_key="k", api_secret="s", client=client)
     else:
         from torchtrade.envs.live.okx.order_executor import OKXFuturesOrderClass as cls
-        account = MagicMock()
+        account = _leverage_echo(MagicMock(), "okx")
         account.get_positions = MagicMock(return_value={"code": "0", "data": [
             {"instId": "BTC-USDT-SWAP", "pos": "1.0", side_key: side}
         ]})

--- a/torchtrade/envs/live/binance/order_executor.py
+++ b/torchtrade/envs/live/binance/order_executor.py
@@ -10,11 +10,7 @@ from dotenv import load_dotenv
 from torchtrade.envs.core.common import TradeMode
 from torchtrade.envs.core.common_types import MarginType, OrderStatus
 from torchtrade.envs.core.state import POSITION_UNKNOWN
-from torchtrade.envs.utils.leverage import (
-    leverage_already_set,
-    require_dict_response,
-    require_leverage_applied,
-)
+from torchtrade.envs.utils.leverage import leverage_already_set, require_leverage_applied
 
 load_dotenv()
 

--- a/torchtrade/envs/live/binance/order_executor.py
+++ b/torchtrade/envs/live/binance/order_executor.py
@@ -10,7 +10,11 @@ from dotenv import load_dotenv
 from torchtrade.envs.core.common import TradeMode
 from torchtrade.envs.core.common_types import MarginType, OrderStatus
 from torchtrade.envs.core.state import POSITION_UNKNOWN
-from torchtrade.envs.utils.leverage import is_already_applied, require_leverage_applied
+from torchtrade.envs.utils.leverage import (
+    leverage_already_set,
+    require_dict_response,
+    require_leverage_applied,
+)
 
 load_dotenv()
 
@@ -131,24 +135,26 @@ class BinanceFuturesOrderClass:
 
     def _setup_futures_account(self):
         """Configure futures account settings."""
-        # Leverage is outside the tolerant block below: it feeds every position size and
-        # account_state[4], and a swallowed rejection left the env sizing against a
-        # leverage the account never had (#277). Binance caps leverage per notional
-        # bracket, so the echoed value is checked too, not just the call.
+        # Not tolerated like the margin type below: leverage sizes every position (#277).
+        # Binance caps leverage per notional bracket, so the echo is checked too --
+        # accepting the call is not applying the request.
         try:
             response = self.client.futures_change_leverage(
                 symbol=self.symbol,
                 leverage=self.leverage
             )
         except Exception as e:
-            if not is_already_applied(e):
+            if not leverage_already_set(e):
                 raise
-            response = {}
+        else:
+            require_leverage_applied(
+                self.symbol,
+                self.leverage,
+                require_dict_response(self.symbol, self.leverage, response).get("leverage"),
+            )
 
-        if isinstance(response, dict):
-            require_leverage_applied(self.symbol, self.leverage, response.get("leverage"))
-
-        # Margin type stays a preference: it does not size anything.
+        # Margin type stays a preference for SIZING; note it does affect liquidation
+        # risk, so a construction that succeeds guarantees leverage only.
         try:
             self.client.futures_change_margin_type(
                 symbol=self.symbol,
@@ -592,29 +598,6 @@ class BinanceFuturesOrderClass:
         except Exception as e:
             logger.error(f"Error getting positions: {str(e)}")
             return {}
-
-    def set_leverage(self, leverage: int) -> bool:
-        """
-        Change leverage for the symbol.
-
-        Args:
-            leverage: New leverage value (1-125)
-
-        Returns:
-            bool: True if successful
-        """
-        try:
-            self.client.futures_change_leverage(
-                symbol=self.symbol,
-                leverage=leverage
-            )
-            self.leverage = leverage
-            logger.info(f"Leverage set to {leverage}x for {self.symbol}")
-            return True
-        except Exception as e:
-            logger.error(f"Error setting leverage: {str(e)}")
-            return False
-
 
 # Example usage
 if __name__ == "__main__":

--- a/torchtrade/envs/live/binance/order_executor.py
+++ b/torchtrade/envs/live/binance/order_executor.py
@@ -10,6 +10,7 @@ from dotenv import load_dotenv
 from torchtrade.envs.core.common import TradeMode
 from torchtrade.envs.core.common_types import MarginType, OrderStatus
 from torchtrade.envs.core.state import POSITION_UNKNOWN
+from torchtrade.envs.utils.leverage import is_already_applied, require_leverage_applied
 
 load_dotenv()
 
@@ -130,26 +131,33 @@ class BinanceFuturesOrderClass:
 
     def _setup_futures_account(self):
         """Configure futures account settings."""
+        # Leverage is outside the tolerant block below: it feeds every position size and
+        # account_state[4], and a swallowed rejection left the env sizing against a
+        # leverage the account never had (#277). Binance caps leverage per notional
+        # bracket, so the echoed value is checked too, not just the call.
         try:
-            # Set leverage
-            self.client.futures_change_leverage(
+            response = self.client.futures_change_leverage(
                 symbol=self.symbol,
                 leverage=self.leverage
             )
-
-            # Set margin type
-            try:
-                self.client.futures_change_margin_type(
-                    symbol=self.symbol,
-                    marginType=self.margin_type.value
-                )
-            except Exception as e:
-                # May fail if already set to this margin type
-                if "No need to change margin type" not in str(e):
-                    logger.warning(f"Could not set margin type: {e}")
-
         except Exception as e:
-            logger.warning(f"Could not setup futures account: {e}")
+            if not is_already_applied(e):
+                raise
+            response = {}
+
+        if isinstance(response, dict):
+            require_leverage_applied(self.symbol, self.leverage, response.get("leverage"))
+
+        # Margin type stays a preference: it does not size anything.
+        try:
+            self.client.futures_change_margin_type(
+                symbol=self.symbol,
+                marginType=self.margin_type.value
+            )
+        except Exception as e:
+            # May fail if already set to this margin type
+            if "No need to change margin type" not in str(e):
+                logger.warning(f"Could not set margin type: {e}")
 
     def _fetch_symbol_filters(self):
         """Cache the tick size and every symbol's LOT_SIZE step and minQty (#271).

--- a/torchtrade/envs/live/binance/order_executor.py
+++ b/torchtrade/envs/live/binance/order_executor.py
@@ -147,11 +147,7 @@ class BinanceFuturesOrderClass:
             if not leverage_already_set(e):
                 raise
         else:
-            require_leverage_applied(
-                self.symbol,
-                self.leverage,
-                require_dict_response(self.symbol, self.leverage, response).get("leverage"),
-            )
+            require_leverage_applied(self.symbol, self.leverage, response, "leverage")
 
         # Margin type stays a preference for SIZING; note it does affect liquidation
         # risk, so a construction that succeeds guarantees leverage only.

--- a/torchtrade/envs/live/bitget/order_executor.py
+++ b/torchtrade/envs/live/bitget/order_executor.py
@@ -343,6 +343,22 @@ class BitgetFuturesOrderClass:
             # May fail if already set or not supported
             logger.warning(f"Could not set position mode (may already be configured): {e}")
 
+        # Margin mode BEFORE leverage: bitget stores leverage per mode, so verifying
+        # it first confirmed a number that stopped being the account's leverage two
+        # statements later (#277). Read outside the try because it was assigned
+        # inside it and referenced from the handler -- a failure in to_ccxt() raised
+        # NameError from the error path, hidden by an outer blanket except.
+        margin_mode_ccxt = self.margin_mode.to_ccxt()
+        try:
+            logger.info(f"Setting margin mode to: {margin_mode_ccxt}")
+            self.client.set_margin_mode(
+                marginMode=margin_mode_ccxt,
+                symbol=self.symbol
+            )
+            logger.info(f"Margin mode set successfully to {margin_mode_ccxt}")
+        except Exception as e:
+            logger.error(f"Error setting margin mode to {margin_mode_ccxt}: {e}")
+
         # Not tolerated like the modes around it: leverage sizes every position (#277).
         try:
             response = self.client.set_leverage(
@@ -359,33 +375,25 @@ class BitgetFuturesOrderClass:
             # not raise -- it silently confirmed nothing, on every account.
             # The unified-account route answers `"data": "success"` with no leverage
             # at all, hence the isinstance rather than a bare index.
-            data = require_dict_response(
-                self.symbol, self.leverage, response
-            ).get("data")
-            if isinstance(data, dict):
-                # Under crossed margin the effective leverage is the cross field; under
-                # isolated the two sides can differ and both size real positions.
-                fields = (
-                    ("crossMarginLeverage",)
-                    if data.get("marginMode") == "crossed"
-                    else ("longLeverage", "shortLeverage")
+            require_dict_response(self.symbol, self.leverage, response)
+            data = response.get("data")
+            # Under crossed margin the effective leverage is the cross field; under
+            # isolated the two sides can differ and both size real positions. A `data`
+            # that is not a dict (the unified-account route answers the string
+            # "success") confirms nothing, and passing over it is the inert check again.
+            if not isinstance(data, dict):
+                raise ValueError(
+                    f"bitget confirmed no leverage for {self.symbol}: set-leverage "
+                    f"answered {data!r}, which carries no leverage to check "
+                    f"{self.leverage}x against."
                 )
-                for field in fields:
-                    require_leverage_applied(self.symbol, self.leverage, data.get(field))
-
-        # Set margin mode using CCXT. Read before the try: it was assigned inside it and
-        # referenced from the handler, so a failure in to_ccxt() raised NameError from
-        # the error path -- invisible only because an outer blanket except caught that too.
-        margin_mode_ccxt = self.margin_mode.to_ccxt()
-        try:
-            logger.info(f"Setting margin mode to: {margin_mode_ccxt}")
-            self.client.set_margin_mode(
-                marginMode=margin_mode_ccxt,
-                symbol=self.symbol
+            fields = (
+                ("crossMarginLeverage",)
+                if data.get("marginMode") == "crossed"
+                else ("longLeverage", "shortLeverage")
             )
-            logger.info(f"Margin mode set successfully to {margin_mode_ccxt}")
-        except Exception as e:
-            logger.error(f"Error setting margin mode to {margin_mode_ccxt}: {e}")
+            for field in fields:
+                require_leverage_applied(self.symbol, self.leverage, data, field)
 
     def trade(
         self,

--- a/torchtrade/envs/live/bitget/order_executor.py
+++ b/torchtrade/envs/live/bitget/order_executor.py
@@ -345,9 +345,7 @@ class BitgetFuturesOrderClass:
 
         # Margin mode BEFORE leverage: bitget stores leverage per mode, so verifying
         # it first confirmed a number that stopped being the account's leverage two
-        # statements later (#277). Read outside the try because it was assigned
-        # inside it and referenced from the handler -- a failure in to_ccxt() raised
-        # NameError from the error path, hidden by an outer blanket except.
+        # statements later (#277). Read outside the try: the handler interpolates it.
         margin_mode_ccxt = self.margin_mode.to_ccxt()
         try:
             logger.info(f"Setting margin mode to: {margin_mode_ccxt}")
@@ -370,17 +368,12 @@ class BitgetFuturesOrderClass:
             if not leverage_already_set(e):
                 raise
         else:
-            # ccxt returns bitget's raw body, which reports the applied leverage per
-            # side under `data` and has no top-level `leverage` key. Reading one did
-            # not raise -- it silently confirmed nothing, on every account.
-            # The unified-account route answers `"data": "success"` with no leverage
-            # at all, hence the isinstance rather than a bare index.
+            # ccxt returns bitget's raw body: the applied leverage sits per side under
+            # `data`, with no top-level `leverage` key (reading one confirmed nothing).
             require_dict_response(self.symbol, self.leverage, response)
             data = response.get("data")
-            # Under crossed margin the effective leverage is the cross field; under
-            # isolated the two sides can differ and both size real positions. A `data`
-            # that is not a dict (the unified-account route answers the string
-            # "success") confirms nothing, and passing over it is the inert check again.
+            # A non-dict `data` (the unified-account route answers "success") confirms
+            # nothing, and passing over it is the inert check again.
             if not isinstance(data, dict):
                 raise ValueError(
                     f"bitget confirmed no leverage for {self.symbol}: set-leverage "

--- a/torchtrade/envs/live/bitget/order_executor.py
+++ b/torchtrade/envs/live/bitget/order_executor.py
@@ -9,7 +9,11 @@ from torchtrade.envs.live.bitget.utils import normalize_symbol
 from torchtrade.envs.core.common import TradeMode
 from torchtrade.envs.core.common_types import OrderStatus
 from torchtrade.envs.core.state import POSITION_UNKNOWN
-from torchtrade.envs.utils.leverage import is_already_applied, require_leverage_applied
+from torchtrade.envs.utils.leverage import (
+    leverage_already_set,
+    require_dict_response,
+    require_leverage_applied,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -339,11 +343,7 @@ class BitgetFuturesOrderClass:
             # May fail if already set or not supported
             logger.warning(f"Could not set position mode (may already be configured): {e}")
 
-        # Set leverage using CCXT unified API. This one is not tolerated on failure:
-        # position and margin mode are preferences, but leverage feeds every position
-        # size and account_state[4]. The blanket handler this block used to sit in
-        # reported "may already be configured" for an outright rejection, and the env
-        # went on sizing against leverage the account did not have (#277).
+        # Not tolerated like the modes around it: leverage sizes every position (#277).
         try:
             response = self.client.set_leverage(
                 leverage=self.leverage,
@@ -351,12 +351,27 @@ class BitgetFuturesOrderClass:
                 params=params
             )
         except Exception as e:
-            if not is_already_applied(e):
+            if not leverage_already_set(e):
                 raise
-            response = {}
-
-        if isinstance(response, dict):
-            require_leverage_applied(self.symbol, self.leverage, response.get("leverage"))
+        else:
+            # ccxt returns bitget's raw body, which reports the applied leverage per
+            # side under `data` and has no top-level `leverage` key. Reading one did
+            # not raise -- it silently confirmed nothing, on every account.
+            # The unified-account route answers `"data": "success"` with no leverage
+            # at all, hence the isinstance rather than a bare index.
+            data = require_dict_response(
+                self.symbol, self.leverage, response
+            ).get("data")
+            if isinstance(data, dict):
+                # Under crossed margin the effective leverage is the cross field; under
+                # isolated the two sides can differ and both size real positions.
+                fields = (
+                    ("crossMarginLeverage",)
+                    if data.get("marginMode") == "crossed"
+                    else ("longLeverage", "shortLeverage")
+                )
+                for field in fields:
+                    require_leverage_applied(self.symbol, self.leverage, data.get(field))
 
         # Set margin mode using CCXT. Read before the try: it was assigned inside it and
         # referenced from the handler, so a failure in to_ccxt() raised NameError from
@@ -773,28 +788,6 @@ class BitgetFuturesOrderClass:
             else:
                 logger.error(f"Error closing position: {str(e)}")
                 return False
-
-    def set_leverage(self, leverage: int) -> bool:
-        """
-        Change leverage for the symbol using CCXT.
-
-        Args:
-            leverage: New leverage value (1-125)
-
-        Returns:
-            bool: True if successful
-        """
-        try:
-            params = {
-                'marginCoin': self.margin_coin,
-            }
-            self.client.set_leverage(leverage, self.symbol, params=params)
-            self.leverage = leverage
-            logger.debug(f"Leverage set to {leverage}x for {self.symbol}")
-            return True
-        except Exception as e:
-            logger.error(f"Error setting leverage: {str(e)}")
-            return False
 
     def set_margin_mode(self, mode: MarginMode) -> bool:
         """

--- a/torchtrade/envs/live/bitget/order_executor.py
+++ b/torchtrade/envs/live/bitget/order_executor.py
@@ -9,6 +9,7 @@ from torchtrade.envs.live.bitget.utils import normalize_symbol
 from torchtrade.envs.core.common import TradeMode
 from torchtrade.envs.core.common_types import OrderStatus
 from torchtrade.envs.core.state import POSITION_UNKNOWN
+from torchtrade.envs.utils.leverage import is_already_applied, require_leverage_applied
 
 logger = logging.getLogger(__name__)
 
@@ -317,50 +318,59 @@ class BitgetFuturesOrderClass:
 
     def _setup_futures_account(self):
         """Configure futures account settings."""
+        params = {
+            'productType': self.product_type,
+            'marginCoin': self.margin_coin,
+        }
+
+        # Set position mode (one-way or hedge)
         try:
-            params = {
-                'productType': self.product_type,
-                'marginCoin': self.margin_coin,
-            }
+            position_mode_value = self.position_mode.value
+            logger.info(f"Setting position mode to: {position_mode_value}")
+            # Bitget API call to set position mode
+            # Note: This is exchange-specific and may not be in CCXT unified API
+            self.client.set_position_mode(
+                hedged=(self.position_mode == PositionMode.HEDGE),
+                symbol=self.symbol,
+                params=params
+            )
+            logger.info(f"Position mode set successfully to {position_mode_value}")
+        except Exception as e:
+            # May fail if already set or not supported
+            logger.warning(f"Could not set position mode (may already be configured): {e}")
 
-            # Set position mode (one-way or hedge)
-            try:
-                position_mode_value = self.position_mode.value
-                logger.info(f"Setting position mode to: {position_mode_value}")
-                # Bitget API call to set position mode
-                # Note: This is exchange-specific and may not be in CCXT unified API
-                response = self.client.set_position_mode(
-                    hedged=(self.position_mode == PositionMode.HEDGE),
-                    symbol=self.symbol,
-                    params=params
-                )
-                logger.info(f"Position mode set successfully to {position_mode_value}")
-            except Exception as e:
-                # May fail if already set or not supported
-                logger.warning(f"Could not set position mode (may already be configured): {e}")
-
-            # Set leverage using CCXT unified API
-            self.client.set_leverage(
+        # Set leverage using CCXT unified API. This one is not tolerated on failure:
+        # position and margin mode are preferences, but leverage feeds every position
+        # size and account_state[4]. The blanket handler this block used to sit in
+        # reported "may already be configured" for an outright rejection, and the env
+        # went on sizing against leverage the account did not have (#277).
+        try:
+            response = self.client.set_leverage(
                 leverage=self.leverage,
                 symbol=self.symbol,
                 params=params
             )
-
-            # Set margin mode using CCXT
-            try:
-                margin_mode_ccxt = self.margin_mode.to_ccxt()
-                logger.info(f"Setting margin mode to: {margin_mode_ccxt}")
-                self.client.set_margin_mode(
-                    marginMode=margin_mode_ccxt,
-                    symbol=self.symbol
-                )
-                logger.info(f"Margin mode set successfully to {margin_mode_ccxt}")
-            except Exception as e:
-                logger.error(f"Error setting margin mode to {margin_mode_ccxt}: {e}")
-
         except Exception as e:
-            # May fail if settings already configured - this is expected
-            logger.warning(f"Could not setup futures account (may already be configured): {e}")
+            if not is_already_applied(e):
+                raise
+            response = {}
+
+        if isinstance(response, dict):
+            require_leverage_applied(self.symbol, self.leverage, response.get("leverage"))
+
+        # Set margin mode using CCXT. Read before the try: it was assigned inside it and
+        # referenced from the handler, so a failure in to_ccxt() raised NameError from
+        # the error path -- invisible only because an outer blanket except caught that too.
+        margin_mode_ccxt = self.margin_mode.to_ccxt()
+        try:
+            logger.info(f"Setting margin mode to: {margin_mode_ccxt}")
+            self.client.set_margin_mode(
+                marginMode=margin_mode_ccxt,
+                symbol=self.symbol
+            )
+            logger.info(f"Margin mode set successfully to {margin_mode_ccxt}")
+        except Exception as e:
+            logger.error(f"Error setting margin mode to {margin_mode_ccxt}: {e}")
 
     def trade(
         self,

--- a/torchtrade/envs/live/bybit/order_executor.py
+++ b/torchtrade/envs/live/bybit/order_executor.py
@@ -7,7 +7,11 @@ from typing import Dict, List, Optional
 from torchtrade.envs.live.bybit.utils import normalize_symbol
 from torchtrade.envs.core.common import TradeMode
 from torchtrade.envs.core.state import POSITION_UNKNOWN
-from torchtrade.envs.utils.leverage import is_already_applied
+from torchtrade.envs.utils.leverage import (
+    leverage_already_set,
+    require_dict_response,
+    require_leverage_applied,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -197,27 +201,24 @@ class BybitFuturesOrderClass:
         except Exception as e:
             logger.warning(f"Could not set position mode (may already be configured): {e}")
 
-        # NOT `except Exception: warning`, unlike the position/margin modes around it.
-        # Those two are preferences; leverage is an input to every position size this
-        # env will compute and to account_state[4]. A swallowed rejection left the env
-        # sizing 20x against an account the venue still had at 5x (#277).
+        # Not tolerated like the modes above: leverage sizes every position (#277).
+        # bybit's response carries no leverage, so refusal is all that can be checked
+        # here -- an accepted-but-clamped leverage goes undetected on this venue.
         try:
             response = self.client.set_leverage(
                 category="linear", symbol=self.symbol,
                 buyLeverage=leverage_str, sellLeverage=leverage_str,
             )
         except Exception as e:
-            if not is_already_applied(e):
+            if not leverage_already_set(e):
                 raise
-            response = None
-
-        # pybit raises on a non-zero retCode, so this reads the code for adapters that
-        # return it instead -- and costs nothing when the exception path already fired.
-        if isinstance(response, dict):
-            ret_code = response.get("retCode")
+        else:
+            ret_code = require_dict_response(
+                self.symbol, self.leverage, response
+            ).get("retCode")
             if ret_code is not None and int(ret_code) != 0:
                 ret_msg = response.get("retMsg", "unknown error")
-                if not is_already_applied(f"{ret_code} {ret_msg}"):
+                if not leverage_already_set(ret_msg):
                     raise ValueError(
                         f"bybit refused {self.leverage}x leverage for {self.symbol} "
                         f"(retCode={ret_code}): {ret_msg}"
@@ -677,35 +678,6 @@ class BybitFuturesOrderClass:
             except Exception:
                 pass
             logger.error(f"Error closing position: {e}")
-            return False
-
-    def set_leverage(self, leverage: int) -> bool:
-        """
-        Change leverage for the symbol.
-
-        Args:
-            leverage: New leverage value (1-100)
-
-        Returns:
-            bool: True if successful
-        """
-        try:
-            response = self.client.set_leverage(
-                category="linear",
-                symbol=self.symbol,
-                buyLeverage=str(leverage),
-                sellLeverage=str(leverage),
-            )
-            ret_code = response.get("retCode") if isinstance(response, dict) else None
-            if ret_code is not None and int(ret_code) != 0:
-                ret_msg = response.get("retMsg", "unknown error")
-                logger.error(f"set_leverage rejected (retCode={ret_code}): {ret_msg}")
-                return False
-            self.leverage = leverage
-            logger.debug(f"Leverage set to {leverage}x for {self.symbol}")
-            return True
-        except Exception as e:
-            logger.error(f"Error setting leverage: {str(e)}")
             return False
 
     def set_margin_mode(self, mode: MarginMode) -> bool:

--- a/torchtrade/envs/live/bybit/order_executor.py
+++ b/torchtrade/envs/live/bybit/order_executor.py
@@ -7,11 +7,7 @@ from typing import Dict, List, Optional
 from torchtrade.envs.live.bybit.utils import normalize_symbol
 from torchtrade.envs.core.common import TradeMode
 from torchtrade.envs.core.state import POSITION_UNKNOWN
-from torchtrade.envs.utils.leverage import (
-    leverage_already_set,
-    require_dict_response,
-    require_leverage_applied,
-)
+from torchtrade.envs.utils.leverage import leverage_already_set, require_dict_response
 
 logger = logging.getLogger(__name__)
 
@@ -201,6 +197,19 @@ class BybitFuturesOrderClass:
         except Exception as e:
             logger.warning(f"Could not set position mode (may already be configured): {e}")
 
+        # Margin mode BEFORE leverage: switch_margin_mode carries buyLeverage and
+        # sellLeverage, so this tolerated call re-applies leverage and could
+        # silently undo the verified set that used to precede it (#277).
+        try:
+            self.client.switch_margin_mode(
+                category="linear", symbol=self.symbol,
+                tradeMode=self.margin_mode.to_pybit(),
+                buyLeverage=leverage_str, sellLeverage=leverage_str,
+            )
+            logger.info(f"Margin mode set to {self.margin_mode.value}")
+        except Exception as e:
+            logger.warning(f"Could not set margin mode (may already be configured): {e}")
+
         # Not tolerated like the modes above: leverage sizes every position (#277).
         # bybit's response carries no leverage, so refusal is all that can be checked
         # here -- an accepted-but-clamped leverage goes undetected on this venue.
@@ -213,9 +222,8 @@ class BybitFuturesOrderClass:
             if not leverage_already_set(e):
                 raise
         else:
-            ret_code = require_dict_response(
-                self.symbol, self.leverage, response
-            ).get("retCode")
+            require_dict_response(self.symbol, self.leverage, response)
+            ret_code = response.get("retCode")
             if ret_code is not None and int(ret_code) != 0:
                 ret_msg = response.get("retMsg", "unknown error")
                 if not leverage_already_set(ret_msg):
@@ -223,16 +231,6 @@ class BybitFuturesOrderClass:
                         f"bybit refused {self.leverage}x leverage for {self.symbol} "
                         f"(retCode={ret_code}): {ret_msg}"
                     )
-
-        try:
-            self.client.switch_margin_mode(
-                category="linear", symbol=self.symbol,
-                tradeMode=self.margin_mode.to_pybit(),
-                buyLeverage=leverage_str, sellLeverage=leverage_str,
-            )
-            logger.info(f"Margin mode set to {self.margin_mode.value}")
-        except Exception as e:
-            logger.warning(f"Could not set margin mode (may already be configured): {e}")
 
     def trade(
         self,

--- a/torchtrade/envs/live/bybit/order_executor.py
+++ b/torchtrade/envs/live/bybit/order_executor.py
@@ -7,6 +7,7 @@ from typing import Dict, List, Optional
 from torchtrade.envs.live.bybit.utils import normalize_symbol
 from torchtrade.envs.core.common import TradeMode
 from torchtrade.envs.core.state import POSITION_UNKNOWN
+from torchtrade.envs.utils.leverage import is_already_applied
 
 logger = logging.getLogger(__name__)
 
@@ -196,13 +197,31 @@ class BybitFuturesOrderClass:
         except Exception as e:
             logger.warning(f"Could not set position mode (may already be configured): {e}")
 
+        # NOT `except Exception: warning`, unlike the position/margin modes around it.
+        # Those two are preferences; leverage is an input to every position size this
+        # env will compute and to account_state[4]. A swallowed rejection left the env
+        # sizing 20x against an account the venue still had at 5x (#277).
         try:
-            self.client.set_leverage(
+            response = self.client.set_leverage(
                 category="linear", symbol=self.symbol,
                 buyLeverage=leverage_str, sellLeverage=leverage_str,
             )
         except Exception as e:
-            logger.warning(f"Could not set leverage (may already be configured): {e}")
+            if not is_already_applied(e):
+                raise
+            response = None
+
+        # pybit raises on a non-zero retCode, so this reads the code for adapters that
+        # return it instead -- and costs nothing when the exception path already fired.
+        if isinstance(response, dict):
+            ret_code = response.get("retCode")
+            if ret_code is not None and int(ret_code) != 0:
+                ret_msg = response.get("retMsg", "unknown error")
+                if not is_already_applied(f"{ret_code} {ret_msg}"):
+                    raise ValueError(
+                        f"bybit refused {self.leverage}x leverage for {self.symbol} "
+                        f"(retCode={ret_code}): {ret_msg}"
+                    )
 
         try:
             self.client.switch_margin_mode(

--- a/torchtrade/envs/live/okx/order_executor.py
+++ b/torchtrade/envs/live/okx/order_executor.py
@@ -250,9 +250,17 @@ class OKXFuturesOrderClass:
                 )
 
             # Every entry: long_short_mode returns one per posSide, and checking only
-            # the first leaves the short side unverified.
-            for entry in res.get("data") or []:
-                require_leverage_applied(self.symbol, self.leverage, entry.get("lever"))
+            # the first leaves the short side unverified. An empty list is not a pass --
+            # okx does not legitimately return one on success, and treating it as
+            # "nothing to check" is how this check goes inert.
+            entries = res.get("data") or []
+            if not entries:
+                raise ValueError(
+                    f"okx confirmed no leverage for {self.symbol}: the set-leverage "
+                    f"response carried no data to check {self.leverage}x against."
+                )
+            for entry in entries:
+                require_leverage_applied(self.symbol, self.leverage, entry, "lever")
 
     def trade(
         self,

--- a/torchtrade/envs/live/okx/order_executor.py
+++ b/torchtrade/envs/live/okx/order_executor.py
@@ -8,6 +8,7 @@ from typing import Dict, List, Optional
 from torchtrade.envs.live.okx.utils import normalize_symbol
 from torchtrade.envs.core.common import TradeMode
 from torchtrade.envs.core.state import POSITION_UNKNOWN
+from torchtrade.envs.utils.leverage import is_already_applied, require_leverage_applied
 
 logger = logging.getLogger(__name__)
 
@@ -217,17 +218,33 @@ class OKXFuturesOrderClass:
         except Exception as e:
             logger.warning(f"Could not set position mode (may already be configured): {e}")
 
-        # Set leverage
+        # Set leverage. Unlike the position mode above, a failure here is not tolerable:
+        # leverage feeds every position size and account_state[4], so a warning left the
+        # env trading at a leverage the account did not have (#277).
         try:
             res = self.account_client.set_leverage(
                 instId=self.symbol,
                 lever=str(self.leverage),
                 mgnMode=self.margin_mode.value,
             )
-            if str(res.get("code", "-1")) != "0":
-                logger.warning(f"Failed to set leverage: code={res.get('code')} msg={res.get('msg')}")
         except Exception as e:
-            logger.warning(f"Could not set leverage (may already be configured): {e}")
+            if not is_already_applied(e):
+                raise
+            res = {}
+
+        code = str(res.get("code", "0"))
+        if code != "0":
+            msg = res.get("msg", "unknown error")
+            if not is_already_applied(f"{code} {msg}"):
+                raise ValueError(
+                    f"okx refused {self.leverage}x leverage for {self.symbol} "
+                    f"(code={code}): {msg}"
+                )
+
+        # OKX echoes the applied leverage, which is the only way to catch a venue that
+        # accepts the call and applies something else.
+        data = res.get("data") or [{}]
+        require_leverage_applied(self.symbol, self.leverage, data[0].get("lever"))
 
     def trade(
         self,

--- a/torchtrade/envs/live/okx/order_executor.py
+++ b/torchtrade/envs/live/okx/order_executor.py
@@ -8,7 +8,11 @@ from typing import Dict, List, Optional
 from torchtrade.envs.live.okx.utils import normalize_symbol
 from torchtrade.envs.core.common import TradeMode
 from torchtrade.envs.core.state import POSITION_UNKNOWN
-from torchtrade.envs.utils.leverage import is_already_applied, require_leverage_applied
+from torchtrade.envs.utils.leverage import (
+    leverage_already_set,
+    require_dict_response,
+    require_leverage_applied,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -218,9 +222,7 @@ class OKXFuturesOrderClass:
         except Exception as e:
             logger.warning(f"Could not set position mode (may already be configured): {e}")
 
-        # Set leverage. Unlike the position mode above, a failure here is not tolerable:
-        # leverage feeds every position size and account_state[4], so a warning left the
-        # env trading at a leverage the account did not have (#277).
+        # Not tolerated like the position mode above: leverage sizes every position (#277).
         try:
             res = self.account_client.set_leverage(
                 instId=self.symbol,
@@ -228,23 +230,29 @@ class OKXFuturesOrderClass:
                 mgnMode=self.margin_mode.value,
             )
         except Exception as e:
-            if not is_already_applied(e):
+            if not leverage_already_set(e):
                 raise
-            res = {}
-
-        code = str(res.get("code", "0"))
-        if code != "0":
-            msg = res.get("msg", "unknown error")
-            if not is_already_applied(f"{code} {msg}"):
+        else:
+            require_dict_response(self.symbol, self.leverage, res)
+            # "-1" default, matching every other code check in this file: a response
+            # with no code is an adapter surprise, not a confirmation.
+            code = str(res.get("code", "-1"))
+            if code != "0":
+                # sMsg carries the real reason; top-level msg is often "All operations
+                # failed" or empty, which points the operator at nothing.
+                entries = res.get("data") or []
+                msg = (entries[0].get("sMsg") if entries else None) or res.get(
+                    "msg", "unknown error"
+                )
                 raise ValueError(
                     f"okx refused {self.leverage}x leverage for {self.symbol} "
                     f"(code={code}): {msg}"
                 )
 
-        # OKX echoes the applied leverage, which is the only way to catch a venue that
-        # accepts the call and applies something else.
-        data = res.get("data") or [{}]
-        require_leverage_applied(self.symbol, self.leverage, data[0].get("lever"))
+            # Every entry: long_short_mode returns one per posSide, and checking only
+            # the first leaves the short side unverified.
+            for entry in res.get("data") or []:
+                require_leverage_applied(self.symbol, self.leverage, entry.get("lever"))
 
     def trade(
         self,
@@ -670,34 +678,6 @@ class OKXFuturesOrderClass:
             except Exception:
                 pass
             logger.error(f"Error closing position: {e}")
-            return False
-
-    def set_leverage(self, leverage: int) -> bool:
-        """
-        Change leverage for the symbol.
-
-        Args:
-            leverage: New leverage value (1-125)
-
-        Returns:
-            bool: True if successful
-        """
-        try:
-            response = self.account_client.set_leverage(
-                instId=self.symbol,
-                lever=str(leverage),
-                mgnMode=self.margin_mode.value,
-            )
-            code = response.get("code", "-1")
-            if str(code) != "0":
-                msg = response.get("msg", "unknown error")
-                logger.error(f"set_leverage rejected (code={code}): {msg}")
-                return False
-            self.leverage = leverage
-            logger.debug(f"Leverage set to {leverage}x for {self.symbol}")
-            return True
-        except Exception as e:
-            logger.error(f"Error setting leverage: {str(e)}")
             return False
 
     def set_margin_mode(self, mode: MarginMode) -> bool:

--- a/torchtrade/envs/utils/leverage.py
+++ b/torchtrade/envs/utils/leverage.py
@@ -1,52 +1,65 @@
-"""The boundary check on the leverage a venue actually applied (#277).
-
-Every exchange's set-leverage call was best-effort: wrapped in `except Exception`,
-logged at warning, and followed by trading that assumed the request had been honoured.
-`self.leverage` then stayed at the configured value whatever the venue did, which is
-wrong in both directions at once -- sizing computes a target against leverage the
-account does not have, and `account_state[4]` reports the config value while flat but
-the venue's value once a position opens, so the element the policy conditions on flips
-between two numbers with no trade in between.
-"""
+"""The boundary check on the leverage a venue actually applied (#277)."""
 
 
-# The venues report "the leverage is already what you asked for" as an API *error*.
-# That is a success -- the account ends up at the requested leverage either way -- and
-# it is the case the blanket `except Exception: warning` existed to tolerate. Keeping
-# the tolerance narrow is what lets every other failure raise.
-_ALREADY_APPLIED = (
-    "110043",                        # bybit: "Set leverage not modified"
-    "-4046",                         # binance: "No need to change leverage"
-    "leverage not modified",
-    "no need to change leverage",
-)
+# bybit alone needs a carve-out: it reports "already at this leverage" as an API error,
+# and that success-shaped-as-failure is the one case the old blanket `except Exception`
+# around every set-leverage call legitimately absorbed. binance, bitget and okx are
+# idempotent here -- repeating the current leverage returns success.
+#
+# Matched on message text and NOT on bybit's 110043: that code is a substring of
+# millisecond timestamps like 1762110043251, which ccxt and requests both embed in the
+# error text they stringify, so a genuine refusal at an unlucky millisecond would read
+# as "already applied".
+_ALREADY_SET = ("leverage not modified",)
 
 
-def is_already_applied(error) -> bool:
+def leverage_already_set(error) -> bool:
     """True when a set-leverage failure only means the venue was already there."""
-    text = str(error).lower()
-    return any(marker in text for marker in _ALREADY_APPLIED)
+    return any(marker in str(error).lower() for marker in _ALREADY_SET)
 
 
 def require_leverage_applied(symbol: str, requested: float, reported) -> None:
     """Raise unless `reported` is the leverage that was asked for.
 
-    `reported` is whatever the venue echoed back in its set-leverage response, or None
-    when it echoed nothing. None is accepted: it means unconfirmed, not refused, and a
-    venue that declines to state the applied leverage leaves nothing to compare against.
-    A rejected *call* is a separate signal and is raised by the caller.
-
-    Compared as floats and not `==` on the raw value because the venues disagree on the
-    type: bybit sends "10", binance sends 10, ccxt sends 10.0.
+    None is accepted deliberately: it means the venue echoed nothing for this field,
+    which is unconfirmed rather than refused. A refused *call* is a separate signal,
+    raised by the caller.
     """
     if reported is None:
         return
 
-    # A non-numeric echo is a broken adapter, not a leverage -- let the ValueError from
-    # float() surface rather than comparing it and concluding "mismatch".
-    if float(reported) != float(requested):
+    # Coerced because the venues disagree on the type -- bybit sends "10", binance sends
+    # 10, ccxt sends "25". A non-numeric echo is a broken adapter, and the bare
+    # "could not convert string to float" it would otherwise raise names neither the
+    # symbol nor the handshake it came from.
+    try:
+        applied = float(reported)
+    except (TypeError, ValueError) as error:
+        raise ValueError(
+            f"{symbol}: venue echoed a non-numeric leverage {reported!r} for a "
+            f"{requested}x request; cannot confirm the account's leverage."
+        ) from error
+
+    # NaN != anything is True, so a NaN on either side raises rather than passing --
+    # the right polarity for a money path (see the `x <= 0` vs isfinite history).
+    if applied != float(requested):
         raise ValueError(
             f"{symbol}: requested {requested}x leverage but the venue applied "
             f"{reported}x. Sizing and the account_state leverage element would both "
             f"be computed from a leverage this account does not have."
         )
+
+
+def require_dict_response(symbol: str, requested: float, response):
+    """Return `response`, or raise if it is not a shape the leverage echo can be read from.
+
+    Skipping silently is what the check exists to prevent: these executors advertise
+    `client=` injection, and a shim returning None on a 200 would erase the whole
+    verification with no diagnostic.
+    """
+    if not isinstance(response, dict):
+        raise TypeError(
+            f"{symbol}: set-leverage returned {type(response).__name__}, not a dict; "
+            f"cannot confirm the venue applied {requested}x."
+        )
+    return response

--- a/torchtrade/envs/utils/leverage.py
+++ b/torchtrade/envs/utils/leverage.py
@@ -1,0 +1,52 @@
+"""The boundary check on the leverage a venue actually applied (#277).
+
+Every exchange's set-leverage call was best-effort: wrapped in `except Exception`,
+logged at warning, and followed by trading that assumed the request had been honoured.
+`self.leverage` then stayed at the configured value whatever the venue did, which is
+wrong in both directions at once -- sizing computes a target against leverage the
+account does not have, and `account_state[4]` reports the config value while flat but
+the venue's value once a position opens, so the element the policy conditions on flips
+between two numbers with no trade in between.
+"""
+
+
+# The venues report "the leverage is already what you asked for" as an API *error*.
+# That is a success -- the account ends up at the requested leverage either way -- and
+# it is the case the blanket `except Exception: warning` existed to tolerate. Keeping
+# the tolerance narrow is what lets every other failure raise.
+_ALREADY_APPLIED = (
+    "110043",                        # bybit: "Set leverage not modified"
+    "-4046",                         # binance: "No need to change leverage"
+    "leverage not modified",
+    "no need to change leverage",
+)
+
+
+def is_already_applied(error) -> bool:
+    """True when a set-leverage failure only means the venue was already there."""
+    text = str(error).lower()
+    return any(marker in text for marker in _ALREADY_APPLIED)
+
+
+def require_leverage_applied(symbol: str, requested: float, reported) -> None:
+    """Raise unless `reported` is the leverage that was asked for.
+
+    `reported` is whatever the venue echoed back in its set-leverage response, or None
+    when it echoed nothing. None is accepted: it means unconfirmed, not refused, and a
+    venue that declines to state the applied leverage leaves nothing to compare against.
+    A rejected *call* is a separate signal and is raised by the caller.
+
+    Compared as floats and not `==` on the raw value because the venues disagree on the
+    type: bybit sends "10", binance sends 10, ccxt sends 10.0.
+    """
+    if reported is None:
+        return
+
+    # A non-numeric echo is a broken adapter, not a leverage -- let the ValueError from
+    # float() surface rather than comparing it and concluding "mismatch".
+    if float(reported) != float(requested):
+        raise ValueError(
+            f"{symbol}: requested {requested}x leverage but the venue applied "
+            f"{reported}x. Sizing and the account_state leverage element would both "
+            f"be computed from a leverage this account does not have."
+        )

--- a/torchtrade/envs/utils/leverage.py
+++ b/torchtrade/envs/utils/leverage.py
@@ -1,60 +1,26 @@
 """The boundary check on the leverage a venue actually applied (#277)."""
 
 
-# bybit alone needs a carve-out: it reports "already at this leverage" as an API error,
-# and that success-shaped-as-failure is the one case the old blanket `except Exception`
-# around every set-leverage call legitimately absorbed. binance, bitget and okx are
-# idempotent here -- repeating the current leverage returns success.
-#
-# Matched on message text and NOT on bybit's 110043: that code is a substring of
-# millisecond timestamps like 1762110043251, which ccxt and requests both embed in the
-# error text they stringify, so a genuine refusal at an unlucky millisecond would read
-# as "already applied".
-_ALREADY_SET = ("leverage not modified",)
+# Venues can report "already at this leverage" as an API *error* -- the one case the old
+# blanket `except Exception` around every set-leverage call legitimately absorbed.
+# Confirmed on bybit; applied at all four call sites because the cost of guessing wrong
+# is refusing to construct on every rerun against an already-configured account.
+# Matched on the message and NOT on bybit's code 110043: that digit string also occurs
+# inside millisecond timestamps such as 1762110043251, which ccxt and requests both embed
+# in the error text they stringify, so a real refusal would have read as "already set".
+_ALREADY_SET = "leverage not modified"
 
 
 def leverage_already_set(error) -> bool:
     """True when a set-leverage failure only means the venue was already there."""
-    return any(marker in str(error).lower() for marker in _ALREADY_SET)
+    return _ALREADY_SET in str(error).lower()
 
 
-def require_leverage_applied(symbol: str, requested: float, reported) -> None:
-    """Raise unless `reported` is the leverage that was asked for.
+def require_dict_response(symbol: str, requested: float, response) -> None:
+    """Raise unless the leverage echo can be read off `response` at all.
 
-    None is accepted deliberately: it means the venue echoed nothing for this field,
-    which is unconfirmed rather than refused. A refused *call* is a separate signal,
-    raised by the caller.
-    """
-    if reported is None:
-        return
-
-    # Coerced because the venues disagree on the type -- bybit sends "10", binance sends
-    # 10, ccxt sends "25". A non-numeric echo is a broken adapter, and the bare
-    # "could not convert string to float" it would otherwise raise names neither the
-    # symbol nor the handshake it came from.
-    try:
-        applied = float(reported)
-    except (TypeError, ValueError) as error:
-        raise ValueError(
-            f"{symbol}: venue echoed a non-numeric leverage {reported!r} for a "
-            f"{requested}x request; cannot confirm the account's leverage."
-        ) from error
-
-    # NaN != anything is True, so a NaN on either side raises rather than passing --
-    # the right polarity for a money path (see the `x <= 0` vs isfinite history).
-    if applied != float(requested):
-        raise ValueError(
-            f"{symbol}: requested {requested}x leverage but the venue applied "
-            f"{reported}x. Sizing and the account_state leverage element would both "
-            f"be computed from a leverage this account does not have."
-        )
-
-
-def require_dict_response(symbol: str, requested: float, response):
-    """Return `response`, or raise if it is not a shape the leverage echo can be read from.
-
-    Skipping silently is what the check exists to prevent: these executors advertise
-    `client=` injection, and a shim returning None on a 200 would erase the whole
+    Skipping silently is the failure this check exists to prevent: these executors
+    accept an injected `client`, and a shim returning None on a 200 would erase the
     verification with no diagnostic.
     """
     if not isinstance(response, dict):
@@ -62,4 +28,38 @@ def require_dict_response(symbol: str, requested: float, response):
             f"{symbol}: set-leverage returned {type(response).__name__}, not a dict; "
             f"cannot confirm the venue applied {requested}x."
         )
-    return response
+
+
+def require_leverage_applied(symbol: str, requested: float, container, key: str) -> None:
+    """Raise unless `container[key]` is the leverage that was asked for.
+
+    An ABSENT key raises rather than passing. Treating "the venue said nothing" as
+    "close enough" is precisely how the first version of this check shipped inert: it
+    read a bitget key that does not exist, found None, and returned happy on every
+    account. A renamed or dropped field must fail loudly, not silently stop verifying.
+    """
+    require_dict_response(symbol, requested, container)
+    if key not in container or container[key] is None:
+        raise ValueError(
+            f"{symbol}: venue did not report {key!r} in its set-leverage response, so "
+            f"there is nothing to confirm {requested}x against. Refusing to size "
+            f"positions from an unconfirmed leverage."
+        )
+
+    reported = container[key]
+    # Coerced because the venues disagree on the type: binance sends 10, ccxt sends "25".
+    try:
+        applied = float(reported)
+    except (TypeError, ValueError) as error:
+        raise ValueError(
+            f"{symbol}: venue echoed a non-numeric {key} {reported!r} for a "
+            f"{requested}x request; cannot confirm the account\'s leverage."
+        ) from error
+
+    # NaN != anything is True, so a NaN on either side raises rather than passing.
+    if applied != float(requested):
+        raise ValueError(
+            f"{symbol}: requested {requested}x leverage but the venue applied "
+            f"{reported}x. Sizing and the account_state leverage element would both "
+            f"be computed from a leverage this account does not have."
+        )


### PR DESCRIPTION
Closes #277.

## The defect

All four futures exchanges wrapped their set-leverage call in `except Exception: logger.warning("may already be configured")`. `self.leverage` then stayed at the configured value whatever the venue did — wrong twice over:

- every position size is computed from leverage the account may not have (config 20x against an account still at 5x sizes 4x the available margin);
- `account_state[4]` reports the config value while flat but the venue's value once a position opens, so the element the policy conditions on flips between two numbers with no trade in between.

## The fix

Leverage raises where position mode and margin mode still warn. Those two are preferences; leverage sizes money.

The carve-out is what makes that shippable: every venue reports *"already at this leverage"* as an API error, and that is the case the blanket handler existed to absorb. Recognising it narrowly (`is_already_applied`) is what lets everything else raise.

Where the venue echoes the leverage it applied (binance, bitget, okx) the echo is checked too — accepting the call is not applying the request, and binance caps leverage per notional bracket.

## What this does NOT cover

A venue that accepts the call, applies something else, and echoes nothing. Catching that needs a read-back, and OKX and Bitget return no position row at all when flat — so it needs their leverage-info endpoints, which I cannot verify against a real API from here. Left explicit rather than guessed at on a money path.

**Item 2 of #277** (empty `liqPrice` defaulting `distance_to_liquidation` to 1.0) was already fixed in the shared futures base by an earlier PR; only the leverage half remained.

## Incidental

Removing bitget's outer blanket handler exposed a latent `NameError`: `margin_mode_ccxt` was assigned *inside* the `try` it was referenced from, so a failure in `to_ccxt()` raised from the error path — invisible only because the outer handler caught that too. Hoisted above the try.

Test doubles that omitted the leverage API (and mocks returning a constant `{"leverage": 10}` regardless of request) now echo the request, as a venue does.

## Evidence

16 cases across 5 parametrized functions, built on **real** order executors — the defect lived in each executor's `_setup_futures_account`, so a fake trader would prove nothing about it. Mutation-verified:

| mutant | cells killed |
|---|---|
| neuter the echo check | exactly the 3 echoing venues |
| swallow refusals again | all 6 refusal cells, all four exchanges |
| drop the already-applied carve-out | the 4 rerun cells |

Full suite: 3146 passed.