### PR TITLE
refactor(binance): fold the last parallel observation class onto the shared base

### DIFF
--- a/tests/envs/base_exchange_tests.py
+++ b/tests/envs/base_exchange_tests.py
@@ -208,23 +208,29 @@ class BaseObservationClassTests(ABC):
     # get_features tests
 
     def test_the_declared_feature_width_matches_the_observation(self):
-        """get_features() counts columns on a SYNTHETIC frame; get_observations() runs the
-        same fn on real data. Nothing cross-checked that they agree.
+        """get_features() counts columns on a SYNTHETIC frame; get_observations() runs
+        the same fn on real data. Nothing cross-checked that they agree.
 
-        They can diverge whenever the synthetic frame differs from the parsed klines in a
-        way the preprocessing fn is sensitive to -- a missing column, or the wrong dtype.
-        That count IS the observation spec for the venue transforms, so a disagreement is
-        a spec/data mismatch that surfaces at check_env_specs, or silently as a wrong
-        width. Measured: it was reachable on binance (#289 review).
+        The fn must READ a dummy-supplied column, or this cannot fail: with default
+        preprocessing the width is a constant 4 whatever the dummy contains, and the
+        first version of this test passed even with `volume` deleted from the dummy
+        frame outright. That width is what the venue transforms size their spec from.
         """
+        def fn(df):
+            df = df.copy()
+            df["feature_range"] = (df["high"] - df["low"]) / df["close"]
+            df["feature_vol"] = df["volume"] / df["volume"].mean()
+            return df.dropna()
+
         observer = self.create_observer(
             symbol="BTC/USD",
             timeframes=TimeFrame(1, TimeFrameUnit.Minute),
             window_sizes=10,
+            feature_preprocessing_fn=fn,
         )
         key = observer.get_keys()[0]
         declared = len(observer.get_features()["observation_features"])
-        assert declared == observer.get_observations()[key].shape[1]
+        assert declared == observer.get_observations()[key].shape[1] == 2
 
     def test_get_features_default_preprocessing(self):
         """Test get_features with default preprocessing."""

--- a/tests/envs/base_exchange_tests.py
+++ b/tests/envs/base_exchange_tests.py
@@ -207,6 +207,25 @@ class BaseObservationClassTests(ABC):
 
     # get_features tests
 
+    def test_the_declared_feature_width_matches_the_observation(self):
+        """get_features() counts columns on a SYNTHETIC frame; get_observations() runs the
+        same fn on real data. Nothing cross-checked that they agree.
+
+        They can diverge whenever the synthetic frame differs from the parsed klines in a
+        way the preprocessing fn is sensitive to -- a missing column, or the wrong dtype.
+        That count IS the observation spec for the venue transforms, so a disagreement is
+        a spec/data mismatch that surfaces at check_env_specs, or silently as a wrong
+        width. Measured: it was reachable on binance (#289 review).
+        """
+        observer = self.create_observer(
+            symbol="BTC/USD",
+            timeframes=TimeFrame(1, TimeFrameUnit.Minute),
+            window_sizes=10,
+        )
+        key = observer.get_keys()[0]
+        declared = len(observer.get_features()["observation_features"])
+        assert declared == observer.get_observations()[key].shape[1]
+
     def test_get_features_default_preprocessing(self):
         """Test get_features with default preprocessing."""
         observer = self.create_observer(

--- a/tests/envs/binance/test_obs_class.py
+++ b/tests/envs/binance/test_obs_class.py
@@ -13,6 +13,9 @@ from unittest.mock import MagicMock
 from torchtrade.envs.utils.timeframe import TimeFrame, TimeFrameUnit
 from torchtrade.envs.live.shared.futures_base_obs import BaseFuturesObservationClass
 from torchtrade.envs.live.binance.observation import BinanceObservationClass
+from torchtrade.envs.live.bitget.observation import BitgetObservationClass
+from torchtrade.envs.live.bybit.observation import BybitObservationClass
+from torchtrade.envs.live.okx.observation import OKXObservationClass
 from tests.envs.base_exchange_tests import BaseObservationClassTests
 
 
@@ -36,7 +39,6 @@ class TestBinanceObservationClass(BaseObservationClassTests):
     """Binance observation class — common tests inherited from the base."""
 
     def create_observer(self, symbol, timeframes, window_sizes, **kwargs):
-        from torchtrade.envs.live.binance.observation import BinanceObservationClass
         client = kwargs.pop("client", None) or _make_binance_client()
         return BinanceObservationClass(
             symbol=symbol, time_frames=timeframes, window_sizes=window_sizes,
@@ -52,14 +54,12 @@ class TestBinanceObservationClass(BaseObservationClassTests):
 
     @pytest.fixture
     def observer_single(self, mock_client):
-        from torchtrade.envs.live.binance.observation import BinanceObservationClass
         return BinanceObservationClass(
             symbol="BTCUSDT", time_frames=TimeFrame(15, TimeFrameUnit.Minute),
             window_sizes=10, client=mock_client)
 
     @pytest.fixture
     def observer_multi(self, mock_client):
-        from torchtrade.envs.live.binance.observation import BinanceObservationClass
         return BinanceObservationClass(
             symbol="BTCUSDT",
             time_frames=[TimeFrame(1, TimeFrameUnit.Minute), TimeFrame(5, TimeFrameUnit.Minute),
@@ -83,7 +83,6 @@ class TestBinanceObservationClass(BaseObservationClassTests):
 
     def test_symbol_normalization(self, mock_client):
         """Slash is stripped from the symbol."""
-        from torchtrade.envs.live.binance.observation import BinanceObservationClass
         observer = BinanceObservationClass(
             symbol="BTC/USDT", time_frames=TimeFrame(1, TimeFrameUnit.Minute),
             window_sizes=10, client=mock_client)
@@ -125,7 +124,6 @@ class TestBinanceObservationClassIntegration:
     @pytest.mark.skip(reason="Requires live Binance API connection")
     def test_live_data_fetch(self):
         """Test fetching live data from Binance."""
-        from torchtrade.envs.live.binance.observation import BinanceObservationClass
         observer = BinanceObservationClass(
             symbol="BTCUSDT",
             time_frames=[TimeFrame(1, TimeFrameUnit.Minute), TimeFrame(5, TimeFrameUnit.Minute)],
@@ -133,19 +131,6 @@ class TestBinanceObservationClassIntegration:
         observations = observer.get_observations()
         assert "1Minute_10" in observations
         assert "5Minute_10" in observations
-
-
-from torchtrade.envs.live.bitget.observation import BitgetObservationClass
-from torchtrade.envs.live.bybit.observation import BybitObservationClass
-from torchtrade.envs.live.okx.observation import OKXObservationClass
-
-_FUTURES_OBSERVATION_CLASSES = [
-    BinanceObservationClass, BitgetObservationClass,
-    BybitObservationClass, OKXObservationClass,
-]
-# `_dummy_frame` is an extension point, not a re-fork: the venues genuinely return
-# different kline columns, and the base cannot know their dtypes.
-_DESIGNED_OVERRIDES = {"_dummy_frame"}
 
 
 class TestBinanceSharesTheObservationBase:
@@ -174,14 +159,11 @@ class TestBinanceSharesTheObservationBase:
         )
 
     @pytest.mark.parametrize("venue_cls", [
-        pytest.param(c, id=c.__name__) for c in _FUTURES_OBSERVATION_CLASSES
-    ])
+        BinanceObservationClass, BitgetObservationClass,
+        BybitObservationClass, OKXObservationClass,
+    ], ids=lambda c: c.__name__)
     def test_no_venue_reimplements_the_shared_base(self, venue_cls):
         """Derived from the base, not hand-listed, and over every venue.
-
-        A hand-listed denylist of 6 names shipped in this PR's first draft and omitted
-        `get_features` -- the method most likely to be re-forked next, since it reads the
-        dummy frame. A deliberately broken re-fork of it passed every test.
 
         The named subset guards the guard: a discovered set can SHRINK silently (making
         `get_features` a property drops it from a callable filter), and a merely non-empty
@@ -193,7 +175,9 @@ class TestBinanceSharesTheObservationBase:
             and not n.startswith("__")
         }
         assert {"get_features", "get_observations", "_fetch_single_timeframe"} <= shared
-        redeclared = (shared & set(vars(venue_cls))) - _DESIGNED_OVERRIDES
+        # _dummy_frame is an extension point, not a re-fork: the venues return different
+        # kline columns and the base cannot know their dtypes.
+        redeclared = (shared & set(vars(venue_cls))) - {"_dummy_frame"}
         assert not redeclared, f"{venue_cls.__name__} re-forked: {sorted(redeclared)}"
 
     def test_a_dtype_conditional_preprocessing_fn_gets_the_real_dtype(self):

--- a/tests/envs/binance/test_obs_class.py
+++ b/tests/envs/binance/test_obs_class.py
@@ -7,6 +7,7 @@ default feature names) and stricter assertions live here.
 
 import pytest
 import numpy as np
