### PR TITLE
feat(vectorized): make reward_function pluggable, with a batched signature

### DIFF
--- a/tests/envs/offline/test_vectorized_reward_parity_289.py
+++ b/tests/envs/offline/test_vectorized_reward_parity_289.py
@@ -178,3 +178,65 @@ def test_the_bankruptcy_reward_constant_matches_the_scalar():
         f"bankruptcy rewards {set(bankrupt_rewards)} -- log_return_reward returns -10.0"
     )
     assert log_return_reward(_History([100.0, 0.0])) == -10.0
+
+
+@pytest.mark.parametrize("env_cls,cfg_cls", [
+    (VectorizedSequentialTradingEnv, VectorizedSequentialTradingEnvConfig),
+])
+def test_the_reward_function_is_pluggable(env_cls, cfg_cls):
+    """#289: the scalar envs take `reward_function`; the vectorized ones did not, and
+    hardcoded the arithmetic inline -- which is why the SLTP twin drifted from it.
+
+    The signature is BATCHED (`fn(old_pvs, new_pvs) -> Tensor`), not the scalar
+    `fn(history) -> float`: calling that per env would be a Python loop over the batch,
+    which is the one thing this class exists to avoid.
+    """
+    n = 200
+    prices = 100 + np.cumsum(np.random.RandomState(11).randn(n) * 0.1)
+    df = pd.DataFrame({
+        "timestamp": pd.date_range("2024-01-01", periods=n, freq="1min"),
+        "open": prices, "high": prices + 0.2, "low": prices - 0.2,
+        "close": prices, "volume": np.ones(n) * 1000,
+    })
+    calls = []
+
+    def constant_reward(old_pvs, new_pvs):
+        calls.append((old_pvs.shape, new_pvs.shape))
+        return torch.full_like(old_pvs, 0.5)
+
+    env = env_cls(
+        df,
+        cfg_cls(time_frames=["1Min"], window_sizes=[10], execute_on="1Min", num_envs=6),
+        reward_function=constant_reward,
+    )
+    td = env.reset()
+    td["action"] = torch.randint(0, env.action_spec.n, (6,))
+    td = env.step(td)["next"]
+
+    assert calls, "the custom reward function was never called"
+    assert calls[0] == (torch.Size([6]), torch.Size([6])), (
+        f"expected batched tensors of shape (6,), got {calls[0]} -- a per-env loop would "
+        f"undo the vectorization this class exists for"
+    )
+    assert torch.allclose(td["reward"].flatten(), torch.full((6,), 0.5))
+
+
+def test_the_default_reward_is_the_batched_log_return():
+    """Unchanged behaviour when nothing is passed -- the default IS the batched
+    equivalent of `log_return_reward`, which the parity test above pins numerically."""
+    from torchtrade.envs.core.default_rewards import batched_log_return_reward
+
+    n = 200
+    prices = 100 + np.cumsum(np.random.RandomState(12).randn(n) * 0.1)
+    df = pd.DataFrame({
+        "timestamp": pd.date_range("2024-01-01", periods=n, freq="1min"),
+        "open": prices, "high": prices + 0.2, "low": prices - 0.2,
+        "close": prices, "volume": np.ones(n) * 1000,
+    })
+    env = VectorizedSequentialTradingEnv(
+        df,
+        VectorizedSequentialTradingEnvConfig(
+            time_frames=["1Min"], window_sizes=[10], execute_on="1Min", num_envs=4,
+        ),
+    )
+    assert env.reward_function is batched_log_return_reward

--- a/tests/envs/offline/test_vectorized_reward_parity_289.py
+++ b/tests/envs/offline/test_vectorized_reward_parity_289.py
@@ -9,6 +9,8 @@ from torchtrade.envs.core.default_rewards import log_return_reward
 from torchtrade.envs.offline import (
     VectorizedSequentialTradingEnv,
     VectorizedSequentialTradingEnvConfig,
+    VectorizedSequentialTradingEnvSLTP,
+    VectorizedSequentialTradingEnvSLTPConfig,
 )
 
 
@@ -180,10 +182,15 @@ def test_the_bankruptcy_reward_constant_matches_the_scalar():
     assert log_return_reward(_History([100.0, 0.0])) == -10.0
 
 
