### PR TITLE
refactor(live): hoist the one identical trade-info builder (#288 step 2)

### DIFF
--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -173,7 +173,10 @@ def test_no_live_env_overrides_shared_method(env_cls, method):
     )
 
 
-@pytest.mark.parametrize("method", ["_get_observation", "_get_portfolio_value"])
+@pytest.mark.parametrize(
+    "method",
+    ["_get_observation", "_get_portfolio_value", "_create_trade_info"],
+)
 @pytest.mark.parametrize("env_cls", FUTURES_ENVS, ids=lambda c: c.__name__)
 def test_no_futures_env_reforks_the_shared_observation(env_cls, method):
     """The 4 futures exchanges share ONE _get_observation/_get_portfolio_value.
@@ -2870,25 +2873,6 @@ def test_every_live_env_reports_the_same_account_state_layout():
     assert not wrong, f"venues disagree with the universal account_state vector: {wrong}"
 
 
-def test_no_futures_env_re_forks_the_trade_info_builder():
-    """Four identical `_create_trade_info` copies (#288).
-
-    MRO owner, not a module allowlist -- `SLTPMixin` sits ahead of the shared base for
-    all four SLTP envs, so a copy there would shadow the hoisted one on every venue at
-    once while a prefix filter stayed green.
-    """
-    from torchtrade.envs.live.shared.futures_live_base import TorchTradeFuturesLiveEnv
-
-    wrong_owner = {
-        c.__name__: next(b for b in c.__mro__ if "_create_trade_info" in b.__dict__).__name__
-        for c in LIVE_ENVS
-        if issubclass(c, TorchTradeFuturesLiveEnv)
-        and next((b for b in c.__mro__ if "_create_trade_info" in b.__dict__), None)
-        is not TorchTradeFuturesLiveEnv
-    }
-    assert not wrong_owner, f"_create_trade_info re-forked on: {wrong_owner}"
-
-
 def test_the_trade_info_defaults_are_the_whole_contract():
     """A path that did not trade still returns this dict, so a MISSING key reads
     downstream as an absent fact rather than a default one -- which is what four copies
@@ -2904,3 +2888,11 @@ def test_the_trade_info_defaults_are_the_whole_contract():
     overridden = TorchTradeFuturesLiveEnv._create_trade_info(None, executed=True, side="BUY")
     assert overridden["executed"] is True and overridden["side"] == "BUY"
     assert overridden["closed_position"] is False and overridden["quantity"] == 0
+
+    # An UNKNOWN key must survive: `at_target` is read by core/live.py to re-arm
+    # current_action_level, so a merge that kept only known keys would silently drop a
+    # money-moving fact. That is the one semantic this hoist actually changed
+    # (`dict(...).update(kwargs)` -> `{**defaults, **kwargs}`) and nothing covered it.
+    extra = TorchTradeFuturesLiveEnv._create_trade_info(None, at_target=True, target_qty=0.5)
+    assert extra["at_target"] is True and extra["target_qty"] == 0.5
+    assert extra["executed"] is False, "an unknown key must not disturb the defaults"

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -2868,3 +2868,39 @@ def test_every_live_env_reports_the_same_account_state_layout():
     assert len(layouts) >= 10, f"only {len(layouts)} concrete live envs checked"
     wrong = {n: v for n, v in layouts.items() if v != expected}
     assert not wrong, f"venues disagree with the universal account_state vector: {wrong}"
+
+
+def test_no_futures_env_re_forks_the_trade_info_builder():
+    """Four identical `_create_trade_info` copies (#288).
+
+    MRO owner, not a module allowlist -- `SLTPMixin` sits ahead of the shared base for
+    all four SLTP envs, so a copy there would shadow the hoisted one on every venue at
+    once while a prefix filter stayed green.
+    """
+    from torchtrade.envs.live.shared.futures_live_base import TorchTradeFuturesLiveEnv
+
+    wrong_owner = {
+        c.__name__: next(b for b in c.__mro__ if "_create_trade_info" in b.__dict__).__name__
+        for c in LIVE_ENVS
+        if issubclass(c, TorchTradeFuturesLiveEnv)
+        and next((b for b in c.__mro__ if "_create_trade_info" in b.__dict__), None)
+        is not TorchTradeFuturesLiveEnv
+    }
+    assert not wrong_owner, f"_create_trade_info re-forked on: {wrong_owner}"
+
+
+def test_the_trade_info_defaults_are_the_whole_contract():
+    """A path that did not trade still returns this dict, so a MISSING key reads
+    downstream as an absent fact rather than a default one -- which is what four copies
+    risked drifting on."""
+    from torchtrade.envs.live.shared.futures_live_base import TorchTradeFuturesLiveEnv
+
+    info = TorchTradeFuturesLiveEnv._create_trade_info(None)
+    assert info == {
+        "executed": False, "quantity": 0, "side": None,
+        "success": None, "closed_position": False,
+    }
+    # kwargs override, and do not silently drop a default.
+    overridden = TorchTradeFuturesLiveEnv._create_trade_info(None, executed=True, side="BUY")
+    assert overridden["executed"] is True and overridden["side"] == "BUY"
+    assert overridden["closed_position"] is False and overridden["quantity"] == 0

--- a/torchtrade/envs/live/binance/env.py
+++ b/torchtrade/envs/live/binance/env.py
@@ -207,18 +207,6 @@ class BinanceFuturesTorchTradingEnv(BinanceBaseTorchTradingEnv):
 
         return next_tensordict
 
-    def _create_trade_info(self, executed=False, **kwargs) -> Dict:
-        """Create trade info dictionary with defaults."""
-        info = {
-            "executed": executed,
-            "quantity": 0,
-            "side": None,
-            "success": None,
-            "closed_position": False,
-        }
-        info.update(kwargs)
-        return info
-
     def _execute_market_order(self, side: str, quantity: float) -> Dict:
         """Execute a market order with error handling."""
         try:

--- a/torchtrade/envs/live/bitget/env.py
+++ b/torchtrade/envs/live/bitget/env.py
@@ -206,18 +206,6 @@ class BitgetFuturesTorchTradingEnv(BitgetBaseTorchTradingEnv):
 
         return next_tensordict
 
-    def _create_trade_info(self, executed=False, **kwargs) -> Dict:
-        """Create trade info dictionary with defaults."""
-        info = {
-            "executed": executed,
-            "quantity": 0,
-            "side": None,
-            "success": None,
-            "closed_position": False,
-        }
-        info.update(kwargs)
-        return info
-
     def _execute_market_order(self, side: str, quantity: float) -> Dict:
         """Execute a market order with error handling."""
         try:

--- a/torchtrade/envs/live/bybit/env.py
+++ b/torchtrade/envs/live/bybit/env.py
@@ -168,18 +168,6 @@ class BybitFuturesTorchTradingEnv(BybitBaseTorchTradingEnv):
 
         return next_tensordict
 
-    def _create_trade_info(self, executed=False, **kwargs) -> Dict:
-        """Create trade info dictionary with defaults."""
-        info = {
-            "executed": executed,
-            "quantity": 0,
-            "side": None,
-            "success": None,
-            "closed_position": False,
-        }
-        info.update(kwargs)
-        return info
-
     def _execute_market_order(self, side: str, quantity: float) -> Dict:
         """Execute a market order with error handling."""
         try:

--- a/torchtrade/envs/live/okx/env.py
+++ b/torchtrade/envs/live/okx/env.py
@@ -173,18 +173,6 @@ class OKXFuturesTorchTradingEnv(OKXBaseTorchTradingEnv):
 
         return next_tensordict
 
-    def _create_trade_info(self, executed=False, **kwargs) -> Dict:
-        """Create trade info dictionary with defaults."""
-        info = {
-            "executed": executed,
-            "quantity": 0,
-            "side": None,
-            "success": None,
-            "closed_position": False,
-        }
-        info.update(kwargs)
-        return info
-
     def _execute_market_order(self, side: str, quantity: float) -> Dict:
         """Execute a market order with error handling."""
         try:

--- a/torchtrade/envs/live/shared/futures_live_base.py
+++ b/torchtrade/envs/live/shared/futures_live_base.py
@@ -9,6 +9,7 @@ Alpaca (spot) is NOT a futures env: it hardcodes leverage=1 and distance_to_liqu
 and reads cash rather than total_wallet_balance. It keeps its own `_get_observation` and
 inherits `TorchTradeLiveEnv` directly.
 """
+from typing import Dict
 import logging
 import math
 
@@ -121,6 +122,23 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
             )
 
         return self._halting(read)
+
+    def _create_trade_info(self, executed: bool = False, **kwargs) -> Dict:
+        """The trade-info dict every futures `_step` returns. Four identical copies (#288).
+
+        The DEFAULTS are the point: `_step` builds this on paths that did not trade, and
+        a missing key there is read downstream as an absent fact rather than a default
+        one. Four copies meant four chances for one venue's default set to drift from
+        the others while every test stayed green.
+        """
+        return {
+            "executed": executed,
+            "quantity": 0,
+            "side": None,
+            "success": None,
+            "closed_position": False,
+            **kwargs,
+        }
 
     def _acquire_post_bar_state(self) -> tuple[float, float, float, TensorDictBase]:
         """Post-bar portfolio value and observation, or halt.


### PR DESCRIPTION
Measured first, as with steps 1 and 5.

The issue describes step 2 as *"4 byte-identical `_create_trade_info`, near-identical `_step`/`_execute_market_order`/`_handle_close_action`/`_execute_fractional_action` (~500 LOC)"*. AST-comparing every method across the four `env.py` files after normalising exchange names:

```
identical across all 4 env.py: 1
  _create_trade_info
```

The issue's own wording is accurate — **one** method is identical; the rest are *near*-identical, and near-identical is where the per-venue facts live (taker fee, lot rounding, position-side handling). Sharing those means parameterising exactly the parts that differ, which is a different change from removing a copy.

## What this does

Hoists the one. Its **defaults** are the point: `_step` returns this dict on paths that did not trade, so a missing key reads downstream as an *absent fact* rather than a default one — four copies were four chances for one venue's default set to drift while every test stayed green.

## Two guards

One asserts the MRO owner is `TorchTradeFuturesLiveEnv` — not a module allowlist, since `SLTPMixin` sits ahead of the shared base for all four SLTP envs and a copy there would shadow the hoisted one on every venue at once (that exact bypass defeated the guard in #384). One pins the five default keys, since that is what a drifted copy would change. Mutation-checked: dropping a default fails.

Full suite **3746 passed**, 0 xfailed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)