### PR TITLE
fix(okx): send posSide where OKX requires it on set-leverage (#363)

### DIFF
--- a/tests/envs/okx/conftest.py
+++ b/tests/envs/okx/conftest.py
@@ -33,10 +33,12 @@ def mock_okx_account_client():
 
     # Mock account configuration
     client.set_position_mode = MagicMock(return_value={"code": "0", "msg": ""})
-    # `lever` present: an entry without it no longer confirms anything (#277).
+    # Echoes `lever` AND `posSide`, as OKX documents: an entry without lever confirms
+    # nothing (#277), and one echoing the wrong side confirmed the wrong leg (#363).
     client.set_leverage = MagicMock(
-        side_effect=lambda instId=None, lever=None, **k: {
-            "code": "0", "msg": "", "data": [{"lever": lever}]})
+        side_effect=lambda instId=None, lever=None, posSide=None, **k: {
+            "code": "0", "msg": "",
+            "data": [{"lever": lever, **({} if posSide is None else {"posSide": posSide})}]})
 
     # Mock position information
     client.get_positions = MagicMock(return_value={

--- a/tests/envs/test_leverage_boundary.py
+++ b/tests/envs/test_leverage_boundary.py
@@ -294,8 +294,11 @@ def test_okx_sets_leverage_per_side_only_where_okx_requires_it(
     seen = []
 
     def record(**kwargs):
-        seen.append(kwargs.get("posSide"))
-        return {"code": "0", "data": [{"lever": "20"}]}
+        pos_side = kwargs.get("posSide")
+        seen.append(pos_side)
+        # Echoes the side back, as OKX documents -- the executor checks it.
+        entry = {"lever": "20", **({} if pos_side is None else {"posSide": pos_side})}
+        return {"code": "0", "data": [entry]}
 
     OKXFuturesOrderClass(
         symbol="BTC-USDT-SWAP", trade_mode="quantity", demo=True, leverage=20,
@@ -333,7 +336,7 @@ def test_okx_refuses_to_construct_when_only_one_side_took_the_leverage():
     def one_sided(**kwargs):
         if kwargs.get("posSide") == "short":
             return {"code": "51004", "data": [{"sMsg": "leverage exceeds risk limit"}]}
-        return {"code": "0", "data": [{"lever": "20"}]}
+        return {"code": "0", "data": [{"lever": "20", "posSide": kwargs.get("posSide")}]}
 
     with pytest.raises(ValueError, match="refused"):
         OKXFuturesOrderClass(

--- a/tests/envs/test_leverage_boundary.py
+++ b/tests/envs/test_leverage_boundary.py
@@ -268,3 +268,45 @@ def test_the_margin_mode_is_applied_before_the_leverage_it_can_overwrite(exchang
         f"{exchange} verified leverage before setting the margin mode that can change "
         f"it; call order was {calls}"
     )
+
+
+@pytest.mark.parametrize("position_mode,margin_mode,expected_sides", [
+    ("LONG_SHORT", "ISOLATED", ["long", "short"]),
+    ("LONG_SHORT", "CROSS", [None]),
+    ("NET", "ISOLATED", [None]),
+], ids=["isolated-long-short", "cross-long-short", "net-isolated"])
+def test_okx_sets_leverage_per_side_only_where_okx_requires_it(
+    position_mode, margin_mode, expected_sides
+):
+    """OKX rejects set-leverage without posSide under isolated + long_short (#363).
+
+    Isolated leverage is stored per side there, so it takes one call each. Omitting
+    posSide had the venue answer code 1 "Parameter posSide error", which #277's
+    swallowed-rejection era turned into sizing against leverage the account never had.
+
+    The other two rows are the ones that make this a real test rather than a shape
+    check: sending posSide where OKX does not expect it is its own rejection, so the
+    per-side path must NOT widen to cross or net.
+    """
+    from torchtrade.envs.live.okx.order_executor import (
+        OKXFuturesOrderClass, MarginMode, PositionMode,
+    )
+    seen = []
+
+    def record(**kwargs):
+        seen.append(kwargs.get("posSide"))
+        return {"code": "0", "data": [{"lever": "20"}]}
+
+    OKXFuturesOrderClass(
+        symbol="BTC-USDT-SWAP", trade_mode="quantity", demo=True, leverage=20,
+        margin_mode=getattr(MarginMode, margin_mode),
+        position_mode=getattr(PositionMode, position_mode),
+        api_key="k", api_secret="s", passphrase="p",
+        client=SimpleNamespace(),
+        account_client=SimpleNamespace(set_leverage=record, set_position_mode=_boom,
+                                       get_positions=_boom),
+        public_client=SimpleNamespace(get_instruments=_boom),
+    )
+    assert seen == expected_sides, (
+        f"{margin_mode}/{position_mode} should set leverage for {expected_sides}, got {seen}"
+    )

--- a/tests/envs/test_leverage_boundary.py
+++ b/tests/envs/test_leverage_boundary.py
@@ -348,3 +348,30 @@ def test_okx_refuses_to_construct_when_only_one_side_took_the_leverage():
                                            set_position_mode=_boom, get_positions=_boom),
             public_client=SimpleNamespace(get_instruments=_boom),
         )
+
+
+def test_okx_refuses_a_confirmation_for_the_wrong_side():
+    """Echoing `lever` is not confirming the leg that was asked about (#363).
+
+    A response carrying posSide="long" for the SHORT call passed verification, because
+    only `lever` was ever compared -- so the short side went unconfirmed while the check
+    reported success. Every fake in this file echoes the CORRECT side, which is why
+    disabling the comparison entirely left all 32 tests green.
+    """
+    from torchtrade.envs.live.okx.order_executor import (
+        OKXFuturesOrderClass, MarginMode, PositionMode,
+    )
+
+    def always_long(**kwargs):
+        return {"code": "0", "data": [{"lever": "20", "posSide": "long"}]}
+
+    with pytest.raises(ValueError, match="posSide"):
+        OKXFuturesOrderClass(
+            symbol="BTC-USDT-SWAP", trade_mode="quantity", demo=True, leverage=20,
+            margin_mode=MarginMode.ISOLATED, position_mode=PositionMode.LONG_SHORT,
+            api_key="k", api_secret="s", passphrase="p",
+            client=SimpleNamespace(),
+            account_client=SimpleNamespace(set_leverage=always_long,
+                                           set_position_mode=_boom, get_positions=_boom),
+            public_client=SimpleNamespace(get_instruments=_boom),
+        )

--- a/tests/envs/test_leverage_boundary.py
+++ b/tests/envs/test_leverage_boundary.py
@@ -307,6 +307,41 @@ def test_okx_sets_leverage_per_side_only_where_okx_requires_it(
                                        get_positions=_boom),
         public_client=SimpleNamespace(get_instruments=_boom),
     )
-    assert seen == expected_sides, (
+    # Order-insensitive: the two calls are independent and nothing in OKX's contract
+    # makes long precede short, so pinning the sequence would break a harmless refactor.
+    assert sorted(seen, key=str) == sorted(expected_sides, key=str), (
         f"{margin_mode}/{position_mode} should set leverage for {expected_sides}, got {seen}"
     )
+
+
+def test_okx_refuses_to_construct_when_only_one_side_took_the_leverage():
+    """Two calls create a partial-failure state one call could not (#363).
+
+    Long accepted at 20x and short refused leaves the account genuinely half-configured,
+    while the env sizes BOTH sides from a single config.leverage. Swallowing the second
+    leg's rejection passed all 31 tests in this file, so the behaviour was correct and
+    unpinned.
+
+    What this proves is that the Python object refuses to exist. It cannot prove the
+    venue rolls back the long leg that already applied -- that is outside the executor's
+    control, and an operator hitting this has one side set and must fix it by hand.
+    """
+    from torchtrade.envs.live.okx.order_executor import (
+        OKXFuturesOrderClass, MarginMode, PositionMode,
+    )
+
+    def one_sided(**kwargs):
+        if kwargs.get("posSide") == "short":
+            return {"code": "51004", "data": [{"sMsg": "leverage exceeds risk limit"}]}
+        return {"code": "0", "data": [{"lever": "20"}]}
+
+    with pytest.raises(ValueError, match="refused"):
+        OKXFuturesOrderClass(
+            symbol="BTC-USDT-SWAP", trade_mode="quantity", demo=True, leverage=20,
+            margin_mode=MarginMode.ISOLATED, position_mode=PositionMode.LONG_SHORT,
+            api_key="k", api_secret="s", passphrase="p",
+            client=SimpleNamespace(),
+            account_client=SimpleNamespace(set_leverage=one_sided,
+                                           set_position_mode=_boom, get_positions=_boom),
+            public_client=SimpleNamespace(get_instruments=_boom),
+        )

--- a/torchtrade/envs/live/okx/order_executor.py
+++ b/torchtrade/envs/live/okx/order_executor.py
@@ -222,12 +222,14 @@ class OKXFuturesOrderClass:
         except Exception as e:
             logger.warning(f"Could not set position mode (may already be configured): {e}")
 
-        # OKX requires posSide on set-leverage under isolated + long_short, and rejects
-        # the call without it (code 1, sMsg "Parameter posSide error"). Isolated leverage
-        # is stored per side there, so it takes one call each -- omitting them left the
-        # env sizing against leverage the account never had, which is #277 on this one
-        # config, and became a hard construction failure once #277 stopped swallowing
-        # rejections (#363).
+        # OKX's docs: "posSide is only required when margin mode is isolated in
+        # long/short position mode". Its leverage-scope table gives the reason -- that
+        # combination is the ONLY one stored per side; every other is per instrument
+        # family, so one call covers it. Omitting the per-side calls left the env sizing
+        # against leverage the account never had, which is #277 on this one config, and
+        # became a hard construction failure once #277 stopped swallowing rejections
+        # (#363). Narrow because posSide is not APPLICABLE elsewhere -- not because
+        # sending it there is refused, which is undocumented either way.
         per_side = (
             self.margin_mode is MarginMode.ISOLATED
             and self.position_mode is PositionMode.LONG_SHORT
@@ -235,7 +237,7 @@ class OKXFuturesOrderClass:
         for pos_side in (("long", "short") if per_side else (None,)):
             self._apply_leverage(pos_side)
 
-    def _apply_leverage(self, pos_side=None):
+    def _apply_leverage(self, pos_side: Optional[str] = None):
         """Set and verify the leverage for one side, or for the net position."""
         # Not tolerated like the position mode above: leverage sizes every position (#277).
         request = dict(
@@ -267,10 +269,10 @@ class OKXFuturesOrderClass:
                     f"(code={code}): {msg}"
                 )
 
-            # Every entry: long_short_mode returns one per posSide, and checking only
-            # the first leaves the short side unverified. An empty list is not a pass --
-            # okx does not legitimately return one on success, and treating it as
-            # "nothing to check" is how this check goes inert.
+            # An empty list is not a pass -- okx does not legitimately return one on
+            # success, and treating it as "nothing to check" is how this check goes
+            # inert. With posSide sent the response is a single entry echoing it; the
+            # loop predates the per-side calls and costs nothing.
             entries = res.get("data") or []
             if not entries:
                 raise ValueError(
@@ -278,6 +280,13 @@ class OKXFuturesOrderClass:
                     f"response carried no data to check {self.leverage}x against."
                 )
             for entry in entries:
+                # The echoed side too: a response carrying posSide="long" for the short
+                # call passed verification, because only `lever` was ever compared.
+                if pos_side is not None and entry.get("posSide") != pos_side:
+                    raise ValueError(
+                        f"okx confirmed leverage for posSide={entry.get('posSide')!r} "
+                        f"when {pos_side!r} was requested for {self.symbol}"
+                    )
                 require_leverage_applied(self.symbol, self.leverage, entry, "lever")
 
     def trade(

--- a/torchtrade/envs/live/okx/order_executor.py
+++ b/torchtrade/envs/live/okx/order_executor.py
@@ -222,13 +222,31 @@ class OKXFuturesOrderClass:
         except Exception as e:
             logger.warning(f"Could not set position mode (may already be configured): {e}")
 
+        # OKX requires posSide on set-leverage under isolated + long_short, and rejects
+        # the call without it (code 1, sMsg "Parameter posSide error"). Isolated leverage
+        # is stored per side there, so it takes one call each -- omitting them left the
+        # env sizing against leverage the account never had, which is #277 on this one
+        # config, and became a hard construction failure once #277 stopped swallowing
+        # rejections (#363).
+        per_side = (
+            self.margin_mode is MarginMode.ISOLATED
+            and self.position_mode is PositionMode.LONG_SHORT
+        )
+        for pos_side in (("long", "short") if per_side else (None,)):
+            self._apply_leverage(pos_side)
+
+    def _apply_leverage(self, pos_side=None):
+        """Set and verify the leverage for one side, or for the net position."""
         # Not tolerated like the position mode above: leverage sizes every position (#277).
+        request = dict(
+            instId=self.symbol,
+            lever=str(self.leverage),
+            mgnMode=self.margin_mode.value,
+        )
+        if pos_side is not None:
+            request["posSide"] = pos_side
         try:
-            res = self.account_client.set_leverage(
-                instId=self.symbol,
-                lever=str(self.leverage),
-                mgnMode=self.margin_mode.value,
-            )
+            res = self.account_client.set_leverage(**request)
         except Exception as e:
             if not leverage_already_set(e):
                 raise


### PR DESCRIPTION
Closes #363. Found while reviewing #362, filed rather than scope-creeping that PR.

## The bug

OKX **requires** `posSide` on set-leverage under isolated margin + `LONG_SHORT` position mode, and rejects the call without it (`code 1`, `sMsg "Parameter posSide error"`). Isolated leverage is stored per side there, so it takes one call each.

- **Before #362**: the rejection was swallowed with a warning and construction continued — the env then sized every position against leverage the account never had. That is #277 exactly, on this one configuration.
- **After #362**: it became a hard construction failure. Safe, but the config is simply unusable.

Now it works.

The verification added in #362 needs no change — it already loops every entry in the response's `data` list, so both sides get confirmed.

## Evidence

Tested in **both directions**, which is what makes this more than a shape check: sending `posSide` where OKX does not expect it is its own rejection, so cross and net must *not* get it.

| mutant | result |
|---|---|
| never send `posSide` (the shipped bug) | fails `isolated-long-short` |
| send it for `LONG_SHORT` regardless of margin mode | fails `cross-long-short` |

Full suite: 3163 passed.

⚠️ Review rounds not yet run.