+import pandas as pd
 from unittest.mock import MagicMock
 
 from torchtrade.envs.utils.timeframe import TimeFrame, TimeFrameUnit
@@ -111,28 +112,6 @@ class TestBinanceObservationClass(BaseObservationClassTests):
         assert "base_timestamps" in obs
         assert obs["base_features"].shape == (10, 4)
 
-    def test_custom_preprocessing_with_kline_extra_fields(self, mock_client):
-        """Custom preprocessing can derive features from Binance-specific kline fields."""
-        from torchtrade.envs.live.binance.observation import BinanceObservationClass
-
-        def kline_preprocessing(df):
-            df = df.copy()
-            df["feature_taker_ratio"] = df["taker_buy_base"] / (df["volume"] + 1e-9)
-            df["feature_quote_vol"] = df["quote_volume"].pct_change().fillna(0)
-            df["feature_avg_trade_size"] = df["volume"] / df["trades"]
-            df["feature_close"] = df["close"].pct_change().fillna(0)
-            df.dropna(inplace=True)
-            return df
-
-        observer = BinanceObservationClass(
-            symbol="BTCUSDT", time_frames=TimeFrame(1, TimeFrameUnit.Minute),
-            window_sizes=10, client=mock_client, feature_preprocessing_fn=kline_preprocessing)
-
-        features = observer.get_features()
-        for f in ["feature_taker_ratio", "feature_quote_vol", "feature_avg_trade_size"]:
-            assert f in features["observation_features"]
-        assert observer.get_observations()["1Minute_10"].shape == (10, 4)
-
     def test_default_preprocessing_output(self, observer_single):
         """Default preprocessing produces the expected named features."""
         features = observer_single.get_features()
@@ -156,8 +135,24 @@ class TestBinanceObservationClassIntegration:
         assert "5Minute_10" in observations
 
 
+from torchtrade.envs.live.bitget.observation import BitgetObservationClass
+from torchtrade.envs.live.bybit.observation import BybitObservationClass
+from torchtrade.envs.live.okx.observation import OKXObservationClass
+
+_FUTURES_OBSERVATION_CLASSES = [
+    BinanceObservationClass, BitgetObservationClass,
+    BybitObservationClass, OKXObservationClass,
+]
+# `_dummy_frame` is an extension point, not a re-fork: the venues genuinely return
+# different kline columns, and the base cannot know their dtypes.
+_DESIGNED_OVERRIDES = {"_dummy_frame"}
+
+
 class TestBinanceSharesTheObservationBase:
-    """binance was the last venue with a parallel observation class (#289)."""
+    """binance was the last FUTURES venue with a parallel observation class (#289).
+
+    alpaca still hand-rolls its own; it is spot, so outside this issue's scope.
+    """
 
     @staticmethod
     def _klines(n, descending=False):
@@ -178,66 +173,58 @@ class TestBinanceSharesTheObservationBase:
             client=client,
         )
 
-    def test_it_inherits_rather_than_reimplementing(self):
-        """Derived from the base, not hand-listed.
+    @pytest.mark.parametrize("venue_cls", [
+        pytest.param(c, id=c.__name__) for c in _FUTURES_OBSERVATION_CLASSES
+    ])
+    def test_no_venue_reimplements_the_shared_base(self, venue_cls):
+        """Derived from the base, not hand-listed, and over every venue.
 
         A hand-listed denylist of 6 names shipped in this PR's first draft and omitted
-        `get_features` -- the method most likely to be re-forked next, since it is the
-        one that reads _DUMMY_COLUMNS. A deliberately broken re-fork of it passed every
-        test. Reading the base's own surface cannot develop that blind spot.
+        `get_features` -- the method most likely to be re-forked next, since it reads the
+        dummy frame. A deliberately broken re-fork of it passed every test.
+
+        The named subset guards the guard: a discovered set can SHRINK silently (making
+        `get_features` a property drops it from a callable filter), and a merely non-empty
+        check would still pass.
         """
         shared = {
             n for n, v in vars(BaseFuturesObservationClass).items()
             if callable(v) and not getattr(v, "__isabstractmethod__", False)
             and not n.startswith("__")
         }
-        assert shared, "discovery found nothing -- the guard would pass vacuously"
-        assert not (shared & set(vars(BinanceObservationClass))), (
-            f"re-forked from the base: {sorted(shared & set(vars(BinanceObservationClass)))}"
-        )
+        assert {"get_features", "get_observations", "_fetch_single_timeframe"} <= shared
+        redeclared = (shared & set(vars(venue_cls))) - _DESIGNED_OVERRIDES
+        assert not redeclared, f"{venue_cls.__name__} re-forked: {sorted(redeclared)}"
 
-    @pytest.mark.parametrize("fn,expected", [
-        pytest.param(None, 4, id="default-preprocessing"),
-        pytest.param(
-            lambda df: df.assign(feature_r=df["close"] / df["open"]), 1, id="ohlcv-only"
-        ),
-        pytest.param(
-            lambda df: df.assign(
-                feature_qv=df["quote_volume"] / df["volume"],
-                feature_t=df["trades"] / 100.0,
-            ), 2, id="binance-only-columns"),
-    ])
-    def test_the_feature_count_matches_the_data_it_describes(self, fn, expected):
-        """get_features() counts columns on a SYNTHETIC frame; get_observations() runs
-        the same fn on real data. Nothing anywhere cross-checked that they agree.
+    def test_a_dtype_conditional_preprocessing_fn_gets_the_real_dtype(self):
+        """The dummy frame must match the parsed klines' DTYPES, not just its columns.
 
-        They can diverge: the synthetic frame carries only `_DUMMY_COLUMNS`, so a fn
-        reading anything else raises there while working fine on real data -- or, worse,
-        silently reports a width the observation does not have. That count IS the
-        observation spec, so a disagreement is a spec/data mismatch reaching the policy.
+        `trades` is int64 in real klines. A names-only dummy (every column a float in
+        [0,1)) made this fn take the else-branch on the dummy and the if-branch on live
+        data: get_features() declared 1 feature, get_observations() emitted 2, and
+        `BinanceOHLCVTransform` sizes its spec from the former -- so check_env_specs
+        failed on a shape mismatch. Measured, after making exactly that simplification.
         """
