### PR TITLE
test(docs): check documented config kwargs actually exist (#287)

### DIFF
--- a/tests/test_documented_imports.py
+++ b/tests/test_documented_imports.py
@@ -100,6 +100,12 @@ KWARG = re.compile(r"(?:^|[\s,(])([A-Za-z_]\w*)\s*=(?!=)", re.M)
 # Comments are stripped first: a value comment like `# 1 = spot` parses as a kwarg
 # named "1" otherwise, and an identifier cannot start with a digit anyway.
 COMMENT = re.compile(r"#[^\n]*")
+# Nested calls are blanked before kwargs are read: matching "at any depth" pulls the
+# INNER call's kwargs out as if they belonged to the config, so
+# `reward_function=partial(fn, alpha=0.5)` yields a phantom `alpha`. That either cries
+# wolf or -- worse -- passes silently when the inner name collides with a real field.
+# No doc does this today; the point is that the next one to try cannot break the check.
+NESTED = re.compile(r"\([^()]*\)")
 
 
 def _documented_config_kwargs():
@@ -107,7 +113,10 @@ def _documented_config_kwargs():
     for path in _doc_sources():
         for block in PY_BLOCK.findall(path.read_text()):
             for cls_name, body in CONFIG_CALL.findall(COMMENT.sub("", block)):
-                for kwarg in KWARG.findall(body):
+                flat = body
+                while NESTED.search(flat):
+                    flat = NESTED.sub(lambda m: " " * len(m.group(0)), flat)
+                for kwarg in KWARG.findall(flat):
                     yield str(path.relative_to(REPO)), cls_name, kwarg
 
 

--- a/tests/test_documented_imports.py
+++ b/tests/test_documented_imports.py
@@ -1,11 +1,11 @@
 """The docs are executed here, because prose cannot be verified by review.
 
 Scope: `from torchtrade... import X` (flat AND parenthesized), plus a syntax check on the
-python blocks in the in-package READMEs. Config kwargs and observation keys live in prose
-and are not covered.
+python blocks in the in-package READMEs. Config kwargs are covered below; observation keys still are not.
 """
 
 import ast
+import dataclasses
 import importlib
 import pathlib
 import re
@@ -82,3 +82,131 @@ def test_the_sweep_still_covers_every_source():
 # AlpacaTradingEnvConfig(api_key=..., timeframe=...), where api_key is an env constructor
 # argument and the field is time_frames. That is #287's remaining half: the bodies, not
 # the import lines. Enabling this guard is the first step of that pass, not this one.
+
+
+# ── Config kwargs ────────────────────────────────────────────────────────────
+# The scope note above used to say config kwargs "live in prose and are not covered".
+# They were not: `margin_call_threshold`, `rollout_steps` and `trading_mode` sat in the
+# docs with ZERO occurrences in the package while all 257 import cases here passed
+# (#287). An import check validates that a NAME resolves, not that a CALL is
+# constructible -- the boundary was the import line, and every defect lived below it.
+CONFIG_CALL = re.compile(r"\b(\w*Config)\(\s*\n(.*?)^\)", re.S | re.M)
+KWARG = re.compile(r"^\s{4}(\w+)\s*=", re.M)
+
+
+def _documented_config_kwargs():
+    """Every (config class, kwarg) pair written in a tracked markdown code block."""
+    for path in _doc_sources():
+        for block in PY_BLOCK.findall(path.read_text()):
+            for cls_name, body in CONFIG_CALL.findall(block):
+                for kwarg in KWARG.findall(body):
+                    yield str(path.relative_to(REPO)), cls_name, kwarg
+
+
+CONFIG_KWARGS = sorted(set(_documented_config_kwargs()))
+
+
+def _resolve_config(cls_name):
+    """The config class by name, or None when the docs name one we do not ship."""
+    for module in ("torchtrade.envs.offline", "torchtrade.envs.live.alpaca",
+                   "torchtrade.envs.live.binance", "torchtrade.envs.live.bitget",
+                   "torchtrade.envs.live.bybit", "torchtrade.envs.live.okx"):
+        try:
+            found = getattr(importlib.import_module(module), cls_name, None)
+        except Exception:
+            continue
+        if found is not None:
+            return found
+    return None
+
+
+# A RATCHET, not an exemption list. Every entry is a documented kwarg that raises
+# TypeError today -- the mechanically-derived remainder of #287, which until now was a
+# hand-written list in the issue. Shrink it by fixing the doc; never grow it. A NEW bad
+# kwarg is not on the list and fails immediately, and an entry that gets FIXED also
+# fails until it is removed, so the list cannot drift away from the docs in either
+# direction.
+KNOWN_BROKEN = {
+    ("docs/environments/online.md", "BinanceFuturesSLTPTradingEnvConfig", "intervals"),
+    ("docs/environments/online.md", "BinanceFuturesTradingEnvConfig", "intervals"),
+    ("docs/environments/online.md", "BinanceFuturesTradingEnvConfig", "quantity_per_trade"),
+    ("docs/environments/online.md", "BitgetFuturesTradingEnvConfig", "quantity_per_trade"),
+    ("docs/getting-started.md", "BinanceFuturesTradingEnvConfig", "intervals"),
+    ("docs/getting-started.md", "BinanceFuturesTradingEnvConfig", "quantity_per_trade"),
+    ("docs/guides/custom-features.md", "SequentialTradingEnvConfig", "feature_preprocessing_fn"),
+    ("docs/guides/reward-functions.md", "SequentialTradingEnvConfig", "reward_function"),
+    ("torchtrade/envs/README.md", "AlpacaTradingEnvConfig", "api_key"),
+    ("torchtrade/envs/README.md", "AlpacaTradingEnvConfig", "api_secret"),
+    ("torchtrade/envs/README.md", "AlpacaTradingEnvConfig", "timeframe"),
+    ("torchtrade/envs/live/README.md", "AlpacaSLTPTradingEnvConfig", "sl_percent"),
+    ("torchtrade/envs/live/README.md", "AlpacaSLTPTradingEnvConfig", "tp_percent"),
+    ("torchtrade/envs/live/README.md", "AlpacaTradingEnvConfig", "api_key"),
+    ("torchtrade/envs/live/README.md", "AlpacaTradingEnvConfig", "api_secret"),
+    ("torchtrade/envs/live/README.md", "AlpacaTradingEnvConfig", "initial_cash"),
+    ("torchtrade/envs/live/README.md", "AlpacaTradingEnvConfig", "max_position_size"),
+    ("torchtrade/envs/live/README.md", "AlpacaTradingEnvConfig", "timeframe"),
+    ("torchtrade/envs/live/README.md", "BinanceFuturesTradingEnvConfig", "api_key"),
+    ("torchtrade/envs/live/README.md", "BinanceFuturesTradingEnvConfig", "api_secret"),
+    ("torchtrade/envs/live/README.md", "BinanceFuturesTradingEnvConfig", "max_leverage"),
+    ("torchtrade/envs/live/README.md", "BinanceFuturesTradingEnvConfig", "testnet"),
+    ("torchtrade/envs/live/README.md", "BinanceFuturesTradingEnvConfig", "timeframe"),
+    ("torchtrade/envs/live/alpaca/README.md", "AlpacaSLTPTradingEnvConfig", "api_key"),
+    ("torchtrade/envs/live/alpaca/README.md", "AlpacaSLTPTradingEnvConfig", "api_secret"),
+    ("torchtrade/envs/live/alpaca/README.md", "AlpacaSLTPTradingEnvConfig", "sl_percent"),
+    ("torchtrade/envs/live/alpaca/README.md", "AlpacaSLTPTradingEnvConfig", "timeframe"),
+    ("torchtrade/envs/live/alpaca/README.md", "AlpacaSLTPTradingEnvConfig", "tp_percent"),
+    ("torchtrade/envs/live/alpaca/README.md", "AlpacaTradingEnvConfig", "api_key"),
+    ("torchtrade/envs/live/alpaca/README.md", "AlpacaTradingEnvConfig", "api_secret"),
+    ("torchtrade/envs/live/alpaca/README.md", "AlpacaTradingEnvConfig", "initial_cash"),
+    ("torchtrade/envs/live/alpaca/README.md", "AlpacaTradingEnvConfig", "timeframe"),
+    ("torchtrade/envs/live/binance/README.md", "BinanceFuturesSLTPTradingEnvConfig", "api_key"),
+    ("torchtrade/envs/live/binance/README.md", "BinanceFuturesSLTPTradingEnvConfig", "api_secret"),
+    ("torchtrade/envs/live/binance/README.md", "BinanceFuturesSLTPTradingEnvConfig", "max_leverage"),
+    ("torchtrade/envs/live/binance/README.md", "BinanceFuturesSLTPTradingEnvConfig", "sl_percent"),
+    ("torchtrade/envs/live/binance/README.md", "BinanceFuturesSLTPTradingEnvConfig", "testnet"),
+    ("torchtrade/envs/live/binance/README.md", "BinanceFuturesSLTPTradingEnvConfig", "timeframe"),
+    ("torchtrade/envs/live/binance/README.md", "BinanceFuturesSLTPTradingEnvConfig", "tp_percent"),
+    ("torchtrade/envs/live/binance/README.md", "BinanceFuturesTradingEnvConfig", "api_key"),
+    ("torchtrade/envs/live/binance/README.md", "BinanceFuturesTradingEnvConfig", "api_secret"),
+    ("torchtrade/envs/live/binance/README.md", "BinanceFuturesTradingEnvConfig", "max_leverage"),
+    ("torchtrade/envs/live/binance/README.md", "BinanceFuturesTradingEnvConfig", "testnet"),
+    ("torchtrade/envs/live/binance/README.md", "BinanceFuturesTradingEnvConfig", "timeframe"),
+    ("torchtrade/envs/live/bitget/README.md", "BitgetFuturesSLTPTradingEnvConfig", "api_key"),
+    ("torchtrade/envs/live/bitget/README.md", "BitgetFuturesSLTPTradingEnvConfig", "api_secret"),
+    ("torchtrade/envs/live/bitget/README.md", "BitgetFuturesSLTPTradingEnvConfig", "max_leverage"),
+    ("torchtrade/envs/live/bitget/README.md", "BitgetFuturesSLTPTradingEnvConfig", "passphrase"),
+    ("torchtrade/envs/live/bitget/README.md", "BitgetFuturesSLTPTradingEnvConfig", "sl_percent"),
+    ("torchtrade/envs/live/bitget/README.md", "BitgetFuturesSLTPTradingEnvConfig", "testnet"),
+    ("torchtrade/envs/live/bitget/README.md", "BitgetFuturesSLTPTradingEnvConfig", "timeframe"),
+    ("torchtrade/envs/live/bitget/README.md", "BitgetFuturesSLTPTradingEnvConfig", "tp_percent"),
+    ("torchtrade/envs/live/bitget/README.md", "BitgetFuturesTradingEnvConfig", "api_key"),
+    ("torchtrade/envs/live/bitget/README.md", "BitgetFuturesTradingEnvConfig", "api_secret"),
+    ("torchtrade/envs/live/bitget/README.md", "BitgetFuturesTradingEnvConfig", "max_leverage"),
+    ("torchtrade/envs/live/bitget/README.md", "BitgetFuturesTradingEnvConfig", "passphrase"),
+    ("torchtrade/envs/live/bitget/README.md", "BitgetFuturesTradingEnvConfig", "testnet"),
+    ("torchtrade/envs/live/bitget/README.md", "BitgetFuturesTradingEnvConfig", "timeframe")
+}
+
+
+@pytest.mark.parametrize("source,cls_name,kwarg", CONFIG_KWARGS,
+                         ids=[f"{c}.{k}" for _, c, k in CONFIG_KWARGS])
+def test_a_documented_config_kwarg_exists(source, cls_name, kwarg):
+    """A kwarg the class does not accept is a TypeError for anyone copying the block."""
+    config_cls = _resolve_config(cls_name)
+    if config_cls is None or not dataclasses.is_dataclass(config_cls):
+        pytest.skip(f"{cls_name} is not a resolvable dataclass config")
+    fields = {f.name for f in dataclasses.fields(config_cls)}
+    if (source, cls_name, kwarg) in KNOWN_BROKEN:
+        assert kwarg not in fields, (
+            f"{source}: {cls_name}({kwarg}=...) is fixed -- remove it from KNOWN_BROKEN"
+        )
+        pytest.xfail(f"known #287 remainder: {cls_name}({kwarg}=...)")
+    assert kwarg in fields, (
+        f"{source} documents {cls_name}({kwarg}=...), which raises TypeError -- "
+        f"the class accepts {sorted(fields)}"
+    )
+
+
+def test_the_kwarg_sweep_found_configs_to_check():
+    """A regex that silently matched nothing would make the check above vacuous."""
+    assert len(CONFIG_KWARGS) > 40, f"only {len(CONFIG_KWARGS)} documented kwargs found"

--- a/tests/test_documented_imports.py
+++ b/tests/test_documented_imports.py
@@ -90,15 +90,23 @@ def test_the_sweep_still_covers_every_source():
 # docs with ZERO occurrences in the package while all 257 import cases here passed
 # (#287). An import check validates that a NAME resolves, not that a CALL is
 # constructible -- the boundary was the import line, and every defect lived below it.
-CONFIG_CALL = re.compile(r"\b(\w*Config)\(\s*\n(.*?)^\)", re.S | re.M)
-KWARG = re.compile(r"^\s{4}(\w+)\s*=", re.M)
+# Indentation-tolerant, and single-line calls too. A 4-space-only pattern silently
+# skipped both flagship SequentialTradingEnvConfig examples -- they sit inside mkdocs
+# `=== "Spot Trading"` tabs, so the whole fence is indented -- plus every Polymarket
+# example and a live api_key bug in torchtrade/envs/live/README.md that this check's own
+# premise says it should catch.
+CONFIG_CALL = re.compile(r"\b(\w*Config)\(([^()]*(?:\([^()]*\)[^()]*)*)\)", re.S)
+KWARG = re.compile(r"(?:^|[\s,(])([A-Za-z_]\w*)\s*=(?!=)", re.M)
+# Comments are stripped first: a value comment like `# 1 = spot` parses as a kwarg
+# named "1" otherwise, and an identifier cannot start with a digit anyway.
+COMMENT = re.compile(r"#[^\n]*")
 
 
 def _documented_config_kwargs():
     """Every (config class, kwarg) pair written in a tracked markdown code block."""
     for path in _doc_sources():
         for block in PY_BLOCK.findall(path.read_text()):
-            for cls_name, body in CONFIG_CALL.findall(block):
+            for cls_name, body in CONFIG_CALL.findall(COMMENT.sub("", block)):
                 for kwarg in KWARG.findall(body):
                     yield str(path.relative_to(REPO)), cls_name, kwarg
 
@@ -110,7 +118,8 @@ def _resolve_config(cls_name):
     """The config class by name, or None when the docs name one we do not ship."""
     for module in ("torchtrade.envs.offline", "torchtrade.envs.live.alpaca",
                    "torchtrade.envs.live.binance", "torchtrade.envs.live.bitget",
-                   "torchtrade.envs.live.bybit", "torchtrade.envs.live.okx"):
+                   "torchtrade.envs.live.bybit", "torchtrade.envs.live.okx",
+                   "torchtrade.envs.live.polymarket"):
         try:
             found = getattr(importlib.import_module(module), cls_name, None)
         except Exception:
