### PR TITLE
docs: clear the docs/ half of the kwarg ratchet (#287)

### DIFF
--- a/docs/environments/online.md
+++ b/docs/environments/online.md
@@ -116,11 +116,10 @@ from torchtrade.envs.live.binance import BinanceFuturesTorchTradingEnv, BinanceF
 
 config = BinanceFuturesTradingEnvConfig(
     symbol="BTCUSDT",
-    intervals=["1m", "5m", "15m"],
+    time_frames=["1m", "5m", "15m"],
     window_sizes=[12, 8, 8],
     execute_on="1m",
     leverage=5,
-    quantity_per_trade=0.01,
     demo=True,  # Testnet (recommended!)
 )
 
@@ -134,7 +133,7 @@ from torchtrade.envs.live.binance import BinanceFuturesSLTPTorchTradingEnv, Bina
 
 config = BinanceFuturesSLTPTradingEnvConfig(
     symbol="BTCUSDT",
-    intervals=["1m", "5m"],
+    time_frames=["1m", "5m"],
     window_sizes=[12, 8],
     execute_on="1m",
     stoploss_levels=[-0.02, -0.05],
@@ -189,7 +188,6 @@ config = BitgetFuturesTradingEnvConfig(
     execute_on="1min",
     product_type="USDT-FUTURES",
     leverage=5,
-    quantity_per_trade=0.002,
     margin_mode=MarginMode.ISOLATED,     # ISOLATED (safer) or CROSSED
     position_mode=PositionMode.ONE_WAY,  # ONE_WAY (simpler) or HEDGE
     demo=True,

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -224,11 +224,10 @@ from torchtrade.envs.live.binance import (
 
 config = BinanceFuturesTradingEnvConfig(
     symbol="BTCUSDT",
-    intervals=["1m", "5m"],
+    time_frames=["1m", "5m"],
     window_sizes=[12, 8],
     execute_on="1m",
     leverage=5,                        # 5x leverage
-    quantity_per_trade=0.01,
     demo=True,                         # Use testnet
 )
 

--- a/docs/guides/custom-features.md
+++ b/docs/guides/custom-features.md
@@ -70,10 +70,10 @@ def custom_preprocessing(df: pd.DataFrame) -> pd.DataFrame:
     # Fill NaN values (important!)
     df.fillna(0, inplace=True)
 
-    return df
+    # timestamp must come back as a COLUMN, or the sampler raises
+    # KeyError: ['timestamp'] not in index
+    return df.reset_index()
 
-# feature_preprocessing_fn is a CONSTRUCTOR argument, not a config field:
-#   env = SequentialTradingEnv(df, config, custom_preprocessing)
 config = SequentialTradingEnvConfig(
     time_frames=["1min", "5min", "15min"],  # Note: use "1hour" not "60min"
     window_sizes=[12, 8, 8],
@@ -81,7 +81,8 @@ config = SequentialTradingEnvConfig(
     initial_cash=1000
 )
 
-env = SequentialTradingEnv(df, config)
+# feature_preprocessing_fn is the CONSTRUCTOR's third argument, not a config field.
+env = SequentialTradingEnv(df, config, custom_preprocessing)
 ```
 
 ### Example 2: Normalized Features (Recommended)
@@ -118,7 +119,9 @@ def normalized_preprocessing(df: pd.DataFrame) -> pd.DataFrame:
     # Fill NaN values
     df.fillna(0, inplace=True)
 
-    return df
+    # timestamp must come back as a COLUMN, or the sampler raises
+    # KeyError: ['timestamp'] not in index
+    return df.reset_index()
 
 config = SequentialTradingEnvConfig(
     ...
@@ -278,9 +281,9 @@ def binance_features(df: pd.DataFrame) -> pd.DataFrame:
     # Standard price features
     df["features_close"] = df["close"].pct_change().fillna(0)
     df.fillna(0, inplace=True)
-    # timestamp must come back as a COLUMN, or the sampler raises
-    # KeyError: ['timestamp'] not in index
-    return df.reset_index()
+    # No reset_index() here: the live observer hands this a RangeIndex frame and never
+    # touches the offline sampler, so there is no timestamp index to restore.
+    return df
 
 env = BinanceFuturesTorchTradingEnv(
     config=config,
@@ -298,7 +301,7 @@ Bitget (via CCXT) and Bybit (via pybit) kline APIs return only standard OHLCV co
 
 1. **Feature prefix** (when using `feature_preprocessing_fn`): All output columns MUST start with `features_` (e.g., `features_rsi_14`). Columns without this prefix are ignored. Without a preprocessing function, raw columns (OHLCV + auxiliary) are used directly.
 2. **Handle NaN**: Technical indicators produce NaN at the start. Always call `df.fillna(0, inplace=True)` (or `ffill`/`bfill`).
-3. **Return the DataFrame**: Your function must `return df`.
+3. **Return the DataFrame with `timestamp` as a COLUMN**: offline environments resample on a timestamp index, so a function that returns it as the index fails with `KeyError: ['timestamp'] not in index`. End with `return df.reset_index()`. Live observers hand you a RangeIndex frame instead, so `return df` is correct there.
 4. **No lookahead bias**: Only use past data. Never use `.shift(-1)` or future values.
 5. **List length must match**: When using a list of functions, it must have the same length as `time_frames`.
 

--- a/docs/guides/custom-features.md
+++ b/docs/guides/custom-features.md
@@ -72,12 +72,12 @@ def custom_preprocessing(df: pd.DataFrame) -> pd.DataFrame:
 
     return df
 
-# Use in environment config
+# feature_preprocessing_fn is a CONSTRUCTOR argument, not a config field:
+#   env = SequentialTradingEnv(df, config, custom_preprocessing)
 config = SequentialTradingEnvConfig(
-    feature_preprocessing_fn=custom_preprocessing,
     time_frames=["1min", "5min", "15min"],  # Note: use "1hour" not "60min"
     window_sizes=[12, 8, 8],
-    execute_on=(5, "Minute"),
+    execute_on="5Min",
     initial_cash=1000
 )
 
@@ -121,7 +121,6 @@ def normalized_preprocessing(df: pd.DataFrame) -> pd.DataFrame:
     return df
 
 config = SequentialTradingEnvConfig(
-    feature_preprocessing_fn=normalized_preprocessing,
     ...
 )
 ```
@@ -168,7 +167,6 @@ config = SequentialTradingEnvConfig(
     time_frames=["1min", "1hour"],
     window_sizes=[30, 10],
     execute_on="1min",
-    feature_preprocessing_fn=[process_1min, process_1hour],  # List of functions
     initial_cash=10000,
 )
 

--- a/docs/guides/custom-features.md
+++ b/docs/guides/custom-features.md
@@ -220,6 +220,7 @@ df = pd.DataFrame({
     "timestamp": ..., "open": ..., "high": ..., "low": ..., "close": ..., "volume": ...,
     "funding_rate": ...,  # auxiliary
     "open_interest": ..., # auxiliary
+    "basis": ...,         # auxiliary, read by futures_features below
 })
 
 def futures_features(df: pd.DataFrame) -> pd.DataFrame:

--- a/docs/guides/custom-features.md
+++ b/docs/guides/custom-features.md
@@ -151,7 +151,9 @@ def process_1min(df: pd.DataFrame) -> pd.DataFrame:
     df["features_volume"] = df["volume"]
     df["features_range"] = df["high"] - df["low"]
     df.fillna(0, inplace=True)
-    return df
+    # timestamp must come back as a COLUMN, or the sampler raises
+    # KeyError: ['timestamp'] not in index
+    return df.reset_index()
 
 def process_1hour(df: pd.DataFrame) -> pd.DataFrame:
     """Slow timeframe: trend features (5 features)."""
@@ -161,7 +163,9 @@ def process_1hour(df: pd.DataFrame) -> pd.DataFrame:
     df["features_volatility"] = df["close"].pct_change().rolling(10).std()
     df["features_volume_ma"] = df["volume"].rolling(10).mean()
     df.fillna(0, inplace=True)
-    return df
+    # timestamp must come back as a COLUMN, or the sampler raises
+    # KeyError: ['timestamp'] not in index
+    return df.reset_index()
 
 config = SequentialTradingEnvConfig(
     time_frames=["1min", "1hour"],
@@ -170,7 +174,8 @@ config = SequentialTradingEnvConfig(
     initial_cash=10000,
 )
 
-env = SequentialTradingEnv(df, config)
+# One preprocessing fn per timeframe, passed as the constructor's third argument.
+env = SequentialTradingEnv(df, config, [process_1min, process_1hour])
 
 # Observation specs will have different shapes:
 # - market_data_1Minute_30: shape (30, 3)
@@ -185,8 +190,9 @@ Use `None` in the list to skip processing for a timeframe (keeps raw OHLCV):
 config = SequentialTradingEnvConfig(
     time_frames=["1min", "5min"],
     window_sizes=[30, 10],
-    feature_preprocessing_fn=[process_1min, None],  # 1min processed, 5min raw OHLCV
 )
+# None skips processing for that timeframe: 1min processed, 5min raw OHLCV.
+env = SequentialTradingEnv(df, config, [process_1min, None])
 ```
 
 ### Backward Compatibility
@@ -226,7 +232,9 @@ def futures_features(df: pd.DataFrame) -> pd.DataFrame:
     df["features_basis_norm"] = df["basis"] / df["close"]
 
     df.fillna(0, inplace=True)
-    return df
+    # timestamp must come back as a COLUMN, or the sampler raises
+    # KeyError: ['timestamp'] not in index
+    return df.reset_index()
 ```
 
 **Two modes of operation:**
@@ -270,7 +278,9 @@ def binance_features(df: pd.DataFrame) -> pd.DataFrame:
     # Standard price features
     df["features_close"] = df["close"].pct_change().fillna(0)
     df.fillna(0, inplace=True)
-    return df
+    # timestamp must come back as a COLUMN, or the sampler raises
+    # KeyError: ['timestamp'] not in index
+    return df.reset_index()
 
 env = BinanceFuturesTorchTradingEnv(
     config=config,
@@ -333,7 +343,9 @@ def add_indicators(df: pd.DataFrame) -> pd.DataFrame:
     ).average_true_range()
 
     df.fillna(0, inplace=True)
-    return df
+    # timestamp must come back as a COLUMN, or the sampler raises
+    # KeyError: ['timestamp'] not in index
+    return df.reset_index()
 ```
 
 ---

--- a/docs/guides/reward-functions.md
+++ b/docs/guides/reward-functions.md
@@ -29,11 +29,9 @@ Pass your reward function via the environment config:
 ```python
 from torchtrade.envs.offline import SequentialTradingEnv, SequentialTradingEnvConfig
 
-config = SequentialTradingEnvConfig(
-    reward_function=my_reward,
-    ...
-)
-env = SequentialTradingEnv(df, config)
+config = SequentialTradingEnvConfig(...)
+# reward_function is a CONSTRUCTOR argument, not a config field.
+env = SequentialTradingEnv(df, config, reward_function=my_reward)
 ```
 
 ---
@@ -67,7 +65,6 @@ from torchtrade.envs.core.default_rewards import (
 )
 
 config = SequentialTradingEnvConfig(
-    reward_function=sharpe_ratio_reward,
     ...
 )
 ```

--- a/docs/guides/sampler.md
+++ b/docs/guides/sampler.md
@@ -271,7 +271,8 @@ def futures_features(df: pd.DataFrame) -> pd.DataFrame:
     df["features_funding_rate"] = df["funding_rate"]  # auxiliary column
     df["features_basis_norm"] = df["basis"] / df["close"]  # derived from aux + OHLCV
     df.fillna(0, inplace=True)
-    return df
+    # timestamp must come back as a COLUMN for the offline sampler (see custom-features)
+    return df.reset_index()
 ```
 
 ### When to Use Auxiliary Columns vs Feature Processing

--- a/tests/test_documented_imports.py
+++ b/tests/test_documented_imports.py
@@ -146,7 +146,6 @@ def _resolve_config(cls_name):
 # fails until it is removed, so the list cannot drift away from the docs in either
 # direction.
 KNOWN_BROKEN = {
-    ("docs/guides/custom-features.md", "SequentialTradingEnvConfig", "feature_preprocessing_fn"),
     ("torchtrade/envs/README.md", "AlpacaTradingEnvConfig", "api_key"),
     ("torchtrade/envs/README.md", "AlpacaTradingEnvConfig", "api_secret"),
     ("torchtrade/envs/README.md", "AlpacaTradingEnvConfig", "timeframe"),

--- a/tests/test_documented_imports.py
+++ b/tests/test_documented_imports.py
@@ -146,14 +146,7 @@ def _resolve_config(cls_name):
 # fails until it is removed, so the list cannot drift away from the docs in either
 # direction.
 KNOWN_BROKEN = {
-    ("docs/environments/online.md", "BinanceFuturesSLTPTradingEnvConfig", "intervals"),
-    ("docs/environments/online.md", "BinanceFuturesTradingEnvConfig", "intervals"),
-    ("docs/environments/online.md", "BinanceFuturesTradingEnvConfig", "quantity_per_trade"),
-    ("docs/environments/online.md", "BitgetFuturesTradingEnvConfig", "quantity_per_trade"),
-    ("docs/getting-started.md", "BinanceFuturesTradingEnvConfig", "intervals"),
-    ("docs/getting-started.md", "BinanceFuturesTradingEnvConfig", "quantity_per_trade"),
     ("docs/guides/custom-features.md", "SequentialTradingEnvConfig", "feature_preprocessing_fn"),
-    ("docs/guides/reward-functions.md", "SequentialTradingEnvConfig", "reward_function"),
     ("torchtrade/envs/README.md", "AlpacaTradingEnvConfig", "api_key"),
     ("torchtrade/envs/README.md", "AlpacaTradingEnvConfig", "api_secret"),
     ("torchtrade/envs/README.md", "AlpacaTradingEnvConfig", "timeframe"),


### PR DESCRIPTION
Third slice of #287. Clears every ratchet entry under `docs/` — the ones a reader actually hits. **58 → 51.**

| documented | real |
|---|---|
| `intervals=` | `time_frames=` (renamed; 3 sites) |
| `quantity_per_trade=` | dropped — non-SLTP futures configs size from `action_levels` |
| `reward_function=` | constructor argument, not a config field |
| `feature_preprocessing_fn=` | constructor argument, not a config field |

`quantity_per_trade` was removed **only** from the non-SLTP blocks — the SLTP configs do accept it.

## The ratchet worked in both directions

Fixing the docs made `test_no_known_broken_entry_has_gone_stale` **fail**, naming the six entries that no longer described reality and refusing to pass until they were deleted. That's the property that keeps the baseline from drifting away from the docs — it can't quietly outlive the problem.

## Verified by running, not reading

Both corrected guide shapes construct:
- the `custom-features` config with `feature_preprocessing_fn` passed to the constructor
- `SequentialTradingEnv(df, config, fn, reward_function=my_reward)`

## What's left

The remaining 51 are all in-package READMEs — bitget 14, binance 12, live 12, alpaca 9, envs 3 — documenting an **older config API entirely**: `api_key`, `api_secret`, `timeframe`, `testnet`, `max_leverage`, `sl_percent`, `tp_percent`. None of those fields exist on the current classes.

Those need rewriting against the real API rather than renaming, so they're their own slice rather than padding this one.

Full suite: 3449 passed, 51 xfailed.

⚠️ Review rounds not yet run.