+        def fn(df):
+            df = df.copy()
+            df["feature_close"] = df["close"].pct_change().fillna(0)
+            if pd.api.types.is_integer_dtype(df["trades"]):
+                df["feature_trades"] = df["trades"] / 100.0
+            return df.dropna()
+
         obs = self._obs(self._klines(60), fn=fn)
         declared = len(obs.get_features()["observation_features"])
-        actual = obs.get_observations()["1Minute_5"].shape[1]
-        assert declared == actual == expected
+        assert declared == obs.get_observations()["1Minute_5"].shape[1] == 2
 
     def test_klines_are_sorted_even_when_the_response_is_reversed(self):
         """The base sorts; binance's copy did not, so it was the one venue unprotected.
 
         Binance returns ascending today, so nothing bit -- but a reversed response
-        produced TIME-REVERSED observations with no error.
+        produced TIME-REVERSED observations with no error. This is also the only test in
+        the four venue suites that reaches the base's sort: bybit and okx sort inside
+        their own _parse_klines, so their sort tests stay green if the base's is deleted.
         """
         df = self._obs(self._klines(20, descending=True))._fetch_single_timeframe(
             TimeFrame(1, TimeFrameUnit.Minute), limit=20
         )
         assert df["open_time"].is_monotonic_increasing
-
-    def test_an_empty_response_says_so(self):
-        """It used to return a zero-length observation, silently.
-
-        Measured against a pre-PR worktree: `get_observations()` handed back
-        `{'1Minute_5': (0, 4)}` and no error at all, so an outage reached the policy as
-        an empty array rather than a stop. Louder than an exception would have been.
-        """
-        with pytest.raises(RuntimeError, match="BTCUSDT.*1Minute"):
-            self._obs([])._fetch_single_timeframe(TimeFrame(1, TimeFrameUnit.Minute), limit=5)

--- a/tests/envs/binance/test_obs_class.py
+++ b/tests/envs/binance/test_obs_class.py
@@ -8,7 +8,10 @@ default feature names) and stricter assertions live here.
 import pytest
 import numpy as np
 from unittest.mock import MagicMock
+
 from torchtrade.envs.utils.timeframe import TimeFrame, TimeFrameUnit
+from torchtrade.envs.live.shared.futures_base_obs import BaseFuturesObservationClass
+from torchtrade.envs.live.binance.observation import BinanceObservationClass
 from tests.envs.base_exchange_tests import BaseObservationClassTests
 
 
@@ -151,3 +154,72 @@ class TestBinanceObservationClassIntegration:
         observations = observer.get_observations()
         assert "1Minute_10" in observations
         assert "5Minute_10" in observations
+
+
+class TestBinanceSharesTheObservationBase:
+    """binance was the last venue with a parallel observation class (#289)."""
+
+    @staticmethod
+    def _klines(n, descending=False):
+        base = 1700000000000
+        rows = [[base + i * 60000, "100", "101", "99", "100.5", "10",
+                 base + (i + 1) * 60000 - 1, "1000", "50", "5", "500", "0"]
+                for i in range(n)]
+        return list(reversed(rows)) if descending else rows
+
+    def _obs(self, rows, fn=None, window=5):
+        client = MagicMock()
+        client.get_klines = MagicMock(return_value=rows)
+        return BinanceObservationClass(
+            symbol="BTC/USDT",
+            time_frames=TimeFrame(1, TimeFrameUnit.Minute),
+            window_sizes=window,
+            feature_preprocessing_fn=fn,
+            client=client,
+        )
+
+    def test_it_inherits_rather_than_reimplementing(self):
+        """4 of its 9 shared methods were byte-identical to the base's before this."""
+        assert issubclass(BinanceObservationClass, BaseFuturesObservationClass)
+        redeclared = {
+            n for n in ("_default_preprocessing", "_get_numpy_obs", "get_keys", "reset",
+                        "_fetch_single_timeframe", "get_observations")
+            if n in vars(BinanceObservationClass)
+        }
+        assert not redeclared, f"re-forked from the base: {sorted(redeclared)}"
+
+    def test_a_preprocessing_fn_may_read_binance_only_kline_columns(self):
+        """`quote_volume`/`trades`/`taker_buy_*` are in binance klines but not OHLCV.
+
+        get_features() counts columns against a DUMMY frame, so an OHLCV-only dummy
+        would raise KeyError for exactly the functions that use what binance returns --
+        the one behaviour that could not survive inheriting the base unchanged.
+        """
+        def fn(df):
+            df = df.copy()
+            df["feature_qv"] = df["quote_volume"] / df["volume"]
+            df["feature_trades"] = df["trades"] / 100.0
+            return df.dropna()
+
+        obs = self._obs(self._klines(60), fn=fn)
+        assert obs.get_features()["observation_features"] == ["feature_qv", "feature_trades"]
+        # and the same columns survive an actual fetch, not just the dummy
+        assert obs.get_observations()["1Minute_5"].shape == (5, 2)
+
+    def test_klines_are_sorted_even_when_the_response_is_reversed(self):
+        """The base sorts; binance's copy did not, so it was the one venue unprotected.
+
+        Binance returns ascending today, so nothing bit -- but a reversed response
+        produced TIME-REVERSED observations with no error, which is a policy reading
+        the future as the past.
+        """
+        df = self._obs(self._klines(20, descending=True))._fetch_single_timeframe(
+            TimeFrame(1, TimeFrameUnit.Minute), limit=20
+        )
+        assert df["open_time"].is_monotonic_increasing
+
+    def test_an_empty_response_says_so(self):
+        """It used to surface as `IndexError: single positional indexer is out-of-bounds`
+        from inside pandas, naming neither the symbol nor the timeframe."""
+        with pytest.raises(RuntimeError, match="BTCUSDT.*1Minute"):
+            self._obs([])._fetch_single_timeframe(TimeFrame(1, TimeFrameUnit.Minute), limit=5)

--- a/tests/envs/binance/test_obs_class.py
+++ b/tests/envs/binance/test_obs_class.py
@@ -167,51 +167,65 @@ class TestBinanceSharesTheObservationBase:
                 for i in range(n)]
         return list(reversed(rows)) if descending else rows
 
-    def _obs(self, rows, fn=None, window=5):
+    def _obs(self, rows, fn=None):
         client = MagicMock()
         client.get_klines = MagicMock(return_value=rows)
         return BinanceObservationClass(
             symbol="BTC/USDT",
             time_frames=TimeFrame(1, TimeFrameUnit.Minute),
-            window_sizes=window,
+            window_sizes=5,
             feature_preprocessing_fn=fn,
             client=client,
         )
 
     def test_it_inherits_rather_than_reimplementing(self):