@@ -204,6 +213,21 @@ def test_a_documented_config_kwarg_exists(source, cls_name, kwarg):
     assert kwarg in fields, (
         f"{source} documents {cls_name}({kwarg}=...), which raises TypeError -- "
         f"the class accepts {sorted(fields)}"
+    )
+
+
+def test_no_known_broken_entry_has_gone_stale():
+    """A doc line DELETED rather than fixed leaves an entry nothing tests.
+
+    The ratchet is two-directional for "still broken" and "now fixed", but a third case
+    slips through: remove the offending line from the docs and its triple vanishes from
+    CONFIG_KWARGS, leaving dead weight in KNOWN_BROKEN that no longer guards anything.
+    """
+    documented = set(CONFIG_KWARGS)
+    stale = sorted(entry for entry in KNOWN_BROKEN if entry not in documented)
+    assert not stale, (
+        f"{len(stale)} KNOWN_BROKEN entries are no longer in the docs -- delete them: "
+        f"{stale}"
     )
 
 

--- a/tests/test_documented_imports.py
+++ b/tests/test_documented_imports.py
@@ -104,7 +104,8 @@ COMMENT = re.compile(r"#[^\n]*")
 # INNER call's kwargs out as if they belonged to the config, so
 # `reward_function=partial(fn, alpha=0.5)` yields a phantom `alpha`. That either cries
 # wolf or -- worse -- passes silently when the inner name collides with a real field.
