### PR TITLE
refactor(live): one wait duration instead of a 17-entry spelling table

### DIFF
--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -2724,3 +2724,32 @@ def test_a_live_account_keeps_its_run_level_bankruptcy_baseline():
     assert env._check_termination(62.5) is True, (
         "62.5 is below 10% of the 1000 this run started with and must terminate"
     )
+
+
+def test_the_bar_wait_derives_from_the_timeframe_not_a_string_alias():
+    """One duration rule, not an alias table that grows per spelling (#288).
+
+    `_wait_for_next_timestamp` looked its unit up in a 17-entry map --
+    "TimeFrameUnit.Minute", "Minute", "Min", "min", "minute", "h", "H", "D", "d",
+    "seconds" -- because five exchanges stringified the same enum four different ways
+    and the map grew an entry per spelling rather than the spellings being fixed. A
+    sixth exchange spelling it a fifth way would have raised at the first bar, in
+    production, on a timer.
+    """
+    from torchtrade.envs.core import live as live_module
+
+    tree = ast.parse(textwrap.dedent(
+        inspect.getsource(live_module.TorchTradeLiveEnv._wait_for_next_timestamp)
+    ))
+    called = {n.func.id for n in ast.walk(tree)
+              if isinstance(n, ast.Call) and isinstance(n.func, ast.Name)}
+    assert "timeframe_to_seconds" in called, "the wait must derive from the TimeFrame"
+
+    # Literals only -- the explanation above quotes the old spellings, and a check that
+    # a comment can trip is a check a comment can also satisfy.
+    literals = {n.value for n in ast.walk(tree)
+                if isinstance(n, ast.Constant) and isinstance(n.value, str)}
+    regrown = literals & {"TimeFrameUnit.Minute", "Minute", "Min", "min", "minute",
+                          "TimeFrameUnit.Hour", "Hour", "h", "H", "seconds",
+                          "TimeFrameUnit.Day", "Day", "D", "d", "hour", "day"}
+    assert not regrown, f"the unit alias table is regrowing in the wait path: {regrown}"

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -2726,6 +2726,62 @@ def test_a_live_account_keeps_its_run_level_bankruptcy_baseline():
     )
 
 
+@pytest.mark.parametrize("cls", LIVE_ENVS, ids=lambda c: c.__name__)
+def test_every_live_env_can_actually_run_the_bar_wait(cls):
+    """RUN it, do not inspect it. This is the test that was missing.
+
+    `_wait_for_next_timestamp` reads `self.execute_on`, and alpaca's base set only
+    `execute_on_value`/`execute_on_unit` -- so both alpaca envs raised AttributeError at
+    the first bar, AFTER the order was placed and the position recorded. 834 exchange
+    tests and 513 contract tests passed, because every one of them stubs this method
+    (`env._wait_for_next_timestamp = lambda: None` or `patch.object(...)`). Nothing ever
+    executed the body.
+
+    Constructing a live env needs credentials, so this asserts the attribute the body
+    reads is set by __init__ on every exchange -- the cheapest thing that fails when it
+    is not.
+    """
+    # The EXCHANGE base, not the whole MRO: TorchTradeLiveEnv initialises
+    # `self.execute_on = None`, so an MRO-wide search passes on a concrete class that
+    # never assigns it -- which is exactly the alpaca break, certified clean. First
+    # version of this test did that and the mutation survived.
+    exchange_bases = [
+        base for base in cls.__mro__
+        if base.__module__.startswith("torchtrade.envs.live.")
+        and not base.__module__.startswith("torchtrade.envs.live.shared")
+    ]
+    if not exchange_bases:
+        pytest.skip(f"{cls.__name__} is a shared base, not an exchange env")
+    assert any(
+        "self.execute_on = " in inspect.getsource(base) for base in exchange_bases
+    ), (
+        f"{cls.__name__} never assigns self.execute_on in its exchange base; the shared "
+        f"bar wait reads it and will AttributeError at the first bar, after the order"
+    )
+
+
+def test_the_bar_wait_actually_sleeps_for_the_timeframe():
+    """Drive the real body with a stub env, since no exchange test ever does."""
+    from unittest.mock import patch
+
+    from torchtrade.envs.core.live import TorchTradeLiveEnv
+    from torchtrade.envs.utils import TimeFrame, TimeFrameUnit
+
+    for value, unit, expected in ((1, TimeFrameUnit.Minute, 60),
+                                  (5, TimeFrameUnit.Minute, 300),
+                                  (4, TimeFrameUnit.Hour, 14400),
+                                  (1, TimeFrameUnit.Day, 86400)):
+        env = SimpleNamespace(execute_on=TimeFrame(value, unit), timezone=None)
+        with patch("torchtrade.envs.core.live.time.sleep") as slept:
+            TorchTradeLiveEnv._wait_for_next_timestamp(env)
+        assert slept.called, f"{value}{unit.name} did not sleep at all"
+        # The truncation to whole minutes means the slept value is within a minute of
+        # the period; the point is that it scales with the timeframe, not that it is exact.
+        assert 0 < slept.call_args[0][0] <= expected, (
+            f"{value}{unit.name} slept {slept.call_args[0][0]}s, not ~{expected}s"
+        )
+
+
 def test_the_bar_wait_derives_from_the_timeframe_not_a_string_alias():
     """One duration rule, not an alias table that grows per spelling (#288).
 

--- a/torchtrade/envs/core/live.py
+++ b/torchtrade/envs/core/live.py
@@ -19,6 +19,7 @@ from torchtrade.envs.core.state import (
     POSITION_DUST_EPS,
     position_qty_from_status,
 )
+from torchtrade.envs.utils.timeframe import timeframe_to_seconds
 from torchtrade.envs.utils.termination import is_bankrupt
 
 
@@ -146,43 +147,17 @@ class TorchTradeLiveEnv(TorchTradeBaseEnv):
         This is COMMON across all live environments - timing logic is universal.
 
         Uses:
-        - self.execute_on_value: Number of time units
-        - self.execute_on_unit: Time unit (e.g., "Minute", "Hour", "Day")
+        - self.execute_on: the execution TimeFrame
         - self.timezone: Timezone for time calculations
         """