-@pytest.mark.parametrize("env_cls,cfg_cls", [
-    (VectorizedSequentialTradingEnv, VectorizedSequentialTradingEnvConfig),
+# BOTH twins. The single genuinely new line in this change is the SLTP env threading
+# `reward_function` through `super().__init__`, and dropping it silently passed the whole
+# offline suite -- a user would have got the default with no error.
+@pytest.mark.parametrize("env_cls,cfg_cls,extra", [
+    (VectorizedSequentialTradingEnv, VectorizedSequentialTradingEnvConfig, {}),
+    (VectorizedSequentialTradingEnvSLTP, VectorizedSequentialTradingEnvSLTPConfig,
+     {"stoploss_levels": [-0.02], "takeprofit_levels": [0.03], "leverage": 5}),
 ])
-def test_the_reward_function_is_pluggable(env_cls, cfg_cls):
+def test_the_reward_function_is_pluggable(env_cls, cfg_cls, extra):
     """#289: the scalar envs take `reward_function`; the vectorized ones did not, and
     hardcoded the arithmetic inline -- which is why the SLTP twin drifted from it.
 
@@ -206,7 +213,8 @@ def test_the_reward_function_is_pluggable(env_cls, cfg_cls):
 
     env = env_cls(
         df,
-        cfg_cls(time_frames=["1Min"], window_sizes=[10], execute_on="1Min", num_envs=6),
+        cfg_cls(time_frames=["1Min"], window_sizes=[10], execute_on="1Min", num_envs=6,
+                **extra),
         reward_function=constant_reward,
     )
     td = env.reset()
@@ -219,6 +227,49 @@ def test_the_reward_function_is_pluggable(env_cls, cfg_cls):
         f"undo the vectorization this class exists for"
     )
     assert torch.allclose(td["reward"].flatten(), torch.full((6,), 0.5))
+
+
+@pytest.mark.parametrize("env_cls,cfg_cls,extra", [
+    (VectorizedSequentialTradingEnv, VectorizedSequentialTradingEnvConfig, {}),
+    (VectorizedSequentialTradingEnvSLTP, VectorizedSequentialTradingEnvSLTPConfig,
+     {"stoploss_levels": [-0.02], "takeprofit_levels": [0.03], "leverage": 5}),
+])
+def test_a_custom_reward_is_not_preempted_by_a_hardcoded_precondition(
+    env_cls, cfg_cls, extra
+):
+    """The precondition belongs to the reward function, not the env.
+
+    The base env kept an inline `old_pvs <= 0` raise after the SLTP twin dropped it, so a
+    custom reward that deliberately tolerates a non-positive old PV was preempted in one
+    env and honoured in the other -- the twin divergence this change exists to remove,
+    moved from the arithmetic to the guard.
+    """
+    n = 200
+    prices = 100 + np.cumsum(np.random.RandomState(21).randn(n) * 0.1)
+    df = pd.DataFrame({
+        "timestamp": pd.date_range("2024-01-01", periods=n, freq="1min"),
+        "open": prices, "high": prices + 0.2, "low": prices - 0.2,
+        "close": prices, "volume": np.ones(n) * 1000,
+    })
+    called = []
+
+    def tolerant_reward(old_pvs, new_pvs):
+        called.append(True)
+        return torch.zeros_like(old_pvs)
+
+    env = env_cls(
+        df,
+        cfg_cls(time_frames=["1Min"], window_sizes=[10], execute_on="1Min", num_envs=4,
+                **extra),
+        reward_function=tolerant_reward,
+    )
+    td = env.reset()
+    env._portfolio_values[1] = -5.0          # what the removed guard rejected
+
+    td["action"] = torch.randint(0, env.action_spec.n, (4,))
+    env.step(td)                              # must not raise
+
+    assert called, "the env preempted the custom reward with its own precondition"
 
 
 def test_the_default_reward_is_the_batched_log_return():

--- a/torchtrade/envs/core/default_rewards.py
+++ b/torchtrade/envs/core/default_rewards.py
@@ -5,6 +5,7 @@ the history tracker interface. Users can use these as-is or create their own.
 """
 
 import numpy as np
+import torch
 
 
 def log_return_reward(history) -> float:
@@ -140,8 +141,6 @@ def batched_log_return_reward(old_pvs, new_pvs):
     an assertion rather than a crash mode. `new_pv <= 0` IS reachable -- it is
     bankruptcy -- and reports -10.0 on both paths.
     """
-    import torch
-
     if (old_pvs <= 0).any():
         broken = torch.nonzero(old_pvs <= 0).flatten().tolist()
         raise ValueError(

--- a/torchtrade/envs/core/default_rewards.py
+++ b/torchtrade/envs/core/default_rewards.py
@@ -126,3 +126,28 @@ def drawdown_penalty_reward(history) -> float:
     dd_penalty = -5.0 * current_drawdown if current_drawdown > 0.1 else 0.0
 
     return log_ret + dd_penalty
+
+
+def batched_log_return_reward(old_pvs, new_pvs):
+    """`log_return_reward` over a batch: same formula, same bankruptcy constant.
+
+    The vectorized envs cannot use the scalar signature -- `fn(history) -> float` would
+    mean a Python loop over the batch, which is what that class exists to avoid -- so the
+    pluggable contract there is `fn(old_pvs, new_pvs) -> Tensor` (#289).
+
+    A non-positive OLD value raises, exactly as the scalar does: the previous step's PV
+    was checked and termination ends any lane that reaches zero, so it is unreachable and
+    an assertion rather than a crash mode. `new_pv <= 0` IS reachable -- it is
+    bankruptcy -- and reports -10.0 on both paths.
+    """
+    import torch
+
+    if (old_pvs <= 0).any():
+        broken = torch.nonzero(old_pvs <= 0).flatten().tolist()
+        raise ValueError(
+            f"Invalid previous portfolio value in envs {broken}: "
+            f"{old_pvs[old_pvs <= 0].tolist()}. Portfolio value must be positive; "
+            f"this indicates a calculation error."
+        )
+    rewards = torch.log(new_pvs.clamp(min=1e-10) / old_pvs)
+    return torch.where(new_pvs <= 0, torch.full_like(rewards, -10.0), rewards)

--- a/torchtrade/envs/offline/vectorized_sequential.py
+++ b/torchtrade/envs/offline/vectorized_sequential.py
@@ -16,8 +16,6 @@ from typing import Callable, List, Optional, Tuple, Union
 
 import pandas as pd
 import torch
-
-from torchtrade.envs.core.default_rewards import batched_log_return_reward
 from tensordict import TensorDict, TensorDictBase
 from torchrl.data import Categorical, Composite, Unbounded
 from torchrl.envs import EnvBase
@@ -31,6 +29,7 @@ from torchtrade.envs.utils.fractional_sizing import (
     POSITION_TOLERANCE_NOTIONAL,
 )
 
+from torchtrade.envs.core.default_rewards import batched_log_return_reward
 from torchtrade.envs.core.common_types import MarginType
 from torchtrade.envs.utils.liquidation import DEFAULT_MAINTENANCE_MARGIN_RATE, require_fee_fits_maintenance
 
@@ -555,23 +554,11 @@ class VectorizedSequentialTradingEnv(EnvBase):
 
         # Rewards: log(new_pv / old_pv), matching log_return_reward exactly.
         old_pvs = self._portfolio_values
-        # A non-positive OLD value is a calculation error: the previous step's PV was
-        # checked and the termination above now ends any lane that reaches zero, so this
-        # is unreachable in normal operation and an assertion rather than a new crash
-        # mode. It matches `log_return_reward`, which raises on the same input.
-        #
-        # It is deliberately NOT the clamp it replaced: `old_pvs.clamp(min=1e-10)` made a
-        # broken accumulator survivable and silent. But the clamp was not producing the
-        # fabricated positive reward an earlier version of this comment claimed -- once
-        # PV reaches 0 the lane's new_pv is 0 too, so the -10.0 branch overrode it. The
-        # real defect was the termination predicate above.
-        if (old_pvs <= 0).any():
-            broken = torch.nonzero(old_pvs <= 0).flatten().tolist()
-            raise ValueError(
-                f"Invalid previous portfolio value in envs {broken}: "
-                f"{old_pvs[old_pvs <= 0].tolist()}. Portfolio value must be positive; "
-                f"this indicates a calculation error."
-            )
+        # The precondition lives in the reward function, not here. Keeping a copy
+        # inline preempted a custom reward that deliberately tolerates a non-positive
+        # old PV -- and the SLTP twin had already dropped it, so the divergence this
+        # change exists to remove had simply moved from the arithmetic to the guard
+        # (#289).
         rewards = self.reward_function(old_pvs, new_pvs)
 
         # Update stored portfolio values

--- a/torchtrade/envs/offline/vectorized_sequential.py
+++ b/torchtrade/envs/offline/vectorized_sequential.py
@@ -16,6 +16,8 @@ from typing import Callable, List, Optional, Tuple, Union
 
 import pandas as pd
 import torch
+
+from torchtrade.envs.core.default_rewards import batched_log_return_reward
 from tensordict import TensorDict, TensorDictBase
 from torchrl.data import Categorical, Composite, Unbounded
 from torchrl.envs import EnvBase
@@ -142,8 +144,17 @@ class VectorizedSequentialTradingEnv(EnvBase):
         df: pd.DataFrame,
         config: VectorizedSequentialTradingEnvConfig,
         feature_preprocessing_fn: Optional[Callable] = None,
+        reward_function: Optional[Callable] = None,
     ):
         self.config = config
+        # A BATCHED signature, not the scalar envs' `fn(history) -> float`. Those take a
+        # HistoryTracker and return one number; calling that per env would be a Python
+        # loop over the batch, which is the one thing this class exists to avoid. So the
+        # contract is `fn(old_pvs, new_pvs) -> Tensor`, same shape in and out (#289).
+        #
+        # `log_return_reward` is the scalar default and this is its batched equivalent;
+        # `test_vectorized_reward_parity_289` pins them to the same numbers.
+        self.reward_function = reward_function or batched_log_return_reward
         self._num_envs = config.num_envs
 
         # Store config values
@@ -561,10 +572,7 @@ class VectorizedSequentialTradingEnv(EnvBase):
                 f"{old_pvs[old_pvs <= 0].tolist()}. Portfolio value must be positive; "
                 f"this indicates a calculation error."
             )
-        # new_pv <= 0 IS reachable -- it is bankruptcy -- and both paths report -10.0.
-        safe_new = new_pvs.clamp(min=1e-10)
-        rewards = torch.log(safe_new / old_pvs)
-        rewards = torch.where(new_pvs <= 0, torch.full_like(rewards, -10.0), rewards)
+        rewards = self.reward_function(old_pvs, new_pvs)
 
         # Update stored portfolio values
         self._portfolio_values = new_pvs

--- a/torchtrade/envs/offline/vectorized_sequential_sltp.py
+++ b/torchtrade/envs/offline/vectorized_sequential_sltp.py
@@ -119,6 +119,7 @@ class VectorizedSequentialTradingEnvSLTP(VectorizedSequentialTradingEnv):
         df: pd.DataFrame,
         config: VectorizedSequentialTradingEnvSLTPConfig,
         feature_preprocessing_fn: Optional[Callable] = None,
+        reward_function: Optional[Callable] = None,
     ):
         # Store SLTP config before parent init
         self.stoploss_levels = config.stoploss_levels
@@ -144,7 +145,7 @@ class VectorizedSequentialTradingEnvSLTP(VectorizedSequentialTradingEnv):
         original_action_levels = config.action_levels
         config.action_levels = [0.0, 1.0]
 
-        super().__init__(df, config, feature_preprocessing_fn)
+        super().__init__(df, config, feature_preprocessing_fn, reward_function)
 
         # Restored on the CONFIG and on the instance: the parent copies the dummy onto
         # self during its own __init__, so restoring only the config leaves
@@ -250,20 +251,7 @@ class VectorizedSequentialTradingEnvSLTP(VectorizedSequentialTradingEnv):
         # 7. Compute rewards: log(new_pv / old_pv)
         new_pvs = self._compute_portfolio_values(new_close)
         old_pvs = self._portfolio_values
-        # Same rule as the non-SLTP twin (#289): a non-positive previous PV is a
-        # calculation error, and clamping made it silent. With `old_pv = -5.0` this path
-        # emitted a reward of +32.21.
-        if (old_pvs <= 0).any():
-            broken = torch.nonzero(old_pvs <= 0).flatten().tolist()
-            raise ValueError(
-                f"Invalid previous portfolio value in envs {broken}: "
-                f"{old_pvs[old_pvs <= 0].tolist()}. Portfolio value must be positive; "
-                f"this indicates a calculation error."
-            )
-        safe_old = old_pvs
-        safe_new = new_pvs.clamp(min=1e-10)
-        rewards = torch.log(safe_new / safe_old)
-        rewards = torch.where(new_pvs <= 0, torch.full_like(rewards, -10.0), rewards)
+        rewards = self.reward_function(old_pvs, new_pvs)
 
         self._portfolio_values = new_pvs
 


### PR DESCRIPTION
The last independent item in #289.

The scalar envs take `reward_function`; the vectorized ones did not, and hardcoded the arithmetic inline — which is exactly why the SLTP twin had drifted from the base and from `log_return_reward` (#388 found it emitting **+32.21** where the scalar raises).

## The signature is batched, deliberately

`fn(old_pvs, new_pvs) -> Tensor`, **not** the scalar `fn(history) -> float`.

Matching the scalar signature would mean calling it once per env with a per-lane `HistoryTracker` — a Python loop over the batch, which is the one thing this class exists to avoid. So parity here is *"the hook exists and is honoured"*, not *"the same callable works in both"*.

`batched_log_return_reward` is the default and lives beside the scalar rewards, so the two are read together and the existing parity test pins them to the same numbers.

## Both twins

The SLTP variant overrides `_step` entirely, so it needed the constructor argument threaded through `super().__init__` — the same override that let its reward drift in the first place.

## Tests

The hook is called; it receives batched tensors of shape `(num_envs,)` rather than scalars; and the default is unchanged when nothing is passed.

Full suite **3823 passed**, 0 xfailed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)