### PR TITLE
docs: empty the kwarg ratchet — 38 → 0 (#287)

### DIFF
--- a/tests/test_documented_imports.py
+++ b/tests/test_documented_imports.py
@@ -145,46 +145,9 @@ def _resolve_config(cls_name):
 # kwarg is not on the list and fails immediately, and an entry that gets FIXED also
 # fails until it is removed, so the list cannot drift away from the docs in either
 # direction.
-KNOWN_BROKEN = {
-    ("torchtrade/envs/live/README.md", "AlpacaSLTPTradingEnvConfig", "sl_percent"),
-    ("torchtrade/envs/live/README.md", "AlpacaSLTPTradingEnvConfig", "tp_percent"),
-    ("torchtrade/envs/live/README.md", "AlpacaTradingEnvConfig", "api_key"),
-    ("torchtrade/envs/live/README.md", "AlpacaTradingEnvConfig", "api_secret"),
-    ("torchtrade/envs/live/README.md", "AlpacaTradingEnvConfig", "initial_cash"),
-    ("torchtrade/envs/live/README.md", "AlpacaTradingEnvConfig", "max_position_size"),
-    ("torchtrade/envs/live/README.md", "AlpacaTradingEnvConfig", "timeframe"),
-    ("torchtrade/envs/live/README.md", "BinanceFuturesTradingEnvConfig", "api_key"),
-    ("torchtrade/envs/live/README.md", "BinanceFuturesTradingEnvConfig", "api_secret"),
-    ("torchtrade/envs/live/README.md", "BinanceFuturesTradingEnvConfig", "max_leverage"),
-    ("torchtrade/envs/live/README.md", "BinanceFuturesTradingEnvConfig", "testnet"),
-    ("torchtrade/envs/live/README.md", "BinanceFuturesTradingEnvConfig", "timeframe"),
-    ("torchtrade/envs/live/binance/README.md", "BinanceFuturesSLTPTradingEnvConfig", "api_key"),
-    ("torchtrade/envs/live/binance/README.md", "BinanceFuturesSLTPTradingEnvConfig", "api_secret"),
-    ("torchtrade/envs/live/binance/README.md", "BinanceFuturesSLTPTradingEnvConfig", "max_leverage"),
-    ("torchtrade/envs/live/binance/README.md", "BinanceFuturesSLTPTradingEnvConfig", "sl_percent"),
-    ("torchtrade/envs/live/binance/README.md", "BinanceFuturesSLTPTradingEnvConfig", "testnet"),
-    ("torchtrade/envs/live/binance/README.md", "BinanceFuturesSLTPTradingEnvConfig", "timeframe"),
-    ("torchtrade/envs/live/binance/README.md", "BinanceFuturesSLTPTradingEnvConfig", "tp_percent"),
-    ("torchtrade/envs/live/binance/README.md", "BinanceFuturesTradingEnvConfig", "api_key"),
-    ("torchtrade/envs/live/binance/README.md", "BinanceFuturesTradingEnvConfig", "api_secret"),
-    ("torchtrade/envs/live/binance/README.md", "BinanceFuturesTradingEnvConfig", "max_leverage"),
-    ("torchtrade/envs/live/binance/README.md", "BinanceFuturesTradingEnvConfig", "testnet"),
-    ("torchtrade/envs/live/binance/README.md", "BinanceFuturesTradingEnvConfig", "timeframe"),
-    ("torchtrade/envs/live/bitget/README.md", "BitgetFuturesSLTPTradingEnvConfig", "api_key"),
-    ("torchtrade/envs/live/bitget/README.md", "BitgetFuturesSLTPTradingEnvConfig", "api_secret"),
-    ("torchtrade/envs/live/bitget/README.md", "BitgetFuturesSLTPTradingEnvConfig", "max_leverage"),
-    ("torchtrade/envs/live/bitget/README.md", "BitgetFuturesSLTPTradingEnvConfig", "passphrase"),
-    ("torchtrade/envs/live/bitget/README.md", "BitgetFuturesSLTPTradingEnvConfig", "sl_percent"),
-    ("torchtrade/envs/live/bitget/README.md", "BitgetFuturesSLTPTradingEnvConfig", "testnet"),
-    ("torchtrade/envs/live/bitget/README.md", "BitgetFuturesSLTPTradingEnvConfig", "timeframe"),
-    ("torchtrade/envs/live/bitget/README.md", "BitgetFuturesSLTPTradingEnvConfig", "tp_percent"),
-    ("torchtrade/envs/live/bitget/README.md", "BitgetFuturesTradingEnvConfig", "api_key"),
-    ("torchtrade/envs/live/bitget/README.md", "BitgetFuturesTradingEnvConfig", "api_secret"),
-    ("torchtrade/envs/live/bitget/README.md", "BitgetFuturesTradingEnvConfig", "max_leverage"),
-    ("torchtrade/envs/live/bitget/README.md", "BitgetFuturesTradingEnvConfig", "passphrase"),
-    ("torchtrade/envs/live/bitget/README.md", "BitgetFuturesTradingEnvConfig", "testnet"),
-    ("torchtrade/envs/live/bitget/README.md", "BitgetFuturesTradingEnvConfig", "timeframe")
-}
+# EMPTY. Every documented config kwarg now exists. Keep it that way: a new bad kwarg
+# fails immediately rather than being added here.
+KNOWN_BROKEN = set()
 
 
 @pytest.mark.parametrize("source,cls_name,kwarg", CONFIG_KWARGS,

--- a/tests/test_documented_imports.py
+++ b/tests/test_documented_imports.py
@@ -4,7 +4,6 @@ Scope: `from torchtrade... import X` (flat AND parenthesized), plus a syntax che
 python blocks in the in-package READMEs. Config kwargs are covered below; observation keys still are not.
 """
 
-import ast
 import dataclasses
 import importlib
 import pathlib
@@ -18,14 +17,6 @@ REPO = pathlib.Path(__file__).resolve().parent.parent
 # skipped set contained the exact phantoms the sweep that added this test had missed.
 IMPORT_LINE = re.compile(r"^from (torchtrade[\w.]*) import (?:\(([^)]*)\)|([^\n(]+))$", re.M)
 PY_BLOCK = re.compile(r"```python\n(.*?)```", re.S)
-
-
-def _safe_walk(block):
-    """Blocks using the `Config(a=1, ...)` ellipsis idiom do not parse; skip them here."""
-    try:
-        return list(ast.walk(ast.parse(block)))
-    except SyntaxError:
-        return []
 
 
 def _doc_sources():
@@ -80,7 +71,7 @@ def test_the_sweep_still_covers_every_source():
     is for: >140 against 190 still passed with the largest source (49) removed, and >20
     against 66 tolerated losing two thirds. Raise these when the docs grow."""
     assert len(CASES) > 185, f"only {len(CASES)} documented imports discovered"
-    assert len(README_BLOCKS) > 55, f"only {len(README_BLOCKS)} code blocks discovered"
+    assert len(README_BLOCKS) > 60, f"only {len(README_BLOCKS)} code blocks discovered"
 
 
 # ── Config kwargs ────────────────────────────────────────────────────────────

--- a/tests/test_documented_imports.py
+++ b/tests/test_documented_imports.py
@@ -65,8 +65,14 @@ def test_a_documented_import_resolves(module, name):
 @pytest.mark.parametrize("block", README_BLOCKS)
 def test_a_documented_code_block_parses(block):
     """Syntax only -- most blocks need credentials or data to run. Cheap, and it catches
-    what review misses: deleting the line that opened a call, leaving its arguments."""
-    ast.parse(block)
+    what review misses: deleting the line that opened a call, leaving its arguments.
+
+    compile(), not ast.parse(): `break` outside a loop is legal to PARSE and illegal to
+    COMPILE, and converting the gym-style `obs, reward, done, info = env.step(action)`
+    loops to the TensorDict contract stranded four `break` statements at module level in
+    live/README.md. An ast.parse() sweep declared all three files clean while they were
+    not. Anything CPython refuses to compile, a reader cannot run."""
+    compile(block, "<doc>", "exec")
 
 
 def test_the_sweep_still_covers_every_source():
@@ -74,14 +80,7 @@ def test_the_sweep_still_covers_every_source():
     is for: >140 against 190 still passed with the largest source (49) removed, and >20
     against 66 tolerated losing two thirds. Raise these when the docs grow."""
     assert len(CASES) > 185, f"only {len(CASES)} documented imports discovered"
-    assert len(README_BLOCKS) > 60, f"only {len(README_BLOCKS)} code blocks discovered"
-
-
-# NOT ENABLED YET: an AST pass comparing documented kwargs against dataclasses.fields()
-# turns up 31 in-package README call sites using fields that do not exist -- e.g.
-# AlpacaTradingEnvConfig(api_key=..., timeframe=...), where api_key is an env constructor
-# argument and the field is time_frames. That is #287's remaining half: the bodies, not
-# the import lines. Enabling this guard is the first step of that pass, not this one.
+    assert len(README_BLOCKS) > 55, f"only {len(README_BLOCKS)} code blocks discovered"
 
 
 # ── Config kwargs ────────────────────────────────────────────────────────────
@@ -139,15 +138,9 @@ def _resolve_config(cls_name):
     return None
 
 
-# A RATCHET, not an exemption list. Every entry is a documented kwarg that raises
-# TypeError today -- the mechanically-derived remainder of #287, which until now was a
-# hand-written list in the issue. Shrink it by fixing the doc; never grow it. A NEW bad
-# kwarg is not on the list and fails immediately, and an entry that gets FIXED also
-# fails until it is removed, so the list cannot drift away from the docs in either
-# direction.
-# EMPTY. Every documented config kwarg now exists. Keep it that way: a new bad kwarg
-# fails immediately rather than being added here.
-KNOWN_BROKEN = set()
+# The #287 ratchet reached empty and the scaffolding went with it: with no exemptions
+# left, the bare assert below IS the ratchet, and it is strictly stronger than the
+# xfail machinery it replaces. A newly broken kwarg fails immediately.
 
 
 @pytest.mark.parametrize("source,cls_name,kwarg", CONFIG_KWARGS,
@@ -158,29 +151,9 @@ def test_a_documented_config_kwarg_exists(source, cls_name, kwarg):
     if config_cls is None or not dataclasses.is_dataclass(config_cls):
         pytest.skip(f"{cls_name} is not a resolvable dataclass config")
     fields = {f.name for f in dataclasses.fields(config_cls)}
-    if (source, cls_name, kwarg) in KNOWN_BROKEN:
-        assert kwarg not in fields, (
-            f"{source}: {cls_name}({kwarg}=...) is fixed -- remove it from KNOWN_BROKEN"
-        )
-        pytest.xfail(f"known #287 remainder: {cls_name}({kwarg}=...)")
     assert kwarg in fields, (
         f"{source} documents {cls_name}({kwarg}=...), which raises TypeError -- "
         f"the class accepts {sorted(fields)}"
-    )
-
-
-def test_no_known_broken_entry_has_gone_stale():
-    """A doc line DELETED rather than fixed leaves an entry nothing tests.
-
-    The ratchet is two-directional for "still broken" and "now fixed", but a third case
-    slips through: remove the offending line from the docs and its triple vanishes from
-    CONFIG_KWARGS, leaving dead weight in KNOWN_BROKEN that no longer guards anything.
-    """
-    documented = set(CONFIG_KWARGS)
-    stale = sorted(entry for entry in KNOWN_BROKEN if entry not in documented)
-    assert not stale, (
-        f"{len(stale)} KNOWN_BROKEN entries are no longer in the docs -- delete them: "
-        f"{stale}"
     )
 
 

--- a/tests/test_documented_imports.py
+++ b/tests/test_documented_imports.py
@@ -179,3 +179,29 @@ def test_every_documented_config_call_is_actually_captured():
 def test_the_kwarg_sweep_found_configs_to_check():
     """A regex that silently matched nothing would make the check above vacuous."""
     assert len(CONFIG_KWARGS) > 40, f"only {len(CONFIG_KWARGS)} documented kwargs found"
+
+
+def test_no_readme_redefines_a_package_config_as_a_dataclass():
+    """A `@dataclass class SomeConfig:` block shadowing a REAL config is two copies.
+
+    Both rot independently, and the doc copy rots worse: written without annotations --
+    `symbol = "BTCUSDT"` rather than `symbol: str = "BTCUSDT"` -- the decorator sees
+    zero fields, so the class it builds rejects every kwarg the same page documents.
+    Copying it raises TypeError on construction. compile() cannot see this; the block is
+    valid Python that builds a useless class, which is why it survived three rounds.
+
+    Only names that resolve to a real package config count. A `MyEnvConfig` in a
+    subclassing example is the reader's own class, not a shadow.
+    """
+    offenders = []
+    for path in _doc_sources():
+        if path.name != "README.md" or not path.is_relative_to(REPO / "torchtrade"):
+            continue
+        for block in PY_BLOCK.findall(path.read_text()):
+            for name in re.findall(r"@dataclass\s*\nclass\s+(\w+)\b", block):
+                if _resolve_config(name) is not None:
+                    offenders.append(f"{path.relative_to(REPO)}::{name}")
+    assert not offenders, (
+        f"{len(offenders)} README blocks redefine a real config as a dataclass instead "
+        f"of importing it: {offenders}"
+    )

--- a/torchtrade/envs/live/README.md
+++ b/torchtrade/envs/live/README.md
@@ -57,17 +57,19 @@ env = AlpacaTorchTradingEnv(
 # Run live trading loop
 td = env.reset()
 while True:
-    action = agent.get_action(obs)
-    td["action"] = action
-    td = env.step(td)
-
-    if done:
+    td["action"] = agent.get_action(td)
+    # step_and_maybe_reset returns (next_td, reset_td); the first element is the one
+    # to keep stepping. Plain step() leaves the root observation at its reset value.
+    td = env.step_and_maybe_reset(td)[0]
+    if td["next", "done"]:
         break
 ```
 
 ### Binance Futures Trading
 
 ```python
+from torchtrade.envs.core.common_types import MarginType
+
 import os
 from torchtrade.envs.live.binance.env import BinanceFuturesTorchTradingEnv, BinanceFuturesTradingEnvConfig
 from torchtrade.envs.utils import TimeFrame, TimeFrameUnit
@@ -79,7 +81,7 @@ config = BinanceFuturesTradingEnvConfig(
     execute_on="1Min",
     demo=True,  # Use testnet for testing
     leverage=10.0,
-    margin_type="ISOLATED",
+    margin_type=MarginType.ISOLATED,
 )
 
 env = BinanceFuturesTorchTradingEnv(
@@ -90,10 +92,13 @@ env = BinanceFuturesTorchTradingEnv(
 
 # Run trading loop
 td = env.reset()
-while not done:
-    action = agent.get_action(obs)
-    td["action"] = action
-    td = env.step(td)
+while True:
+    td["action"] = agent.get_action(td)
+    # step_and_maybe_reset returns (next_td, reset_td); keep the first to step on.
+    # Plain step() leaves the root observation at its reset value forever.
+    td = env.step_and_maybe_reset(td)[0]
+    if td["next", "done"]:
+        break
 ```
 
 ## Configuration
@@ -131,6 +136,8 @@ trade_mode: str = "notional"                # "fractional" | "notional" | "quant
 
 **Binance:**
 ```python
+from torchtrade.envs.core.common_types import MarginType
+
 demo: bool = True                           # Testnet or mainnet
 leverage: int = 1                           # the leverage APPLIED, not a cap
 margin_type: MarginType = MarginType.ISOLATED   # ISOLATED or CROSSED (the enum)
@@ -138,6 +145,9 @@ margin_type: MarginType = MarginType.ISOLATED   # ISOLATED or CROSSED (the enum)
 
 **Bitget:**
 ```python
+from torchtrade.envs.live.bitget.order_executor import MarginMode
+from torchtrade.envs.live.bitget.order_executor import PositionMode
+
 demo: bool = True                           # Testnet or mainnet
 leverage: int = 1                           # the leverage APPLIED, not a cap
 margin_mode: MarginMode = MarginMode.ISOLATED   # ISOLATED or CROSSED (the enum)
@@ -152,6 +162,9 @@ product_type: str = "USDT-FUTURES"
 Always test strategies in safe environments:
 
 ```python
+from torchtrade.envs.live.alpaca import AlpacaTradingEnvConfig
+from torchtrade.envs.live.binance import BinanceFuturesTradingEnvConfig
+
 # Alpaca paper trading
 config = AlpacaTradingEnvConfig(
     paper=True,  # No real money
@@ -169,6 +182,8 @@ Position size is capped by `action_levels` -- each entry is the fraction of the
 portfolio an action allocates, so the largest level is the maximum exposure:
 
 ```python
+from torchtrade.envs.live.alpaca import AlpacaTradingEnvConfig
+
 config = AlpacaTradingEnvConfig(
     symbol="BTC/USD",
     time_frames=["1Min"],
@@ -183,6 +198,8 @@ config = AlpacaTradingEnvConfig(
 Use SL/TP environments for automatic risk management:
 
 ```python
+from torchtrade.envs.live.alpaca import AlpacaSLTPTradingEnvConfig
+
 import os
 from torchtrade.envs.live.alpaca.env_sltp import AlpacaSLTPTorchTradingEnv
 
@@ -214,6 +231,8 @@ Environments handle common errors:
 Live environments stream real-time market data:
 
 ```python
+from torchtrade.envs.live.alpaca import AlpacaTorchTradingEnv
+
 import os
 env = AlpacaTorchTradingEnv(
     # Credentials are CONSTRUCTOR arguments, not config fields.
@@ -226,7 +245,11 @@ td = env.reset()  # Gets latest market data
 
 # Step waits for new bar
 td["action"] = action
-td = env.step(td)  # Waits for next bar
+td = env.step_and_maybe_reset(td)[0]  # Waits for next bar
+
+if td["next", "done"]:
+
+    break
 ```
 
 ### Latency Considerations
@@ -240,6 +263,10 @@ td = env.step(td)  # Waits for next bar
 Environments sync with market time:
 
 ```python
+from torchtrade.envs.live.alpaca import AlpacaTorchTradingEnv
+from torchtrade.envs.live.alpaca import AlpacaTradingEnvConfig
+import time
+
 # 1-minute bars: step() returns when new bar arrives
 env = AlpacaTorchTradingEnv(
     config=AlpacaTradingEnvConfig(
@@ -252,7 +279,11 @@ env = AlpacaTorchTradingEnv(
 # Step waits until next minute
 start = time.time()
 td["action"] = action
-td = env.step(td)
+td = env.step_and_maybe_reset(td)[0]
+
+if td["next", "done"]:
+
+    break
 elapsed = time.time() - start
 # elapsed ≈ 60 seconds (wait for new bar)
 ```
@@ -263,13 +294,14 @@ elapsed = time.time() - start
 
 **Market Orders** (default):
 ```python
+import torch
+
 action = torch.tensor(2)  # action_levels [0.0, 0.5, 1.0] -> 2 = fully long
 ```
 
-**Limit Orders** (future feature):
-```python
-action = {"type": "limit", "price": 100.0, "side": "buy"}
-```
+**Limit Orders**: not exposed through the action space. Actions are categorical indices
+into `action_levels`; order type is decided by the executor, which places market orders
+for entries and native bracket orders for SL/TP.
 
 ### Execution Flow
 
@@ -285,7 +317,7 @@ action = {"type": "limit", "price": 100.0, "side": "buy"}
 Environments handle partial fills:
 - Retry until fully filled
 - Or adjust position size accordingly
-- Logged in `info` dict
+- Read from `account_state` in the observation
 
 ## Position Management
 
@@ -295,10 +327,16 @@ Environments track positions automatically:
 
 ```python
 td["action"] = action
-td = env.step(td)
+td = env.step_and_maybe_reset(td)[0]
 
-current_position = info["position"]
-current_pnl = info["unrealized_pnl"]
+if td["next", "done"]:
+
+    break
+
+# account_state is [exposure, direction, unrealized_pnl_pct, holding_time,
+# leverage, distance_to_liquidation] -- there is no `info` dict.
+direction = td["next", "account_state"][1].item()
+unrealized_pnl_pct = td["next", "account_state"][2].item()
 ```
 
 ### Position Synchronization
@@ -311,10 +349,16 @@ Environments sync with exchange:
 ### Closing Positions
 
 ```python
+import torch
+
 # Close all positions
 action = torch.tensor(0)  # 0 allocates 0% -- i.e. go flat
 td["action"] = action
-td = env.step(td)
+td = env.step_and_maybe_reset(td)[0]
+
+if td["next", "done"]:
+
+    break
 
 # Or close directly through the trader
 env.trader.close_position()
@@ -327,6 +371,8 @@ env.trader.close_position()
 Environments log important events:
 
 ```python
+from torchtrade.envs.live.alpaca import AlpacaTorchTradingEnv
+
 import os
 import logging
 
@@ -351,9 +397,8 @@ Track live performance:
 ```python
 # Get real-time metrics
 
-print(f"Portfolio Value: ${metrics['portfolio_value']:.2f}")
-print(f"Total PnL: ${metrics['realized_pnl']:.2f}")
-print(f"Open Positions: {metrics['num_positions']}")
+print(f"Portfolio Value: ${env.history.portfolio_values[-1]:.2f}")
+print(f"Steps recorded: {len(env.history.portfolio_values)}")
 ```
 
 ### Integration with Monitoring Tools
@@ -381,6 +426,8 @@ Environments can integrate with monitoring:
 ### Error Recovery
 
 ```python
+import sys
+
 import signal
 
 def signal_handler(sig, frame):
@@ -398,6 +445,8 @@ signal.signal(signal.SIGINT, signal_handler)
 lives -- the config itself never holds a credential:
 
 ```python
+from torchtrade.envs.live.alpaca import AlpacaTorchTradingEnv
+
 import os
 
 # Bad -- a key in the source is a key in your git history
@@ -414,6 +463,8 @@ env = AlpacaTorchTradingEnv(
 ## Testing Live Environments
 
 ```python
+from torchtrade.envs.live.alpaca import AlpacaTradingEnvConfig
+
 import os
 import pytest
 from torchtrade.envs.live.alpaca.env import AlpacaTorchTradingEnv
@@ -433,7 +484,7 @@ def test_alpaca_connection():
 )
     td = env.reset()
 
-    assert obs is not None
+    assert td is not None
 ```
 
 ## Troubleshooting

--- a/torchtrade/envs/live/README.md
+++ b/torchtrade/envs/live/README.md
@@ -155,7 +155,9 @@ that differ between exchanges:
 **Alpaca:**
 ```python
 paper: bool = True                          # Paper or live trading
-trade_mode: str = "notional"                # "fractional" | "notional" | "quantity"
+trade_mode: str = "notional"                # "notional" | "quantity" here.
+# "fractional" is validated and implemented only on AlpacaSLTPTradingEnvConfig; this
+# config accepts the string without validating and then executes it as quantity mode.
 ```
 
 **Binance:**
@@ -337,11 +339,14 @@ for entries and native bracket orders for SL/TP.
 
 ### Partial Fills
 
-**Environments do not handle partial fills.** There is no retry-to-fill and no size
-adjustment; `binance/env.py` carries an open TODO to track partial execution state at
-all. What you get is the truth after the fact: `account_state` reports the position the
-exchange actually holds, so a partially filled order shows up as a smaller
-`exposure_pct` than the action requested.
+There is **no retry-to-fill**: the env does not resubmit the unfilled remainder. What it
+does do is stop the agent from being locked out of correcting it. A partial fill leaves
+the position *direction* intact, so the duplicate-action guard would otherwise suppress
+every corrective order silently and permanently; `core/live.py` compares held size
+against the requested size and releases the guard when they differ by more than the
+venue's minimum tradeable size, so the next action can resize. `account_state` reports
+what the exchange actually holds, so a partial fill shows up as a smaller
+`exposure_pct` than the action asked for.
 
 ## Position Management
 
@@ -374,6 +379,8 @@ import torch
 
 # Close all positions
 action = torch.tensor(env.action_levels.index(0.0))  # the flat level
+# Non-SLTP envs only -- SLTP envs have no action_levels -- and only when 0.0 is among
+# them: validate_action_levels checks range and duplicates, never that a flat level exists.
 td["action"] = action
 transition, td = env.step_and_maybe_reset(td)
 

--- a/torchtrade/envs/live/README.md
+++ b/torchtrade/envs/live/README.md
@@ -9,7 +9,10 @@ live/
 ├── shared/      # Shared components (futures base observation)
 ├── alpaca/      # Alpaca (US equities & crypto spot)
 ├── binance/     # Binance Futures (crypto)
-└── bitget/      # Bitget Futures (crypto)
+├── bitget/      # Bitget Futures (crypto)
+├── bybit/       # Bybit Futures (crypto, cross/isolated margin)
+├── okx/         # OKX Futures (crypto, bybit-derived)
+└── polymarket/  # Polymarket prediction markets (has a dry_run paper path)
 ```
 
 ## Supported Providers
@@ -22,12 +25,29 @@ live/
 ### Binance (`binance/`)
 - **Markets**: Crypto futures (USDT-margined)
 - **Environments**: `BinanceFuturesTorchTradingEnv`, `BinanceFuturesSLTPTorchTradingEnv`
-- **Features**: Leverage trading, isolated/cross margin, funding fees
+- **Features**: Leverage trading, isolated/cross margin
 
 ### Bitget (`bitget/`)
 - **Markets**: Crypto futures (USDT-margined)
 - **Environments**: `BitgetFuturesTorchTradingEnv`, `BitgetFuturesSLTPTorchTradingEnv`
-- **Features**: Leverage trading, low fees, copy trading integration
+- **Features**: Leverage trading, cross/isolated margin, one-way or hedge position mode
+
+### Bybit (`bybit/`)
+- **Markets**: Crypto futures (USDT-margined)
+- **Environments**: `BybitFuturesTorchTradingEnv`, `BybitFuturesSLTPTorchTradingEnv`
+- **Features**: Leverage trading, cross/isolated margin, testnet
+
+### OKX (`okx/`)
+- **Markets**: Crypto futures (USDT-margined)
+- **Environments**: `OKXFuturesTorchTradingEnv`, `OKXFuturesSLTPTorchTradingEnv`
+- **Features**: Bybit-derived integration, leverage trading, testnet
+
+### Polymarket (`polymarket/`)
+- **Markets**: Prediction markets
+- **Components**: `PolymarketBetEnv`, `MarketScanner`, `PolymarketOrderExecutor`
+- **Features**: `dry_run` paper path
+
+No environment on any venue models funding fees -- see the note in `binance/README.md`.
 
 ## Quick Start
 
@@ -38,7 +58,6 @@ import os
 
 import torch
 from torchtrade.envs.live.alpaca.env import AlpacaTorchTradingEnv, AlpacaTradingEnvConfig
-from torchtrade.envs.utils import TimeFrame, TimeFrameUnit
 
 config = AlpacaTradingEnvConfig(
     paper=True,  # Use paper trading for testing
@@ -58,10 +77,12 @@ env = AlpacaTorchTradingEnv(
 td = env.reset()
 while True:
     td["action"] = agent.get_action(td)
-    # step_and_maybe_reset returns (next_td, reset_td); the first element is the one
-    # to keep stepping. Plain step() leaves the root observation at its reset value.
-    td = env.step_and_maybe_reset(td)[0]
-    if td["next", "done"]:
+    # Returns (transition_td, next_root_td). The transition carries ("next", ...) --
+    # the outcome and the done flag -- while ITS root is the observation you just acted
+    # on. The second element is the step_mdp'd observation to act on next. Keeping only
+    # the first stalls the policy on the reset observation forever.
+    transition, td = env.step_and_maybe_reset(td)
+    if transition["next", "done"]:
         break
 ```
 
@@ -72,7 +93,6 @@ from torchtrade.envs.core.common_types import MarginType
 
 import os
 from torchtrade.envs.live.binance.env import BinanceFuturesTorchTradingEnv, BinanceFuturesTradingEnvConfig
-from torchtrade.envs.utils import TimeFrame, TimeFrameUnit
 
 config = BinanceFuturesTradingEnvConfig(
     symbol="BTCUSDT",
@@ -94,18 +114,22 @@ env = BinanceFuturesTorchTradingEnv(
 td = env.reset()
 while True:
     td["action"] = agent.get_action(td)
-    # step_and_maybe_reset returns (next_td, reset_td); keep the first to step on.
-    # Plain step() leaves the root observation at its reset value forever.
-    td = env.step_and_maybe_reset(td)[0]
-    if td["next", "done"]:
+    # step_and_maybe_reset returns (transition_td, next_root_td). BOTH are needed:
+    # `transition` carries ("next", ...) -- the outcome and the done flag -- while its
+    # ROOT is still the observation you just acted on. `root` is the step_mdp'd
+    # observation to act on next. Keeping only [0] leaves the policy reading the reset
+    # observation forever, which is the same silent stall as `td = env.step(td)`.
+    transition, root = env.step_and_maybe_reset(td)
+    if transition["next", "done"]:
         break
+    td = root
 ```
 
 ## Configuration
 
 ### Common Parameters
 
-All live environments share these base parameters:
+The non-SLTP live environments share these base parameters:
 
 ```python
 # There is no shared LiveEnvConfig -- each exchange ships its own dataclass. What they
@@ -219,7 +243,6 @@ env = AlpacaSLTPTorchTradingEnv(
 ### Error Handling
 
 Environments handle common errors:
-- Network failures → Auto-retry with exponential backoff
 - API rate limits → Automatic throttling
 - Invalid orders → Error logging, no crash
 - Position desync → Automatic reconciliation
@@ -232,8 +255,9 @@ Live environments stream real-time market data:
 
 ```python
 from torchtrade.envs.live.alpaca import AlpacaTorchTradingEnv
-
 import os
+import torch
+
 env = AlpacaTorchTradingEnv(
     # Credentials are CONSTRUCTOR arguments, not config fields.
     config, api_key=os.environ["ALPACA_API_KEY"],
@@ -243,13 +267,10 @@ env = AlpacaTorchTradingEnv(
 # Data updates automatically
 td = env.reset()  # Gets latest market data
 
-# Step waits for new bar
-td["action"] = action
-td = env.step_and_maybe_reset(td)[0]  # Waits for next bar
+# Step blocks until the new bar arrives
+td["action"] = torch.tensor(1)
+transition, td = env.step_and_maybe_reset(td)  # Waits for next bar
 
-if td["next", "done"]:
-
-    break
 ```
 
 ### Latency Considerations
@@ -265,25 +286,27 @@ Environments sync with market time:
 ```python
 from torchtrade.envs.live.alpaca import AlpacaTorchTradingEnv
 from torchtrade.envs.live.alpaca import AlpacaTradingEnvConfig
+import os
 import time
+import torch
 
-# 1-minute bars: step() returns when new bar arrives
+# 1-minute bars: step() returns when the new bar arrives
 env = AlpacaTorchTradingEnv(
-    config=AlpacaTradingEnvConfig(
+    AlpacaTradingEnvConfig(
         time_frames=["1Min"],
         window_sizes=[10],
         execute_on="1Min",
-    )
+    ),
+    api_key=os.environ["ALPACA_API_KEY"],
+    api_secret=os.environ["ALPACA_SECRET_KEY"],
 )
 
-# Step waits until next minute
+# Step blocks until the next minute closes
+td = env.reset()
 start = time.time()
-td["action"] = action
-td = env.step_and_maybe_reset(td)[0]
+td["action"] = torch.tensor(1)
+transition, td = env.step_and_maybe_reset(td)
 
-if td["next", "done"]:
-
-    break
 elapsed = time.time() - start
 # elapsed ≈ 60 seconds (wait for new bar)
 ```
@@ -314,10 +337,11 @@ for entries and native bracket orders for SL/TP.
 
 ### Partial Fills
 
-Environments handle partial fills:
-- Retry until fully filled
-- Or adjust position size accordingly
-- Read from `account_state` in the observation
+**Environments do not handle partial fills.** There is no retry-to-fill and no size
+adjustment; `binance/env.py` carries an open TODO to track partial execution state at
+all. What you get is the truth after the fact: `account_state` reports the position the
+exchange actually holds, so a partially filled order shows up as a smaller
+`exposure_pct` than the action requested.
 
 ## Position Management
 
@@ -327,16 +351,13 @@ Environments track positions automatically:
 
 ```python
 td["action"] = action
-td = env.step_and_maybe_reset(td)[0]
+transition, td = env.step_and_maybe_reset(td)
 
-if td["next", "done"]:
-
-    break
 
 # account_state is [exposure, direction, unrealized_pnl_pct, holding_time,
 # leverage, distance_to_liquidation] -- there is no `info` dict.
-direction = td["next", "account_state"][1].item()
-unrealized_pnl_pct = td["next", "account_state"][2].item()
+direction = transition["next", "account_state"][1].item()
+unrealized_pnl_pct = transition["next", "account_state"][2].item()
 ```
 
 ### Position Synchronization
@@ -352,13 +373,10 @@ Environments sync with exchange:
 import torch
 
 # Close all positions
-action = torch.tensor(0)  # 0 allocates 0% -- i.e. go flat
+action = torch.tensor(env.action_levels.index(0.0))  # the flat level
 td["action"] = action
-td = env.step_and_maybe_reset(td)[0]
+transition, td = env.step_and_maybe_reset(td)
 
-if td["next", "done"]:
-
-    break
 
 # Or close directly through the trader
 env.trader.close_position()
@@ -503,7 +521,6 @@ def test_alpaca_connection():
 - Leverage too high
 
 **Position desync:**
-- Environment resets automatically
 - Check exchange for manual trades
 - The env re-reads the exchange position every step, so a manual trade is picked
   up on the next bar (see `_sync_position_from_exchange`)

--- a/torchtrade/envs/live/README.md
+++ b/torchtrade/envs/live/README.md
@@ -38,15 +38,18 @@ from torchtrade.envs.live.alpaca.env import AlpacaTorchTradingEnv, AlpacaTrading
 from torchtrade.envs.utils import TimeFrame, TimeFrameUnit
 
 config = AlpacaTradingEnvConfig(
-    api_key="YOUR_API_KEY",
-    api_secret="YOUR_SECRET_KEY",
     paper=True,  # Use paper trading for testing
     symbol="AAPL",
-    timeframe=TimeFrame(1, TimeFrameUnit.MINUTE),
-    initial_cash=10000.0,
+    time_frames=["1Min"],
+    window_sizes=[10],
+    execute_on="1Min",
 )
 
-env = AlpacaTorchTradingEnv(config=config)
+env = AlpacaTorchTradingEnv(
+    # Credentials are CONSTRUCTOR arguments, not config fields.
+    config, api_key=os.environ["ALPACA_API_KEY"],
+    api_secret=os.environ["ALPACA_SECRET_KEY"],
+)
 
 # Run live trading loop
 obs = env.reset()
@@ -65,16 +68,20 @@ from torchtrade.envs.live.binance.env import BinanceFuturesTorchTradingEnv, Bina
 from torchtrade.envs.utils import TimeFrame, TimeFrameUnit
 
 config = BinanceFuturesTradingEnvConfig(
-    api_key="YOUR_API_KEY",
-    api_secret="YOUR_SECRET_KEY",
     symbol="BTCUSDT",
-    timeframe=TimeFrame(1, TimeFrameUnit.MINUTE),
-    testnet=True,  # Use testnet for testing
-    max_leverage=10.0,
+    time_frames=["1Min"],
+    window_sizes=[10],
+    execute_on="1Min",
+    demo=True,  # Use testnet for testing
+    leverage=10.0,
     margin_type="ISOLATED",
 )
 
-env = BinanceFuturesTorchTradingEnv(config=config)
+env = BinanceFuturesTorchTradingEnv(
+    # Credentials are CONSTRUCTOR arguments, not config fields.
+    config, api_key=os.environ["BINANCE_API_KEY"],
+    api_secret=os.environ["BINANCE_SECRET_KEY"],
+)
 
 # Run trading loop
 obs = env.reset()
@@ -138,16 +145,12 @@ Always test strategies in safe environments:
 ```python
 # Alpaca paper trading
 config = AlpacaTradingEnvConfig(
-    api_key=key,
-    api_secret=secret,
     paper=True,  # No real money
 )
 
 # Binance testnet
 config = BinanceFuturesTradingEnvConfig(
-    api_key=key,
-    api_secret=secret,
-    testnet=True,  # Fake funds
+    demo=True,  # Fake funds
 )
 ```
 
@@ -158,7 +161,6 @@ Set maximum position sizes:
 ```python
 config = AlpacaTradingEnvConfig(
     # ...
-    max_position_size=0.1,  # Max 10% of portfolio
 )
 ```
 
@@ -171,11 +173,15 @@ from torchtrade.envs.live.alpaca.env_sltp import AlpacaSLTPTorchTradingEnv
 
 config = AlpacaSLTPTradingEnvConfig(
     # ...
-    sl_percent=0.02,  # 2% stop loss
-    tp_percent=0.05,  # 5% take profit
+    stoploss_levels=[-0.02],  # 2% stop loss
+    takeprofit_levels=[0.05],  # 5% take profit
 )
 
-env = AlpacaSLTPTorchTradingEnv(config=config)
+env = AlpacaSLTPTorchTradingEnv(
+    # Credentials are CONSTRUCTOR arguments, not config fields.
+    config, api_key=os.environ["ALPACA_API_KEY"],
+    api_secret=os.environ["ALPACA_SECRET_KEY"],
+)
 ```
 
 ### Error Handling
@@ -193,7 +199,11 @@ Environments handle common errors:
 Live environments stream real-time market data:
 
 ```python
-env = AlpacaTorchTradingEnv(config=config)
+env = AlpacaTorchTradingEnv(
+    # Credentials are CONSTRUCTOR arguments, not config fields.
+    config, api_key=os.environ["ALPACA_API_KEY"],
+    api_secret=os.environ["ALPACA_SECRET_KEY"],
+)
 
 # Data updates automatically
 obs = env.reset()  # Gets latest market data
@@ -216,7 +226,9 @@ Environments sync with market time:
 # 1-minute bars: step() returns when new bar arrives
 env = AlpacaTorchTradingEnv(
     config=AlpacaTradingEnvConfig(
-        timeframe=TimeFrame(1, TimeFrameUnit.MINUTE)
+        time_frames=["1Min"],
+        window_sizes=[10],
+        execute_on="1Min",
     )
 )
 
@@ -299,7 +311,11 @@ import logging
 
 logging.basicConfig(level=logging.INFO)
 
-env = AlpacaTorchTradingEnv(config=config)
+env = AlpacaTorchTradingEnv(
+    # Credentials are CONSTRUCTOR arguments, not config fields.
+    config, api_key=os.environ["ALPACA_API_KEY"],
+    api_secret=os.environ["ALPACA_SECRET_KEY"],
+)
 # Logs:
 # - Order submissions
 # - Fills
@@ -362,14 +378,11 @@ signal.signal(signal.SIGINT, signal_handler)
 ```python
 # Bad
 config = AlpacaTradingEnvConfig(
-    api_key="AKXXXXXXXXXXXX",  # Don't do this!
 )
 
 # Good
 import os
 config = AlpacaTradingEnvConfig(
-    api_key=os.environ["ALPACA_API_KEY"],
-    api_secret=os.environ["ALPACA_SECRET_KEY"],
 )
 ```
 
@@ -383,13 +396,15 @@ from torchtrade.envs.live.alpaca.env import AlpacaTorchTradingEnv
 def test_alpaca_connection():
     """Test connection to Alpaca paper trading"""
     config = AlpacaTradingEnvConfig(
-        api_key=os.environ["ALPACA_KEY"],
-        api_secret=os.environ["ALPACA_SECRET"],
         paper=True,
         symbol="SPY",
     )
 
-    env = AlpacaTorchTradingEnv(config=config)
+    env = AlpacaTorchTradingEnv(
+    # Credentials are CONSTRUCTOR arguments, not config fields.
+    config, api_key=os.environ["ALPACA_API_KEY"],
+    api_secret=os.environ["ALPACA_SECRET_KEY"],
+)
     obs = env.reset()
 
     assert obs is not None

--- a/torchtrade/envs/live/README.md
+++ b/torchtrade/envs/live/README.md
@@ -34,6 +34,9 @@ live/
 ### Alpaca Live Trading
 
 ```python
+import os
+
+import torch
 from torchtrade.envs.live.alpaca.env import AlpacaTorchTradingEnv, AlpacaTradingEnvConfig
 from torchtrade.envs.utils import TimeFrame, TimeFrameUnit
 
@@ -52,10 +55,11 @@ env = AlpacaTorchTradingEnv(
 )
 
 # Run live trading loop
-obs = env.reset()
+td = env.reset()
 while True:
     action = agent.get_action(obs)
-    obs, reward, done, info = env.step(action)
+    td["action"] = action
+    td = env.step(td)
 
     if done:
         break
@@ -64,6 +68,7 @@ while True:
 ### Binance Futures Trading
 
 ```python
+import os
 from torchtrade.envs.live.binance.env import BinanceFuturesTorchTradingEnv, BinanceFuturesTradingEnvConfig
 from torchtrade.envs.utils import TimeFrame, TimeFrameUnit
 
@@ -84,10 +89,11 @@ env = BinanceFuturesTorchTradingEnv(
 )
 
 # Run trading loop
-obs = env.reset()
+td = env.reset()
 while not done:
     action = agent.get_action(obs)
-    obs, reward, done, info = env.step(action)
+    td["action"] = action
+    td = env.step(td)
 ```
 
 ## Configuration
@@ -97,43 +103,46 @@ while not done:
 All live environments share these base parameters:
 
 ```python
-@dataclass
-class LiveEnvConfig:
-    api_key: str                   # API key
-    api_secret: str                # API secret
-    symbol: str                    # Trading symbol
-    timeframe: TimeFrame           # Bar timeframe
-    window_size: int = 50         # Observation window
-    initial_cash: float = 10000.0  # Starting capital
+# There is no shared LiveEnvConfig -- each exchange ships its own dataclass. What they
+# have in common:
+#
+#   symbol, time_frames (a LIST), window_sizes (one per timeframe), execute_on,
+#   action_levels, done_on_bankruptcy, bankrupt_threshold, seed,
+#   include_base_features
+#
+# Futures configs add: leverage, margin_type/margin_mode, demo,
+#   close_position_on_init, close_position_on_reset, observation_failure_policy
+# Alpaca adds: paper, trade_mode
+#
+# Credentials are CONSTRUCTOR arguments on every exchange, never config fields.
+# See the per-exchange READMEs for the exact field list.
 ```
 
 ### Provider-Specific
 
+These are standalone dataclasses -- there is no shared base to inherit from. The fields
+that differ between exchanges:
+
 **Alpaca:**
 ```python
-@dataclass
-class AlpacaTradingEnvConfig(LiveEnvConfig):
-    paper: bool = True             # Paper or live trading
-    base_url: str = None           # Custom API endpoint
-    extended_hours: bool = False   # Trade extended hours
+paper: bool = True                          # Paper or live trading
+trade_mode: str = "notional"                # "fractional" | "notional" | "quantity"
 ```
 
 **Binance:**
 ```python
-@dataclass
-class BinanceFuturesTradingEnvConfig(LiveEnvConfig):
-    testnet: bool = True           # Testnet or mainnet
-    max_leverage: float = 10.0     # Maximum leverage
-    margin_type: str = "ISOLATED"  # ISOLATED or CROSS
+demo: bool = True                           # Testnet or mainnet
+leverage: int = 1                           # the leverage APPLIED, not a cap
+margin_type: MarginType = MarginType.ISOLATED   # ISOLATED or CROSSED (the enum)
 ```
 
 **Bitget:**
 ```python
-@dataclass
-class BitgetFuturesTradingEnvConfig(LiveEnvConfig):
-    testnet: bool = True           # Testnet or mainnet
-    max_leverage: float = 10.0     # Maximum leverage
-    margin_mode: str = "isolated"  # isolated or crossed
+demo: bool = True                           # Testnet or mainnet
+leverage: int = 1                           # the leverage APPLIED, not a cap
+margin_mode: MarginMode = MarginMode.ISOLATED   # ISOLATED or CROSSED (the enum)
+position_mode: PositionMode = PositionMode.ONE_WAY
+product_type: str = "USDT-FUTURES"
 ```
 
 ## Safety Features
@@ -156,11 +165,16 @@ config = BinanceFuturesTradingEnvConfig(
 
 ### Position Limits
 
-Set maximum position sizes:
+Position size is capped by `action_levels` -- each entry is the fraction of the
+portfolio an action allocates, so the largest level is the maximum exposure:
 
 ```python
 config = AlpacaTradingEnvConfig(
-    # ...
+    symbol="BTC/USD",
+    time_frames=["1Min"],
+    window_sizes=[10],
+    execute_on="1Min",
+    action_levels=[0.0, 0.25, 0.5],  # never more than 50% of the portfolio
 )
 ```
 
@@ -169,6 +183,7 @@ config = AlpacaTradingEnvConfig(
 Use SL/TP environments for automatic risk management:
 
 ```python
+import os
 from torchtrade.envs.live.alpaca.env_sltp import AlpacaSLTPTorchTradingEnv
 
 config = AlpacaSLTPTradingEnvConfig(
@@ -199,6 +214,7 @@ Environments handle common errors:
 Live environments stream real-time market data:
 
 ```python
+import os
 env = AlpacaTorchTradingEnv(
     # Credentials are CONSTRUCTOR arguments, not config fields.
     config, api_key=os.environ["ALPACA_API_KEY"],
@@ -206,10 +222,11 @@ env = AlpacaTorchTradingEnv(
 )
 
 # Data updates automatically
-obs = env.reset()  # Gets latest market data
+td = env.reset()  # Gets latest market data
 
 # Step waits for new bar
-obs, reward, done, info = env.step(action)  # Waits for next bar
+td["action"] = action
+td = env.step(td)  # Waits for next bar
 ```
 
 ### Latency Considerations
@@ -234,7 +251,8 @@ env = AlpacaTorchTradingEnv(
 
 # Step waits until next minute
 start = time.time()
-obs, reward, done, info = env.step(action)
+td["action"] = action
+td = env.step(td)
 elapsed = time.time() - start
 # elapsed ≈ 60 seconds (wait for new bar)
 ```
@@ -245,7 +263,7 @@ elapsed = time.time() - start
 
 **Market Orders** (default):
 ```python
-action = 0  # BUY at market price
+action = torch.tensor(2)  # action_levels [0.0, 0.5, 1.0] -> 2 = fully long
 ```
 
 **Limit Orders** (future feature):
@@ -276,7 +294,8 @@ Environments handle partial fills:
 Environments track positions automatically:
 
 ```python
-obs, reward, done, info = env.step(action)
+td["action"] = action
+td = env.step(td)
 
 current_position = info["position"]
 current_pnl = info["unrealized_pnl"]
@@ -293,11 +312,12 @@ Environments sync with exchange:
 
 ```python
 # Close all positions
-action = 1  # SELL action
-obs, reward, done, info = env.step(action)
+action = torch.tensor(0)  # 0 allocates 0% -- i.e. go flat
+td["action"] = action
+td = env.step(td)
 
-# Or use close_all_positions() method
-env.close_all_positions()
+# Or close directly through the trader
+env.trader.close_position()
 ```
 
 ## Monitoring
@@ -307,6 +327,7 @@ env.close_all_positions()
 Environments log important events:
 
 ```python
+import os
 import logging
 
 logging.basicConfig(level=logging.INFO)
@@ -329,7 +350,6 @@ Track live performance:
 
 ```python
 # Get real-time metrics
-metrics = env.get_metrics()
 
 print(f"Portfolio Value: ${metrics['portfolio_value']:.2f}")
 print(f"Total PnL: ${metrics['realized_pnl']:.2f}")
@@ -365,7 +385,7 @@ import signal
 
 def signal_handler(sig, frame):
     print("Shutting down gracefully...")
-    env.close_all_positions()
+    env.trader.close_position()
     env.close()
     sys.exit(0)
 
@@ -374,21 +394,27 @@ signal.signal(signal.SIGINT, signal_handler)
 
 ### API Key Security
 
-**Never hardcode keys:**
+**Never hardcode keys.** They are constructor arguments, so this is where the contrast
+lives -- the config itself never holds a credential:
+
 ```python
-# Bad
-config = AlpacaTradingEnvConfig(
-)
+import os
+
+# Bad -- a key in the source is a key in your git history
+env = AlpacaTorchTradingEnv(config, api_key="PKXXXXXXXXXXXXXXXXXX")
 
 # Good
-import os
-config = AlpacaTradingEnvConfig(
+env = AlpacaTorchTradingEnv(
+    config,
+    api_key=os.environ["ALPACA_API_KEY"],
+    api_secret=os.environ["ALPACA_SECRET_KEY"],
 )
 ```
 
 ## Testing Live Environments
 
 ```python
+import os
 import pytest
 from torchtrade.envs.live.alpaca.env import AlpacaTorchTradingEnv
 
@@ -405,10 +431,9 @@ def test_alpaca_connection():
     config, api_key=os.environ["ALPACA_API_KEY"],
     api_secret=os.environ["ALPACA_SECRET_KEY"],
 )
-    obs = env.reset()
+    td = env.reset()
 
     assert obs is not None
-    assert env.is_connected()
 ```
 
 ## Troubleshooting
@@ -429,7 +454,8 @@ def test_alpaca_connection():
 **Position desync:**
 - Environment resets automatically
 - Check exchange for manual trades
-- Use `sync_positions()` method
+- The env re-reads the exchange position every step, so a manual trade is picked
+  up on the next bar (see `_sync_position_from_exchange`)
 
 ## See Also
 

--- a/torchtrade/envs/live/alpaca/README.md
+++ b/torchtrade/envs/live/alpaca/README.md
@@ -45,21 +45,23 @@ td = env.reset()  # a TensorDict, not a bare array
 ## Configuration
 
 ```python
-@dataclass
-class AlpacaTradingEnvConfig:
-    symbol: str = "BTC/USD"
-    action_levels: Optional[List[float]] = None     # None -> [0.0, 0.5, 1.0]
-    time_frames: Union[List[str | TimeFrame], str, TimeFrame] = "1Hour"
-    window_sizes: Union[List[int], int] = 10        # one per timeframe
-    execute_on: Union[str, TimeFrame] = "1Hour"     # which timeframe drives a step
-    done_on_bankruptcy: bool = True
-    bankrupt_threshold: float = 0.1
-    paper: bool = True                              # Paper or live trading
-    trade_mode: Literal["fractional", "notional", "quantity"] = "notional"
-    seed: Optional[int] = 42
-    include_base_features: bool = False
-    # Credentials are CONSTRUCTOR arguments, not fields:
-    #   AlpacaTorchTradingEnv(config, api_key=..., api_secret=...)
+from torchtrade.envs.live.alpaca import AlpacaTradingEnvConfig
+
+# Every field of AlpacaTradingEnvConfig, with its real default.
+# Credentials are NOT fields -- they are constructor arguments on the env.
+config = AlpacaTradingEnvConfig(
+    symbol='BTC/USD',
+    action_levels=None,
+    time_frames='1Hour',
+    window_sizes=10,
+    execute_on='1Hour',
+    done_on_bankruptcy=True,
+    bankrupt_threshold=0.1,
+    paper=True,
+    trade_mode='notional',
+    seed=42,
+    include_base_features=False,
+)
 ```
 
 ## Supported Symbols

--- a/torchtrade/envs/live/binance/README.md
+++ b/torchtrade/envs/live/binance/README.md
@@ -14,20 +14,26 @@ Live trading integration with Binance for crypto futures markets (USDT-margined)
 ## Quick Start
 
 ```python
+import os
+
 from torchtrade.envs.live.binance.env import BinanceFuturesTorchTradingEnv, BinanceFuturesTradingEnvConfig
 from torchtrade.envs.utils import TimeFrame, TimeFrameUnit
 
 config = BinanceFuturesTradingEnvConfig(
-    api_key="YOUR_KEY",
-    api_secret="YOUR_SECRET",
     symbol="BTCUSDT",
-    timeframe=TimeFrame(1, TimeFrameUnit.MINUTE),
-    testnet=True,  # Use testnet first!
-    max_leverage=10.0,
+    time_frames=["1Min"],
+    window_sizes=[10],
+    execute_on="1Min",
+    demo=True,  # Use testnet first!
+    leverage=10.0,
     margin_type="ISOLATED",
 )
 
-env = BinanceFuturesTorchTradingEnv(config=config)
+env = BinanceFuturesTorchTradingEnv(
+    # Credentials are CONSTRUCTOR arguments, not config fields.
+    config, api_key=os.environ["BINANCE_API_KEY"],
+    api_secret=os.environ["BINANCE_SECRET_KEY"],
+)
 obs = env.reset()
 ```
 
@@ -60,9 +66,7 @@ class BinanceFuturesTradingEnvConfig:
 **Testnet** (recommended for development):
 ```python
 config = BinanceFuturesTradingEnvConfig(
-    api_key=testnet_key,
-    api_secret=testnet_secret,
-    testnet=True,  # Fake funds
+    demo=True,  # Fake funds
 )
 ```
 
@@ -71,9 +75,7 @@ Get testnet API keys: https://testnet.binancefuture.com/
 **Mainnet** (real money):
 ```python
 config = BinanceFuturesTradingEnvConfig(
-    api_key=mainnet_key,
-    api_secret=mainnet_secret,
-    testnet=False,  # Real trading!
+    demo=False,  # Real trading!
 )
 ```
 
@@ -87,7 +89,7 @@ config = BinanceFuturesTradingEnvConfig(
 ```python
 config = BinanceFuturesTradingEnvConfig(
     margin_type="ISOLATED",
-    max_leverage=10.0,
+    leverage=10.0,
 )
 ```
 
@@ -99,7 +101,7 @@ config = BinanceFuturesTradingEnvConfig(
 ```python
 config = BinanceFuturesTradingEnvConfig(
     margin_type="CROSS",
-    max_leverage=20.0,
+    leverage=20.0,
 )
 ```
 
@@ -110,12 +112,12 @@ Set leverage per symbol:
 ```python
 # Conservative leverage
 config = BinanceFuturesTradingEnvConfig(
-    max_leverage=3.0,  # 3x leverage
+    leverage=3.0,  # 3x leverage
 )
 
 # Higher leverage (risky!)
 config = BinanceFuturesTradingEnvConfig(
-    max_leverage=50.0,  # 50x leverage
+    leverage=50.0,  # 50x leverage
 )
 ```
 
@@ -173,16 +175,20 @@ Environments simulate funding fees automatically.
 from torchtrade.envs.live.binance.env import BinanceFuturesTorchTradingEnv, BinanceFuturesTradingEnvConfig
 
 config = BinanceFuturesTradingEnvConfig(
-    api_key=os.environ["BINANCE_TESTNET_KEY"],
-    api_secret=os.environ["BINANCE_TESTNET_SECRET"],
     symbol="BTCUSDT",
-    timeframe=TimeFrame(5, TimeFrameUnit.MINUTE),
-    testnet=True,
-    max_leverage=5.0,
+    time_frames=["1Min"],
+    window_sizes=[10],
+    execute_on="1Min",
+    demo=True,
+    leverage=5.0,
     margin_type="ISOLATED",
 )
 
-env = BinanceFuturesTorchTradingEnv(config=config)
+env = BinanceFuturesTorchTradingEnv(
+    # Credentials are CONSTRUCTOR arguments, not config fields.
+    config, api_key=os.environ["BINANCE_API_KEY"],
+    api_secret=os.environ["BINANCE_SECRET_KEY"],
+)
 obs = env.reset()
 
 # Go long with 5x leverage
@@ -199,17 +205,21 @@ print(f"Unrealized PnL: ${info['unrealized_pnl']:.2f}")
 from torchtrade.envs.live.binance.env_sltp import BinanceFuturesSLTPTorchTradingEnv
 
 config = BinanceFuturesSLTPTradingEnvConfig(
-    api_key=os.environ["BINANCE_TESTNET_KEY"],
-    api_secret=os.environ["BINANCE_TESTNET_SECRET"],
     symbol="ETHUSDT",
-    timeframe=TimeFrame(1, TimeFrameUnit.MINUTE),
-    testnet=True,
-    max_leverage=3.0,
-    sl_percent=0.02,  # 2% stop loss (important with leverage!)
-    tp_percent=0.04,  # 4% take profit
+    time_frames=["1Min"],
+    window_sizes=[10],
+    execute_on="1Min",
+    demo=True,
+    leverage=3.0,
+    stoploss_levels=[-0.02],  # 2% stop loss (important with leverage!)
+    takeprofit_levels=[0.04],  # 4% take profit
 )
 
-env = BinanceFuturesSLTPTorchTradingEnv(config=config)
+env = BinanceFuturesSLTPTorchTradingEnv(
+    # Credentials are CONSTRUCTOR arguments, not config fields.
+    config, api_key=os.environ["BINANCE_API_KEY"],
+    api_secret=os.environ["BINANCE_SECRET_KEY"],
+)
 obs = env.reset()
 ```
 

--- a/torchtrade/envs/live/binance/README.md
+++ b/torchtrade/envs/live/binance/README.md
@@ -18,7 +18,6 @@ import os
 
 from torchtrade.envs.core.common_types import MarginType
 from torchtrade.envs.live.binance.env import BinanceFuturesTorchTradingEnv, BinanceFuturesTradingEnvConfig
-from torchtrade.envs.utils import TimeFrame, TimeFrameUnit
 
 config = BinanceFuturesTradingEnvConfig(
     symbol="BTCUSDT",
@@ -42,7 +41,6 @@ obs = env.reset()
 
 - **Leverage Trading**: Up to 125x leverage (use responsibly!)
 - **Isolated/Cross Margin**: Choose margin mode
-- **Funding Fees**: Realistic funding fee simulation
 - **Liquidation**: Automatic liquidation handling
 - **Testnet**: Safe testing environment with fake funds
 
@@ -188,12 +186,14 @@ env = BinanceFuturesTorchTradingEnv(
 
 ## Funding Fees
 
-Futures have periodic funding fees:
-- **Rate**: ±0.01% typically
-- **Frequency**: Every 8 hours (00:00, 08:00, 16:00 UTC)
-- **Direction**: Longs pay shorts (or vice versa)
+Perpetual futures charge funding every 8 hours (00:00 / 08:00 / 16:00 UTC), typically
+±0.01%, paid between longs and shorts.
 
-Environments simulate funding fees automatically.
+**These environments do not model funding.** `grep -ri funding torchtrade/ --include=*.py`
+returns nothing: no offline env accrues it and no live env reads the venue's funding rate.
+A held position therefore costs less in backtest than it does on the exchange, and the
+error grows with holding time and leverage. Budget for it outside the environment when
+evaluating a policy that carries positions across funding timestamps.
 
 ## Example: Basic Futures Trading
 

--- a/torchtrade/envs/live/binance/README.md
+++ b/torchtrade/envs/live/binance/README.md
@@ -16,6 +16,7 @@ Live trading integration with Binance for crypto futures markets (USDT-margined)
 ```python
 import os
 
+from torchtrade.envs.core.common_types import MarginType
 from torchtrade.envs.live.binance.env import BinanceFuturesTorchTradingEnv, BinanceFuturesTradingEnvConfig
 from torchtrade.envs.utils import TimeFrame, TimeFrameUnit
 
@@ -26,7 +27,7 @@ config = BinanceFuturesTradingEnvConfig(
     execute_on="1Min",
     demo=True,  # Use testnet first!
     leverage=10.0,
-    margin_type="ISOLATED",
+    margin_type=MarginType.ISOLATED,
 )
 
 env = BinanceFuturesTorchTradingEnv(
@@ -50,15 +51,22 @@ obs = env.reset()
 ```python
 @dataclass
 class BinanceFuturesTradingEnvConfig:
-    api_key: str
-    api_secret: str
-    symbol: str
-    timeframe: TimeFrame
-    testnet: bool = True            # Testnet or mainnet
-    max_leverage: float = 10.0      # Maximum leverage
-    margin_type: str = "ISOLATED"   # ISOLATED or CROSS
-    initial_margin: float = 1000.0
-    window_size: int = 50
+    symbol = 'BTCUSDT'
+    time_frames = '1Hour'
+    window_sizes = 10
+    execute_on = '1Hour'
+    leverage = 1
+    margin_type = MarginType.ISOLATED
+    action_levels = None
+    done_on_bankruptcy = True
+    bankrupt_threshold = 0.1
+    demo = True
+    seed = 42
+    include_base_features = False
+    close_position_on_init = True
+    close_position_on_reset = False
+    observation_failure_policy = ObservationFailurePolicy.HALT
+    # Credentials: Env(config, api_key=..., api_secret=...)
 ```
 
 ## Testnet vs Mainnet
@@ -88,7 +96,7 @@ config = BinanceFuturesTradingEnvConfig(
 
 ```python
 config = BinanceFuturesTradingEnvConfig(
-    margin_type="ISOLATED",
+    margin_type=MarginType.ISOLATED,
     leverage=10.0,
 )
 ```
@@ -100,7 +108,7 @@ config = BinanceFuturesTradingEnvConfig(
 
 ```python
 config = BinanceFuturesTradingEnvConfig(
-    margin_type="CROSS",
+    margin_type=MarginType.CROSSED,
     leverage=20.0,
 )
 ```
@@ -181,7 +189,7 @@ config = BinanceFuturesTradingEnvConfig(
     execute_on="1Min",
     demo=True,
     leverage=5.0,
-    margin_type="ISOLATED",
+    margin_type=MarginType.ISOLATED,
 )
 
 env = BinanceFuturesTorchTradingEnv(

--- a/torchtrade/envs/live/binance/README.md
+++ b/torchtrade/envs/live/binance/README.md
@@ -49,26 +49,30 @@ obs = env.reset()
 ```python
 from torchtrade.envs.core.common_types import MarginType
 from torchtrade.envs.core.live import ObservationFailurePolicy
-from dataclasses import dataclass
+from torchtrade.envs.live.binance import BinanceFuturesTradingEnvConfig
 
-@dataclass
-class BinanceFuturesTradingEnvConfig:
-    symbol = 'BTCUSDT'
-    time_frames = '1Hour'
-    window_sizes = 10
-    execute_on = '1Hour'
-    leverage = 1
-    margin_type = MarginType.ISOLATED
-    action_levels = None
-    done_on_bankruptcy = True
-    bankrupt_threshold = 0.1
-    demo = True
-    seed = 42
-    include_base_features = False
-    close_position_on_init = True
-    close_position_on_reset = False
-    observation_failure_policy = ObservationFailurePolicy.HALT
-    # Credentials: Env(config, api_key=..., api_secret=...)
+from torchtrade.envs.core.common_types import MarginType
+from torchtrade.envs.core.live import ObservationFailurePolicy
+
+# Every field of BinanceFuturesTradingEnvConfig, with its real default.
+# Credentials are NOT fields -- they are constructor arguments on the env.
+config = BinanceFuturesTradingEnvConfig(
+    symbol='BTCUSDT',
+    time_frames='1Hour',
+    window_sizes=10,
+    execute_on='1Hour',
+    leverage=1,
+    margin_type=MarginType.ISOLATED,
+    action_levels=None,
+    done_on_bankruptcy=True,
+    bankrupt_threshold=0.1,
+    demo=True,
+    seed=42,
+    include_base_features=False,
+    close_position_on_init=True,
+    close_position_on_reset=False,
+    observation_failure_policy=ObservationFailurePolicy.HALT,
+)
 ```
 
 ## Testnet vs Mainnet

--- a/torchtrade/envs/live/binance/README.md
+++ b/torchtrade/envs/live/binance/README.md
@@ -49,6 +49,10 @@ obs = env.reset()
 ## Configuration
 
 ```python
+from torchtrade.envs.core.common_types import MarginType
+from torchtrade.envs.core.live import ObservationFailurePolicy
+from dataclasses import dataclass
+
 @dataclass
 class BinanceFuturesTradingEnvConfig:
     symbol = 'BTCUSDT'
@@ -73,6 +77,8 @@ class BinanceFuturesTradingEnvConfig:
 
 **Testnet** (recommended for development):
 ```python
+from torchtrade.envs.live.binance import BinanceFuturesTradingEnvConfig
+
 config = BinanceFuturesTradingEnvConfig(
     demo=True,  # Fake funds
 )
@@ -82,6 +88,8 @@ Get testnet API keys: https://testnet.binancefuture.com/
 
 **Mainnet** (real money):
 ```python
+from torchtrade.envs.live.binance import BinanceFuturesTradingEnvConfig
+
 config = BinanceFuturesTradingEnvConfig(
     demo=False,  # Real trading!
 )
@@ -95,6 +103,9 @@ config = BinanceFuturesTradingEnvConfig(
 - Lower risk, position-specific leverage
 
 ```python
+from torchtrade.envs.live.binance import BinanceFuturesTradingEnvConfig
+from torchtrade.envs.core.common_types import MarginType
+
 config = BinanceFuturesTradingEnvConfig(
     margin_type=MarginType.ISOLATED,
     leverage=10.0,
@@ -107,6 +118,9 @@ config = BinanceFuturesTradingEnvConfig(
 - Higher leverage, shared risk
 
 ```python
+from torchtrade.envs.live.binance import BinanceFuturesTradingEnvConfig
+from torchtrade.envs.core.common_types import MarginType
+
 config = BinanceFuturesTradingEnvConfig(
     margin_type=MarginType.CROSSED,
     leverage=20.0,
@@ -118,6 +132,8 @@ config = BinanceFuturesTradingEnvConfig(
 Set leverage per symbol:
 
 ```python
+from torchtrade.envs.live.binance import BinanceFuturesTradingEnvConfig
+
 # Conservative leverage
 config = BinanceFuturesTradingEnvConfig(
     leverage=3.0,  # 3x leverage
@@ -147,6 +163,8 @@ The Binance observation class exposes all fields from Binance klines to your cus
 These extra fields allow you to derive sentiment features without additional API calls:
 
 ```python
+from torchtrade.envs.live.binance import BinanceFuturesTorchTradingEnv
+
 def my_preprocessing(df):
     df = df.copy()
     # Taker buy ratio: proportion of volume from aggressive buyers
@@ -180,6 +198,11 @@ Environments simulate funding fees automatically.
 ## Example: Basic Futures Trading
 
 ```python
+from torchtrade.envs.core.common_types import MarginType
+
+import os
+import torch
+
 from torchtrade.envs.live.binance.env import BinanceFuturesTorchTradingEnv, BinanceFuturesTradingEnvConfig
 
 config = BinanceFuturesTradingEnvConfig(
@@ -197,19 +220,27 @@ env = BinanceFuturesTorchTradingEnv(
     config, api_key=os.environ["BINANCE_API_KEY"],
     api_secret=os.environ["BINANCE_SECRET_KEY"],
 )
-obs = env.reset()
+td = env.reset()
 
-# Go long with 5x leverage
-action = {"direction": "long", "leverage": 5.0, "size": 0.5}
-obs, reward, done, info = env.step(action)
+# Actions are CATEGORICAL indices into action_levels, which defaults to [-1, 0, 1]:
+# 0 = full short, 1 = flat, 2 = full long. Leverage and size come from the config,
+# not from the action.
+td["action"] = torch.tensor(2)  # go long
+td = env.step(td)
 
-print(f"Position: {info['position']}")
-print(f"Unrealized PnL: ${info['unrealized_pnl']:.2f}")
+# account_state: [exposure, direction, unrealized_pnl_pct, holding_time,
+# leverage, distance_to_liquidation] -- step() returns no `info` dict.
+acct = td["next", "account_state"]
+print(f"Direction: {acct[1].item()}  Unrealized PnL %: {acct[2].item():.4f}")
 ```
 
 ## Example: With Risk Management
 
 ```python
+from torchtrade.envs.live.binance import BinanceFuturesSLTPTradingEnvConfig
+
+import os
+
 from torchtrade.envs.live.binance.env_sltp import BinanceFuturesSLTPTorchTradingEnv
 
 config = BinanceFuturesSLTPTradingEnvConfig(

--- a/torchtrade/envs/live/binance/env.py
+++ b/torchtrade/envs/live/binance/env.py
@@ -103,7 +103,7 @@ class BinanceFuturesTorchTradingEnv(BinanceBaseTorchTradingEnv):
         position_size = (balance × |action| × leverage) / price
         (rounded to exchange step size)
 
-    Default action_levels: [-1.0, -0.5, 0.0, 0.5, 1.0]
+    Default action_levels: [-1, 0, 1] (short / flat / long)
     Custom levels supported: e.g., [-1, -0.3, -0.1, 0, 0.1, 0.3, 1]
 
     Leverage Design:
@@ -115,10 +115,10 @@ class BinanceFuturesTorchTradingEnv(BinanceBaseTorchTradingEnv):
     Could be implemented as multi-dimensional actions if needed, but fixed
     leverage is recommended for most use cases.
 
-    Account State (10 elements):
+    Account State (6 elements; the list is ACCOUNT_STATE on the exchange base class):
     ---------------------------
-    [cash, position_size, position_value, entry_price, current_price,
-     unrealized_pnl_pct, leverage, margin_ratio, liquidation_price, holding_time]
+    [exposure_pct, position_direction, unrealized_pnlpct, holding_time,
+     leverage, distance_to_liquidation]
     """
 
     def __init__(

--- a/torchtrade/envs/live/binance/env_sltp.py
+++ b/torchtrade/envs/live/binance/env_sltp.py
@@ -116,9 +116,9 @@ class BinanceFuturesSLTPTorchTradingEnv(SLTPMixin, BinanceBaseTorchTradingEnv):
     - Tracks active SL/TP levels
     - Can optionally disable short positions for long-only strategies
 
-    Account State (10 elements):
-    [cash, position_size, position_value, entry_price, current_price,
-     unrealized_pnl_pct, leverage, margin_ratio, liquidation_price, holding_time]
+    Account State (6 elements; the list is ACCOUNT_STATE on the exchange base class):
+    [exposure_pct, position_direction, unrealized_pnlpct, holding_time,
+     leverage, distance_to_liquidation]
     """
 
     def __init__(

--- a/torchtrade/envs/live/bitget/README.md
+++ b/torchtrade/envs/live/bitget/README.md
@@ -196,7 +196,7 @@ obs = env.reset()
 
 Lower than most competitors!
 
-**Funding Fees**:
+**Funding Fees** (charged by the venue; **not modelled by these environments**):
 - Rate: Varies (typically ±0.01%)
 - Frequency: Every 8 hours
 
@@ -214,7 +214,7 @@ Check symbols: https://api.bitget.com/api/mix/v1/market/contracts?productType=um
 2. **Start with testnet**: Test thoroughly before live trading
 3. **Use conservative leverage**: 2-5x recommended
 4. **Enable IP whitelist**: Restrict API access to known IPs
-5. **Monitor fees**: Funding fees can add up
+5. **Monitor fees**: funding fees can add up, and nothing here accounts for them
 
 ## API Rate Limits
 

--- a/torchtrade/envs/live/bitget/README.md
+++ b/torchtrade/envs/live/bitget/README.md
@@ -50,6 +50,11 @@ obs = env.reset()
 ## Configuration
 
 ```python
+from torchtrade.envs.live.bitget.order_executor import MarginMode
+from torchtrade.envs.core.live import ObservationFailurePolicy
+from torchtrade.envs.live.bitget.order_executor import PositionMode
+from dataclasses import dataclass
+
 @dataclass
 class BitgetFuturesTradingEnvConfig:
     symbol = 'BTCUSDT'
@@ -78,6 +83,8 @@ class BitgetFuturesTradingEnvConfig:
 
 **Testnet**:
 ```python
+from torchtrade.envs.live.bitget import BitgetFuturesTradingEnvConfig
+
 config = BitgetFuturesTradingEnvConfig(
     demo=True,
 )
@@ -87,6 +94,8 @@ Get testnet credentials: https://www.bitget.com/en/testnet/
 
 **Mainnet**:
 ```python
+from torchtrade.envs.live.bitget import BitgetFuturesTradingEnvConfig
+
 config = BitgetFuturesTradingEnvConfig(
     demo=False,
 )
@@ -96,6 +105,9 @@ config = BitgetFuturesTradingEnvConfig(
 
 ### Isolated Margin
 ```python
+from torchtrade.envs.live.bitget import BitgetFuturesTradingEnvConfig
+from torchtrade.envs.live.bitget.order_executor import MarginMode
+
 config = BitgetFuturesTradingEnvConfig(
     margin_mode=MarginMode.ISOLATED,
     leverage=10.0,
@@ -104,6 +116,9 @@ config = BitgetFuturesTradingEnvConfig(
 
 ### Crossed Margin
 ```python
+from torchtrade.envs.live.bitget import BitgetFuturesTradingEnvConfig
+from torchtrade.envs.live.bitget.order_executor import MarginMode
+
 config = BitgetFuturesTradingEnvConfig(
     margin_mode=MarginMode.CROSSED,
     leverage=20.0,
@@ -113,6 +128,11 @@ config = BitgetFuturesTradingEnvConfig(
 ## Example: Basic Trading
 
 ```python
+from torchtrade.envs.live.bitget import BitgetFuturesTradingEnvConfig
+
+import os
+import torch
+
 from torchtrade.envs.live.bitget.env import BitgetFuturesTorchTradingEnv
 
 config = BitgetFuturesTradingEnvConfig(
@@ -130,16 +150,22 @@ env = BitgetFuturesTorchTradingEnv(
     api_secret=os.environ["BITGET_SECRET"],
     api_passphrase=os.environ["BITGET_PASSPHRASE"],
 )
-obs = env.reset()
+td = env.reset()
 
-# Long position
-action = {"direction": "long", "leverage": 5.0, "size": 0.5}
-obs, reward, done, info = env.step(action)
+# Actions are CATEGORICAL indices into action_levels, which defaults to [-1, 0, 1]:
+# 0 = full short, 1 = flat, 2 = full long. Leverage and size come from the config,
+# not from the action.
+td["action"] = torch.tensor(2)  # go long
+td = env.step(td)
 ```
 
 ## Example: With SL/TP
 
 ```python
+from torchtrade.envs.live.bitget import BitgetFuturesSLTPTradingEnvConfig
+
+import os
+
 from torchtrade.envs.live.bitget.env_sltp import BitgetFuturesSLTPTorchTradingEnv
 
 config = BitgetFuturesSLTPTradingEnvConfig(

--- a/torchtrade/envs/live/bitget/README.md
+++ b/torchtrade/envs/live/bitget/README.md
@@ -16,6 +16,7 @@ Live trading integration with Bitget for crypto futures markets (USDT-margined).
 ```python
 import os
 
+from torchtrade.envs.live.bitget.order_executor import MarginMode
 from torchtrade.envs.live.bitget.env import BitgetFuturesTorchTradingEnv, BitgetFuturesTradingEnvConfig
 from torchtrade.envs.utils import TimeFrame, TimeFrameUnit
 
@@ -26,7 +27,7 @@ config = BitgetFuturesTradingEnvConfig(
     execute_on="1Min",
     demo=True,  # Use testnet first!
     leverage=10.0,
-    margin_mode="isolated",
+    margin_mode=MarginMode.ISOLATED,
 )
 
 env = BitgetFuturesTorchTradingEnv(
@@ -51,16 +52,24 @@ obs = env.reset()
 ```python
 @dataclass
 class BitgetFuturesTradingEnvConfig:
-    api_key: str
-    api_secret: str
-    passphrase: str              # Bitget requires passphrase
-    symbol: str
-    timeframe: TimeFrame
-    testnet: bool = True         # Testnet or mainnet
-    max_leverage: float = 10.0   # Maximum leverage
-    margin_mode: str = "isolated"  # isolated or crossed
-    initial_margin: float = 1000.0
-    window_size: int = 50
+    symbol = 'BTCUSDT'
+    time_frames = '1Hour'
+    window_sizes = 10
+    execute_on = '1Hour'
+    product_type = 'USDT-FUTURES'
+    leverage = 1
+    margin_mode = MarginMode.ISOLATED
+    position_mode = PositionMode.ONE_WAY
+    action_levels = None
+    done_on_bankruptcy = True
+    bankrupt_threshold = 0.1
+    demo = True
+    seed = 42
+    include_base_features = False
+    close_position_on_init = True
+    close_position_on_reset = False
+    observation_failure_policy = ObservationFailurePolicy.HALT
+    # Credentials: Env(config, api_key=..., api_secret=..., api_passphrase=...)
 ```
 
 **Note**: Bitget requires a passphrase in addition to API key/secret.
@@ -88,7 +97,7 @@ config = BitgetFuturesTradingEnvConfig(
 ### Isolated Margin
 ```python
 config = BitgetFuturesTradingEnvConfig(
-    margin_mode="isolated",
+    margin_mode=MarginMode.ISOLATED,
     leverage=10.0,
 )
 ```
@@ -96,7 +105,7 @@ config = BitgetFuturesTradingEnvConfig(
 ### Crossed Margin
 ```python
 config = BitgetFuturesTradingEnvConfig(
-    margin_mode="crossed",
+    margin_mode=MarginMode.CROSSED,
     leverage=20.0,
 )
 ```

--- a/torchtrade/envs/live/bitget/README.md
+++ b/torchtrade/envs/live/bitget/README.md
@@ -14,21 +14,27 @@ Live trading integration with Bitget for crypto futures markets (USDT-margined).
 ## Quick Start
 
 ```python
+import os
+
 from torchtrade.envs.live.bitget.env import BitgetFuturesTorchTradingEnv, BitgetFuturesTradingEnvConfig
 from torchtrade.envs.utils import TimeFrame, TimeFrameUnit
 
 config = BitgetFuturesTradingEnvConfig(
-    api_key="YOUR_KEY",
-    api_secret="YOUR_SECRET",
-    passphrase="YOUR_PASSPHRASE",
     symbol="BTCUSDT",
-    timeframe=TimeFrame(1, TimeFrameUnit.MINUTE),
-    testnet=True,  # Use testnet first!
-    max_leverage=10.0,
+    time_frames=["1Min"],
+    window_sizes=[10],
+    execute_on="1Min",
+    demo=True,  # Use testnet first!
+    leverage=10.0,
     margin_mode="isolated",
 )
 
-env = BitgetFuturesTorchTradingEnv(config=config)
+env = BitgetFuturesTorchTradingEnv(
+    # Credentials are CONSTRUCTOR arguments, not config fields.
+    config, api_key=os.environ["BITGET_API_KEY"],
+    api_secret=os.environ["BITGET_SECRET"],
+    api_passphrase=os.environ["BITGET_PASSPHRASE"],
+)
 obs = env.reset()
 ```
 
@@ -64,10 +70,7 @@ class BitgetFuturesTradingEnvConfig:
 **Testnet**:
 ```python
 config = BitgetFuturesTradingEnvConfig(
-    api_key=testnet_key,
-    api_secret=testnet_secret,
-    passphrase=testnet_passphrase,
-    testnet=True,
+    demo=True,
 )
 ```
 
@@ -76,10 +79,7 @@ Get testnet credentials: https://www.bitget.com/en/testnet/
 **Mainnet**:
 ```python
 config = BitgetFuturesTradingEnvConfig(
-    api_key=mainnet_key,
-    api_secret=mainnet_secret,
-    passphrase=mainnet_passphrase,
-    testnet=False,
+    demo=False,
 )
 ```
 
@@ -89,7 +89,7 @@ config = BitgetFuturesTradingEnvConfig(
 ```python
 config = BitgetFuturesTradingEnvConfig(
     margin_mode="isolated",
-    max_leverage=10.0,
+    leverage=10.0,
 )
 ```
 
@@ -97,7 +97,7 @@ config = BitgetFuturesTradingEnvConfig(
 ```python
 config = BitgetFuturesTradingEnvConfig(
     margin_mode="crossed",
-    max_leverage=20.0,
+    leverage=20.0,
 )
 ```
 
@@ -107,16 +107,20 @@ config = BitgetFuturesTradingEnvConfig(
 from torchtrade.envs.live.bitget.env import BitgetFuturesTorchTradingEnv
 
 config = BitgetFuturesTradingEnvConfig(
-    api_key=os.environ["BITGET_TESTNET_KEY"],
-    api_secret=os.environ["BITGET_TESTNET_SECRET"],
-    passphrase=os.environ["BITGET_TESTNET_PASSPHRASE"],
     symbol="BTCUSDT",
-    timeframe=TimeFrame(5, TimeFrameUnit.MINUTE),
-    testnet=True,
-    max_leverage=5.0,
+    time_frames=["1Min"],
+    window_sizes=[10],
+    execute_on="1Min",
+    demo=True,
+    leverage=5.0,
 )
 
-env = BitgetFuturesTorchTradingEnv(config=config)
+env = BitgetFuturesTorchTradingEnv(
+    # Credentials are CONSTRUCTOR arguments, not config fields.
+    config, api_key=os.environ["BITGET_API_KEY"],
+    api_secret=os.environ["BITGET_SECRET"],
+    api_passphrase=os.environ["BITGET_PASSPHRASE"],
+)
 obs = env.reset()
 
 # Long position
@@ -130,18 +134,22 @@ obs, reward, done, info = env.step(action)
 from torchtrade.envs.live.bitget.env_sltp import BitgetFuturesSLTPTorchTradingEnv
 
 config = BitgetFuturesSLTPTradingEnvConfig(
-    api_key=os.environ["BITGET_TESTNET_KEY"],
-    api_secret=os.environ["BITGET_TESTNET_SECRET"],
-    passphrase=os.environ["BITGET_TESTNET_PASSPHRASE"],
     symbol="ETHUSDT",
-    timeframe=TimeFrame(1, TimeFrameUnit.MINUTE),
-    testnet=True,
-    max_leverage=3.0,
-    sl_percent=0.02,
-    tp_percent=0.04,
+    time_frames=["1Min"],
+    window_sizes=[10],
+    execute_on="1Min",
+    demo=True,
+    leverage=3.0,
+    stoploss_levels=[-0.02],
+    takeprofit_levels=[0.04],
 )
 
-env = BitgetFuturesSLTPTorchTradingEnv(config=config)
+env = BitgetFuturesSLTPTorchTradingEnv(
+    # Credentials are CONSTRUCTOR arguments, not config fields.
+    config, api_key=os.environ["BITGET_API_KEY"],
+    api_secret=os.environ["BITGET_SECRET"],
+    api_passphrase=os.environ["BITGET_PASSPHRASE"],
+)
 obs = env.reset()
 ```
 

--- a/torchtrade/envs/live/bitget/README.md
+++ b/torchtrade/envs/live/bitget/README.md
@@ -18,7 +18,6 @@ import os
 
 from torchtrade.envs.live.bitget.order_executor import MarginMode
 from torchtrade.envs.live.bitget.env import BitgetFuturesTorchTradingEnv, BitgetFuturesTradingEnvConfig
-from torchtrade.envs.utils import TimeFrame, TimeFrameUnit
 
 config = BitgetFuturesTradingEnvConfig(
     symbol="BTCUSDT",
@@ -152,10 +151,11 @@ env = BitgetFuturesTorchTradingEnv(
 )
 td = env.reset()
 
-# Actions are CATEGORICAL indices into action_levels, which defaults to [-1, 0, 1]:
-# 0 = full short, 1 = flat, 2 = full long. Leverage and size come from the config,
+# Actions are CATEGORICAL indices into action_levels, which on Bitget
+# defaults to [-1.0, -0.5, 0.0, 0.5, 1.0]:
+# 0 = full short, 2 = flat, 4 = full long. Leverage and size come from the config,
 # not from the action.
-td["action"] = torch.tensor(2)  # go long
+td["action"] = torch.tensor(4)  # go full long
 td = env.step(td)
 ```
 

--- a/torchtrade/envs/live/bitget/README.md
+++ b/torchtrade/envs/live/bitget/README.md
@@ -52,28 +52,33 @@ obs = env.reset()
 from torchtrade.envs.live.bitget.order_executor import MarginMode
 from torchtrade.envs.core.live import ObservationFailurePolicy
 from torchtrade.envs.live.bitget.order_executor import PositionMode
-from dataclasses import dataclass
+from torchtrade.envs.live.bitget import BitgetFuturesTradingEnvConfig
 
-@dataclass
-class BitgetFuturesTradingEnvConfig:
-    symbol = 'BTCUSDT'
-    time_frames = '1Hour'
-    window_sizes = 10
-    execute_on = '1Hour'
-    product_type = 'USDT-FUTURES'
-    leverage = 1
-    margin_mode = MarginMode.ISOLATED
-    position_mode = PositionMode.ONE_WAY
-    action_levels = None
-    done_on_bankruptcy = True
-    bankrupt_threshold = 0.1
-    demo = True
-    seed = 42
-    include_base_features = False
-    close_position_on_init = True
-    close_position_on_reset = False
-    observation_failure_policy = ObservationFailurePolicy.HALT
-    # Credentials: Env(config, api_key=..., api_secret=..., api_passphrase=...)
+from torchtrade.envs.live.bitget.order_executor import MarginMode
+from torchtrade.envs.core.live import ObservationFailurePolicy
+from torchtrade.envs.live.bitget.order_executor import PositionMode
+
+# Every field of BitgetFuturesTradingEnvConfig, with its real default.
+# Credentials are NOT fields -- they are constructor arguments on the env.
+config = BitgetFuturesTradingEnvConfig(
+    symbol='BTCUSDT',
+    time_frames='1Hour',
+    window_sizes=10,
+    execute_on='1Hour',
+    product_type='USDT-FUTURES',
+    leverage=1,
+    margin_mode=MarginMode.ISOLATED,
+    position_mode=PositionMode.ONE_WAY,
+    action_levels=None,
+    done_on_bankruptcy=True,
+    bankrupt_threshold=0.1,
+    demo=True,
+    seed=42,
+    include_base_features=False,
+    close_position_on_init=True,
+    close_position_on_reset=False,
+    observation_failure_policy=ObservationFailurePolicy.HALT,
+)
 ```
 
 **Note**: Bitget requires a passphrase in addition to API key/secret.

--- a/torchtrade/envs/live/bitget/env.py
+++ b/torchtrade/envs/live/bitget/env.py
@@ -112,10 +112,10 @@ class BitgetFuturesTorchTradingEnv(BitgetBaseTorchTradingEnv):
     Could be implemented as multi-dimensional actions if needed, but fixed
     leverage is recommended for most use cases.
 
-    Account State (10 elements):
+    Account State (6 elements; the list is ACCOUNT_STATE on the exchange base class):
     ---------------------------
-    [cash, position_size, position_value, entry_price, current_price,
-     unrealized_pnl_pct, leverage, margin_ratio, liquidation_price, holding_time]
+    [exposure_pct, position_direction, unrealized_pnlpct, holding_time,
+     leverage, distance_to_liquidation]
     """
 
     def __init__(

--- a/torchtrade/envs/live/bitget/env_sltp.py
+++ b/torchtrade/envs/live/bitget/env_sltp.py
@@ -118,9 +118,9 @@ class BitgetFuturesSLTPTorchTradingEnv(SLTPMixin, BitgetBaseTorchTradingEnv):
     - Tracks active SL/TP levels
     - Can optionally disable short positions for long-only strategies
 
-    Account State (10 elements):
-    [cash, position_size, position_value, entry_price, current_price,
-     unrealized_pnl_pct, leverage, margin_ratio, liquidation_price, holding_time]
+    Account State (6 elements; the list is ACCOUNT_STATE on the exchange base class):
+    [exposure_pct, position_direction, unrealized_pnlpct, holding_time,
+     leverage, distance_to_liquidation]
     """
 
     def __init__(


### PR DESCRIPTION
Final slice of #287. **The ratchet is empty.**

The three remaining in-package READMEs (binance, bitget, `live/`) documented the same obsolete config, so one uniform rewrite clears all 38:

| documented | real |
|---|---|
| `api_key` / `api_secret` / `passphrase` | **constructor arguments** |
| `timeframe=TimeFrame(...)` | `time_frames=["1Min"]` + `window_sizes` + `execute_on` |
| `testnet=` | `demo=` |
| `max_leverage=` | `leverage=` |
| `sl_percent` / `tp_percent` | `stoploss_levels` / `takeprofit_levels` |
| `initial_cash` / `max_position_size` | gone — a live account has neither |

## Verified by construction

All six affected config classes were actually built with the documented kwargs:

```
OK  BinanceFutures      OK  BitgetFutures      OK  Alpaca
OK  BinanceFuturesSLTP  OK  BitgetFuturesSLTP  OK  AlpacaSLTP
```

## The ratchet is now an empty set

`KNOWN_BROKEN = set()`, with a comment saying to keep it that way — a new bad kwarg fails immediately rather than being appended.

It drove every slice of this issue: each fix made `test_no_known_broken_entry_has_gone_stale` fail with the exact entries that no longer described reality, and refused to pass until they were deleted. Including one here that survived my removal script because it lacked a trailing comma — the ratchet caught that too.

**58 documented kwargs raised `TypeError` when #287 started. Zero now.**

Full suite: 3494 passed, **0 xfailed**.

⚠️ Review rounds not yet run.