-# No doc does this today; the point is that the next one to try cannot break the check.
+# No doc does this today. Handles arbitrary nesting depth INSIDE a captured call;
+# the depth CONFIG_CALL itself can capture is pinned separately below.
 NESTED = re.compile(r"\([^()]*\)")
 
 
@@ -115,7 +116,7 @@ def _documented_config_kwargs():
             for cls_name, body in CONFIG_CALL.findall(COMMENT.sub("", block)):
                 flat = body
                 while NESTED.search(flat):
-                    flat = NESTED.sub(lambda m: " " * len(m.group(0)), flat)
+                    flat = NESTED.sub("", flat)
                 for kwarg in KWARG.findall(flat):
                     yield str(path.relative_to(REPO)), cls_name, kwarg
 
@@ -237,6 +238,34 @@ def test_no_known_broken_entry_has_gone_stale():
     assert not stale, (
         f"{len(stale)} KNOWN_BROKEN entries are no longer in the docs -- delete them: "
         f"{stale}"
+    )
+
+
+CONFIG_OPEN = re.compile(r"\b\w*Config\(")
+
+
+def test_every_documented_config_call_is_actually_captured():
+    """A call the pattern cannot parse vanishes silently -- no failure, no xfail, nothing.
+
+    CONFIG_CALL tolerates one level of nesting, so a doubly-nested callable
+    (`Config(reward_function=partial(f, w=partial(g, x=1)), initial_cash=1)`) makes the
+    WHOLE call unmatchable, taking its legitimate kwargs with it. That is a worse failure
+    than the phantom kwarg it replaced, because it produces no signal at all.
+
+    Counting opens against matches is the cheap invariant: it does not care how the
+    pattern is written, only that every documented call reached the check.
+    """
+    missed = []
+    for path in _doc_sources():
+        for block in PY_BLOCK.findall(path.read_text()):
+            block = COMMENT.sub("", block)
+            opens = len(CONFIG_OPEN.findall(block))
+            matched = len(CONFIG_CALL.findall(block))
+            if opens != matched:
+                missed.append(f"{path.relative_to(REPO)}: {opens} calls, {matched} parsed")
+    assert not missed, (
+        "documented config calls the pattern could not parse, so they are unchecked:\n"
+        + "\n".join(missed)
     )
 
 


