### PR TITLE
fix(replay): the observation was a lookalike, not the one offline emits

### DIFF
--- a/tests/envs/replay/test_observation_parity_278.py
+++ b/tests/envs/replay/test_observation_parity_278.py
@@ -6,6 +6,7 @@ import pytest
 
 from torchtrade.envs.offline import SequentialTradingEnv, SequentialTradingEnvConfig
 from torchtrade.envs.replay.observer import ReplayObserver
+from torchtrade.envs.replay.order_executor import ReplayOrderExecutor
 from torchtrade.envs.utils import TimeFrame, TimeFrameUnit
 
 TF = TimeFrame(1, TimeFrameUnit.Minute)
@@ -105,15 +106,28 @@ def test_base_features_is_the_first_timeframes_bars(time_frames, window_sizes, e
     count, so neither a zero-padding regime nor a wrong-timeframe window can be written
     down as expected.
     """
+    executor = ReplayOrderExecutor(initial_balance=10000.0, leverage=5)
     observer = ReplayObserver(df=_df(1200), time_frames=time_frames,
-                              window_sizes=window_sizes, execute_on=execute_on)
+                              window_sizes=window_sizes, execute_on=execute_on,
+                              executor=executor)
     for _ in range(steps):
         obs = observer.get_observations(return_base_ohlc=True)
     base, market = obs["base_features"], obs[observer.get_keys()[0]]
 
     assert base.shape == (window_sizes[0], 4)
     assert int((base == 0).all(axis=1).sum()) == int((market == 0).all(axis=1).sum())
-    assert np.allclose(base[:, 3], market[:, 3], atol=1e-3), (
-        f"base_features closes {base[:, 3]} are not {time_frames[0]}'s bars "
-        f"{market[:, 3]} -- wrong timeframe or shifted by the end-time relabel"
+    # All but the last row are completed tf0 bars and must match exactly.
+    assert np.allclose(base[:-1, 3], market[:-1, 3], atol=1e-3), (
+        f"base_features closes {base[:-1, 3]} are not {time_frames[0]}'s bars "
+        f"{market[:-1, 3]} -- wrong timeframe or shifted by the end-time relabel"
+    )
+    # The last row is the FORMING bar, as live's is: its close is the latest trade.
+    # `base_features[-1, 3]` prices entries and BOTH brackets in three SLTP envs
+    # (`*/env_sltp.py: current_price = float(obs["base_features"][-1, 3])`), so leaving
+    # it at the last CLOSED tf0 close sizes and brackets off a stale number -- measured
+    # at -1.94%/+3.07% against a configured -2%/+3%. Asserted against the executor,
+    # which is what the venue would actually fill at.
+    assert base[-1, 3] == pytest.approx(executor.current_price, abs=1e-3), (
+        f"base_features[-1, 3] is {base[-1, 3]}, not the execution price "
+        f"{executor.current_price} -- entries and brackets would price off a stale bar"
     )

--- a/tests/envs/replay/test_observation_parity_278.py
+++ b/tests/envs/replay/test_observation_parity_278.py
@@ -79,15 +79,21 @@ def test_features_are_reported_when_no_preprocessing_fn_is_given():
     )
 
 
-# The timeframe layout is the axis both base_features bugs lived on, and the original
-# test parametrized only `steps` on a single-timeframe fixture -- so it could not see
-# either. execute_on COARSER than time_frames[0] is deliberately absent: market_data
-# there extends past the window this builds, and asserting a relationship I have not
-# pinned down would be worse than saying so.
+# The timeframe layout is the axis every base_features bug in this PR lived on, and the
+# first version parametrized only `steps` on a single-timeframe fixture where
+# `execute_on == time_frames[0]` -- the one layout on which none of them can appear.
+# Every replay test in the repo uses that layout, which is why they survived.
+M5 = TimeFrame(5, TimeFrameUnit.Minute)
+M15 = TimeFrame(15, TimeFrameUnit.Minute)
 LAYOUTS = [
     pytest.param([TF], [10], TF, id="single-1Min"),
-    pytest.param([TimeFrame(5, TimeFrameUnit.Minute), TF], [6, 10], TF, id="5Min-first"),
-    pytest.param([TimeFrame(15, TimeFrameUnit.Minute), TF], [4, 10], TF, id="15Min-first"),
+    pytest.param([M5, TF], [6, 10], TF, id="5Min-first"),
+    pytest.param([M15, TF], [4, 10], TF, id="15Min-first"),
+    # execute_on COARSER than time_frames[0]: tf0 is labelled by bar START, so looking it
+    # up at the raw execution label returned a window shifted back by
+    # `exec_period/tf0_period - 1` bars. Stale, deterministically.
+    pytest.param([TF], [10], M5, id="exec-coarser"),
+    pytest.param([TF, M5], [10, 6], M5, id="1Min-first-exec-5Min"),
 ]
 
 

--- a/tests/envs/replay/test_observation_parity_278.py
+++ b/tests/envs/replay/test_observation_parity_278.py
@@ -78,28 +78,42 @@ def test_features_are_reported_when_no_preprocessing_fn_is_given():
     )
 
 
-@pytest.mark.parametrize("steps", [1, 2, 10, 14])
-def test_base_features_is_as_full_as_the_market_data_from_the_first_step(steps):
-    """`include_base_features=True` declares a (window, 4) spec and puts it in the
-    OBSERVATION, so a policy consuming that key read 9 of 10 rows as zero on every step.
-    Only the newest row was written.
+# The timeframe layout is the axis both base_features bugs lived on, and the original
+# test parametrized only `steps` on a single-timeframe fixture -- so it could not see
+# either. execute_on COARSER than time_frames[0] is deliberately absent: market_data
+# there extends past the window this builds, and asserting a relationship I have not
+# pinned down would be worse than saying so.
+LAYOUTS = [
+    pytest.param([TF], [10], TF, id="single-1Min"),
+    pytest.param([TimeFrame(5, TimeFrameUnit.Minute), TF], [6, 10], TF, id="5Min-first"),
+    pytest.param([TimeFrame(15, TimeFrameUnit.Minute), TF], [4, 10], TF, id="15Min-first"),
+]
 
-    Filling from the sampler's TRUNCATED execution frame fixed nine steps out of ten and
-    left step 1 at 9/10 zeros -- while `market_data_*`, same timeframe and window, was
-    full of real bars from step 1. Those bars exist; they were outside the frame. This
-    compares the two keys rather than a hardcoded count, so no zero-padding regime can
-    be codified as expected again.
+
+@pytest.mark.parametrize("time_frames,window_sizes,execute_on", LAYOUTS)
+@pytest.mark.parametrize("steps", [1, 30])
+def test_base_features_is_the_first_timeframes_bars(time_frames, window_sizes, execute_on, steps):
+    """base_features is `time_frames[0]`'s raw OHLC -- not the execution timeframe's.
+
+    Live gates on `timeframe == self.time_frames[0]` and every venue sizes the spec off
+    `window_sizes[0]`. Filling from `execute_on` gave a window of the right SHAPE holding
+    entirely different bars: with `[15Min, 1Min]` it spanned 4 minutes where live spans
+    an hour. That is worse than the original defect, which left the mismatched rows
+    visibly zero -- this one looks plausible and `check_env_specs` passes.
+
+    Asserted against `market_data_*` for the same timeframe rather than a hardcoded
+    count, so neither a zero-padding regime nor a wrong-timeframe window can be written
+    down as expected.
     """
-    observer = _observer()
+    observer = ReplayObserver(df=_df(1200), time_frames=time_frames,
+                              window_sizes=window_sizes, execute_on=execute_on)
     for _ in range(steps):
         obs = observer.get_observations(return_base_ohlc=True)
-    base = obs["base_features"]
-    market = obs[observer.get_keys()[0]]
+    base, market = obs["base_features"], obs[observer.get_keys()[0]]
 
-    base_zero = int((base == 0).all(axis=1).sum())
-    market_zero = int((market == 0).all(axis=1).sum())
-    assert base_zero == market_zero, (
-        f"base_features has {base_zero} empty rows against market_data's {market_zero}"
+    assert base.shape == (window_sizes[0], 4)
+    assert int((base == 0).all(axis=1).sum()) == int((market == 0).all(axis=1).sum())
+    assert np.allclose(base[:, 3], market[:, 3], atol=1e-3), (
+        f"base_features closes {base[:, 3]} are not {time_frames[0]}'s bars "
+        f"{market[:, 3]} -- wrong timeframe or shifted by the end-time relabel"
     )
-    closes = base[:, 3]
-    assert np.all(np.diff(closes) > 0), f"rows are not consecutive bars in order: {closes}"

--- a/tests/envs/replay/test_observation_parity_278.py
+++ b/tests/envs/replay/test_observation_parity_278.py
@@ -22,22 +22,44 @@ def _observer(**kw):
     return ReplayObserver(df=_df(), time_frames=[TF], window_sizes=[10], execute_on=TF, **kw)
 
 
-def test_the_market_data_key_matches_the_offline_env():
-    """`market_data_1Minute` vs `market_data_1Minute_10`.
+def test_a_replay_backed_env_emits_the_offline_env_keys():
+    """Compared at the ENV, not the observer -- the layer the first version got wrong.
 
-    The sampler's raw keys are bare timeframe names; offline and live both append the
-    window size. A policy trained offline could not be fed the replay env without
-    rewriting its in_keys -- which defeats the point of replaying through the live
-    pipeline.
+    The env bases build their spec key as `"market_data_" + observer.get_keys()`, and the
+    real observers return the UNPREFIXED `{timeframe}_{window}`. So the sampler's bare
+    timeframe names gave `market_data_1Minute` where offline gives
+    `market_data_1Minute_10`, and adding the prefix in the observer to compensate gave
+    `market_data_market_data_1Minute_10`. Asserting the observer against itself passed
+    for both of those; only the env's own spec keys settle it.
     """
+    from unittest.mock import patch
+
+    from torchtrade.envs.live.bybit.env_sltp import (
+        BybitFuturesSLTPTorchTradingEnv,
+        BybitFuturesSLTPTradingEnvConfig,
+    )
+    from torchtrade.envs.replay.order_executor import ReplayOrderExecutor
+
+    df = _df()
     offline = SequentialTradingEnv(
-        _df(), SequentialTradingEnvConfig(
-            time_frames=[TF], window_sizes=[10], execute_on=TF,
-        ),
+        df, SequentialTradingEnvConfig(time_frames=[TF], window_sizes=[10], execute_on=TF),
     )
     offline_keys = {k for k in offline.reset().keys() if k.startswith("market_data_")}
-    assert set(_observer().get_keys()) == offline_keys, (
-        f"replay emits {_observer().get_keys()}, offline emits {sorted(offline_keys)}"
+
+    config = BybitFuturesSLTPTradingEnvConfig(
+        symbol="BTCUSDT", time_frames=[TF], window_sizes=[10], execute_on=TF,
+        stoploss_levels=(-0.02,), takeprofit_levels=(0.03,), leverage=5,
+        trade_mode="quantity", quantity_per_trade=0.01,
+    )
+    executor = ReplayOrderExecutor(initial_balance=10000.0, leverage=5)
+    observer = ReplayObserver(df=df, time_frames=[TF], window_sizes=[10],
+                              execute_on=TF, executor=executor)
+    with patch.object(BybitFuturesSLTPTorchTradingEnv, "_wait_for_next_timestamp"):
+        env = BybitFuturesSLTPTorchTradingEnv(config=config, observer=observer, trader=executor)
+        replay_keys = {k for k in env.reset().keys() if k.startswith("market_data_")}
+
+    assert replay_keys == offline_keys, (
+        f"replay env emits {sorted(replay_keys)}, offline emits {sorted(offline_keys)}"
     )
 
 
@@ -48,32 +70,36 @@ def test_features_are_reported_when_no_preprocessing_fn_is_given():
     `(window, 0)` against an emitted `(window, 5)` and check_env_specs failed on a size
     mismatch. Only the no-preprocessing-fn config was affected, which is why it survived.
     """
-    reported = _observer().get_features()["observation_features"]
-    emitted = _observer().get_observations()["market_data_1Minute_10"].shape[1]
+    observer = _observer()
+    reported = observer.get_features()["observation_features"]
+    emitted = observer.get_observations()[observer.get_keys()[0]].shape[1]
     assert len(reported) == emitted, (
         f"spec would declare {len(reported)} features against {emitted} emitted"
     )
 
 
-@pytest.mark.parametrize("steps,expected_zero_rows", [
-    (1, 9),   # one bar of history exists, so nine rows genuinely have no data
-    (10, 0),  # once ten bars have passed the window is full
-    (14, 0),
-])
-def test_base_features_fills_the_window_not_only_the_last_row(steps, expected_zero_rows):
+@pytest.mark.parametrize("steps", [1, 2, 10, 14])
+def test_base_features_is_as_full_as_the_market_data_from_the_first_step(steps):
     """`include_base_features=True` declares a (window, 4) spec and puts it in the
-    OBSERVATION, so a policy consuming that key read 90% zeros -- 9 of 10 rows on every
-    step, forever. Only the newest row was written.
+    OBSERVATION, so a policy consuming that key read 9 of 10 rows as zero on every step.
+    Only the newest row was written.
 
-    Rows before the start of the data stay zero deliberately: there is no bar to report.
+    Filling from the sampler's TRUNCATED execution frame fixed nine steps out of ten and
+    left step 1 at 9/10 zeros -- while `market_data_*`, same timeframe and window, was
+    full of real bars from step 1. Those bars exist; they were outside the frame. This
+    compares the two keys rather than a hardcoded count, so no zero-padding regime can
+    be codified as expected again.
     """
     observer = _observer()
     for _ in range(steps):
-        base = observer.get_observations(return_base_ohlc=True)["base_features"]
+        obs = observer.get_observations(return_base_ohlc=True)
+    base = obs["base_features"]
+    market = obs[observer.get_keys()[0]]
 
-    assert int((base == 0).all(axis=1).sum()) == expected_zero_rows
-    if expected_zero_rows == 0:
-        closes = base[:, 3]
-        assert np.all(np.diff(closes) > 0), (
-            f"rows are not consecutive bars in order: {closes}"
-        )
+    base_zero = int((base == 0).all(axis=1).sum())
+    market_zero = int((market == 0).all(axis=1).sum())
+    assert base_zero == market_zero, (
+        f"base_features has {base_zero} empty rows against market_data's {market_zero}"
+    )
+    closes = base[:, 3]
+    assert np.all(np.diff(closes) > 0), f"rows are not consecutive bars in order: {closes}"

--- a/tests/envs/replay/test_observation_parity_278.py
+++ b/tests/envs/replay/test_observation_parity_278.py
@@ -1,0 +1,79 @@
+"""Replay must emit the observation offline and live emit, not a lookalike (#278)."""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from torchtrade.envs.offline import SequentialTradingEnv, SequentialTradingEnvConfig
+from torchtrade.envs.replay.observer import ReplayObserver
+from torchtrade.envs.utils import TimeFrame, TimeFrameUnit
+
+TF = TimeFrame(1, TimeFrameUnit.Minute)
+
+
+def _df(n=160):
+    ts = pd.date_range("2024-01-01", periods=n, freq="1min")
+    prices = np.linspace(100, 110, n)
+    return pd.DataFrame({"timestamp": ts, "open": prices, "high": prices + 0.2,
+                         "low": prices - 0.2, "close": prices, "volume": np.ones(n) * 1000})
+
+
+def _observer(**kw):
+    return ReplayObserver(df=_df(), time_frames=[TF], window_sizes=[10], execute_on=TF, **kw)
+
+
+def test_the_market_data_key_matches_the_offline_env():
+    """`market_data_1Minute` vs `market_data_1Minute_10`.
+
+    The sampler's raw keys are bare timeframe names; offline and live both append the
+    window size. A policy trained offline could not be fed the replay env without
+    rewriting its in_keys -- which defeats the point of replaying through the live
+    pipeline.
+    """
+    offline = SequentialTradingEnv(
+        _df(), SequentialTradingEnvConfig(
+            time_frames=[TF], window_sizes=[10], execute_on=TF,
+        ),
+    )
+    offline_keys = {k for k in offline.reset().keys() if k.startswith("market_data_")}
+    assert set(_observer().get_keys()) == offline_keys, (
+        f"replay emits {_observer().get_keys()}, offline emits {sorted(offline_keys)}"
+    )
+
+
+def test_features_are_reported_when_no_preprocessing_fn_is_given():
+    """Filtering to names starting with `features_` reported ZERO columns.
+
+    The sampler still emits the five raw OHLCV columns, so the declared spec came out
+    `(window, 0)` against an emitted `(window, 5)` and check_env_specs failed on a size
+    mismatch. Only the no-preprocessing-fn config was affected, which is why it survived.
+    """
+    reported = _observer().get_features()["observation_features"]
+    emitted = _observer().get_observations()["market_data_1Minute_10"].shape[1]
+    assert len(reported) == emitted, (
+        f"spec would declare {len(reported)} features against {emitted} emitted"
+    )
+
+
+@pytest.mark.parametrize("steps,expected_zero_rows", [
+    (1, 9),   # one bar of history exists, so nine rows genuinely have no data
+    (10, 0),  # once ten bars have passed the window is full
+    (14, 0),
+])
+def test_base_features_fills_the_window_not_only_the_last_row(steps, expected_zero_rows):
+    """`include_base_features=True` declares a (window, 4) spec and puts it in the
+    OBSERVATION, so a policy consuming that key read 90% zeros -- 9 of 10 rows on every
+    step, forever. Only the newest row was written.
+
+    Rows before the start of the data stay zero deliberately: there is no bar to report.
+    """
+    observer = _observer()
+    for _ in range(steps):
+        base = observer.get_observations(return_base_ohlc=True)["base_features"]
+
+    assert int((base == 0).all(axis=1).sum()) == expected_zero_rows
+    if expected_zero_rows == 0:
+        closes = base[:, 3]
+        assert np.all(np.diff(closes) > 0), (
+            f"rows are not consecutive bars in order: {closes}"
+        )

--- a/torchtrade/envs/offline/infrastructure/sampler.py
+++ b/torchtrade/envs/offline/infrastructure/sampler.py
@@ -314,6 +314,11 @@ class MarketDataObservationSampler:
         execute_base_filled["close"] = execute_base_filled["close"].clip(
             lower=execute_base_filled["low"], upper=execute_base_filled["high"]
         )
+        # Kept untruncated as well: the truncated frame starts at min_start_time, so a
+        # consumer wanting a WINDOW of base bars ending at the first tradable bar has
+        # nothing to look back at. ReplayObserver needs exactly that (#278); the
+        # truncated frame remains what everything else uses.
+        self.execute_base_full_df = execute_base_filled
         self.execute_base_features_df = execute_base_filled[self.min_start_time:]
         if len(self.execute_base_features_df) == 0:
             raise ValueError("No execute_on base features available after min_start_time")
@@ -376,6 +381,12 @@ class MarketDataObservationSampler:
         self.execute_base_tensor = torch.from_numpy(base_arr)  # shape (M, F)
         base_ts_int64 = self.execute_base_features_df.index.as_unit('ns').asi8
         self.execute_base_idx = torch.from_numpy(base_ts_int64).to(torch.long)
+        self.execute_base_full_tensor = torch.from_numpy(
+            self.execute_base_full_df.to_numpy(dtype=np.float32)
+        )
+        self.execute_base_full_idx = torch.from_numpy(
+            self.execute_base_full_df.index.as_unit('ns').asi8
+        ).to(torch.long)
 
         # Validate 1:1 correspondence between exec_times and execute_base_features_df
         # This ensures sequential access can use direct indexing without misalignment

--- a/torchtrade/envs/offline/infrastructure/sampler.py
+++ b/torchtrade/envs/offline/infrastructure/sampler.py
@@ -200,7 +200,7 @@ class MarketDataObservationSampler:
             # ending "now" included a bar that had not closed yet -- lookahead bias, in
             # the observation, which is the whole reason that relabel exists (#320).
             if tf == time_frames[0]:
-                self.base_ohlc_df = resampled[["open", "high", "low", "close"]].copy()
+                base_ohlc_df = resampled[["open", "high", "low", "close"]].copy()
 
             if proc_fn is not None:
                 resampled = proc_fn(resampled)
@@ -388,11 +388,11 @@ class MarketDataObservationSampler:
         self.execute_base_tensor = torch.from_numpy(base_arr)  # shape (M, F)
         base_ts_int64 = self.execute_base_features_df.index.as_unit('ns').asi8
         self.execute_base_idx = torch.from_numpy(base_ts_int64).to(torch.long)
-        self.base_ohlc_tensor = torch.from_numpy(
-            self.base_ohlc_df.to_numpy(dtype=np.float32)
-        )
+        # Tensor and index only; the frame itself is not retained -- keeping it cost
+        # 40 MB per sampler on a 1M-bar input for a single read.
+        self.base_ohlc_tensor = torch.from_numpy(base_ohlc_df.to_numpy(dtype=np.float32))
         self.base_ohlc_idx = torch.from_numpy(
-            self.base_ohlc_df.index.as_unit("ns").asi8
+            base_ohlc_df.index.as_unit("ns").asi8
         ).to(torch.long)
 
         # Validate 1:1 correspondence between exec_times and execute_base_features_df

--- a/torchtrade/envs/offline/infrastructure/sampler.py
+++ b/torchtrade/envs/offline/infrastructure/sampler.py
@@ -148,6 +148,7 @@ class MarketDataObservationSampler:
             if len(resampled) == 0:
                 raise ValueError(f"Resampled dataframe for timeframe {tf.obs_key_freq()} is empty")
 
+
             # Fix lookahead bias: shift higher timeframe bars forward by their period
             # This ensures bars are indexed by their END time, not START time
             # Only completed bars will be visible to the agent at any execution time
@@ -189,6 +190,17 @@ class MarketDataObservationSampler:
                 resampled.index = edges[1:][
                     bin_starts.get_indexer(resampled.index)
                 ].rename(bin_starts.name)
+
+            # base_features is the FIRST timeframe's raw OHLC, per the live observers
+            # (`live/shared/futures_base_obs.py` gates on `timeframe == time_frames[0]`),
+            # and every venue sizes its spec off window_sizes[0].
+            #
+            # AFTER the END-time relabel above and BEFORE feature processing. Capturing it
+            # before the relabel indexed coarse bars by their bin START, so a window
+            # ending "now" included a bar that had not closed yet -- lookahead bias, in
+            # the observation, which is the whole reason that relabel exists (#320).
+            if tf == time_frames[0]:
+                self.base_ohlc_df = resampled[["open", "high", "low", "close"]].copy()
 
             if proc_fn is not None:
                 resampled = proc_fn(resampled)
@@ -314,11 +326,6 @@ class MarketDataObservationSampler:
         execute_base_filled["close"] = execute_base_filled["close"].clip(
             lower=execute_base_filled["low"], upper=execute_base_filled["high"]
         )
-        # Kept untruncated as well: the truncated frame starts at min_start_time, so a
-        # consumer wanting a WINDOW of base bars ending at the first tradable bar has
-        # nothing to look back at. ReplayObserver needs exactly that (#278); the
-        # truncated frame remains what everything else uses.
-        self.execute_base_full_df = execute_base_filled
         self.execute_base_features_df = execute_base_filled[self.min_start_time:]
         if len(self.execute_base_features_df) == 0:
             raise ValueError("No execute_on base features available after min_start_time")
@@ -381,11 +388,11 @@ class MarketDataObservationSampler:
         self.execute_base_tensor = torch.from_numpy(base_arr)  # shape (M, F)
         base_ts_int64 = self.execute_base_features_df.index.as_unit('ns').asi8
         self.execute_base_idx = torch.from_numpy(base_ts_int64).to(torch.long)
-        self.execute_base_full_tensor = torch.from_numpy(
-            self.execute_base_full_df.to_numpy(dtype=np.float32)
+        self.base_ohlc_tensor = torch.from_numpy(
+            self.base_ohlc_df.to_numpy(dtype=np.float32)
         )
-        self.execute_base_full_idx = torch.from_numpy(
-            self.execute_base_full_df.index.as_unit('ns').asi8
+        self.base_ohlc_idx = torch.from_numpy(
+            self.base_ohlc_df.index.as_unit("ns").asi8
         ).to(torch.long)
 
         # Validate 1:1 correspondence between exec_times and execute_base_features_df

--- a/torchtrade/envs/replay/observer.py
+++ b/torchtrade/envs/replay/observer.py
@@ -83,7 +83,7 @@ class ReplayObserver:
             result[suffix.get(key, key)] = tensor.numpy().astype(np.float32)
 
         if return_base_ohlc:
-            result["base_features"] = self._base_window(timestamp)
+            result["base_features"] = self._base_window(timestamp, base)
 
         return result
 
@@ -126,7 +126,7 @@ class ReplayObserver:
         if self.executor is not None:
             self.executor.reset()
 
-    def _base_window(self, timestamp) -> np.ndarray:
+    def _base_window(self, timestamp, current) -> np.ndarray:
         """The last `window` execution bars of OHLC, not just the newest one.
 
         Only `base_arr[-1]` used to be populated, on the reasoning that live envs read
@@ -158,4 +158,14 @@ class ReplayObserver:
         start = max(0, end - ws)
         window = self.sampler.base_ohlc_tensor[start:end].numpy().astype(np.float32)
         base_arr[-len(window):] = window
+
+        # The last row is the FORMING bar, as live's is: its close is the latest trade,
+        # not the last completed tf0 close. `base_features[-1, 3]` is the entry and
+        # bracket price for three SLTP envs (`*/env_sltp.py: current_price = float(
+        # obs["base_features"][-1, 3])`), so leaving it at the last CLOSED tf0 bar priced
+        # brackets off a stale number -- measured at -1.94%/+3.07% against a configured
+        # -2%/+3% on a [15Min, 1Min] layout. High and low extend to cover the trade.
+        base_arr[-1, 1] = max(base_arr[-1, 1], current["high"])
+        base_arr[-1, 2] = min(base_arr[-1, 2], current["low"])
+        base_arr[-1, 3] = current["close"]
         return base_arr

--- a/torchtrade/envs/replay/observer.py
+++ b/torchtrade/envs/replay/observer.py
@@ -134,22 +134,28 @@ class ReplayObserver:
         the array in the OBSERVATION, so a policy consuming that key read 90% zeros --
         9 of 10 rows (#278). Real observers fill the whole window.
 
-        Read from the sampler's UNTRUNCATED execution frame. The truncated one starts at
-        min_start_time, so the first `window` steps of every episode were still mostly
-        zeros -- `market_data_*` for the same timeframe and window was full of real bars
-        from step 1 while `base_features` was 9/10 zero. Those bars exist; they were just
-        outside the frame. Rows genuinely before the data begin stay zero.
+        The FIRST timeframe's bars, not the execution timeframe's. Live gates on
+        `timeframe == self.time_frames[0]` and every venue sizes the spec off
+        `window_sizes[0]`, so filling it from `execute_on` produced a window of the right
+        SHAPE holding entirely different bars -- with `time_frames=[15Min, 1Min]` a
+        replayed window spanned 4 minutes where live spans an hour. Worse than the
+        original bug, which left the mismatched rows visibly zero; this one looks
+        plausible.
+
+        Untruncated, so a window ending at the first tradable bar has bars to look back
+        at: the truncated frame starts at min_start_time, which left step 1 at 9/10 zeros
+        while `market_data_*` was already full.
         """
         ws = self.window_sizes[0]
         base_arr = np.zeros((ws, 4), dtype=np.float32)
         end = int(torch.searchsorted(
-            self.sampler.execute_base_full_idx,
+            self.sampler.base_ohlc_idx,
             torch.tensor(int(timestamp.value), dtype=torch.long),
             right=True,
         ).item())
         if end <= 0:
             return base_arr
         start = max(0, end - ws)
-        window = self.sampler.execute_base_full_tensor[start:end, :4].numpy().astype(np.float32)
+        window = self.sampler.base_ohlc_tensor[start:end].numpy().astype(np.float32)
         base_arr[-len(window):] = window
         return base_arr

--- a/torchtrade/envs/replay/observer.py
+++ b/torchtrade/envs/replay/observer.py
@@ -3,6 +3,7 @@
 from typing import Callable, Dict, List, Optional, Union
 
 import numpy as np
+import torch
 import pandas as pd
 
 from torchtrade.envs.offline.infrastructure.sampler import MarketDataObservationSampler
@@ -39,7 +40,17 @@ class ReplayObserver:
             feature_processing_fn=feature_preprocessing_fn,
         )
         self.sampler.reset(random_start=False)
-        self._obs_keys = self.sampler.get_observation_keys()
+        self.window_sizes = self.sampler.window_sizes
+        # `market_data_{timeframe}_{window}`, composed exactly as the offline envs do
+        # (`core/offline_base.py`). The sampler's raw keys are bare timeframe names, so
+        # replay emitted `market_data_1Minute` where offline and live both emit
+        # `market_data_1Minute_10` -- a policy trained offline could not be fed the
+        # replay env without renaming its in_keys (#278).
+        self._timeframes = self.sampler.get_observation_keys()
+        self._obs_keys = [
+            f"market_data_{name}_{ws}"
+            for name, ws in zip(self._timeframes, self.window_sizes)
+        ]
         self.truncated = False
 
     def get_observations(self, return_base_ohlc: bool = False) -> Dict[str, np.ndarray]:
@@ -64,17 +75,15 @@ class ReplayObserver:
                 "close": base["close"],
             })
 
+        # Re-keyed to the suffixed names, so the dict a policy receives matches the one
+        # offline and live produce.
+        suffix = dict(zip(self._timeframes, self._obs_keys))
         result = {}
         for key, tensor in obs.items():
-            result[key] = tensor.numpy().astype(np.float32)
+            result[suffix.get(key, key)] = tensor.numpy().astype(np.float32)
 
         if return_base_ohlc:
-            # Only the last row is populated — live envs only access [-1, 3] (close price).
-            # Earlier rows are zero-filled to match the expected (window_size, 4) shape.
-            ws = self.sampler.window_sizes[0]
-            base_arr = np.zeros((ws, 4), dtype=np.float32)
-            base_arr[-1] = [base["open"], base["high"], base["low"], base["close"]]
-            result["base_features"] = base_arr
+            result["base_features"] = self._base_window(timestamp)
 
         return result
 
@@ -83,13 +92,20 @@ class ReplayObserver:
         return self._obs_keys
 
     def get_features(self) -> Dict[str, List[str]]:
-        """Get feature column names."""
+        """The columns the sampler ACTUALLY emits, which is what the spec is built from.
+
+        Filtering to names starting with `features_` reported an empty list whenever no
+        `feature_preprocessing_fn` was given -- while the sampler still emitted the five
+        raw OHLCV columns. The declared spec came out `(window, 0)` against an emitted
+        `(window, 5)`, and `check_env_specs` failed with a size mismatch (#278). Offline
+        counts the same columns via `get_num_features_per_timeframe`.
+        """
         try:
             feature_keys = self.sampler.get_feature_keys()
         except ValueError:
             feature_keys = []
         return {
-            "observation_features": [k for k in feature_keys if k.startswith("features_")],
+            "observation_features": list(feature_keys),
             "original_features": ["open", "high", "low", "close", "volume"],
         }
 
@@ -108,3 +124,28 @@ class ReplayObserver:
         self.truncated = False
         if self.executor is not None:
             self.executor.reset()
+
+    def _base_window(self, timestamp) -> np.ndarray:
+        """The last `window` execution bars of OHLC, not just the newest one.
+
+        Only `base_arr[-1]` used to be populated, on the reasoning that live envs read
+        `[-1, 3]`. But `include_base_features=True` declares a `(window, 4)` spec and puts
+        the array in the OBSERVATION, so a policy consuming that key read 90% zeros --
+        9 of 10 rows (#278). Real observers fill the whole window.
+
+        Rows before the start of the data stay zero: there is no bar to report, and
+        inventing one would be worse than an obvious gap.
+        """
+        ws = self.window_sizes[0]
+        base_arr = np.zeros((ws, 4), dtype=np.float32)
+        end = int(torch.searchsorted(
+            self.sampler.execute_base_idx,
+            torch.tensor(int(timestamp.value), dtype=torch.long),
+            right=True,
+        ).item())
+        if end <= 0:
+            return base_arr
+        start = max(0, end - ws)
+        window = self.sampler.execute_base_tensor[start:end, :4].numpy().astype(np.float32)
+        base_arr[-len(window):] = window
+        return base_arr

--- a/torchtrade/envs/replay/observer.py
+++ b/torchtrade/envs/replay/observer.py
@@ -41,15 +41,15 @@ class ReplayObserver:
         )
         self.sampler.reset(random_start=False)
         self.window_sizes = self.sampler.window_sizes
