### PR TITLE
fix(live): reserve the entry fee in SLTP fractional sizing (#278)

### DIFF
--- a/docs/environments/online.md
+++ b/docs/environments/online.md
@@ -656,7 +656,7 @@ All live SLTP environments support three position sizing modes, matching the off
 
 | Mode | Config field | Formula | Use case |
 |------|-------------|---------|----------|
-| `"fractional"` | `position_fraction` | `account_balance × fraction × leverage / price` | Adaptive sizing (scales with account) |
+| `"fractional"` | `position_fraction` | `account_balance × fraction × leverage / price`, net of the entry fee | Adaptive sizing (scales with account) |
 | `"notional"` | `quantity_per_trade` | `quantity_per_trade / price` | Fixed USD per trade |
 | `"quantity"` | `quantity_per_trade` | `quantity_per_trade` directly | Fixed base-asset units per trade |
 

--- a/tests/envs/binance/test_torch_env_futures_sltp.py
+++ b/tests/envs/binance/test_torch_env_futures_sltp.py
@@ -1174,7 +1174,7 @@ class TestBinanceSLTPNotionalTradeMode:
         from torchtrade.envs.live.binance.order_executor import TAKER_FEE
         # Net of the reserved entry fee: sizing on the raw allocation left
         # nothing for the fee, so every open was refused (#278).
-        expected_qty = 1100.0 * 0.1 * 5 / 50050.0 / (1 + 5 * TAKER_FEE)
+        expected_qty = 1100.0 * 0.1 * 5 / 50050.0 * 0.98 / (1 + 5 * TAKER_FEE)
         assert call_kwargs["quantity"] == pytest.approx(expected_qty, rel=1e-4)
 
 

--- a/tests/envs/binance/test_torch_env_futures_sltp.py
+++ b/tests/envs/binance/test_torch_env_futures_sltp.py
@@ -1106,7 +1106,14 @@ class TestBinanceSLTPNotionalTradeMode:
         assert call_kwargs["quantity"] == pytest.approx(0.001, rel=1e-6)
 
     def test_fractional_converts_balance_to_quantity(self):
-        """Fractional mode must compute quantity from balance * fraction * leverage / price."""
+        """Fractional mode sizes from balance * fraction * leverage / price, NET OF FEE.
+
+        The raw figure asks for margin equal to the whole allocation, leaving nothing for
+        the entry fee, so the affordability check refuses the open (#278). The shared
+        sizer reserves it via fee_multiplier = 1 + leverage*fee, which is the same rule
+        the non-SLTP path and the offline envs have always used. Asserted as the rule
+        rather than a constant, so it tracks the venue's taker rate.
+        """
         from torchtrade.envs.live.binance.env_sltp import (
             BinanceFuturesSLTPTorchTradingEnv,
             BinanceFuturesSLTPTradingEnvConfig,
@@ -1164,7 +1171,10 @@ class TestBinanceSLTPNotionalTradeMode:
 
         call_kwargs = mock_trader.trade.call_args[1]
         # margin_balance=1100 * fraction=0.1 * leverage=5 / candle_close=50050 ≈ 0.01099
-        expected_qty = 1100.0 * 0.1 * 5 / 50050.0
+        from torchtrade.envs.live.binance.order_executor import TAKER_FEE
+        # Net of the reserved entry fee: sizing on the raw allocation left
+        # nothing for the fee, so every open was refused (#278).
+        expected_qty = 1100.0 * 0.1 * 5 / 50050.0 / (1 + 5 * TAKER_FEE)
         assert call_kwargs["quantity"] == pytest.approx(expected_qty, rel=1e-4)
 
 

--- a/tests/envs/bitget/test_torch_env_futures_sltp.py
+++ b/tests/envs/bitget/test_torch_env_futures_sltp.py
@@ -856,7 +856,7 @@ class TestBitgetSLTPNotionalTradeMode:
         from torchtrade.envs.live.bitget.order_executor import TAKER_FEE
         # Net of the reserved entry fee: sizing on the raw allocation left
         # nothing for the fee, so every open was refused (#278).
-        expected_qty = 1100.0 * 0.1 * 5 / 50050.0 / (1 + 5 * TAKER_FEE)
+        expected_qty = 1100.0 * 0.1 * 5 / 50050.0 * 0.98 / (1 + 5 * TAKER_FEE)
         assert call_kwargs["quantity"] == pytest.approx(expected_qty, rel=1e-4)
 
 

--- a/tests/envs/bitget/test_torch_env_futures_sltp.py
+++ b/tests/envs/bitget/test_torch_env_futures_sltp.py
@@ -788,7 +788,14 @@ class TestBitgetSLTPNotionalTradeMode:
         assert call_kwargs["quantity"] == pytest.approx(0.001, rel=1e-6)
 
     def test_fractional_converts_balance_to_quantity(self):
-        """Fractional mode must compute quantity from balance * fraction * leverage / price."""
+        """Fractional mode sizes from balance * fraction * leverage / price, NET OF FEE.
+
+        The raw figure asks for margin equal to the whole allocation, leaving nothing for
+        the entry fee, so the affordability check refuses the open (#278). The shared
+        sizer reserves it via fee_multiplier = 1 + leverage*fee, which is the same rule
+        the non-SLTP path and the offline envs have always used. Asserted as the rule
+        rather than a constant, so it tracks the venue's taker rate.
+        """
         from torchtrade.envs.live.bitget.env_sltp import (
             BitgetFuturesSLTPTorchTradingEnv,
             BitgetFuturesSLTPTradingEnvConfig,
@@ -846,7 +853,10 @@ class TestBitgetSLTPNotionalTradeMode:
 
         call_kwargs = mock_trader.trade.call_args[1]
         # margin_balance=1100 * fraction=0.1 * leverage=5 / candle_close=50050 ≈ 0.01099
-        expected_qty = 1100.0 * 0.1 * 5 / 50050.0
+        from torchtrade.envs.live.bitget.order_executor import TAKER_FEE
+        # Net of the reserved entry fee: sizing on the raw allocation left
+        # nothing for the fee, so every open was refused (#278).
+        expected_qty = 1100.0 * 0.1 * 5 / 50050.0 / (1 + 5 * TAKER_FEE)
         assert call_kwargs["quantity"] == pytest.approx(expected_qty, rel=1e-4)
 
 

--- a/tests/envs/bybit/test_torch_env_futures_sltp.py
+++ b/tests/envs/bybit/test_torch_env_futures_sltp.py
@@ -674,6 +674,19 @@ class TestBybitSLTPNotionalTradeMode:
             # margin_balance=1100 * fraction=0.1 * leverage=5 / price=50000 = 0.011
             from torchtrade.envs.live.bybit.order_executor import TAKER_FEE
             expected = 0.011 * 0.98 / (1 + 5 * TAKER_FEE)
+
+            # The ACCEPTED branch of the fee guard, which nothing else exercises: every
+            # SLTP test passes a MagicMock trader, and a MagicMock is REJECTED, so they
+            # all assert the venue-constant fallback. Tighten the guard to reject
+            # everything and the suite stays green while #278 returns.
+            baseline_qty = mock_env_trader.trade.call_args[1]["quantity"]
+            mock_env_trader.transaction_fee = 0.002
+            mock_env_trader.trade.reset_mock()
+            env._execute_trade_if_needed(("long", -0.02, 0.03))
+            assert mock_env_trader.trade.call_args[1]["quantity"] < baseline_qty, (
+                "the env must reserve the trader's higher rate, sizing SMALLER than the "
+                "venue constant -- otherwise the venue refuses the open"
+            )
         assert call_kwargs["quantity"] == pytest.approx(expected, rel=1e-4)
 
 

--- a/tests/envs/bybit/test_torch_env_futures_sltp.py
+++ b/tests/envs/bybit/test_torch_env_futures_sltp.py
@@ -626,7 +626,14 @@ class TestBybitSLTPNotionalTradeMode:
             assert call_kwargs["quantity"] == pytest.approx(0.001, rel=1e-6)
 
     def test_fractional_converts_balance_to_quantity(self, mock_env_observer, mock_env_trader):
-        """Fractional mode must compute quantity from balance * fraction * leverage / price."""
+        """Fractional mode sizes from balance * fraction * leverage / price, NET OF FEE.
+
+        The raw figure asks for margin equal to the whole allocation, leaving nothing for
+        the entry fee, so the affordability check refuses the open (#278). The shared
+        sizer reserves it via fee_multiplier = 1 + leverage*fee, which is the same rule
+        the non-SLTP path and the offline envs have always used. Asserted as the rule
+        rather than a constant, so it tracks the venue's taker rate.
+        """
         from torchtrade.envs.live.bybit.env_sltp import (
             BybitFuturesSLTPTorchTradingEnv,
             BybitFuturesSLTPTradingEnvConfig,
@@ -665,7 +672,9 @@ class TestBybitSLTPNotionalTradeMode:
 
             call_kwargs = mock_env_trader.trade.call_args[1]
             # margin_balance=1100 * fraction=0.1 * leverage=5 / price=50000 = 0.011
-            assert call_kwargs["quantity"] == pytest.approx(0.011, rel=1e-4)
+            from torchtrade.envs.live.bybit.order_executor import TAKER_FEE
+            expected = 0.011 / (1 + 5 * TAKER_FEE)
+        assert call_kwargs["quantity"] == pytest.approx(expected, rel=1e-4)
 
 
 class TestBybitSLTPLockPosition:

--- a/tests/envs/bybit/test_torch_env_futures_sltp.py
+++ b/tests/envs/bybit/test_torch_env_futures_sltp.py
@@ -673,7 +673,7 @@ class TestBybitSLTPNotionalTradeMode:
             call_kwargs = mock_env_trader.trade.call_args[1]
             # margin_balance=1100 * fraction=0.1 * leverage=5 / price=50000 = 0.011
             from torchtrade.envs.live.bybit.order_executor import TAKER_FEE
-            expected = 0.011 / (1 + 5 * TAKER_FEE)
+            expected = 0.011 * 0.98 / (1 + 5 * TAKER_FEE)
         assert call_kwargs["quantity"] == pytest.approx(expected, rel=1e-4)
 
 

--- a/tests/envs/okx/test_torch_env_futures_sltp.py
+++ b/tests/envs/okx/test_torch_env_futures_sltp.py
@@ -384,7 +384,7 @@ class TestOKXSLTPNotionalTradeMode:
             # margin_balance=1100 * fraction=0.1 * leverage=5 / price=50000 = 0.011
             from torchtrade.envs.live.okx.order_executor import TAKER_FEE
             # Net of the reserved entry fee (#278).
-            expected = 0.011 / (1 + 5 * TAKER_FEE)
+            expected = 0.011 * 0.98 / (1 + 5 * TAKER_FEE)
             assert mock_env_trader.trade.call_args[1]["quantity"] == pytest.approx(expected, rel=1e-4)
 
 

--- a/tests/envs/okx/test_torch_env_futures_sltp.py
+++ b/tests/envs/okx/test_torch_env_futures_sltp.py
@@ -350,7 +350,14 @@ class TestOKXSLTPNotionalTradeMode:
             assert mock_env_trader.trade.call_args[1]["quantity"] == pytest.approx(0.001, rel=1e-6)
 
     def test_fractional_converts_balance_to_quantity(self, mock_env_observer, mock_env_trader):
-        """Fractional mode must compute quantity from balance * fraction * leverage / price."""
+        """Fractional mode sizes from balance * fraction * leverage / price, NET OF FEE.
+
+        The raw figure asks for margin equal to the whole allocation, leaving nothing for
+        the entry fee, so the affordability check refuses the open (#278). The shared
+        sizer reserves it via fee_multiplier = 1 + leverage*fee, which is the same rule
+        the non-SLTP path and the offline envs have always used. Asserted as the rule
+        rather than a constant, so it tracks the venue's taker rate.
+        """
         from torchtrade.envs.live.okx.env_sltp import OKXFuturesSLTPTorchTradingEnv, OKXFuturesSLTPTradingEnvConfig
 
         config = OKXFuturesSLTPTradingEnvConfig(
@@ -375,7 +382,10 @@ class TestOKXSLTPNotionalTradeMode:
             env.reset()
             env._execute_trade_if_needed(("long", -0.02, 0.03))
             # margin_balance=1100 * fraction=0.1 * leverage=5 / price=50000 = 0.011
-            assert mock_env_trader.trade.call_args[1]["quantity"] == pytest.approx(0.011, rel=1e-4)
+            from torchtrade.envs.live.okx.order_executor import TAKER_FEE
+            # Net of the reserved entry fee (#278).
+            expected = 0.011 / (1 + 5 * TAKER_FEE)
+            assert mock_env_trader.trade.call_args[1]["quantity"] == pytest.approx(expected, rel=1e-4)
 
 
 class TestOKXSLTPLockPosition:

--- a/tests/envs/test_leverage_boundary.py
+++ b/tests/envs/test_leverage_boundary.py
@@ -375,3 +375,38 @@ def test_okx_refuses_a_confirmation_for_the_wrong_side():
                                            set_position_mode=_boom, get_positions=_boom),
             public_client=SimpleNamespace(get_instruments=_boom),
         )
+
+
+@pytest.mark.parametrize("venue", ["binance", "bitget", "bybit", "okx"])
+def test_sltp_fractional_sizing_reserves_the_entry_fee(venue):
+    """Sizing on the raw balance made every fractional open unaffordable (#278).
+
+    margin = notional/leverage and fee = notional*rate, so asking for margin equal to the
+    WHOLE balance leaves nothing for the fee: balance=10000, lev=5, fee=0.0004 needs
+    10020 and has 10000. Replay refused every action and reported a flat 'strategy'.
+
+    The shared sizer reserves it via fee_multiplier = 1 + leverage*fee -- the rule the
+    non-SLTP live path and both offline engines have always used. Asserted against the
+    affordability arithmetic rather than a magic quantity, so it tracks each venue's rate.
+    """
+    from torchtrade.envs.utils.fractional_sizing import (
+        PositionCalculationParams, calculate_fractional_position,
+    )
+    taker = __import__(
+        f"torchtrade.envs.live.{venue}.order_executor", fromlist=["TAKER_FEE"]
+    ).TAKER_FEE
+
+    balance, leverage, price = 10_000.0, 5, 100.0
+    qty = abs(calculate_fractional_position(PositionCalculationParams(
+        balance=balance, action_value=1.0, current_price=price,
+        leverage=leverage, transaction_fee=taker,
+    ))[0])
+
+    notional = qty * price
+    required = notional / leverage + notional * taker
+    assert required <= balance + 1e-6, (
+        f"{venue}: sizing at full fraction needs {required:.2f} against {balance:.2f} -- "
+        f"the venue would refuse every open"
+    )
+    # And it is not trivially small: the fee reservation should cost only the fee.
+    assert required == pytest.approx(balance, rel=1e-6)

--- a/tests/envs/test_leverage_boundary.py
+++ b/tests/envs/test_leverage_boundary.py
@@ -378,16 +378,23 @@ def test_okx_refuses_a_confirmation_for_the_wrong_side():
 
 
 @pytest.mark.parametrize("venue", ["binance", "bitget", "bybit", "okx"])
-def test_sltp_fractional_sizing_is_affordable_through_the_real_executor(venue):
-    """Drives the ENV's sizing into a real ReplayOrderExecutor (#278).
+def test_the_sizing_rule_is_affordable_against_a_real_executor(venue):
+    """The sizing RULE against a real ReplayOrderExecutor -- not the env (#278).
 
-    The first version of this test called the sizer directly and never touched an
-    env_sltp -- reverting all four envs to the broken inline arithmetic still passed it.
-    It has to go through the env, because that is where the defect lived.
+    Scope stated exactly, because two earlier versions of this test claimed more than
+    they did: it reproduces the expression env_sltp uses and feeds the result to a real
+    executor. It therefore proves the rule is affordable, and is structurally BLIND to an
+    env reverting to the old inline arithmetic. Verified: reverting all four env_sltp.py
+    to main leaves this passing 4/4.
 
-    Also varies the executor's own fee: the env reserves what the TRADER will charge, not
-    a constant, so a caller with a higher rate must still be able to open. Reserving the
-    venue constant left those callers refused, which is #278 reproduced one level over.
+    Env-path coverage lives in the four per-venue test_fractional_converts_balance_to_
+    quantity tests, which construct the real env and do catch that revert, the missing
+    0.98 buffer, and the MagicMock-fee guard -- all mutation-verified.
+
+    What this adds over those: strength. The leverage/fee cells are chosen so the 0.98
+    buffer cannot absorb the reservation -- (25, 0.001) catches dropping it entirely and
+    (50, 0.001) catches HALVING it, which no smaller cell sees. The `balance > 0`
+    assertion is what the two leverage-5 cells are for.
     """
     from torchtrade.envs.replay.order_executor import ReplayOrderExecutor
     from torchtrade.envs.utils.fractional_sizing import (

--- a/tests/envs/test_leverage_boundary.py
+++ b/tests/envs/test_leverage_boundary.py
@@ -378,17 +378,18 @@ def test_okx_refuses_a_confirmation_for_the_wrong_side():
 
 
 @pytest.mark.parametrize("venue", ["binance", "bitget", "bybit", "okx"])
-def test_sltp_fractional_sizing_reserves_the_entry_fee(venue):
-    """Sizing on the raw balance made every fractional open unaffordable (#278).
+def test_sltp_fractional_sizing_is_affordable_through_the_real_executor(venue):
+    """Drives the ENV's sizing into a real ReplayOrderExecutor (#278).
 
-    margin = notional/leverage and fee = notional*rate, so asking for margin equal to the
-    WHOLE balance leaves nothing for the fee: balance=10000, lev=5, fee=0.0004 needs
-    10020 and has 10000. Replay refused every action and reported a flat 'strategy'.
+    The first version of this test called the sizer directly and never touched an
+    env_sltp -- reverting all four envs to the broken inline arithmetic still passed it.
+    It has to go through the env, because that is where the defect lived.
 
-    The shared sizer reserves it via fee_multiplier = 1 + leverage*fee -- the rule the
-    non-SLTP live path and both offline engines have always used. Asserted against the
-    affordability arithmetic rather than a magic quantity, so it tracks each venue's rate.
+    Also varies the executor's own fee: the env reserves what the TRADER will charge, not
+    a constant, so a caller with a higher rate must still be able to open. Reserving the
+    venue constant left those callers refused, which is #278 reproduced one level over.
     """
+    from torchtrade.envs.replay.order_executor import ReplayOrderExecutor
     from torchtrade.envs.utils.fractional_sizing import (
         PositionCalculationParams, calculate_fractional_position,
     )
@@ -396,17 +397,22 @@ def test_sltp_fractional_sizing_reserves_the_entry_fee(venue):
         f"torchtrade.envs.live.{venue}.order_executor", fromlist=["TAKER_FEE"]
     ).TAKER_FEE
 
-    balance, leverage, price = 10_000.0, 5, 100.0
-    qty = abs(calculate_fractional_position(PositionCalculationParams(
-        balance=balance, action_value=1.0, current_price=price,
-        leverage=leverage, transaction_fee=taker,
-    ))[0])
-
-    notional = qty * price
-    required = notional / leverage + notional * taker
-    assert required <= balance + 1e-6, (
-        f"{venue}: sizing at full fraction needs {required:.2f} against {balance:.2f} -- "
-        f"the venue would refuse every open"
-    )
-    # And it is not trivially small: the fee reservation should cost only the fee.
-    assert required == pytest.approx(balance, rel=1e-6)
+    balance, price = 10_000.0, 100.0
+    # leverage*fee must exceed the 0.98 buffer or the buffer absorbs the fee and the
+    # reservation is untested -- (25, 0.001) gives 1.025 against a 1.02 cushion.
+    for leverage, charged in ((5, taker), (5, 0.001), (25, 0.001), (50, 0.001)):
+        # The expression the env now uses: the trader's rate, on 98% of equity.
+        qty = abs(calculate_fractional_position(PositionCalculationParams(
+            balance=balance * 0.98, action_value=1.0, current_price=price,
+            leverage=leverage, transaction_fee=charged,
+        ))[0])
+        ex = ReplayOrderExecutor(
+            initial_balance=balance, leverage=leverage, transaction_fee=charged
+        )
+        ex.advance_bar({"open": price, "high": price, "low": price, "close": price})
+        assert ex.trade("buy", qty), (
+            f"{venue}: an open at full fraction was refused with fee={charged}"
+        )
+        assert ex.balance > 0, (
+            f"{venue}: the open consumed every dollar of equity, leaving no buffer"
+        )

--- a/torchtrade/envs/core/common.py
+++ b/torchtrade/envs/core/common.py
@@ -10,7 +10,8 @@ TradeMode = Literal["fractional", "notional", "quantity"]
 Position sizing mode for trading environments.
 
 - "fractional": Fraction of portfolio per trade (e.g., 0.1 = 10%)
-  - Position size: portfolio_value * position_fraction * leverage / price
+  - Position size: portfolio_value * position_fraction * leverage / price,
+    net of the entry fee (see fractional_sizing.fee_multiplier, #278)
   - Best for: training and adaptive live sizing
 
 - "quantity": Fixed quantity per trade (e.g., 0.001 BTC)

--- a/torchtrade/envs/live/alpaca/env_sltp.py
+++ b/torchtrade/envs/live/alpaca/env_sltp.py
@@ -286,6 +286,10 @@ class AlpacaSLTPTorchTradingEnv(SLTPMixin, AlpacaBaseTorchTradingEnv):
             return -1  # Close full position
 
         if self.config.trade_mode == "fractional":
+            # Not fee-reserved, unlike the futures SLTP envs (#278). Alpaca's rate is
+            # asset-class dependent -- commission-free on stocks, a taker fee on crypto --
+            # so there is no single constant to reserve, and spot at leverage 1 makes the
+            # shortfall the fee itself rather than a multiple of it. Left deliberately.
             return self.balance * self.config.position_fraction
         elif self.config.trade_mode == "notional":
             return float(self.config.quantity_per_trade)

--- a/torchtrade/envs/live/binance/env.py
+++ b/torchtrade/envs/live/binance/env.py
@@ -15,6 +15,7 @@ from torchtrade.envs.core.live import (
 )
 from torchtrade.envs.live.binance.observation import BinanceObservationClass
 from torchtrade.envs.live.binance.order_executor import (
+    TAKER_FEE,
     BinanceFuturesOrderClass,
     MarginType,
 )
@@ -327,7 +328,7 @@ class BinanceFuturesTorchTradingEnv(BinanceBaseTorchTradingEnv):
         # Use shared utility for core position calculation
         # Reserve 2% buffer for exchange maintenance margin requirements
         effective_balance = total_balance * 0.98
-        fee_rate = 0.0004  # Binance futures maker/taker fee
+        fee_rate = TAKER_FEE
         params = PositionCalculationParams(
             balance=effective_balance,
             action_value=action_value,

--- a/torchtrade/envs/live/binance/env.py
+++ b/torchtrade/envs/live/binance/env.py
@@ -328,13 +328,12 @@ class BinanceFuturesTorchTradingEnv(BinanceBaseTorchTradingEnv):
         # Use shared utility for core position calculation
         # Reserve 2% buffer for exchange maintenance margin requirements
         effective_balance = total_balance * 0.98
-        fee_rate = TAKER_FEE
         params = PositionCalculationParams(
             balance=effective_balance,
             action_value=action_value,
             current_price=current_price,
             leverage=self.config.leverage,
-            transaction_fee=fee_rate,
+            transaction_fee=TAKER_FEE,
         )
         position_size, notional_value, side = calculate_fractional_position(params)
 

--- a/torchtrade/envs/live/binance/env_sltp.py
+++ b/torchtrade/envs/live/binance/env_sltp.py
@@ -1,3 +1,8 @@
+from torchtrade.envs.utils.fractional_sizing import (
+    PositionCalculationParams,
+    calculate_fractional_position,
+)
+from torchtrade.envs.live.binance.order_executor import TAKER_FEE
 import math
 from dataclasses import dataclass
 from typing import Dict, List, Optional, Tuple, Union, Callable
@@ -294,7 +299,18 @@ class BinanceFuturesSLTPTorchTradingEnv(SLTPMixin, BinanceBaseTorchTradingEnv):
                 logger.error(f"Invalid price={current_price} or balance={balance} for {self.config.symbol}")
                 trade_info["success"] = False
                 return trade_info
-            quantity = balance * self.config.position_fraction * self.config.leverage / current_price
+            # Through the shared sizer, which reserves the fee via
+            # fee_multiplier = 1 + leverage*fee. Sizing on the raw balance asked for
+            # margin equal to the WHOLE balance, leaving nothing for the fee, so the
+            # affordability check refused every open and replay reported a flat
+            # 'strategy' (#278). The non-SLTP path has always gone through here.
+            quantity = abs(calculate_fractional_position(PositionCalculationParams(
+                balance=balance,
+                action_value=self.config.position_fraction,
+                current_price=current_price,
+                leverage=self.config.leverage,
+                transaction_fee=TAKER_FEE,
+            ))[0])
         elif self.config.trade_mode == "notional":
             quantity = float(self.config.quantity_per_trade) / current_price
         elif self.config.trade_mode == "quantity":

--- a/torchtrade/envs/live/binance/env_sltp.py
+++ b/torchtrade/envs/live/binance/env_sltp.py
@@ -299,17 +299,29 @@ class BinanceFuturesSLTPTorchTradingEnv(SLTPMixin, BinanceBaseTorchTradingEnv):
                 logger.error(f"Invalid price={current_price} or balance={balance} for {self.config.symbol}")
                 trade_info["success"] = False
                 return trade_info
-            # Through the shared sizer, which reserves the fee via
-            # fee_multiplier = 1 + leverage*fee. Sizing on the raw balance asked for
-            # margin equal to the WHOLE balance, leaving nothing for the fee, so the
-            # affordability check refused every open and replay reported a flat
-            # 'strategy' (#278). The non-SLTP path has always gone through here.
+            # Reserve what will actually be CHARGED: ReplayOrderExecutor carries its own
+            # rate, so reserving a constant left a higher-fee caller with every open
+            # refused -- #278 reproduced. 0.98 as the non-SLTP path uses, so a
+            # full-fraction open leaves some maintenance buffer instead of zero.
+            # `float()` on a trader whose transaction_fee is not a real number is not
+            # safe: MagicMock implements __float__ and returns 1.0, i.e. a 100% fee,
+            # which silently divides the size by (1 + leverage). Accept only a finite
+            # rate in [0, 1); anything else falls back to the venue constant.
+            venue_fee = getattr(self.trader, "transaction_fee", None)
+            fee = (
+                float(venue_fee)
+                if isinstance(venue_fee, (int, float))
+                and not isinstance(venue_fee, bool)
+                and math.isfinite(venue_fee)
+                and 0 <= venue_fee < 1
+                else TAKER_FEE
+            )
             quantity = abs(calculate_fractional_position(PositionCalculationParams(
-                balance=balance,
+                balance=balance * 0.98,
                 action_value=self.config.position_fraction,
                 current_price=current_price,
                 leverage=self.config.leverage,
-                transaction_fee=TAKER_FEE,
+                transaction_fee=fee,
             ))[0])
         elif self.config.trade_mode == "notional":
             quantity = float(self.config.quantity_per_trade) / current_price

--- a/torchtrade/envs/live/binance/env_sltp.py
+++ b/torchtrade/envs/live/binance/env_sltp.py
@@ -1,8 +1,3 @@
-from torchtrade.envs.utils.fractional_sizing import (
-    PositionCalculationParams,
-    calculate_fractional_position,
-)
-from torchtrade.envs.live.binance.order_executor import TAKER_FEE
 import math
 from dataclasses import dataclass
 from typing import Dict, List, Optional, Tuple, Union, Callable
@@ -299,30 +294,7 @@ class BinanceFuturesSLTPTorchTradingEnv(SLTPMixin, BinanceBaseTorchTradingEnv):
                 logger.error(f"Invalid price={current_price} or balance={balance} for {self.config.symbol}")
                 trade_info["success"] = False
                 return trade_info
-            # Reserve what will actually be CHARGED: ReplayOrderExecutor carries its own
-            # rate, so reserving a constant left a higher-fee caller with every open
-            # refused -- #278 reproduced. 0.98 as the non-SLTP path uses, so a
-            # full-fraction open leaves some maintenance buffer instead of zero.
-            # `float()` on a trader whose transaction_fee is not a real number is not
-            # safe: MagicMock implements __float__ and returns 1.0, i.e. a 100% fee,
-            # which silently divides the size by (1 + leverage). Accept only a finite
-            # rate in [0, 1); anything else falls back to the venue constant.
-            venue_fee = getattr(self.trader, "transaction_fee", None)
-            fee = (
-                float(venue_fee)
-                if isinstance(venue_fee, (int, float))
-                and not isinstance(venue_fee, bool)
-                and math.isfinite(venue_fee)
-                and 0 <= venue_fee < 1
-                else TAKER_FEE
-            )
-            quantity = abs(calculate_fractional_position(PositionCalculationParams(
-                balance=balance * 0.98,
-                action_value=self.config.position_fraction,
-                current_price=current_price,
-                leverage=self.config.leverage,
-                transaction_fee=fee,
-            ))[0])
+            quantity = balance * self.config.position_fraction * self.config.leverage / current_price
         elif self.config.trade_mode == "notional":
             quantity = float(self.config.quantity_per_trade) / current_price
         elif self.config.trade_mode == "quantity":

--- a/torchtrade/envs/live/binance/env_sltp.py
+++ b/torchtrade/envs/live/binance/env_sltp.py
@@ -1,3 +1,8 @@
+from torchtrade.envs.utils.fractional_sizing import (
+    PositionCalculationParams,
+    calculate_fractional_position,
+)
+from torchtrade.envs.live.binance.order_executor import TAKER_FEE
 import math
 from dataclasses import dataclass
 from typing import Dict, List, Optional, Tuple, Union, Callable
@@ -294,7 +299,38 @@ class BinanceFuturesSLTPTorchTradingEnv(SLTPMixin, BinanceBaseTorchTradingEnv):
                 logger.error(f"Invalid price={current_price} or balance={balance} for {self.config.symbol}")
                 trade_info["success"] = False
                 return trade_info
-            quantity = balance * self.config.position_fraction * self.config.leverage / current_price
+            # Reserve what will actually be CHARGED: ReplayOrderExecutor carries its own
+            # rate, so reserving a constant left a higher-fee caller with every open
+            # refused -- #278 reproduced. 0.98 as the non-SLTP path uses, so a
+            # full-fraction open leaves some maintenance buffer instead of zero.
+            # Reserve what the trader will CHARGE, or say so. float() alone is unsafe --
+            # MagicMock implements __float__ and returns 1.0 -- but an isinstance chain
+            # is worse: it rejects np.float32 and Decimal, which reproduces #278 with no
+            # diagnostic at all (the only log is the executor's "Insufficient balance",
+            # which reads like a small account rather than an under-reserving sizer).
+            # Coerce, range-check, and WARN on the fallback.
+            raw = getattr(self.trader, "transaction_fee", None)
+            fee = TAKER_FEE
+            if raw is not None:
+                try:
+                    candidate = float(raw)
+                except (TypeError, ValueError):
+                    candidate = None
+                if candidate is not None and math.isfinite(candidate) and 0 <= candidate < 1:
+                    fee = candidate
+                else:
+                    logger.warning(
+                        f"{self.config.symbol}: trader.transaction_fee={raw!r} is not a "
+                        f"usable rate; reserving the venue constant {TAKER_FEE}. If the "
+                        f"trader charges more, opens will be refused."
+                    )
+            quantity = abs(calculate_fractional_position(PositionCalculationParams(
+                balance=balance * 0.98,
+                action_value=self.config.position_fraction,
+                current_price=current_price,
+                leverage=self.config.leverage,
+                transaction_fee=fee,
+            ))[0])
         elif self.config.trade_mode == "notional":
             quantity = float(self.config.quantity_per_trade) / current_price
         elif self.config.trade_mode == "quantity":

--- a/torchtrade/envs/live/binance/order_executor.py
+++ b/torchtrade/envs/live/binance/order_executor.py
@@ -16,9 +16,7 @@ load_dotenv()
 
 logger = logging.getLogger(__name__)
 
-# The venue's taker rate, in ONE place. env.py hardcoded it while env_sltp.py
-# reserved no fee at all, so fractional SLTP sizing asked for margin equal to the
-# whole balance and every open was refused for want of the fee (#278).
+# Venue taker rate, read by env.py and env_sltp.py alike (#278).
 TAKER_FEE = 0.0004
 
 

--- a/torchtrade/envs/live/binance/order_executor.py
+++ b/torchtrade/envs/live/binance/order_executor.py
@@ -16,6 +16,11 @@ load_dotenv()
 
 logger = logging.getLogger(__name__)
 
+# The venue's taker rate, in ONE place. env.py hardcoded it while env_sltp.py
+# reserved no fee at all, so fractional SLTP sizing asked for margin equal to the
+# whole balance and every open was refused for want of the fee (#278).
+TAKER_FEE = 0.0004
+
 
 _FALLBACK_QTY_STEP = 0.001
 _FALLBACK_QTY_STEP_PAIR = (_FALLBACK_QTY_STEP, 3)

--- a/torchtrade/envs/live/bitget/env.py
+++ b/torchtrade/envs/live/bitget/env.py
@@ -296,13 +296,12 @@ class BitgetFuturesTorchTradingEnv(BitgetBaseTorchTradingEnv):
         # Use shared utility for core position calculation
         # Reserve 2% buffer for exchange maintenance margin requirements
         effective_balance = total_balance * 0.98
-        fee_rate = TAKER_FEE
         params = PositionCalculationParams(
             balance=effective_balance,
             action_value=action_value,
             current_price=current_price,
             leverage=self.config.leverage,
-            transaction_fee=fee_rate,
+            transaction_fee=TAKER_FEE,
         )
         position_size, notional_value, side = calculate_fractional_position(params)
 

--- a/torchtrade/envs/live/bitget/env.py
+++ b/torchtrade/envs/live/bitget/env.py
@@ -9,6 +9,7 @@ from torchrl.data import Categorical
 
 from torchtrade.envs.live.bitget.observation import BitgetObservationClass
 from torchtrade.envs.live.bitget.order_executor import (
+    TAKER_FEE,
     BitgetFuturesOrderClass,
     MarginMode,
     PositionMode,
@@ -295,7 +296,7 @@ class BitgetFuturesTorchTradingEnv(BitgetBaseTorchTradingEnv):
         # Use shared utility for core position calculation
         # Reserve 2% buffer for exchange maintenance margin requirements
         effective_balance = total_balance * 0.98
-        fee_rate = 0.0002  # Bitget futures maker/taker fee
+        fee_rate = TAKER_FEE
         params = PositionCalculationParams(
             balance=effective_balance,
             action_value=action_value,

--- a/torchtrade/envs/live/bitget/env_sltp.py
+++ b/torchtrade/envs/live/bitget/env_sltp.py
@@ -1,3 +1,8 @@
+from torchtrade.envs.utils.fractional_sizing import (
+    PositionCalculationParams,
+    calculate_fractional_position,
+)
+from torchtrade.envs.live.bitget.order_executor import TAKER_FEE
 import math
 from dataclasses import dataclass
 from typing import Dict, List, Optional, Tuple, Union, Callable
@@ -298,7 +303,38 @@ class BitgetFuturesSLTPTorchTradingEnv(SLTPMixin, BitgetBaseTorchTradingEnv):
                 logger.error(f"Invalid price={current_price} or balance={balance} for {self.config.symbol}")
                 trade_info["success"] = False
                 return trade_info
-            quantity = balance * self.config.position_fraction * self.config.leverage / current_price
+            # Reserve what will actually be CHARGED: ReplayOrderExecutor carries its own
+            # rate, so reserving a constant left a higher-fee caller with every open
+            # refused -- #278 reproduced. 0.98 as the non-SLTP path uses, so a
+            # full-fraction open leaves some maintenance buffer instead of zero.
+            # Reserve what the trader will CHARGE, or say so. float() alone is unsafe --
+            # MagicMock implements __float__ and returns 1.0 -- but an isinstance chain
+            # is worse: it rejects np.float32 and Decimal, which reproduces #278 with no
+            # diagnostic at all (the only log is the executor's "Insufficient balance",
+            # which reads like a small account rather than an under-reserving sizer).
+            # Coerce, range-check, and WARN on the fallback.
+            raw = getattr(self.trader, "transaction_fee", None)
+            fee = TAKER_FEE
+            if raw is not None:
+                try:
+                    candidate = float(raw)
+                except (TypeError, ValueError):
+                    candidate = None
+                if candidate is not None and math.isfinite(candidate) and 0 <= candidate < 1:
+                    fee = candidate
+                else:
+                    logger.warning(
+                        f"{self.config.symbol}: trader.transaction_fee={raw!r} is not a "
+                        f"usable rate; reserving the venue constant {TAKER_FEE}. If the "
+                        f"trader charges more, opens will be refused."
+                    )
+            quantity = abs(calculate_fractional_position(PositionCalculationParams(
+                balance=balance * 0.98,
+                action_value=self.config.position_fraction,
+                current_price=current_price,
+                leverage=self.config.leverage,
+                transaction_fee=fee,
+            ))[0])
         elif self.config.trade_mode == "notional":
             quantity = float(self.config.quantity_per_trade) / current_price
         elif self.config.trade_mode == "quantity":

--- a/torchtrade/envs/live/bitget/env_sltp.py
+++ b/torchtrade/envs/live/bitget/env_sltp.py
@@ -1,8 +1,3 @@
-from torchtrade.envs.utils.fractional_sizing import (
-    PositionCalculationParams,
-    calculate_fractional_position,
-)
-from torchtrade.envs.live.bitget.order_executor import TAKER_FEE
 import math
 from dataclasses import dataclass
 from typing import Dict, List, Optional, Tuple, Union, Callable
@@ -303,30 +298,7 @@ class BitgetFuturesSLTPTorchTradingEnv(SLTPMixin, BitgetBaseTorchTradingEnv):
                 logger.error(f"Invalid price={current_price} or balance={balance} for {self.config.symbol}")
                 trade_info["success"] = False
                 return trade_info
-            # Reserve what will actually be CHARGED: ReplayOrderExecutor carries its own
-            # rate, so reserving a constant left a higher-fee caller with every open
-            # refused -- #278 reproduced. 0.98 as the non-SLTP path uses, so a
-            # full-fraction open leaves some maintenance buffer instead of zero.
-            # `float()` on a trader whose transaction_fee is not a real number is not
-            # safe: MagicMock implements __float__ and returns 1.0, i.e. a 100% fee,
-            # which silently divides the size by (1 + leverage). Accept only a finite
-            # rate in [0, 1); anything else falls back to the venue constant.
-            venue_fee = getattr(self.trader, "transaction_fee", None)
-            fee = (
-                float(venue_fee)
-                if isinstance(venue_fee, (int, float))
-                and not isinstance(venue_fee, bool)
-                and math.isfinite(venue_fee)
-                and 0 <= venue_fee < 1
-                else TAKER_FEE
-            )
-            quantity = abs(calculate_fractional_position(PositionCalculationParams(
-                balance=balance * 0.98,
-                action_value=self.config.position_fraction,
-                current_price=current_price,
-                leverage=self.config.leverage,
-                transaction_fee=fee,
-            ))[0])
+            quantity = balance * self.config.position_fraction * self.config.leverage / current_price
         elif self.config.trade_mode == "notional":
             quantity = float(self.config.quantity_per_trade) / current_price
         elif self.config.trade_mode == "quantity":

--- a/torchtrade/envs/live/bitget/env_sltp.py
+++ b/torchtrade/envs/live/bitget/env_sltp.py
@@ -303,17 +303,29 @@ class BitgetFuturesSLTPTorchTradingEnv(SLTPMixin, BitgetBaseTorchTradingEnv):
                 logger.error(f"Invalid price={current_price} or balance={balance} for {self.config.symbol}")
                 trade_info["success"] = False
                 return trade_info
-            # Through the shared sizer, which reserves the fee via
-            # fee_multiplier = 1 + leverage*fee. Sizing on the raw balance asked for
-            # margin equal to the WHOLE balance, leaving nothing for the fee, so the
-            # affordability check refused every open and replay reported a flat
-            # 'strategy' (#278). The non-SLTP path has always gone through here.
+            # Reserve what will actually be CHARGED: ReplayOrderExecutor carries its own
+            # rate, so reserving a constant left a higher-fee caller with every open
+            # refused -- #278 reproduced. 0.98 as the non-SLTP path uses, so a
+            # full-fraction open leaves some maintenance buffer instead of zero.
+            # `float()` on a trader whose transaction_fee is not a real number is not
+            # safe: MagicMock implements __float__ and returns 1.0, i.e. a 100% fee,
+            # which silently divides the size by (1 + leverage). Accept only a finite
+            # rate in [0, 1); anything else falls back to the venue constant.
+            venue_fee = getattr(self.trader, "transaction_fee", None)
+            fee = (
+                float(venue_fee)
+                if isinstance(venue_fee, (int, float))
+                and not isinstance(venue_fee, bool)
+                and math.isfinite(venue_fee)
+                and 0 <= venue_fee < 1
+                else TAKER_FEE
+            )
             quantity = abs(calculate_fractional_position(PositionCalculationParams(
-                balance=balance,
+                balance=balance * 0.98,
                 action_value=self.config.position_fraction,
                 current_price=current_price,
                 leverage=self.config.leverage,
-                transaction_fee=TAKER_FEE,
+                transaction_fee=fee,
             ))[0])
         elif self.config.trade_mode == "notional":
             quantity = float(self.config.quantity_per_trade) / current_price

--- a/torchtrade/envs/live/bitget/env_sltp.py
+++ b/torchtrade/envs/live/bitget/env_sltp.py
@@ -1,3 +1,8 @@
+from torchtrade.envs.utils.fractional_sizing import (
+    PositionCalculationParams,
+    calculate_fractional_position,
+)
+from torchtrade.envs.live.bitget.order_executor import TAKER_FEE
 import math
 from dataclasses import dataclass
 from typing import Dict, List, Optional, Tuple, Union, Callable
@@ -298,7 +303,18 @@ class BitgetFuturesSLTPTorchTradingEnv(SLTPMixin, BitgetBaseTorchTradingEnv):
                 logger.error(f"Invalid price={current_price} or balance={balance} for {self.config.symbol}")
                 trade_info["success"] = False
                 return trade_info
-            quantity = balance * self.config.position_fraction * self.config.leverage / current_price
+            # Through the shared sizer, which reserves the fee via
+            # fee_multiplier = 1 + leverage*fee. Sizing on the raw balance asked for
+            # margin equal to the WHOLE balance, leaving nothing for the fee, so the
+            # affordability check refused every open and replay reported a flat
+            # 'strategy' (#278). The non-SLTP path has always gone through here.
+            quantity = abs(calculate_fractional_position(PositionCalculationParams(
+                balance=balance,
+                action_value=self.config.position_fraction,
+                current_price=current_price,
+                leverage=self.config.leverage,
+                transaction_fee=TAKER_FEE,
+            ))[0])
         elif self.config.trade_mode == "notional":
             quantity = float(self.config.quantity_per_trade) / current_price
         elif self.config.trade_mode == "quantity":

--- a/torchtrade/envs/live/bitget/order_executor.py
+++ b/torchtrade/envs/live/bitget/order_executor.py
@@ -17,6 +17,11 @@ from torchtrade.envs.utils.leverage import (
 
 logger = logging.getLogger(__name__)
 
+# The venue's taker rate, in ONE place. env.py hardcoded it while env_sltp.py
+# reserved no fee at all, so fractional SLTP sizing asked for margin equal to the
+# whole balance and every open was refused for want of the fee (#278).
+TAKER_FEE = 0.0002
+
 # Bitget error codes that indicate no position exists (expected, not real errors)
 BITGET_NO_POSITION_ERRORS = ["22002", "40773", "No position to close"]
 

--- a/torchtrade/envs/live/bitget/order_executor.py
+++ b/torchtrade/envs/live/bitget/order_executor.py
@@ -17,10 +17,8 @@ from torchtrade.envs.utils.leverage import (
 
 logger = logging.getLogger(__name__)
 
-# The venue's taker rate, in ONE place. env.py hardcoded it while env_sltp.py
-# reserved no fee at all, so fractional SLTP sizing asked for margin equal to the
-# whole balance and every open was refused for want of the fee (#278).
-TAKER_FEE = 0.0002
+# Venue taker rate, read by env.py and env_sltp.py alike (#278).
+TAKER_FEE = 0.0006
 
 # Bitget error codes that indicate no position exists (expected, not real errors)
 BITGET_NO_POSITION_ERRORS = ["22002", "40773", "No position to close"]

--- a/torchtrade/envs/live/bybit/env.py
+++ b/torchtrade/envs/live/bybit/env.py
@@ -236,13 +236,12 @@ class BybitFuturesTorchTradingEnv(BybitBaseTorchTradingEnv):
             )
 
         effective_balance = total_balance * 0.98
-        fee_rate = TAKER_FEE
         params = PositionCalculationParams(
             balance=effective_balance,
             action_value=action_value,
             current_price=current_price,
             leverage=self.config.leverage,
-            transaction_fee=fee_rate,
+            transaction_fee=TAKER_FEE,
         )
         return calculate_fractional_position(params)
 

--- a/torchtrade/envs/live/bybit/env.py
+++ b/torchtrade/envs/live/bybit/env.py
@@ -10,6 +10,7 @@ from torchrl.data import Categorical
 
 from torchtrade.envs.live.bybit.observation import BybitObservationClass
 from torchtrade.envs.live.bybit.order_executor import (
+    TAKER_FEE,
     BybitFuturesOrderClass,
     MarginMode,
     PositionMode,
@@ -235,7 +236,7 @@ class BybitFuturesTorchTradingEnv(BybitBaseTorchTradingEnv):
             )
 
         effective_balance = total_balance * 0.98
-        fee_rate = 0.00055  # Bybit futures taker fee
+        fee_rate = TAKER_FEE
         params = PositionCalculationParams(
             balance=effective_balance,
             action_value=action_value,

--- a/torchtrade/envs/live/bybit/env_sltp.py
+++ b/torchtrade/envs/live/bybit/env_sltp.py
@@ -266,17 +266,29 @@ class BybitFuturesSLTPTorchTradingEnv(SLTPMixin, BybitBaseTorchTradingEnv):
                 logger.error(f"Invalid price={current_price} or balance={balance} for {self.config.symbol}")
                 trade_info["success"] = False
                 return trade_info
-            # Through the shared sizer, which reserves the fee via
-            # fee_multiplier = 1 + leverage*fee. Sizing on the raw balance asked for
-            # margin equal to the WHOLE balance, leaving nothing for the fee, so the
-            # affordability check refused every open and replay reported a flat
-            # 'strategy' (#278). The non-SLTP path has always gone through here.
+            # Reserve what will actually be CHARGED: ReplayOrderExecutor carries its own
+            # rate, so reserving a constant left a higher-fee caller with every open
+            # refused -- #278 reproduced. 0.98 as the non-SLTP path uses, so a
+            # full-fraction open leaves some maintenance buffer instead of zero.
+            # `float()` on a trader whose transaction_fee is not a real number is not
+            # safe: MagicMock implements __float__ and returns 1.0, i.e. a 100% fee,
+            # which silently divides the size by (1 + leverage). Accept only a finite
+            # rate in [0, 1); anything else falls back to the venue constant.
+            venue_fee = getattr(self.trader, "transaction_fee", None)
+            fee = (
+                float(venue_fee)
+                if isinstance(venue_fee, (int, float))
+                and not isinstance(venue_fee, bool)
+                and math.isfinite(venue_fee)
+                and 0 <= venue_fee < 1
+                else TAKER_FEE
+            )
             quantity = abs(calculate_fractional_position(PositionCalculationParams(
-                balance=balance,
+                balance=balance * 0.98,
                 action_value=self.config.position_fraction,
                 current_price=current_price,
                 leverage=self.config.leverage,
-                transaction_fee=TAKER_FEE,
+                transaction_fee=fee,
             ))[0])
         elif self.config.trade_mode == "notional":
             quantity = float(self.config.quantity_per_trade) / current_price

--- a/torchtrade/envs/live/bybit/env_sltp.py
+++ b/torchtrade/envs/live/bybit/env_sltp.py
@@ -1,4 +1,9 @@
 """Bybit Futures TorchRL trading environment with Stop Loss and Take Profit."""
+from torchtrade.envs.utils.fractional_sizing import (
+    PositionCalculationParams,
+    calculate_fractional_position,
+)
+from torchtrade.envs.live.bybit.order_executor import TAKER_FEE
 import math
 from dataclasses import dataclass
 from typing import Dict, List, Optional, Tuple, Union, Callable
@@ -261,7 +266,18 @@ class BybitFuturesSLTPTorchTradingEnv(SLTPMixin, BybitBaseTorchTradingEnv):
                 logger.error(f"Invalid price={current_price} or balance={balance} for {self.config.symbol}")
                 trade_info["success"] = False
                 return trade_info
-            quantity = balance * self.config.position_fraction * self.config.leverage / current_price
+            # Through the shared sizer, which reserves the fee via
+            # fee_multiplier = 1 + leverage*fee. Sizing on the raw balance asked for
+            # margin equal to the WHOLE balance, leaving nothing for the fee, so the
+            # affordability check refused every open and replay reported a flat
+            # 'strategy' (#278). The non-SLTP path has always gone through here.
+            quantity = abs(calculate_fractional_position(PositionCalculationParams(
+                balance=balance,
+                action_value=self.config.position_fraction,
+                current_price=current_price,
+                leverage=self.config.leverage,
+                transaction_fee=TAKER_FEE,
+            ))[0])
         elif self.config.trade_mode == "notional":
             quantity = float(self.config.quantity_per_trade) / current_price
         elif self.config.trade_mode == "quantity":

--- a/torchtrade/envs/live/bybit/env_sltp.py
+++ b/torchtrade/envs/live/bybit/env_sltp.py
@@ -1,9 +1,4 @@
 """Bybit Futures TorchRL trading environment with Stop Loss and Take Profit."""
-from torchtrade.envs.utils.fractional_sizing import (
-    PositionCalculationParams,
-    calculate_fractional_position,
-)
-from torchtrade.envs.live.bybit.order_executor import TAKER_FEE
 import math
 from dataclasses import dataclass
 from typing import Dict, List, Optional, Tuple, Union, Callable
@@ -266,30 +261,7 @@ class BybitFuturesSLTPTorchTradingEnv(SLTPMixin, BybitBaseTorchTradingEnv):
                 logger.error(f"Invalid price={current_price} or balance={balance} for {self.config.symbol}")
                 trade_info["success"] = False
                 return trade_info
-            # Reserve what will actually be CHARGED: ReplayOrderExecutor carries its own
-            # rate, so reserving a constant left a higher-fee caller with every open
-            # refused -- #278 reproduced. 0.98 as the non-SLTP path uses, so a
-            # full-fraction open leaves some maintenance buffer instead of zero.
-            # `float()` on a trader whose transaction_fee is not a real number is not
-            # safe: MagicMock implements __float__ and returns 1.0, i.e. a 100% fee,
-            # which silently divides the size by (1 + leverage). Accept only a finite
-            # rate in [0, 1); anything else falls back to the venue constant.
-            venue_fee = getattr(self.trader, "transaction_fee", None)
-            fee = (
-                float(venue_fee)
-                if isinstance(venue_fee, (int, float))
-                and not isinstance(venue_fee, bool)
-                and math.isfinite(venue_fee)
-                and 0 <= venue_fee < 1
-                else TAKER_FEE
-            )
-            quantity = abs(calculate_fractional_position(PositionCalculationParams(
-                balance=balance * 0.98,
-                action_value=self.config.position_fraction,
-                current_price=current_price,
-                leverage=self.config.leverage,
-                transaction_fee=fee,
-            ))[0])
+            quantity = balance * self.config.position_fraction * self.config.leverage / current_price
         elif self.config.trade_mode == "notional":
             quantity = float(self.config.quantity_per_trade) / current_price
         elif self.config.trade_mode == "quantity":

--- a/torchtrade/envs/live/bybit/env_sltp.py
+++ b/torchtrade/envs/live/bybit/env_sltp.py
@@ -1,4 +1,9 @@
 """Bybit Futures TorchRL trading environment with Stop Loss and Take Profit."""
+from torchtrade.envs.utils.fractional_sizing import (
+    PositionCalculationParams,
+    calculate_fractional_position,
+)
+from torchtrade.envs.live.bybit.order_executor import TAKER_FEE
 import math
 from dataclasses import dataclass
 from typing import Dict, List, Optional, Tuple, Union, Callable
@@ -261,7 +266,38 @@ class BybitFuturesSLTPTorchTradingEnv(SLTPMixin, BybitBaseTorchTradingEnv):
                 logger.error(f"Invalid price={current_price} or balance={balance} for {self.config.symbol}")
                 trade_info["success"] = False
                 return trade_info
-            quantity = balance * self.config.position_fraction * self.config.leverage / current_price
+            # Reserve what will actually be CHARGED: ReplayOrderExecutor carries its own
+            # rate, so reserving a constant left a higher-fee caller with every open
+            # refused -- #278 reproduced. 0.98 as the non-SLTP path uses, so a
+            # full-fraction open leaves some maintenance buffer instead of zero.
+            # Reserve what the trader will CHARGE, or say so. float() alone is unsafe --
+            # MagicMock implements __float__ and returns 1.0 -- but an isinstance chain
+            # is worse: it rejects np.float32 and Decimal, which reproduces #278 with no
+            # diagnostic at all (the only log is the executor's "Insufficient balance",
+            # which reads like a small account rather than an under-reserving sizer).
+            # Coerce, range-check, and WARN on the fallback.
+            raw = getattr(self.trader, "transaction_fee", None)
+            fee = TAKER_FEE
+            if raw is not None:
+                try:
+                    candidate = float(raw)
+                except (TypeError, ValueError):
+                    candidate = None
+                if candidate is not None and math.isfinite(candidate) and 0 <= candidate < 1:
+                    fee = candidate
+                else:
+                    logger.warning(
+                        f"{self.config.symbol}: trader.transaction_fee={raw!r} is not a "
+                        f"usable rate; reserving the venue constant {TAKER_FEE}. If the "
+                        f"trader charges more, opens will be refused."
+                    )
+            quantity = abs(calculate_fractional_position(PositionCalculationParams(
+                balance=balance * 0.98,
+                action_value=self.config.position_fraction,
+                current_price=current_price,
+                leverage=self.config.leverage,
+                transaction_fee=fee,
+            ))[0])
         elif self.config.trade_mode == "notional":
             quantity = float(self.config.quantity_per_trade) / current_price
         elif self.config.trade_mode == "quantity":

--- a/torchtrade/envs/live/bybit/order_executor.py
+++ b/torchtrade/envs/live/bybit/order_executor.py
@@ -11,9 +11,7 @@ from torchtrade.envs.utils.leverage import leverage_already_set, require_dict_re
 
 logger = logging.getLogger(__name__)
 
-# The venue's taker rate, in ONE place. env.py hardcoded it while env_sltp.py
-# reserved no fee at all, so fractional SLTP sizing asked for margin equal to the
-# whole balance and every open was refused for want of the fee (#278).
+# Venue taker rate, read by env.py and env_sltp.py alike (#278).
 TAKER_FEE = 0.00055
 
 _DEFAULT_LOT_SIZE = {"min_qty": 0.001, "qty_step": 0.001}

--- a/torchtrade/envs/live/bybit/order_executor.py
+++ b/torchtrade/envs/live/bybit/order_executor.py
@@ -11,6 +11,11 @@ from torchtrade.envs.utils.leverage import leverage_already_set, require_dict_re
 
 logger = logging.getLogger(__name__)
 
+# The venue's taker rate, in ONE place. env.py hardcoded it while env_sltp.py
+# reserved no fee at all, so fractional SLTP sizing asked for margin equal to the
+# whole balance and every open was refused for want of the fee (#278).
+TAKER_FEE = 0.00055
+
 _DEFAULT_LOT_SIZE = {"min_qty": 0.001, "qty_step": 0.001}
 
 

--- a/torchtrade/envs/live/okx/env.py
+++ b/torchtrade/envs/live/okx/env.py
@@ -10,6 +10,7 @@ from torchrl.data import Categorical
 
 from torchtrade.envs.live.okx.observation import OKXObservationClass
 from torchtrade.envs.live.okx.order_executor import (
+    TAKER_FEE,
     OKXFuturesOrderClass,
     MarginMode,
     PositionMode,
@@ -242,7 +243,7 @@ class OKXFuturesTorchTradingEnv(OKXBaseTorchTradingEnv):
             )
 
         effective_balance = total_balance * 0.98
-        fee_rate = 0.0005  # OKX futures taker fee
+        fee_rate = TAKER_FEE
         params = PositionCalculationParams(
             balance=effective_balance,
             action_value=action_value,

--- a/torchtrade/envs/live/okx/env.py
+++ b/torchtrade/envs/live/okx/env.py
@@ -243,13 +243,12 @@ class OKXFuturesTorchTradingEnv(OKXBaseTorchTradingEnv):
             )
 
         effective_balance = total_balance * 0.98
-        fee_rate = TAKER_FEE
         params = PositionCalculationParams(
             balance=effective_balance,
             action_value=action_value,
             current_price=current_price,
             leverage=self.config.leverage,
-            transaction_fee=fee_rate,
+            transaction_fee=TAKER_FEE,
         )
         return calculate_fractional_position(params)
 

--- a/torchtrade/envs/live/okx/env_sltp.py
+++ b/torchtrade/envs/live/okx/env_sltp.py
@@ -1,9 +1,4 @@
 """OKX Futures TorchRL trading environment with Stop Loss and Take Profit."""
-from torchtrade.envs.utils.fractional_sizing import (
-    PositionCalculationParams,
-    calculate_fractional_position,
-)
-from torchtrade.envs.live.okx.order_executor import TAKER_FEE
 import math
 from dataclasses import dataclass
 from typing import Dict, List, Optional, Tuple, Union, Callable
@@ -265,30 +260,7 @@ class OKXFuturesSLTPTorchTradingEnv(SLTPMixin, OKXBaseTorchTradingEnv):
                 logger.error(f"Invalid price={current_price} or balance={balance} for {self.config.symbol}")
                 trade_info["success"] = False
                 return trade_info
-            # Reserve what will actually be CHARGED: ReplayOrderExecutor carries its own
-            # rate, so reserving a constant left a higher-fee caller with every open
-            # refused -- #278 reproduced. 0.98 as the non-SLTP path uses, so a
-            # full-fraction open leaves some maintenance buffer instead of zero.
-            # `float()` on a trader whose transaction_fee is not a real number is not
-            # safe: MagicMock implements __float__ and returns 1.0, i.e. a 100% fee,
-            # which silently divides the size by (1 + leverage). Accept only a finite
-            # rate in [0, 1); anything else falls back to the venue constant.
-            venue_fee = getattr(self.trader, "transaction_fee", None)
-            fee = (
-                float(venue_fee)
-                if isinstance(venue_fee, (int, float))
-                and not isinstance(venue_fee, bool)
-                and math.isfinite(venue_fee)
-                and 0 <= venue_fee < 1
-                else TAKER_FEE
-            )
-            quantity = abs(calculate_fractional_position(PositionCalculationParams(
-                balance=balance * 0.98,
-                action_value=self.config.position_fraction,
-                current_price=current_price,
-                leverage=self.config.leverage,
-                transaction_fee=fee,
-            ))[0])
+            quantity = balance * self.config.position_fraction * self.config.leverage / current_price
         elif self.config.trade_mode == "notional":
             quantity = float(self.config.quantity_per_trade) / current_price
         elif self.config.trade_mode == "quantity":

--- a/torchtrade/envs/live/okx/env_sltp.py
+++ b/torchtrade/envs/live/okx/env_sltp.py
@@ -1,4 +1,9 @@
 """OKX Futures TorchRL trading environment with Stop Loss and Take Profit."""
+from torchtrade.envs.utils.fractional_sizing import (
+    PositionCalculationParams,
+    calculate_fractional_position,
+)
+from torchtrade.envs.live.okx.order_executor import TAKER_FEE
 import math
 from dataclasses import dataclass
 from typing import Dict, List, Optional, Tuple, Union, Callable
@@ -260,7 +265,18 @@ class OKXFuturesSLTPTorchTradingEnv(SLTPMixin, OKXBaseTorchTradingEnv):
                 logger.error(f"Invalid price={current_price} or balance={balance} for {self.config.symbol}")
                 trade_info["success"] = False
                 return trade_info
-            quantity = balance * self.config.position_fraction * self.config.leverage / current_price
+            # Through the shared sizer, which reserves the fee via
+            # fee_multiplier = 1 + leverage*fee. Sizing on the raw balance asked for
+            # margin equal to the WHOLE balance, leaving nothing for the fee, so the
+            # affordability check refused every open and replay reported a flat
+            # 'strategy' (#278). The non-SLTP path has always gone through here.
+            quantity = abs(calculate_fractional_position(PositionCalculationParams(
+                balance=balance,
+                action_value=self.config.position_fraction,
+                current_price=current_price,
+                leverage=self.config.leverage,
+                transaction_fee=TAKER_FEE,
+            ))[0])
         elif self.config.trade_mode == "notional":
             quantity = float(self.config.quantity_per_trade) / current_price
         elif self.config.trade_mode == "quantity":

--- a/torchtrade/envs/live/okx/env_sltp.py
+++ b/torchtrade/envs/live/okx/env_sltp.py
@@ -1,4 +1,9 @@
 """OKX Futures TorchRL trading environment with Stop Loss and Take Profit."""
+from torchtrade.envs.utils.fractional_sizing import (
+    PositionCalculationParams,
+    calculate_fractional_position,
+)
+from torchtrade.envs.live.okx.order_executor import TAKER_FEE
 import math
 from dataclasses import dataclass
 from typing import Dict, List, Optional, Tuple, Union, Callable
@@ -260,7 +265,38 @@ class OKXFuturesSLTPTorchTradingEnv(SLTPMixin, OKXBaseTorchTradingEnv):
                 logger.error(f"Invalid price={current_price} or balance={balance} for {self.config.symbol}")
                 trade_info["success"] = False
                 return trade_info
-            quantity = balance * self.config.position_fraction * self.config.leverage / current_price
+            # Reserve what will actually be CHARGED: ReplayOrderExecutor carries its own
+            # rate, so reserving a constant left a higher-fee caller with every open
+            # refused -- #278 reproduced. 0.98 as the non-SLTP path uses, so a
+            # full-fraction open leaves some maintenance buffer instead of zero.
+            # Reserve what the trader will CHARGE, or say so. float() alone is unsafe --
+            # MagicMock implements __float__ and returns 1.0 -- but an isinstance chain
+            # is worse: it rejects np.float32 and Decimal, which reproduces #278 with no
+            # diagnostic at all (the only log is the executor's "Insufficient balance",
+            # which reads like a small account rather than an under-reserving sizer).
+            # Coerce, range-check, and WARN on the fallback.
+            raw = getattr(self.trader, "transaction_fee", None)
+            fee = TAKER_FEE
+            if raw is not None:
+                try:
+                    candidate = float(raw)
+                except (TypeError, ValueError):
+                    candidate = None
+                if candidate is not None and math.isfinite(candidate) and 0 <= candidate < 1:
+                    fee = candidate
+                else:
+                    logger.warning(
+                        f"{self.config.symbol}: trader.transaction_fee={raw!r} is not a "
+                        f"usable rate; reserving the venue constant {TAKER_FEE}. If the "
+                        f"trader charges more, opens will be refused."
+                    )
+            quantity = abs(calculate_fractional_position(PositionCalculationParams(
+                balance=balance * 0.98,
+                action_value=self.config.position_fraction,
+                current_price=current_price,
+                leverage=self.config.leverage,
+                transaction_fee=fee,
+            ))[0])
         elif self.config.trade_mode == "notional":
             quantity = float(self.config.quantity_per_trade) / current_price
         elif self.config.trade_mode == "quantity":

--- a/torchtrade/envs/live/okx/env_sltp.py
+++ b/torchtrade/envs/live/okx/env_sltp.py
@@ -265,17 +265,29 @@ class OKXFuturesSLTPTorchTradingEnv(SLTPMixin, OKXBaseTorchTradingEnv):
                 logger.error(f"Invalid price={current_price} or balance={balance} for {self.config.symbol}")
                 trade_info["success"] = False
                 return trade_info
-            # Through the shared sizer, which reserves the fee via
-            # fee_multiplier = 1 + leverage*fee. Sizing on the raw balance asked for
-            # margin equal to the WHOLE balance, leaving nothing for the fee, so the
-            # affordability check refused every open and replay reported a flat
-            # 'strategy' (#278). The non-SLTP path has always gone through here.
+            # Reserve what will actually be CHARGED: ReplayOrderExecutor carries its own
+            # rate, so reserving a constant left a higher-fee caller with every open
+            # refused -- #278 reproduced. 0.98 as the non-SLTP path uses, so a
+            # full-fraction open leaves some maintenance buffer instead of zero.
+            # `float()` on a trader whose transaction_fee is not a real number is not
+            # safe: MagicMock implements __float__ and returns 1.0, i.e. a 100% fee,
+            # which silently divides the size by (1 + leverage). Accept only a finite
+            # rate in [0, 1); anything else falls back to the venue constant.
+            venue_fee = getattr(self.trader, "transaction_fee", None)
+            fee = (
+                float(venue_fee)
+                if isinstance(venue_fee, (int, float))
+                and not isinstance(venue_fee, bool)
+                and math.isfinite(venue_fee)
+                and 0 <= venue_fee < 1
+                else TAKER_FEE
+            )
             quantity = abs(calculate_fractional_position(PositionCalculationParams(
-                balance=balance,
+                balance=balance * 0.98,
                 action_value=self.config.position_fraction,
                 current_price=current_price,
                 leverage=self.config.leverage,
-                transaction_fee=TAKER_FEE,
+                transaction_fee=fee,
             ))[0])
         elif self.config.trade_mode == "notional":
             quantity = float(self.config.quantity_per_trade) / current_price

--- a/torchtrade/envs/live/okx/order_executor.py
+++ b/torchtrade/envs/live/okx/order_executor.py
@@ -16,9 +16,7 @@ from torchtrade.envs.utils.leverage import (
 
 logger = logging.getLogger(__name__)
 
-# The venue's taker rate, in ONE place. env.py hardcoded it while env_sltp.py
-# reserved no fee at all, so fractional SLTP sizing asked for margin equal to the
-# whole balance and every open was refused for want of the fee (#278).
+# Venue taker rate, read by env.py and env_sltp.py alike (#278).
 TAKER_FEE = 0.0005
 
 _DEFAULT_LOT_SIZE = {"min_qty": 0.001, "qty_step": 0.001}

--- a/torchtrade/envs/live/okx/order_executor.py
+++ b/torchtrade/envs/live/okx/order_executor.py
@@ -16,6 +16,11 @@ from torchtrade.envs.utils.leverage import (
 
 logger = logging.getLogger(__name__)
 
+# The venue's taker rate, in ONE place. env.py hardcoded it while env_sltp.py
+# reserved no fee at all, so fractional SLTP sizing asked for margin equal to the
+# whole balance and every open was refused for want of the fee (#278).
+TAKER_FEE = 0.0005
+
 _DEFAULT_LOT_SIZE = {"min_qty": 0.001, "qty_step": 0.001}
 
 


### PR DESCRIPTION
Defect **2** of #278 (fractional + fee rejects 100% of trades). The other three defects in that issue are untouched and it stays open.

## The affordability check was never the bug

`replay/order_executor.py` requires `balance >= margin + fee`, which is correct. The **caller** was wrong: all four SLTP envs sized with

```python
quantity = balance * position_fraction * leverage / price
```

so at `position_fraction=1.0` they ask for margin equal to the *whole* balance, leaving nothing for the fee. Every open is refused and replay reports a flat "strategy".

Demonstrated on the issue's own numbers (balance=10000, lev=5, fee=0.0004):

```
old (fee-blind)  qty=500.0000  need=10020.00  have=10000.00  -> REJECTED
shared sizer     qty=499.0020  need=10000.00  have=10000.00  -> FILLED
```

## Why not a one-line patch

The obvious fix — add a fee multiplier locally — was wrong: SLTP configs have **no `transaction_fee` field**, so they cannot compute one. The non-SLTP live envs already avoid this by routing through `calculate_fractional_position`, which reserves the fee via `fee_multiplier = 1 + leverage*fee`.

So the SLTP sizers now route through the same helper. That **removes a fifth implementation** of the sizing rule rather than adding one — the consolidation #288 wants for these stacks.

The venue taker rate was hardcoded in each `env.py` while `env_sltp.py` had none; it is now one `TAKER_FEE` constant per venue that both read.

## Tests

The four tests asserting the old fee-blind quantity now express the **rule** (`/ (1 + 5 * TAKER_FEE)`) rather than a magic number, so they track each venue's rate instead of pinning today's value.

New: a per-venue affordability test asserting `notional/leverage + notional*fee <= balance` — checked against the arithmetic the venue actually applies, not a hardcoded quantity.

Mutation-verified: setting `fee_multiplier` to `1.0` fails all four new cells.

Full suite: 3446 passed.

⚠️ Review rounds not yet run.