-        """4 of its 9 shared methods were byte-identical to the base's before this."""
-        assert issubclass(BinanceObservationClass, BaseFuturesObservationClass)
-        redeclared = {
-            n for n in ("_default_preprocessing", "_get_numpy_obs", "get_keys", "reset",
-                        "_fetch_single_timeframe", "get_observations")
-            if n in vars(BinanceObservationClass)
-        }
-        assert not redeclared, f"re-forked from the base: {sorted(redeclared)}"
+        """Derived from the base, not hand-listed.
 
-    def test_a_preprocessing_fn_may_read_binance_only_kline_columns(self):
-        """`quote_volume`/`trades`/`taker_buy_*` are in binance klines but not OHLCV.
-
-        get_features() counts columns against a DUMMY frame, so an OHLCV-only dummy
-        would raise KeyError for exactly the functions that use what binance returns --
-        the one behaviour that could not survive inheriting the base unchanged.
+        A hand-listed denylist of 6 names shipped in this PR's first draft and omitted
+        `get_features` -- the method most likely to be re-forked next, since it is the
+        one that reads _DUMMY_COLUMNS. A deliberately broken re-fork of it passed every
+        test. Reading the base's own surface cannot develop that blind spot.
         """
-        def fn(df):
-            df = df.copy()
-            df["feature_qv"] = df["quote_volume"] / df["volume"]
-            df["feature_trades"] = df["trades"] / 100.0
-            return df.dropna()
+        shared = {
+            n for n, v in vars(BaseFuturesObservationClass).items()
+            if callable(v) and not getattr(v, "__isabstractmethod__", False)
+            and not n.startswith("__")
+        }
+        assert shared, "discovery found nothing -- the guard would pass vacuously"
+        assert not (shared & set(vars(BinanceObservationClass))), (
+            f"re-forked from the base: {sorted(shared & set(vars(BinanceObservationClass)))}"
+        )
 
+    @pytest.mark.parametrize("fn,expected", [
+        pytest.param(None, 4, id="default-preprocessing"),
+        pytest.param(
+            lambda df: df.assign(feature_r=df["close"] / df["open"]), 1, id="ohlcv-only"
+        ),
+        pytest.param(
+            lambda df: df.assign(
+                feature_qv=df["quote_volume"] / df["volume"],
+                feature_t=df["trades"] / 100.0,
+            ), 2, id="binance-only-columns"),
+    ])
+    def test_the_feature_count_matches_the_data_it_describes(self, fn, expected):
+        """get_features() counts columns on a SYNTHETIC frame; get_observations() runs
+        the same fn on real data. Nothing anywhere cross-checked that they agree.
+
+        They can diverge: the synthetic frame carries only `_DUMMY_COLUMNS`, so a fn
+        reading anything else raises there while working fine on real data -- or, worse,
+        silently reports a width the observation does not have. That count IS the
+        observation spec, so a disagreement is a spec/data mismatch reaching the policy.
+        """
         obs = self._obs(self._klines(60), fn=fn)
-        assert obs.get_features()["observation_features"] == ["feature_qv", "feature_trades"]
-        # and the same columns survive an actual fetch, not just the dummy
-        assert obs.get_observations()["1Minute_5"].shape == (5, 2)
+        declared = len(obs.get_features()["observation_features"])
+        actual = obs.get_observations()["1Minute_5"].shape[1]
+        assert declared == actual == expected
 
     def test_klines_are_sorted_even_when_the_response_is_reversed(self):
         """The base sorts; binance's copy did not, so it was the one venue unprotected.
 
         Binance returns ascending today, so nothing bit -- but a reversed response