-        # Map time unit strings to timedelta kwargs
-        unit_to_timedelta = {
-            "TimeFrameUnit.Minute": "minutes",
-            "TimeFrameUnit.Hour": "hours",
-            "TimeFrameUnit.Day": "days",
-            # Alpaca uses different naming
-            "Minute": "minutes",
-            "Hour": "hours",
-            "Day": "days",
-            # Pandas frequency codes (from TimeFrameUnit enum values)
-            "Min": "minutes",
-            "H": "hours",
-            # Lowercase variants (TimeFrameUnit.value uses lowercase)
-            "min": "minutes",
-            "h": "hours",
-            "d": "days",
-            "minute": "minutes",
-            "hour": "hours",
-            "day": "days",
-            "seconds": "seconds",
-            "D": "days",
-        }
-
-        if self.execute_on_unit not in unit_to_timedelta:
-            raise ValueError(
-                f"Unsupported time unit: {self.execute_on_unit}. "
-                f"Supported: {list(unit_to_timedelta.keys())}"
-            )
-
-        # Calculate wait duration
-        wait_duration = timedelta(
-            **{unit_to_timedelta[self.execute_on_unit]: self.execute_on_value}
-        )
+        # One canonical duration, from the TimeFrame itself. This used to look the
+        # unit up in a 17-entry alias map -- "TimeFrameUnit.Minute", "Minute", "Min",
+        # "min", "minute", "h", "H", "D", "d", "seconds" -- because five exchanges
+        # stringified the same enum four different ways (`str(unit)`, `str(unit.value)`,
+        # a hardcoded "seconds") and the map grew an entry per spelling rather than the
+        # spellings being fixed. A sixth exchange spelling it a fifth way would have
+        # raised at the first bar, in production, on a timer (#288).
+        wait_duration = timedelta(seconds=timeframe_to_seconds(self.execute_on))
 
         # Calculate next step time
         current_time = datetime.now(self.timezone)

--- a/torchtrade/envs/core/live.py
+++ b/torchtrade/envs/core/live.py
@@ -105,8 +105,7 @@ class TorchTradeLiveEnv(TorchTradeBaseEnv):
         # Store execution timeframe
         # Note: Subclasses should ensure execute_on has 'value' and 'unit' attributes
         # For TimeFrame objects: execute_on.value (int) and execute_on.unit (TimeFrameUnit enum)
-        self.execute_on_value = None
-        self.execute_on_unit = None
+        self.execute_on = None
 
         # Initialize trading clients (observer and trader)
         # Subclasses should override _init_trading_clients to provide provider-specific setup

--- a/torchtrade/envs/live/alpaca/base.py
+++ b/torchtrade/envs/live/alpaca/base.py
@@ -96,8 +96,7 @@ class AlpacaBaseTorchTradingEnv(TorchTradeLiveEnv):
         )
 
         # Extract execute_on timeframe
-        self.execute_on_value = config.execute_on.value
-        self.execute_on_unit = str(config.execute_on.unit.value)
+        self.execute_on = config.execute_on
 
         # Reset settings
         self.trader.close_all_positions()

--- a/torchtrade/envs/live/binance/base.py
+++ b/torchtrade/envs/live/binance/base.py
@@ -89,8 +89,6 @@ class BinanceBaseTorchTradingEnv(TorchTradeFuturesLiveEnv):
 
         # Extract execute timeframe and convert to seconds
         self.execute_on = config.execute_on
-        self.execute_on_value = timeframe_to_seconds(config.execute_on)
-        self.execute_on_unit = "seconds"  # Binance uses simple seconds-based intervals
 
         # Flatten on startup for a clean state (configurable, default: True)
         self.trader.cancel_open_orders()

