### PR TITLE
docs: rewrite the Alpaca READMEs against the real config API (#287)

### DIFF
--- a/tests/test_documented_imports.py
+++ b/tests/test_documented_imports.py
@@ -146,9 +146,6 @@ def _resolve_config(cls_name):
 # fails until it is removed, so the list cannot drift away from the docs in either
 # direction.
 KNOWN_BROKEN = {
-    ("torchtrade/envs/README.md", "AlpacaTradingEnvConfig", "api_key"),
-    ("torchtrade/envs/README.md", "AlpacaTradingEnvConfig", "api_secret"),
-    ("torchtrade/envs/README.md", "AlpacaTradingEnvConfig", "timeframe"),
     ("torchtrade/envs/live/README.md", "AlpacaSLTPTradingEnvConfig", "sl_percent"),
     ("torchtrade/envs/live/README.md", "AlpacaSLTPTradingEnvConfig", "tp_percent"),
     ("torchtrade/envs/live/README.md", "AlpacaTradingEnvConfig", "api_key"),
@@ -161,15 +158,6 @@ KNOWN_BROKEN = {
     ("torchtrade/envs/live/README.md", "BinanceFuturesTradingEnvConfig", "max_leverage"),
     ("torchtrade/envs/live/README.md", "BinanceFuturesTradingEnvConfig", "testnet"),
     ("torchtrade/envs/live/README.md", "BinanceFuturesTradingEnvConfig", "timeframe"),
-    ("torchtrade/envs/live/alpaca/README.md", "AlpacaSLTPTradingEnvConfig", "api_key"),
-    ("torchtrade/envs/live/alpaca/README.md", "AlpacaSLTPTradingEnvConfig", "api_secret"),
-    ("torchtrade/envs/live/alpaca/README.md", "AlpacaSLTPTradingEnvConfig", "sl_percent"),
-    ("torchtrade/envs/live/alpaca/README.md", "AlpacaSLTPTradingEnvConfig", "timeframe"),
-    ("torchtrade/envs/live/alpaca/README.md", "AlpacaSLTPTradingEnvConfig", "tp_percent"),
-    ("torchtrade/envs/live/alpaca/README.md", "AlpacaTradingEnvConfig", "api_key"),
-    ("torchtrade/envs/live/alpaca/README.md", "AlpacaTradingEnvConfig", "api_secret"),
-    ("torchtrade/envs/live/alpaca/README.md", "AlpacaTradingEnvConfig", "initial_cash"),
-    ("torchtrade/envs/live/alpaca/README.md", "AlpacaTradingEnvConfig", "timeframe"),
     ("torchtrade/envs/live/binance/README.md", "BinanceFuturesSLTPTradingEnvConfig", "api_key"),
     ("torchtrade/envs/live/binance/README.md", "BinanceFuturesSLTPTradingEnvConfig", "api_secret"),
     ("torchtrade/envs/live/binance/README.md", "BinanceFuturesSLTPTradingEnvConfig", "max_leverage"),

--- a/torchtrade/envs/README.md
+++ b/torchtrade/envs/README.md
@@ -46,12 +46,16 @@ env = SequentialTradingEnv(df=your_dataframe, config=config)
 from torchtrade.envs.live.alpaca.env import AlpacaTorchTradingEnv, AlpacaTradingEnvConfig
 
 # Create an Alpaca live trading environment
+# Credentials are CONSTRUCTOR arguments, not config fields; the config carries the
+# market/observation shape. `time_frames` is a list -- there is no `timeframe`.
 config = AlpacaTradingEnvConfig(
-    api_key="your_key",
-    api_secret="your_secret",
-    timeframe=TimeFrame(1, TimeFrameUnit.MINUTE),
+    symbol="BTC/USD",
+    time_frames=["1Min"],
+    window_sizes=[10],
+    execute_on="1Min",
+    paper=True,
 )
-env = AlpacaTorchTradingEnv(config=config)
+env = AlpacaTorchTradingEnv(config, api_key="your_key", api_secret="your_secret")
 ```
 
 ## Architecture Overview

--- a/torchtrade/envs/live/alpaca/README.md
+++ b/torchtrade/envs/live/alpaca/README.md
@@ -17,16 +17,19 @@ Live trading integration with Alpaca for US equities and crypto spot markets.
 from torchtrade.envs.live.alpaca.env import AlpacaTorchTradingEnv, AlpacaTradingEnvConfig
 from torchtrade.envs.utils import TimeFrame, TimeFrameUnit
 
+# Credentials are CONSTRUCTOR arguments, not config fields. The config carries the
+# market and observation shape: `time_frames` (a list) with matching `window_sizes`,
+# and `execute_on`. There is no `timeframe` or `initial_cash` -- a live account's cash
+# comes from the broker.
 config = AlpacaTradingEnvConfig(
-    api_key="YOUR_KEY",
-    api_secret="YOUR_SECRET",
     paper=True,  # Paper trading
     symbol="AAPL",
-    timeframe=TimeFrame(1, TimeFrameUnit.MINUTE),
-    initial_cash=10000.0,
+    time_frames=["1Min"],
+    window_sizes=[10],
+    execute_on="1Min",
 )
 
-env = AlpacaTorchTradingEnv(config=config)
+env = AlpacaTorchTradingEnv(config, api_key="YOUR_KEY", api_secret="YOUR_SECRET")
 obs = env.reset()
 ```
 
@@ -91,14 +94,18 @@ from torchtrade.envs.live.alpaca.env import AlpacaTorchTradingEnv, AlpacaTrading
 
 # Load keys from environment
 config = AlpacaTradingEnvConfig(
-    api_key=os.environ["ALPACA_KEY"],
-    api_secret=os.environ["ALPACA_SECRET"],
     paper=True,
     symbol="SPY",
-    timeframe=TimeFrame(1, TimeFrameUnit.MINUTE),
+    time_frames=["1Min"],
+    window_sizes=[10],
+    execute_on="1Min",
 )
 
-env = AlpacaTorchTradingEnv(config=config)
+env = AlpacaTorchTradingEnv(
+    config,
+    api_key=os.environ["ALPACA_KEY"],
+    api_secret=os.environ["ALPACA_SECRET"],
+)
 
 # Trading loop
 obs = env.reset()
@@ -117,17 +124,23 @@ print(f"Final value: ${env.portfolio_value:.2f}")
 ```python
 from torchtrade.envs.live.alpaca.env_sltp import AlpacaSLTPTorchTradingEnv, AlpacaSLTPTradingEnvConfig
 
+# SL/TP are LEVELS lists, not single percentages -- the action space is one entry per
+# (stoploss, takeprofit) pair, so a single number could not describe it.
 config = AlpacaSLTPTradingEnvConfig(
-    api_key=os.environ["ALPACA_KEY"],
-    api_secret=os.environ["ALPACA_SECRET"],
     paper=True,
     symbol="AAPL",
-    timeframe=TimeFrame(1, TimeFrameUnit.MINUTE),
-    sl_percent=0.02,  # 2% stop loss
-    tp_percent=0.05,  # 5% take profit
+    time_frames=["1Min"],
+    window_sizes=[10],
+    execute_on="1Min",
+    stoploss_levels=[-0.02],   # 2% stop loss
+    takeprofit_levels=[0.05],  # 5% take profit
 )
 
-env = AlpacaSLTPTorchTradingEnv(config=config)
+env = AlpacaSLTPTorchTradingEnv(
+    config,
+    api_key=os.environ["ALPACA_KEY"],
+    api_secret=os.environ["ALPACA_SECRET"],
+)
 obs = env.reset()
 
 # SL/TP triggers automatically

--- a/torchtrade/envs/live/alpaca/README.md
+++ b/torchtrade/envs/live/alpaca/README.md
@@ -14,6 +14,8 @@ Live trading integration with Alpaca for US equities and crypto spot markets.
 ## Quick Start
 
 ```python
+from torchrl.envs.utils import step_mdp
+
 from torchtrade.envs.live.alpaca.env import AlpacaTorchTradingEnv, AlpacaTradingEnvConfig
 
 # Credentials are CONSTRUCTOR arguments, not config fields. The config carries the
@@ -93,6 +95,8 @@ action = 1  # action 0 is flat/HOLD; 1..N open a position
 
 ```python
 import os
+from torchrl.envs.utils import step_mdp
+
 from torchtrade.envs.live.alpaca.env import AlpacaTorchTradingEnv, AlpacaTradingEnvConfig
 
 # Load keys from environment
@@ -114,11 +118,13 @@ env = AlpacaTorchTradingEnv(
 td = env.reset()
 for _ in range(100):
     td["action"] = agent.get_action(td)
-    # step_and_maybe_reset, not step: step() nests the outcome under "next", so
-    # re-feeding its output to step() would re-step from the stale observation.
-    td = env.step_and_maybe_reset(td)
+    td = env.step(td)
     if td["next", "done"]:
         break
+    # step_mdp, NOT step_and_maybe_reset: the latter returns a 2-tuple, and its
+    # auto-reset calls cancel_open_orders() on the real broker -- it would cancel the
+    # SL/TP brackets placed below and clear env.history.
+    td = step_mdp(td)
 
 print(f"Final value: ${env.history.portfolio_values[-1]:.2f}")
 ```

--- a/torchtrade/envs/live/alpaca/README.md
+++ b/torchtrade/envs/live/alpaca/README.md
@@ -29,7 +29,7 @@ config = AlpacaTradingEnvConfig(
 )
 
 env = AlpacaTorchTradingEnv(config, api_key="YOUR_KEY", api_secret="YOUR_SECRET")
-obs = env.reset()
+td = env.reset()  # a TensorDict, not a bare array
 ```
 
 ## Features
@@ -46,16 +46,16 @@ obs = env.reset()
 @dataclass
 class AlpacaTradingEnvConfig:
     symbol: str = "BTC/USD"
-    time_frames: list = ...         # e.g. ["1Min", "5Min"] -- a LIST
-    window_sizes: list = ...        # one per timeframe
-    execute_on: str = "1Min"        # which timeframe drives a step
-    action_levels: list = ...       # fraction of portfolio per action
-    paper: bool = True              # Paper or live trading
-    trade_mode: str = "fractional"
+    action_levels: Optional[List[float]] = None     # None -> [0.0, 0.5, 1.0]
+    time_frames: Union[List[str | TimeFrame], str, TimeFrame] = "1Hour"
+    window_sizes: Union[List[int], int] = 10        # one per timeframe
+    execute_on: Union[str, TimeFrame] = "1Hour"     # which timeframe drives a step
     done_on_bankruptcy: bool = True
     bankrupt_threshold: float = 0.1
+    paper: bool = True                              # Paper or live trading
+    trade_mode: Literal["fractional", "notional", "quantity"] = "notional"
+    seed: Optional[int] = 42
     include_base_features: bool = False
-    seed: int = 42
     # Credentials are CONSTRUCTOR arguments, not fields:
     #   AlpacaTorchTradingEnv(config, api_key=..., api_secret=...)
 ```
@@ -111,20 +111,23 @@ env = AlpacaTorchTradingEnv(
 )
 
 # Trading loop
-obs = env.reset()
+td = env.reset()
 for _ in range(100):
-    action = agent.get_action(obs)
-    td = env.step(td)  # step takes and returns a TensorDict
-
-    if done:
+    td["action"] = agent.get_action(td)
+    # step_and_maybe_reset, not step: step() nests the outcome under "next", so
+    # re-feeding its output to step() would re-step from the stale observation.
+    td = env.step_and_maybe_reset(td)
+    if td["next", "done"]:
         break
 
-print(f"Final value: ${env._get_portfolio_value():.2f}")
+print(f"Final value: ${env.history.portfolio_values[-1]:.2f}")
 ```
 
 ## Example: With Stop-Loss/Take-Profit
 
 ```python
+import os
+
 import torch
 
 from torchtrade.envs.live.alpaca.env_sltp import AlpacaSLTPTorchTradingEnv, AlpacaSLTPTradingEnvConfig

--- a/torchtrade/envs/live/alpaca/README.md
+++ b/torchtrade/envs/live/alpaca/README.md
@@ -15,7 +15,6 @@ Live trading integration with Alpaca for US equities and crypto spot markets.
 
 ```python
 from torchtrade.envs.live.alpaca.env import AlpacaTorchTradingEnv, AlpacaTradingEnvConfig
-from torchtrade.envs.utils import TimeFrame, TimeFrameUnit
 
 # Credentials are CONSTRUCTOR arguments, not config fields. The config carries the
 # market and observation shape: `time_frames` (a list) with matching `window_sizes`,
@@ -46,15 +45,19 @@ obs = env.reset()
 ```python
 @dataclass
 class AlpacaTradingEnvConfig:
-    api_key: str
-    api_secret: str
-    symbol: str
-    timeframe: TimeFrame
+    symbol: str = "BTC/USD"
+    time_frames: list = ...         # e.g. ["1Min", "5Min"] -- a LIST
+    window_sizes: list = ...        # one per timeframe
+    execute_on: str = "1Min"        # which timeframe drives a step
+    action_levels: list = ...       # fraction of portfolio per action
     paper: bool = True              # Paper or live trading
-    base_url: str = None            # Custom API endpoint
-    extended_hours: bool = False    # Trade extended hours
-    initial_cash: float = 10000.0
-    window_size: int = 50
+    trade_mode: str = "fractional"
+    done_on_bankruptcy: bool = True
+    bankrupt_threshold: float = 0.1
+    include_base_features: bool = False
+    seed: int = 42
+    # Credentials are CONSTRUCTOR arguments, not fields:
+    #   AlpacaTorchTradingEnv(config, api_key=..., api_secret=...)
 ```
 
 ## Supported Symbols
@@ -81,7 +84,7 @@ Check Alpaca docs for full list: https://alpaca.markets/docs/trading/
 
 **Market Orders** (default):
 ```python
-action = 0  # BUY at current market price
+action = 1  # action 0 is flat/HOLD; 1..N open a position
 ```
 
 **Time-in-Force**: Day orders (default), good-til-canceled (GTC) optional
@@ -111,17 +114,19 @@ env = AlpacaTorchTradingEnv(
 obs = env.reset()
 for _ in range(100):
     action = agent.get_action(obs)
-    obs, reward, done, info = env.step(action)
+    td = env.step(td)  # step takes and returns a TensorDict
 
     if done:
         break
 
-print(f"Final value: ${env.portfolio_value:.2f}")
+print(f"Final value: ${env._get_portfolio_value():.2f}")
 ```
 
 ## Example: With Stop-Loss/Take-Profit
 
 ```python
+import torch
+
 from torchtrade.envs.live.alpaca.env_sltp import AlpacaSLTPTorchTradingEnv, AlpacaSLTPTradingEnvConfig
 
 # SL/TP are LEVELS lists, not single percentages -- the action space is one entry per
@@ -141,14 +146,12 @@ env = AlpacaSLTPTorchTradingEnv(
     api_key=os.environ["ALPACA_KEY"],
     api_secret=os.environ["ALPACA_SECRET"],
 )
-obs = env.reset()
+td = env.reset()
 
-# SL/TP triggers automatically
-action = 0  # BUY
-obs, reward, done, info = env.step(action)
-
-if info.get("sl_triggered"):
-    print("Stop loss hit!")
+# The bracket is placed with the entry; SL/TP then trigger on the venue.
+# Action 0 is HOLD -- 1..N are the (stoploss, takeprofit) pairs.
+td["action"] = torch.tensor(1)
+td = env.step(td)
 ```
 
 ## Best Practices


### PR DESCRIPTION
Fourth slice of #287. **Ratchet 50 → 38.**

The in-package READMEs document a config that hasn't existed for some time — not renamed fields, a genuinely different shape. So these are rewrites, not substitutions:

| documented | real |
|---|---|
| `api_key=` / `api_secret=` | **constructor arguments** — the config carries market/observation shape, not credentials |
| `timeframe=TimeFrame(1, MINUTE)` | `time_frames=["1Min"]` — a **list**, with matching `window_sizes` and `execute_on` |
| `initial_cash=` | gone — a live account's cash comes from the broker |
| `sl_percent` / `tp_percent` | `stoploss_levels` / `takeprofit_levels` — the action space is one entry per (SL, TP) pair, so a single number can't describe it |

## Verified by construction

Both corrected configs were actually built, not eyeballed:

```
both corrected configs construct: AlpacaTradingEnvConfig AlpacaSLTPTradingEnvConfig
```

That check is the one I've skipped and been caught on repeatedly across this issue's slices.

## The ratchet drove it

Each fix made `test_no_known_broken_entry_has_gone_stale` **fail**, naming the exact entries that no longer described reality and refusing to pass until they were deleted. **12 cleared** in this commit.

## What's left

38 entries: bitget (14), binance (12), `live/` (12) — same obsolete API, same rewrite shape, so they're a natural next slice.

Full suite: 3462 passed, 38 xfailed.

⚠️ Review rounds not yet run.