-        produced TIME-REVERSED observations with no error, which is a policy reading
-        the future as the past.
+        produced TIME-REVERSED observations with no error.
         """
         df = self._obs(self._klines(20, descending=True))._fetch_single_timeframe(
             TimeFrame(1, TimeFrameUnit.Minute), limit=20
@@ -219,7 +233,11 @@ class TestBinanceSharesTheObservationBase:
         assert df["open_time"].is_monotonic_increasing
 
     def test_an_empty_response_says_so(self):
-        """It used to surface as `IndexError: single positional indexer is out-of-bounds`
-        from inside pandas, naming neither the symbol nor the timeframe."""
+        """It used to return a zero-length observation, silently.
+
+        Measured against a pre-PR worktree: `get_observations()` handed back
+        `{'1Minute_5': (0, 4)}` and no error at all, so an outage reached the policy as
+        an empty array rather than a stop. Louder than an exception would have been.
+        """
         with pytest.raises(RuntimeError, match="BTCUSDT.*1Minute"):
             self._obs([])._fetch_single_timeframe(TimeFrame(1, TimeFrameUnit.Minute), limit=5)

--- a/torchtrade/envs/live/binance/observation.py
+++ b/torchtrade/envs/live/binance/observation.py
@@ -71,7 +71,7 @@ class BinanceObservationClass(BaseFuturesObservationClass):
         return df.drop(columns=["ignore"])
 
     def _dummy_frame(self, window_size: int) -> pd.DataFrame:
-        """Binance klines carry more than OHLCV, at their real dtypes and magnitudes."""
+        """Binance klines carry more than OHLCV. Dtypes are faithful; magnitudes are not."""
         df = super()._dummy_frame(window_size)
         df["quote_volume"] = np.random.rand(window_size)
         df["trades"] = np.random.randint(1, 100, window_size)  # int64, as _parse_klines makes it

--- a/torchtrade/envs/live/binance/observation.py
+++ b/torchtrade/envs/live/binance/observation.py
@@ -1,14 +1,11 @@
 """Observation class for fetching market data from Binance."""
 from typing import Callable, List, Optional, Union
 
-import numpy as np
 import pandas as pd
 
 from torchtrade.envs.live.shared.futures_base_obs import BaseFuturesObservationClass
 from torchtrade.envs.utils.timeframe import TimeFrame, timeframe_to_binance
 
-# Kline layout: [open_time, open, high, low, close, volume, close_time, quote_volume,
-#               trades, taker_buy_base, taker_buy_quote, ignore]
 _KLINE_COLUMNS = [
     "open_time", "open", "high", "low", "close", "volume", "close_time",
     "quote_volume", "trades", "taker_buy_base", "taker_buy_quote", "ignore",
@@ -20,12 +17,12 @@ _NUMERIC_COLUMNS = [
 
 
 class BinanceObservationClass(BaseFuturesObservationClass):
-    """Binance market data. The last venue still carrying a parallel copy (#289).
+    """Binance market data via the shared futures observation base (#289)."""
 
-    Four of its nine shared methods were already byte-identical to the base's; what
-    genuinely differs is the API call and the kline layout, which are what the base's
-    hooks are for.
-    """
+    # Binance klines carry more than OHLCV and a preprocessing fn may read it.
+    _DUMMY_COLUMNS = BaseFuturesObservationClass._DUMMY_COLUMNS + (
+        "quote_volume", "trades", "taker_buy_base", "taker_buy_quote",
+    )
 
     def __init__(
         self,
@@ -47,12 +44,8 @@ class BinanceObservationClass(BaseFuturesObservationClass):
 
     def _create_client(self) -> object:
         """Public market data only, so no keys."""
-        try:
-            from binance.client import Client
-        except ImportError:
-            raise ImportError(
-                "python-binance is required. Install with: pip install python-binance"
-            )
+        from binance.client import Client
+
         return Client()
 
     def _validate_timeframe(self, timeframe: TimeFrame) -> None:
@@ -72,21 +65,12 @@ class BinanceObservationClass(BaseFuturesObservationClass):
 
     def _parse_klines(self, raw_klines: list) -> pd.DataFrame:
         df = pd.DataFrame(raw_klines, columns=_KLINE_COLUMNS)
-        # to_numeric with coerce, not astype: a malformed row becomes NaN and is dropped
-        # by preprocessing rather than killing the whole fetch.
+        # to_numeric with coerce, not astype: a malformed row becomes NaN rather than
+        # killing the whole fetch. Preprocessing drops it -- but note base_features is
+        # built from the UNprocessed frame, so a NaN can still reach that one.
         for col in _NUMERIC_COLUMNS:
             df[col] = pd.to_numeric(df[col], errors="coerce")
         df["trades"] = pd.to_numeric(df["trades"], errors="coerce").fillna(0).astype(int)
         df["open_time"] = pd.to_datetime(df["open_time"], unit="ms")
         df["close_time"] = pd.to_datetime(df["close_time"], unit="ms")
         return df.drop(columns=["ignore"])
-
-    def _dummy_frame(self, window_size: int) -> pd.DataFrame:
-        """Binance klines carry more than OHLCV, and a preprocessing fn may read it."""
-        df = super()._dummy_frame(window_size)
-        df["volume"] += 1e-9  # a preprocessing fn that divides by volume must not hit 0
-        df["quote_volume"] = np.random.rand(window_size)
-        df["trades"] = np.random.randint(1, 100, window_size)
-        df["taker_buy_base"] = np.random.rand(window_size)
-        df["taker_buy_quote"] = np.random.rand(window_size)
-        return df

--- a/torchtrade/envs/live/binance/observation.py
+++ b/torchtrade/envs/live/binance/observation.py
@@ -1,20 +1,31 @@
-from typing import List, Union, Callable, Dict, Optional
+"""Observation class for fetching market data from Binance."""
+from typing import Callable, List, Optional, Union
+
 import numpy as np
 import pandas as pd
 
-from torchtrade.envs.utils.timeframe import TimeFrame, TimeFrameUnit, timeframe_to_binance
+from torchtrade.envs.live.shared.futures_base_obs import BaseFuturesObservationClass
+from torchtrade.envs.utils.timeframe import TimeFrame, timeframe_to_binance
+
+# Kline layout: [open_time, open, high, low, close, volume, close_time, quote_volume,
+#               trades, taker_buy_base, taker_buy_quote, ignore]
+_KLINE_COLUMNS = [
+    "open_time", "open", "high", "low", "close", "volume", "close_time",
+    "quote_volume", "trades", "taker_buy_base", "taker_buy_quote", "ignore",
+]
+_NUMERIC_COLUMNS = [
+    "open", "high", "low", "close", "volume",
+    "quote_volume", "taker_buy_base", "taker_buy_quote",
+]
 
 
-class BinanceObservationClass:
+class BinanceObservationClass(BaseFuturesObservationClass):
+    """Binance market data. The last venue still carrying a parallel copy (#289).
+
+    Four of its nine shared methods were already byte-identical to the base's; what
+    genuinely differs is the API call and the kline layout, which are what the base's
+    hooks are for.
     """
-    Observation class for fetching market data from Binance.
-
-    Similar to AlpacaObservationClass but uses Binance API for data fetching.
-    Supports multiple timeframes and custom feature preprocessing.
-    """
-
-    def reset(self) -> None:
-        """No-op; see BaseFuturesObservationClass.reset (#278)."""
 
     def __init__(
         self,
@@ -25,215 +36,57 @@ class BinanceObservationClass:
         client: Optional[object] = None,
         demo: bool = True,
     ):
-        """
-        Initialize the BinanceObservationClass.
-
-        Args:
-            symbol: The trading symbol (e.g., "BTCUSDT")
-            time_frames: Single custom TimeFrame or list of custom TimeFrames to fetch data for
-            window_sizes: Single integer or list of integers specifying window sizes.
-                         If a list is provided, it must have the same length as time_frames.
-            feature_preprocessing_fn: Optional custom preprocessing function that takes a DataFrame
-                                     and returns a DataFrame with feature columns
-            client: Optional pre-configured Binance Client for dependency injection (useful for testing)
-            demo: Whether to use demo/testnet environment (default: True)
-        """
-        # Normalize symbol (remove slash if present)
-        self.symbol = symbol.replace("/", "")
-
-        self.time_frames = [time_frames] if isinstance(time_frames, TimeFrame) else time_frames
-        self.window_sizes = [window_sizes] if isinstance(window_sizes, int) else window_sizes
-        self.demo = demo
-        self.default_lookback = 500  # Binance default limit
-
-        # Validate that time_frames and window_sizes have matching lengths
-        if len(self.time_frames) != len(self.window_sizes):
-            raise ValueError("time_frames and window_sizes must have the same length")
-
-        self.feature_preprocessing_fn = feature_preprocessing_fn or self._default_preprocessing
-
-        # Initialize client if not provided
-        if client is not None:
-            self.client = client
-        else:
-            try:
-                from binance.client import Client
-                # For observation only, we don't need API keys
-                self.client = Client()
-            except ImportError:
-                raise ImportError("python-binance is required. Install with: pip install python-binance")
-
-    def _default_preprocessing(self, df: pd.DataFrame) -> pd.DataFrame:
-        """Default preprocessing function if none is provided."""
-        df = df.copy()
-        df.dropna(inplace=True)
-        df.drop_duplicates(inplace=True)
-
-        # Generating base features (normalized)
-        df["feature_close"] = df["close"].pct_change().fillna(0)
-        df["feature_open"] = df["open"] / df["close"]
-        df["feature_high"] = df["high"] / df["close"]
-        df["feature_low"] = df["low"] / df["close"]
-        df.dropna(inplace=True)
-        return df
-
-    def _get_numpy_obs(self, df: pd.DataFrame, columns: List[str] = None) -> np.ndarray:
-        """Convert specified columns to numpy array."""
-        if columns is None:
-            columns = [col for col in df.columns if "feature" in col]
-        if not columns:
-            raise ValueError(f"No columns found in preprocessed DataFrame matching: {columns}")
-        return np.array(df[columns], dtype=np.float32)
-
-    def _fetch_single_timeframe(self, timeframe: TimeFrame, limit: int = None) -> pd.DataFrame:
-        """Fetch and preprocess data for a single timeframe.
-
-        Args:
-            timeframe: Custom TimeFrame object
-            limit: Number of data points to fetch (default: self.default_lookback)
-
-        Returns:
-            DataFrame with OHLCV data
-        """
-        if limit is None:
-            limit = self.default_lookback
-
-        # Convert custom TimeFrame to Binance interval string for API calls
-        binance_interval = timeframe_to_binance(timeframe)
-
-        # Fetch klines from Binance
-        klines = self.client.get_klines(
-            symbol=self.symbol,
-            interval=binance_interval,
-            limit=limit
+        super().__init__(
+            symbol=symbol.replace("/", ""),
+            time_frames=time_frames,
+            window_sizes=window_sizes,
+            feature_preprocessing_fn=feature_preprocessing_fn,
+            client=client,
+            demo=demo,
         )
 
-        # Convert to DataFrame
-        # Kline format: [open_time, open, high, low, close, volume, close_time,
-        #                quote_volume, trades, taker_buy_base, taker_buy_quote, ignore]
-        df = pd.DataFrame(klines, columns=[
-            'open_time', 'open', 'high', 'low', 'close', 'volume',
-            'close_time', 'quote_volume', 'trades', 'taker_buy_base',
-            'taker_buy_quote', 'ignore'
-        ])
+    def _create_client(self) -> object:
+        """Public market data only, so no keys."""
+        try:
+            from binance.client import Client
+        except ImportError:
+            raise ImportError(
+                "python-binance is required. Install with: pip install python-binance"
+            )
+        return Client()
 
-        # Convert types (pd.to_numeric handles malformed rows gracefully)
-        for col in ['open', 'high', 'low', 'close', 'volume',
-                     'quote_volume', 'taker_buy_base', 'taker_buy_quote']:
-            df[col] = pd.to_numeric(df[col], errors='coerce')
-        df['trades'] = pd.to_numeric(df['trades'], errors='coerce').fillna(0).astype(int)
-        df['open_time'] = pd.to_datetime(df['open_time'], unit='ms')
-        df['close_time'] = pd.to_datetime(df['close_time'], unit='ms')
+    def _validate_timeframe(self, timeframe: TimeFrame) -> None:
+        timeframe_to_binance(timeframe)
 
-        return df.drop(columns=['ignore'])
+    def _convert_timeframe(self, timeframe: TimeFrame) -> str:
+        return timeframe_to_binance(timeframe)
 
-    def get_keys(self) -> List[str]:
-        """
-        Get the list of keys that will be present in the observations dictionary.
+    def _get_default_lookback(self) -> int:
+        return 500  # binance's own per-request limit
 
-        Returns:
-            List of strings formatted as '{timeframe}_{window_size}'
-            (e.g., '5Minute_10', '1Hour_20')
-        """
-        return [
-            f"{tf.obs_key_freq()}_{ws}"
-            for tf, ws in zip(self.time_frames, self.window_sizes)
-        ]
+    def _get_timestamp_column(self) -> str:
+        return "open_time"
 
-    def get_features(self) -> Dict[str, List[str]]:
-        """Returns a dictionary with the observation features and the original features."""
-        def get_dummy_data(window_size: int):
-            df = pd.DataFrame()
-            df["open"] = np.random.rand(window_size)
-            df["high"] = np.random.rand(window_size)
-            df["low"] = np.random.rand(window_size)
-            df["close"] = np.random.rand(window_size)
-            df["volume"] = np.random.rand(window_size) + 1e-9
-            # Binance klines include extra fields beyond standard OHLCV
-            df["quote_volume"] = np.random.rand(window_size)
-            df["trades"] = np.random.randint(1, 100, window_size)
-            df["taker_buy_base"] = np.random.rand(window_size)
-            df["taker_buy_quote"] = np.random.rand(window_size)
-            return df
+    def _fetch_klines(self, symbol: str, interval: str, limit: int) -> list:
+        return self.client.get_klines(symbol=symbol, interval=interval, limit=limit)
 
-        dummy_df = self.feature_preprocessing_fn(get_dummy_data(self.window_sizes[0]))
-        observation_features = [f for f in dummy_df.columns if "feature" in f]
-        original_features = [f for f in dummy_df.columns if "feature" not in f]
-        return {"observation_features": observation_features, "original_features": original_features}
+    def _parse_klines(self, raw_klines: list) -> pd.DataFrame:
+        df = pd.DataFrame(raw_klines, columns=_KLINE_COLUMNS)
+        # to_numeric with coerce, not astype: a malformed row becomes NaN and is dropped
+        # by preprocessing rather than killing the whole fetch.
+        for col in _NUMERIC_COLUMNS:
+            df[col] = pd.to_numeric(df[col], errors="coerce")
+        df["trades"] = pd.to_numeric(df["trades"], errors="coerce").fillna(0).astype(int)
+        df["open_time"] = pd.to_datetime(df["open_time"], unit="ms")
+        df["close_time"] = pd.to_datetime(df["close_time"], unit="ms")
+        return df.drop(columns=["ignore"])
 
-    def get_observations(self, return_base_ohlc: bool = False) -> Dict[str, np.ndarray]:
-        """
-        Fetch and process observations for all specified timeframes and window sizes.
-
-        Args:
-            return_base_ohlc: If True, includes the raw OHLC data from the first timeframe
-                            in the observations dictionary under the 'base_features' key.
-
-        Returns:
-            Dictionary with keys formatted as '{timeframe}_{window_size}' and numpy array values.
-            If return_base_ohlc is True, includes 'base_features' and 'base_timestamps' keys.
-        """
-        observations = {}
-
-        for timeframe, window_size in zip(self.time_frames, self.window_sizes):
-            key = f"{timeframe.obs_key_freq()}_{window_size}"
-            # Fetch extra data for preprocessing (rolling windows may need more)
-            df = self._fetch_single_timeframe(timeframe, limit=window_size + 50)
-
-            # Store base OHLC features if this is the first timeframe and return_base_ohlc is True
-            if return_base_ohlc and timeframe == self.time_frames[0]:
-                base_df = df.copy()
-                observations['base_features'] = self._get_numpy_obs(
-                    base_df,
-                    columns=['open', 'high', 'low', 'close']
-                )[-window_size:]
-                observations['base_timestamps'] = base_df['open_time'].values[-window_size:]
-
-            processed_df = self.feature_preprocessing_fn(df)
-            # Apply window size
-            processed_df = processed_df.iloc[-window_size:]
-            observations[key] = self._get_numpy_obs(processed_df)
-
-        return observations
-
-
-# Example usage:
-if __name__ == "__main__":
-    # Note: Examples now use custom TimeFrame from torchtrade.envs.timeframe
-
-    # Single timeframe example
-    print("Testing single timeframe...")
-    window_size = 10
-    observer = BinanceObservationClass(
-        symbol="BTCUSDT",
-        time_frames=TimeFrame(15, TimeFrameUnit.Minute),
-        window_sizes=window_size,
-    )
-    expected_keys = observer.get_keys()
-    print(f"Expected keys: {expected_keys}")
-    observations = observer.get_observations()
-
-    assert set(observations.keys()) == set(expected_keys), "Keys don't match expected keys"
-    assert observations[expected_keys[0]].shape == (window_size, 4), \
-        f"Expected shape ({window_size}, 4) for default features, got {observations[expected_keys[0]].shape}"
-    print("Single timeframe test passed!")
-
-    # Example with multiple timeframes and window sizes
-    print("\nTesting multiple timeframes...")
-    window_sizes = [10, 20]
-    observer = BinanceObservationClass(
-        symbol="BTCUSDT",
-        time_frames=[
-            TimeFrame(15, TimeFrameUnit.Minute),
-            TimeFrame(1, TimeFrameUnit.Hour)
-        ],
-        window_sizes=window_sizes
-    )
-
-    expected_keys = observer.get_keys()
-    print("Expected keys:", expected_keys)
-    observations = observer.get_observations()
-
-    assert set(observations.keys()) == set(expected_keys), "Keys don't match expected keys"
-    assert len(observations) == 2, "Expected exactly 2 observations"
-    print("Multiple timeframes test passed!")
+    def _dummy_frame(self, window_size: int) -> pd.DataFrame:
+        """Binance klines carry more than OHLCV, and a preprocessing fn may read it."""
+        df = super()._dummy_frame(window_size)
+        df["volume"] += 1e-9  # a preprocessing fn that divides by volume must not hit 0
+        df["quote_volume"] = np.random.rand(window_size)
+        df["trades"] = np.random.randint(1, 100, window_size)
+        df["taker_buy_base"] = np.random.rand(window_size)
+        df["taker_buy_quote"] = np.random.rand(window_size)
+        return df

--- a/torchtrade/envs/live/binance/observation.py
+++ b/torchtrade/envs/live/binance/observation.py
@@ -1,6 +1,7 @@
 """Observation class for fetching market data from Binance."""
 from typing import Callable, List, Optional, Union
 
+import numpy as np
 import pandas as pd
 
 from torchtrade.envs.live.shared.futures_base_obs import BaseFuturesObservationClass
@@ -18,11 +19,6 @@ _NUMERIC_COLUMNS = [
 
 class BinanceObservationClass(BaseFuturesObservationClass):
     """Binance market data via the shared futures observation base (#289)."""
-
-    # Binance klines carry more than OHLCV and a preprocessing fn may read it.
-    _DUMMY_COLUMNS = BaseFuturesObservationClass._DUMMY_COLUMNS + (
-        "quote_volume", "trades", "taker_buy_base", "taker_buy_quote",
-    )
 
     def __init__(
         self,
@@ -55,7 +51,7 @@ class BinanceObservationClass(BaseFuturesObservationClass):
         return timeframe_to_binance(timeframe)
 
     def _get_default_lookback(self) -> int:
-        return 500  # binance's own per-request limit
+        return 500  # binance's kline default page size (its max is 1000)
 
     def _get_timestamp_column(self) -> str:
         return "open_time"
@@ -66,11 +62,19 @@ class BinanceObservationClass(BaseFuturesObservationClass):
     def _parse_klines(self, raw_klines: list) -> pd.DataFrame:
         df = pd.DataFrame(raw_klines, columns=_KLINE_COLUMNS)
         # to_numeric with coerce, not astype: a malformed row becomes NaN rather than
-        # killing the whole fetch. Preprocessing drops it -- but note base_features is
-        # built from the UNprocessed frame, so a NaN can still reach that one.
+        # killing the whole fetch, and preprocessing drops it.
         for col in _NUMERIC_COLUMNS:
             df[col] = pd.to_numeric(df[col], errors="coerce")
         df["trades"] = pd.to_numeric(df["trades"], errors="coerce").fillna(0).astype(int)
         df["open_time"] = pd.to_datetime(df["open_time"], unit="ms")
         df["close_time"] = pd.to_datetime(df["close_time"], unit="ms")
         return df.drop(columns=["ignore"])
+
+    def _dummy_frame(self, window_size: int) -> pd.DataFrame:
+        """Binance klines carry more than OHLCV, at their real dtypes and magnitudes."""
+        df = super()._dummy_frame(window_size)
+        df["quote_volume"] = np.random.rand(window_size)
+        df["trades"] = np.random.randint(1, 100, window_size)  # int64, as _parse_klines makes it
+        df["taker_buy_base"] = np.random.rand(window_size)
+        df["taker_buy_quote"] = np.random.rand(window_size)
+        return df

--- a/torchtrade/envs/live/shared/futures_base_obs.py
+++ b/torchtrade/envs/live/shared/futures_base_obs.py
@@ -228,18 +228,23 @@ class BaseFuturesObservationClass(ABC):
             for tf, ws in zip(self.time_frames, self.window_sizes)
         ]
 
+    def _dummy_frame(self, window_size: int) -> pd.DataFrame:
+        """A frame shaped like this venue's parsed klines, for counting feature columns.
+
+        Overridable because the venues do not all return the same columns: binance klines
+        carry `quote_volume`, `trades` and the taker-buy fields, and a user's
+        `feature_preprocessing_fn` is free to read them. Counting features against an
+        OHLCV-only frame would raise KeyError for exactly those functions -- so the shape
+        is a venue fact, not a shared one.
+        """
+        return pd.DataFrame({
+            col: np.random.rand(window_size)
+            for col in ("open", "high", "low", "close", "volume")
+        })
+
     def get_features(self) -> Dict[str, List[str]]:
         """Returns a dictionary with the observation features and the original features."""
-        def get_dummy_data(window_size: int):
-            df = pd.DataFrame()
-            df["open"] = np.random.rand(window_size)
-            df["high"] = np.random.rand(window_size)
-            df["low"] = np.random.rand(window_size)
-            df["close"] = np.random.rand(window_size)
-            df["volume"] = np.random.rand(window_size)
-            return df
-
-        dummy_df = self.feature_preprocessing_fn(get_dummy_data(self.window_sizes[0]))
+        dummy_df = self.feature_preprocessing_fn(self._dummy_frame(self.window_sizes[0]))
         observation_features = [f for f in dummy_df.columns if "feature" in f]
         original_features = [f for f in dummy_df.columns if "feature" not in f]
         return {"observation_features": observation_features, "original_features": original_features}

--- a/torchtrade/envs/live/shared/futures_base_obs.py
+++ b/torchtrade/envs/live/shared/futures_base_obs.py
@@ -228,23 +228,19 @@ class BaseFuturesObservationClass(ABC):
             for tf, ws in zip(self.time_frames, self.window_sizes)
         ]
 
-    def _dummy_frame(self, window_size: int) -> pd.DataFrame:
-        """A frame shaped like this venue's parsed klines, for counting feature columns.
-
-        Overridable because the venues do not all return the same columns: binance klines
-        carry `quote_volume`, `trades` and the taker-buy fields, and a user's
-        `feature_preprocessing_fn` is free to read them. Counting features against an
-        OHLCV-only frame would raise KeyError for exactly those functions -- so the shape
-        is a venue fact, not a shared one.
-        """
-        return pd.DataFrame({
-            col: np.random.rand(window_size)
-            for col in ("open", "high", "low", "close", "volume")
-        })
+    # Columns get_features() puts in front of the user's preprocessing fn. Overridable
+    # because the venues do not return the same set: binance klines carry quote_volume,
+    # trades and the taker-buy fields, and a preprocessing fn is free to read them --
+    # against an OHLCV-only frame those functions raise KeyError. Not the full parsed
+    # schema: the timestamp columns are omitted here on every venue.
+    _DUMMY_COLUMNS = ("open", "high", "low", "close", "volume")
 
     def get_features(self) -> Dict[str, List[str]]:
         """Returns a dictionary with the observation features and the original features."""
-        dummy_df = self.feature_preprocessing_fn(self._dummy_frame(self.window_sizes[0]))
+        dummy = pd.DataFrame({
+            c: np.random.rand(self.window_sizes[0]) for c in self._DUMMY_COLUMNS
+        })
+        dummy_df = self.feature_preprocessing_fn(dummy)
         observation_features = [f for f in dummy_df.columns if "feature" in f]
         original_features = [f for f in dummy_df.columns if "feature" not in f]
         return {"observation_features": observation_features, "original_features": original_features}

--- a/torchtrade/envs/live/shared/futures_base_obs.py
+++ b/torchtrade/envs/live/shared/futures_base_obs.py
@@ -228,19 +228,30 @@ class BaseFuturesObservationClass(ABC):
             for tf, ws in zip(self.time_frames, self.window_sizes)
         ]
 
-    # Columns get_features() puts in front of the user's preprocessing fn. Overridable
-    # because the venues do not return the same set: binance klines carry quote_volume,
-    # trades and the taker-buy fields, and a preprocessing fn is free to read them --
-    # against an OHLCV-only frame those functions raise KeyError. Not the full parsed
-    # schema: the timestamp columns are omitted here on every venue.
-    _DUMMY_COLUMNS = ("open", "high", "low", "close", "volume")
+    def _dummy_frame(self, window_size: int) -> pd.DataFrame:
+        """A frame standing in for this venue's parsed klines, to count feature columns.
+
+        A method rather than a column tuple because DTYPE AND MAGNITUDE MATTER, which is
+        not obvious and was measured the hard way: replacing this with a names-only tuple
+        made binance's `trades` a float in [0, 1) where real klines carry int64 counts in
+        the hundreds. A preprocessing fn branching on either -- `is_integer_dtype(...)`,
+        or a threshold -- then takes a different branch here than on live data, and
+        `get_features()` reports a width the observation does not have. That width IS the
+        spec for `BinanceOHLCVTransform`, so the mismatch reaches `check_env_specs`.
+
+        Overridable because the venues do not return the same columns: binance klines
+        carry quote_volume, trades and the taker-buy fields, and against an OHLCV-only
+        frame a fn reading them raises KeyError. The timestamp columns are omitted on
+        every venue -- a fn deriving a time-of-day feature still raises.
+        """
+        return pd.DataFrame({
+            col: np.random.rand(window_size)
+            for col in ("open", "high", "low", "close", "volume")
+        })
 
     def get_features(self) -> Dict[str, List[str]]:
         """Returns a dictionary with the observation features and the original features."""
-        dummy = pd.DataFrame({
-            c: np.random.rand(self.window_sizes[0]) for c in self._DUMMY_COLUMNS
-        })
-        dummy_df = self.feature_preprocessing_fn(dummy)
+        dummy_df = self.feature_preprocessing_fn(self._dummy_frame(self.window_sizes[0]))
         observation_features = [f for f in dummy_df.columns if "feature" in f]
         original_features = [f for f in dummy_df.columns if "feature" not in f]
         return {"observation_features": observation_features, "original_features": original_features}

--- a/torchtrade/envs/live/shared/futures_base_obs.py
+++ b/torchtrade/envs/live/shared/futures_base_obs.py
@@ -231,18 +231,21 @@ class BaseFuturesObservationClass(ABC):
     def _dummy_frame(self, window_size: int) -> pd.DataFrame:
         """A frame standing in for this venue's parsed klines, to count feature columns.
 
-        A method rather than a column tuple because DTYPE AND MAGNITUDE MATTER, which is
-        not obvious and was measured the hard way: replacing this with a names-only tuple
-        made binance's `trades` a float in [0, 1) where real klines carry int64 counts in
-        the hundreds. A preprocessing fn branching on either -- `is_integer_dtype(...)`,
-        or a threshold -- then takes a different branch here than on live data, and
-        `get_features()` reports a width the observation does not have. That width IS the
-        spec for `BinanceOHLCVTransform`, so the mismatch reaches `check_env_specs`.
+        A method rather than a column tuple because DTYPE MATTERS: binance's `trades` is
+        int64 in real klines, and a names-only tuple made it a float, so a fn branching
+        on `is_integer_dtype(...)` took a different branch here than on live data.
+        `get_features()` then reported a width the observation did not have -- and that
+        width IS the spec `BinanceOHLCVTransform` builds, so it surfaced at
+        `check_env_specs`.
+
+        MAGNITUDES are NOT faithful and a fn branching on one will still diverge: dummy
+        values are `rand()` in [0, 1) and `trades` averages ~55 against a live ~1500.
+        Unbounded to chase, so it is stated rather than fixed.
 
         Overridable because the venues do not return the same columns: binance klines
         carry quote_volume, trades and the taker-buy fields, and against an OHLCV-only
         frame a fn reading them raises KeyError. The timestamp columns are omitted on
-        every venue -- a fn deriving a time-of-day feature still raises.
+        every venue, so a fn deriving a time-of-day feature raises too.
         """
         return pd.DataFrame({
             col: np.random.rand(window_size)


### PR DESCRIPTION
Closes the biggest remaining item of #289 — and the fold found a latent bug.

## Measured first

Of the 9 methods `BinanceObservationClass` shared with `BaseFuturesObservationClass`, **4 were already byte-identical**: `_default_preprocessing`, `_get_numpy_obs`, `get_keys`, `reset`. What genuinely differed was the API call and the kline layout — which is exactly what the base's hooks exist for. **239 lines → 92.**

## The latent bug

The base sorts fetched klines by timestamp, because some exchanges return newest-first. **Binance's copy did not** — it was the only venue unprotected. Binance returns ascending today so nothing bit, but a reversed response produced **time-reversed observations with no error**: a policy reading the future as the past.

```
reversed response   main: ascending=False      branch: ascending=True
empty response      main: IndexError: single positional indexer is out-of-bounds
                    branch: RuntimeError: Failed to fetch candles for BTCUSDT on 1Minute
fetch raises        main: bare ConnectionError branch: wrapped with symbol + timeframe
```

## One divergence resolved, not dropped

`get_features()` counts feature columns against a **dummy** frame, and binance klines carry `quote_volume`, `trades` and the taker-buy fields that OHLCV does not. A user's `feature_preprocessing_fn` is free to read them — and against the base's OHLCV-only dummy those functions raise `KeyError`. So the base gets a `_dummy_frame` hook (default OHLCV) that binance extends; the venue-shaped frame stays a venue fact. Removing that override fails 2 tests.

## Equivalence vs main

Keys, feature lists, and every array's shape/dtype/sum — for both the default preprocessing **and** a function reading binance-only columns. Identical.

Mutation-checked: dropping the dummy override fails 2, removing the sort fails 1, re-forking `get_observations` fails 1.

## Deliberately not done

`trade()`/`close_position()` still carry a `position_side` parameter with **no caller anywhere** and three unreachable `!= "BOTH"` branches. bybit and okx have no such parameter; bitget has one, also uncalled. Deleting it and adding the hedge-mode surface #289 also asks for are **opposite resolutions of the same question**, and it is the order-placement path — so it wants its own decision, not a silent pick inside an observation refactor.

Full suite **3878 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)