### PR TITLE
chore: pin the version at 0.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "torchtrade"
-version = "0.0.1"
+version = "0.1.0"
 description = "Reinforcement learning environments for trading applications"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_version_pin.py
+++ b/tests/test_version_pin.py
@@ -1,0 +1,33 @@
+"""The version lives in two files; keep them one number."""
+
+import pathlib
+import re
+
+import torchtrade
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+
+
+def test_the_package_version_matches_pyproject():
+    """Two files holding one number is exactly the shape that drifts.
+
+    `pyproject.toml` is what pip installs and `torchtrade.__version__` is what a user
+    prints when reporting a bug -- so a mismatch means the version in a bug report is
+    not the version that was installed, which is the one case the number exists for.
+    """
+    declared = re.search(
+        r'^version = "([^"]+)"', (REPO / "pyproject.toml").read_text(), re.M
+    )
+    assert declared, "pyproject.toml has no version"
+    assert torchtrade.__version__ == declared.group(1), (
+        f"torchtrade.__version__ is {torchtrade.__version__} but pyproject.toml says "
+        f"{declared.group(1)}"
+    )
+
+
+def test_the_version_is_a_release_not_the_placeholder():
+    """0.0.1 was the hatchling default and stayed for 1000+ commits."""
+    assert torchtrade.__version__ != "0.0.1"
+    assert re.fullmatch(r"\d+\.\d+\.\d+", torchtrade.__version__), (
+        f"{torchtrade.__version__} is not a plain semver triple"
+    )

--- a/torchtrade/__init__.py
+++ b/torchtrade/__init__.py
@@ -1,3 +1,9 @@
+"""TorchTrade: reinforcement learning environments for trading."""
+
+# Kept in step with pyproject.toml by tests/test_version_pin.py -- two files
+# holding one number is exactly the shape that drifts.
+__version__ = "0.1.0"
+
 from torchtrade.envs.offline import (
     SequentialTradingEnv,
     SequentialTradingEnvConfig,


### PR DESCRIPTION
The sweep's final step. All 30 PRs from this run are merged.

`0.0.1` was hatchling's default and survived **1011 commits**, so nothing installed from this repo could be identified. This sweep merged 30 PRs closing 20 issues, most of them money-path defects in the live and replay pipelines — a reader needs to be able to say which side of that their install sits on.

## Why 0.1.0 and not 1.0.0

The four-exchange dedup (#288 steps 1–3, ~2,000 LOC) is unstarted, and **#279** and **#295** are open design decisions that change behaviour for already-trained checkpoints. That is not a 1.0 surface.

## `__version__`

`pyproject.toml` is what pip installs, but a user reporting a bug prints the attribute — and until now there was nothing to print. Two files holding one number is exactly the shape that drifts, so a test pins them together and separately refuses the `0.0.1` placeholder. Mutation-checked: bumping one file alone fails it.

Full suite **3742 passed**, 0 xfailed.

## Still open after this

| issue | state |
|---|---|
| #279 | Asymmetry documented and pinned; **the mirroring decision is yours** |
| #295 | Premise corrected (the `auto_reset` API doesn't exist in the pinned torchrl); **parts 1–2 are your call** |
| #288 | Steps 4 merged, step 5 measured as ~90% already done; **steps 1–3 remain** |
| #289 | Alpaca flags merged; the rest waits on #288 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)