### PR TITLE
fix(binance): a close reported "CLOSE" as its side, losing the side it sent

### DIFF
--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -175,7 +175,12 @@ def test_no_live_env_overrides_shared_method(env_cls, method):
 
 @pytest.mark.parametrize(
     "method",
-    ["_get_observation", "_get_portfolio_value", "_create_trade_info"],
+    [
+        "_get_observation",
+        "_get_portfolio_value",
+        "_create_trade_info",
+        "_handle_close_action",
+    ],
 )
 @pytest.mark.parametrize("env_cls", FUTURES_ENVS, ids=lambda c: c.__name__)
 def test_no_futures_env_reforks_the_shared_observation(env_cls, method):
@@ -2896,3 +2901,42 @@ def test_the_trade_info_defaults_are_the_whole_contract():
     extra = TorchTradeFuturesLiveEnv._create_trade_info(None, at_target=True, target_qty=0.5)
     assert extra["at_target"] is True and extra["target_qty"] == 0.5
     assert extra["executed"] is False, "an unknown key must not disturb the defaults"
+
+
+@pytest.mark.parametrize("qty,expected_side", [(0.5, "sell"), (-0.5, "buy")])
+def test_closing_reports_the_order_side_that_closed_it(qty, expected_side):
+    """binance reported the literal "CLOSE" where its three siblings report the real side.
+
+    `side` is what went to the venue, and `closed_position=True` in the same dict already
+    says it was a close -- so the literal added nothing and lost the one fact this field
+    carries. That is the silent per-exchange divergence #288 exists to remove, and it is
+    why the four copies could not be hoisted until it was resolved: whichever version
+    became shared, one venue's observable output changed, and it had to change
+    deliberately.
+    """
+    from types import SimpleNamespace
+
+    from torchtrade.envs.live.shared.futures_live_base import TorchTradeFuturesLiveEnv
+
+    env = SimpleNamespace(
+        trader=SimpleNamespace(close_position=lambda: True),
+        config=SimpleNamespace(symbol="BTCUSDT"),
+        position=SimpleNamespace(current_position=1),
+        _create_trade_info=TorchTradeFuturesLiveEnv._create_trade_info.__get__(object()),
+    )
+    info = TorchTradeFuturesLiveEnv._handle_close_action(env, qty)
+
+    assert info["side"] == expected_side, "a close must report the side it sent"
+    assert info["closed_position"] is True and info["executed"] is True
+    assert info["quantity"] == abs(qty)
+    assert env.position.current_position == 0, "a successful close must zero the position"
+
+
+def test_a_close_with_no_position_does_not_report_a_trade():
+    from types import SimpleNamespace
+
+    from torchtrade.envs.live.shared.futures_live_base import TorchTradeFuturesLiveEnv
+
+    env = SimpleNamespace(_create_trade_info=TorchTradeFuturesLiveEnv._create_trade_info.__get__(object()))
+    info = TorchTradeFuturesLiveEnv._handle_close_action(env, 0)
+    assert info["executed"] is False and info["side"] is None

--- a/tests/envs/test_live_trade_state.py
+++ b/tests/envs/test_live_trade_state.py
@@ -290,14 +290,39 @@ class TestBinanceDirectionSwitch:
         assert trader.position_qty == 0.5
         assert len([t for t in trader.trades_executed if t["side"] == "SELL"]) == 0
 
+    def test_a_switch_whose_open_fails_does_not_leave_a_phantom_position(self):
+        """The one path where binance's missing `current_position = 0` survived (#288).
+
+        On a normal close, `_record_position_after_trade` overwrites the cache from
+        `sign(desired_action)` anyway -- so the zeroing binance lacked was invisible.
+        The exception is a direction switch whose CLOSE succeeds and whose OPEN then
+        fails: that early-returns on `executed=False`, leaving the pre-close value
+        standing. binance reported a long against an exchange holding nothing, which is
+        invariant 2 -- the cache outliving exchange truth -- and it is what the shared
+        version fixes.
+        """
+        trader = MockTrader(position_qty=0.5, balance=10000.0)
+        trader.trade_should_raise = True  # the close lands, the re-open does not
+        env = _make_binance_env(trader)
+        env.position.current_position = 1
+
+        env._execute_fractional_action(-1.0)
+
+        assert trader.position_qty == 0.0, "the close itself must have succeeded"
+        assert env.position.current_position == 0, (
+            "the exchange is flat but the env still believes it holds a long"
+        )
+
 
 # ---------------------------------------------------------------------------