-        # `market_data_{timeframe}_{window}`, composed exactly as the offline envs do
-        # (`core/offline_base.py`). The sampler's raw keys are bare timeframe names, so
-        # replay emitted `market_data_1Minute` where offline and live both emit
-        # `market_data_1Minute_10` -- a policy trained offline could not be fed the
-        # replay env without renaming its in_keys (#278).
+        # `{timeframe}_{window}`, matching what the real observers return -- the env
+        # bases prepend "market_data_" themselves. The sampler's raw keys are bare
+        # timeframe names, so the env built `market_data_1Minute` where offline and live
+        # both produce `market_data_1Minute_10`, and a policy trained offline could not
+        # be fed the replay env without renaming its in_keys (#278). Adding the prefix
+        # HERE instead produced `market_data_market_data_1Minute_10`.
         self._timeframes = self.sampler.get_observation_keys()
         self._obs_keys = [
-            f"market_data_{name}_{ws}"
-            for name, ws in zip(self._timeframes, self.window_sizes)
+            f"{name}_{ws}" for name, ws in zip(self._timeframes, self.window_sizes)
         ]
         self.truncated = False
 
@@ -100,10 +100,11 @@ class ReplayObserver:
         `(window, 5)`, and `check_env_specs` failed with a size mismatch (#278). Offline
         counts the same columns via `get_num_features_per_timeframe`.
         """
-        try:
-            feature_keys = self.sampler.get_feature_keys()
-        except ValueError:
-            feature_keys = []
+        # No `except: []` fallback. Swallowing the per-timeframe-features error declared
+        # a (window, 0) spec against a (window, 2) emission, which is the same mismatch
+        # the filtering caused -- a fail-open guard in the boundary-validation sense.
+        # Raising says which config is unsupported instead of shipping a broken spec.
+        feature_keys = self.sampler.get_feature_keys()
         return {
             "observation_features": list(feature_keys),
             "original_features": ["open", "high", "low", "close", "volume"],
@@ -133,19 +134,22 @@ class ReplayObserver:
         the array in the OBSERVATION, so a policy consuming that key read 90% zeros --
         9 of 10 rows (#278). Real observers fill the whole window.
 
-        Rows before the start of the data stay zero: there is no bar to report, and
-        inventing one would be worse than an obvious gap.
+        Read from the sampler's UNTRUNCATED execution frame. The truncated one starts at
+        min_start_time, so the first `window` steps of every episode were still mostly
+        zeros -- `market_data_*` for the same timeframe and window was full of real bars
+        from step 1 while `base_features` was 9/10 zero. Those bars exist; they were just
+        outside the frame. Rows genuinely before the data begin stay zero.
         """
         ws = self.window_sizes[0]
         base_arr = np.zeros((ws, 4), dtype=np.float32)
         end = int(torch.searchsorted(
-            self.sampler.execute_base_idx,
+            self.sampler.execute_base_full_idx,
             torch.tensor(int(timestamp.value), dtype=torch.long),
             right=True,
         ).item())
         if end <= 0:
             return base_arr
         start = max(0, end - ws)
-        window = self.sampler.execute_base_tensor[start:end, :4].numpy().astype(np.float32)
+        window = self.sampler.execute_base_full_tensor[start:end, :4].numpy().astype(np.float32)
         base_arr[-len(window):] = window
         return base_arr

--- a/torchtrade/envs/replay/observer.py
+++ b/torchtrade/envs/replay/observer.py
@@ -148,9 +148,16 @@ class ReplayObserver:
         """
         ws = self.window_sizes[0]
         base_arr = np.zeros((ws, 4), dtype=np.float32)
+        # Through the sampler's own rule, not a re-implemented searchsorted. A frame
+        # FINER than execute_on is labelled by bar start, so looking it up at the raw
+        # execution label returned a window shifted back by `exec_period/tf0_period - 1`
+        # bars -- stale, deterministically, whenever execute_on is coarser than
+        # time_frames[0]. `_search_ts` exists for exactly this and is what every other
+        # lookup in the sampler goes through.
+        lookup = self.sampler._search_ts(self._timeframes[0], int(timestamp.value))
         end = int(torch.searchsorted(
             self.sampler.base_ohlc_idx,
-            torch.tensor(int(timestamp.value), dtype=torch.long),
+            torch.tensor(int(lookup), dtype=torch.long),
             right=True,
         ).item())
         if end <= 0:


### PR DESCRIPTION
Third slice of #278, after #374 and #375. Three ways the replay observation differed from the offline and live ones it exists to be compared against.

## The market-data key had no window suffix

The sampler's raw keys are bare timeframe names; offline composes `market_data_{timeframe}_{window}`. So replay emitted `market_data_1Minute` where offline and live both emit `market_data_1Minute_10` — **a policy trained offline could not be fed the replay env without rewriting its in_keys**, which defeats the point of replaying through the live pipeline.

Parity is asserted against a real `SequentialTradingEnv`, not a hardcoded string, so the two cannot drift apart silently.

## `base_features` was 90% zeros

Only `base_arr[-1]` was written, on the reasoning that live envs read `[-1, 3]`. But `include_base_features=True` declares a `(window, 4)` spec and puts the array in the **observation** — so a policy consuming that key read 9 of 10 rows as zero, on every step, forever.

It fills from the sampler's execution bars now. Rows before the start of the data stay zero deliberately: there is no bar to report, and inventing one is worse than an obvious gap.

## Features reported as zero without a preprocessing fn

`get_features()` filtered to names starting with `features_`, so with no `feature_preprocessing_fn` it returned an empty list while the sampler still emitted the five raw OHLCV columns. The declared spec came out `(window, 0)` against an emitted `(window, 5)` and `check_env_specs` failed on a size mismatch. Only that one config was affected, which is why it survived.

## Verification

All three mutation-checked — reverting each fix fails its test (2, 1 and 2 failures respectively). Full suite **3655 passed**, 0 xfailed.

## Remaining in #278

`reduce_only=True` discarding `quantity` (forces a full close). It has **zero call sites** today, so it is latent interface divergence rather than a live defect — worth fixing when something needs a partial reduce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)