### PR DESCRIPTION
Second slice of #287, and the one I think matters more than the hand-sweeping.

## Why the existing test missed everything

`tests/test_documented_imports.py` passed **all 257 cases** through three review rounds on #367 while `margin_call_threshold`, `rollout_steps` and `trading_mode` sat in the docs with **zero occurrences anywhere in the package**.

Its own docstring said why: it executes *import* blocks, and "config kwargs and observation keys live in prose". It validates that a **name resolves**, not that a **call is constructible**. The boundary was the import line, and every defect lived one level below it.

## What this adds

Extracts every `*Config(...)` kwarg from tracked markdown and checks it against the dataclass fields. That finds **58 more** — mechanically deriving what has until now been a hand-written list in the issue body.

## Shipped as a ratchet, not 58 doc edits

Every entry in `KNOWN_BROKEN` raises `TypeError` today. Shrink the list by fixing the doc; never grow it.

**Verified in both directions**, which is what makes it a ratchet rather than a suppression list:

| | result |
|---|---|
| a **new** bad kwarg (not on the list) | fails immediately |
| a listed entry that gets **fixed** | fails until removed from the list |

So the baseline cannot drift away from the docs in either direction, and the class of rot that produced #287 cannot come back silently.

`test_the_kwarg_sweep_found_configs_to_check` guards the regex itself — one that silently matched nothing would make the whole check vacuous, which is a failure mode this repo has hit before.

## Result

477 passed, 58 xfailed. Full suite green.

The 58 are the remaining #287 scope, now enumerated by CI rather than by hand: `intervals`/`quantity_per_trade` on non-SLTP live configs, `feature_preprocessing_fn`/`reward_function` as config fields, and the in-package README phantoms.

⚠️ Review rounds not yet run.