--- a/torchtrade/envs/live/bitget/base.py
+++ b/torchtrade/envs/live/bitget/base.py
@@ -8,7 +8,6 @@ from tensordict import TensorDictBase
 from torchrl.data import Unbounded
 from torchrl.data.tensor_specs import Composite
 
-from torchtrade.envs.utils.timeframe import TimeFrame
 from torchtrade.envs.live.bitget.observation import BitgetObservationClass
 from torchtrade.envs.live.bitget.order_executor import BitgetFuturesOrderClass
 from torchtrade.envs.live.shared.futures_live_base import TorchTradeFuturesLiveEnv
@@ -93,10 +92,7 @@ class BitgetBaseTorchTradingEnv(TorchTradeFuturesLiveEnv):
 
         # Extract execute timeframe
         self.execute_on = config.execute_on
-        # Set execute_on_value and execute_on_unit from the TimeFrame object
-        # Both arms of the old isinstance check were byte-identical.
-        self.execute_on_value = config.execute_on.value
-        self.execute_on_unit = str(config.execute_on.unit)
+        # The execution timeframe, read by the shared bar wait.
 
         # Flatten on startup for a clean state (configurable, default: True)
         self.trader.cancel_open_orders()

--- a/torchtrade/envs/live/bitget/base.py
+++ b/torchtrade/envs/live/bitget/base.py
@@ -94,13 +94,9 @@ class BitgetBaseTorchTradingEnv(TorchTradeFuturesLiveEnv):
         # Extract execute timeframe
         self.execute_on = config.execute_on
         # Set execute_on_value and execute_on_unit from the TimeFrame object
-        if isinstance(config.execute_on, TimeFrame):
-            self.execute_on_value = config.execute_on.value
-            self.execute_on_unit = str(config.execute_on.unit)  # e.g., "TimeFrameUnit.Minute"
-        else:
-            # Fallback: should not happen after normalization, but handle it
-            self.execute_on_value = config.execute_on.value
-            self.execute_on_unit = str(config.execute_on.unit)
+        # Both arms of the old isinstance check were byte-identical.
+        self.execute_on_value = config.execute_on.value
+        self.execute_on_unit = str(config.execute_on.unit)
 
         # Flatten on startup for a clean state (configurable, default: True)
         self.trader.cancel_open_orders()

--- a/torchtrade/envs/live/bybit/base.py
+++ b/torchtrade/envs/live/bybit/base.py
@@ -78,8 +78,6 @@ class BybitBaseTorchTradingEnv(TorchTradeFuturesLiveEnv):
 
         # Extract execute timeframe (already normalized to TimeFrame in config.__post_init__)
         self.execute_on = config.execute_on
-        self.execute_on_value = config.execute_on.value
-        self.execute_on_unit = str(config.execute_on.unit)
 
         # Flatten on startup for a clean state (configurable, default: True)
         self.trader.cancel_open_orders()

--- a/torchtrade/envs/live/okx/base.py
+++ b/torchtrade/envs/live/okx/base.py
@@ -81,8 +81,6 @@ class OKXBaseTorchTradingEnv(TorchTradeFuturesLiveEnv):
 
         # Extract execute timeframe (already normalized to TimeFrame in config.__post_init__)
         self.execute_on = config.execute_on
-        self.execute_on_value = config.execute_on.value
-        self.execute_on_unit = str(config.execute_on.unit)
 
         # Flatten on startup for a clean state (configurable, default: True)
         self.trader.cancel_open_orders()


### PR DESCRIPTION
Second slice of #288 — the ceremony cleanups.

## The alias table

`_wait_for_next_timestamp` looked its time unit up in a **17-entry** map: `"TimeFrameUnit.Minute"`, `"Minute"`, `"Min"`, `"min"`, `"minute"`, `"h"`, `"H"`, `"D"`, `"d"`, `"seconds"`, `"hour"`, `"day"`…

The reason is that **five exchanges stringify the same enum four different ways**:

| exchange | assignment |
|---|---|
| bybit / okx / bitget | `str(config.execute_on.unit)` → `"TimeFrameUnit.Minute"` |
| alpaca | `str(config.execute_on.unit.value)` → `"min"` |
| binance | hardcoded `"seconds"` |

The table grew an entry per spelling instead of the spellings being fixed. A sixth exchange spelling it a fifth way would have raised **at the first bar** — in production, on a timer, after the env had already opened positions.

It derives from the TimeFrame now: `timedelta(seconds=timeframe_to_seconds(execute_on))`. Verified identical for 1Min/5Min/1H/4H/1D.

Also: bitget's `isinstance(config.execute_on, TimeFrame)` branch had **byte-identical arms**, one commented "should not happen after normalization" — three lines of ceremony for one assignment.

## The guard

It reads **literals out of the AST**, not the source text. My first version grepped the source and failed on its own explanatory comment, which quotes the old spellings — a check a comment can trip is a check a comment can also satisfy, and this PR series has been bitten by that in both directions. Mutation-checked: reintroducing a two-entry alias table fails it.

Full suite **3694 passed**, 0 xfailed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)