-# Bitget-specific tests: _handle_close_action updates current_position
+# _handle_close_action updates current_position -- SHARED by all four venues since
+# #288 hoisted it, so this exercises the base through a bitget instance rather than
+# anything bitget-specific.
 # ---------------------------------------------------------------------------
 
 
-class TestBitgetClosePositionState:
-    """Bitget-specific: _handle_close_action conditionally updates current_position."""
+class TestClosePositionState:
+    """_handle_close_action conditionally updates current_position (shared, #288)."""
 
     @pytest.mark.parametrize("close_should_fail,expected_position", [
         (True, 1),   # Failed close: position unchanged

--- a/torchtrade/envs/live/binance/env.py
+++ b/torchtrade/envs/live/binance/env.py
@@ -225,25 +225,6 @@ class BinanceFuturesTorchTradingEnv(BinanceBaseTorchTradingEnv):
             logger.error(f"{side} trade failed for {self.config.symbol}: quantity={quantity}, error={e}")
             return self._create_trade_info(executed=False, success=False)
 
-    def _handle_close_action(self, current_qty: float) -> Dict:
-        """Handle close position action."""
-        if current_qty == 0:
-            return self._create_trade_info(executed=False)
-
-        try:
-            success = self.trader.close_position()
-        except Exception as e:
-            logger.error(f"Close position failed for {self.config.symbol}: {e}")
-            return self._create_trade_info(executed=False, success=False)
-
-        return self._create_trade_info(
-            executed=True,
-            quantity=abs(current_qty),
-            side="CLOSE",
-            success=success,
-            closed_position=True,
-        )
-
 
     def _get_symbol_info(self) -> Dict:
         """Get exchange symbol information for precision and lot size.

--- a/torchtrade/envs/live/bitget/env.py
+++ b/torchtrade/envs/live/bitget/env.py
@@ -224,30 +224,6 @@ class BitgetFuturesTorchTradingEnv(BitgetBaseTorchTradingEnv):
             logger.error(f"{side.capitalize()} trade failed for {self.config.symbol}: quantity={quantity}, error={e}")
             return self._create_trade_info(executed=False, success=False)
 
-    def _handle_close_action(self, current_qty: float) -> Dict:
-        """Handle close position action."""
-        if current_qty == 0:
-            return self._create_trade_info(executed=False)
-
-        try:
-            success = self.trader.close_position()
-        except Exception as e:
-            logger.error(f"Close position failed for {self.config.symbol}: {e}")
-            return self._create_trade_info(executed=False, success=False)
-
-        side = "sell" if current_qty > 0 else "buy"
-
-        if success:
-            self.position.current_position = 0
-
-        return self._create_trade_info(
-            executed=True,
-            quantity=abs(current_qty),
-            side=side,
-            success=success,
-            closed_position=True,
-        )
-
 
     def _calculate_fractional_position(self, action_value: float, current_price: float) -> tuple[float, float, str]:
         """Calculate target position size from fractional action.

--- a/torchtrade/envs/live/bybit/env.py
+++ b/torchtrade/envs/live/bybit/env.py
@@ -186,29 +186,6 @@ class BybitFuturesTorchTradingEnv(BybitBaseTorchTradingEnv):
             logger.error(f"{side.capitalize()} trade failed for {self.config.symbol}: quantity={quantity}, error={e}")
             return self._create_trade_info(executed=False, success=False)
 
-    def _handle_close_action(self, current_qty: float) -> Dict:
-        """Handle close position action."""
-        if current_qty == 0:
-            return self._create_trade_info(executed=False)
-
-        try:
-            success = self.trader.close_position()
-        except Exception as e:
-            logger.error(f"Close position failed for {self.config.symbol}: {e}")
-            return self._create_trade_info(executed=False, success=False)
-
-        side = "sell" if current_qty > 0 else "buy"
-
-        if success:
-            self.position.current_position = 0
-
-        return self._create_trade_info(
-            executed=True,
-            quantity=abs(current_qty),
-            side=side,
-            success=success,
-            closed_position=True,
-        )
 
     def _calculate_fractional_position(self, action_value: float, current_price: float) -> tuple[float, float, str]:
         """Calculate target position size from fractional action."""

--- a/torchtrade/envs/live/okx/env.py
+++ b/torchtrade/envs/live/okx/env.py
@@ -191,29 +191,6 @@ class OKXFuturesTorchTradingEnv(OKXBaseTorchTradingEnv):
             logger.error(f"{side.capitalize()} trade failed for {self.config.symbol}: quantity={quantity}, error={e}")
             return self._create_trade_info(executed=False, success=False)
 
-    def _handle_close_action(self, current_qty: float) -> Dict:
-        """Handle close position action."""
-        if current_qty == 0:
-            return self._create_trade_info(executed=False)
-
-        try:
-            success = self.trader.close_position()
-        except Exception as e:
-            logger.error(f"Close position failed for {self.config.symbol}: {e}")
-            return self._create_trade_info(executed=False, success=False)
-
-        side = "sell" if current_qty > 0 else "buy"
-
-        if success:
-            self.position.current_position = 0
-
-        return self._create_trade_info(
-            executed=True,
-            quantity=abs(current_qty),
-            side=side,
-            success=success,
-            closed_position=True,
-        )
 
     def _calculate_fractional_position(self, action_value: float, current_price: float) -> tuple[float, float, str]:
         """Calculate target position size from fractional action."""

--- a/torchtrade/envs/live/shared/futures_live_base.py
+++ b/torchtrade/envs/live/shared/futures_live_base.py
@@ -140,6 +140,36 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
             **kwargs,
         }
 
+    def _handle_close_action(self, current_qty: float) -> Dict:
+        """Close the position and report the ORDER SIDE that closed it.
+
+        Four identical copies once binance stopped reporting the literal "CLOSE" (#288).
+        `side` is what went to the venue -- `closed_position=True` in the same dict
+        already says it was a close, so a literal there lost the only fact this field
+        carries.
+        """
+        if current_qty == 0:
+            return self._create_trade_info(executed=False)
+
+        try:
+            success = self.trader.close_position()
+        except Exception as e:
+            logger.error(f"Close position failed for {self.config.symbol}: {e}")
+            return self._create_trade_info(executed=False, success=False)
+
+        side = "sell" if current_qty > 0 else "buy"
+
+        if success:
+            self.position.current_position = 0
+
+        return self._create_trade_info(
+            executed=True,
+            quantity=abs(current_qty),
+            side=side,
+            success=success,
+            closed_position=True,
+        )
+
     def _acquire_post_bar_state(self) -> tuple[float, float, float, TensorDictBase]:
         """Post-bar portfolio value and observation, or halt.
 


### PR DESCRIPTION
The divergence that was blocking #288 step 2's remaining hoists — resolved as **drift**.

## The finding

binance's `_handle_close_action` reported `side="CLOSE"` where bitget, bybit and okx all report the order side actually sent (`"sell"` closing a long, `"buy"` closing a short).

`"CLOSE"` is an *action name*, not a side — and `closed_position=True` sits in the same dict, so the literal added nothing while losing the one fact that field carries. binance also skipped the `self.position.current_position = 0` the other three set on success.

Nothing consumes `side` expecting `"CLOSE"`. A venue reporting an action name where its siblings report a side is exactly the silent per-exchange divergence this issue exists to remove.

## Why this had to come first

Resolving it makes all four `_handle_close_action` **byte-identical**, so the hoist that was blocked is now a clean four-venue one rather than three-plus-an-override.

That ordering was the point: folding the copies together first would have buried the question of which version wins, and one venue's observable output would have changed as a *side effect of a refactor* rather than as a decision.

## Verification

`_handle_close_action` added to the existing parametrized re-fork guard, plus tests pinning the side for both directions and the no-position path. Mutation-checked — the `"CLOSE"` literal fails 2, an inverted side fails 2, an okx re-fork fails 1.

Full suite **3772 passed**, 0 xfailed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)