### PR TITLE
fix(live): engage the failure policy on a mark-price read, and refuse a short observation

### DIFF
--- a/docs/environments/online.md
+++ b/docs/environments/online.md
@@ -805,22 +805,29 @@ size, exposure and liquidation distance the env has just admitted it cannot veri
 
 So the env **halts**: it raises `LiveObservationHalt` and produces no transition.
 
-**Which reads this covers.** Only the post-bar state read — the portfolio value and
-observation taken after the bar closes. Every *other* venue read raises its original
-exception with no latch and no emergency flatten:
+**Which reads this covers.** The post-bar state read — the portfolio value and
+observation taken after the bar closes — and the pre-trade state read. Both include the
+observation itself, so one the env refuses to emit (a stale last bar, or one shorter than
+its declared spec) engages the policy like any other unreadable state.
+
+The pre-trade read also covers the mark price: a fetch that fails now raises `ValueError`
+rather than the venue's own type, so `ObservationFailurePolicy` is consulted (#394).
+Before that fix the raw exception escaped and the policy was silently bypassed.
+
+Every *other* venue read still raises its original exception with no latch and no
+emergency flatten:
 
 | read | raises |
 |---|---|
 | position read at the top of `_step()` (position sync, duplicate-action guard) | `PositionUnknownError` |
 | the initial read inside `_reset()` | `ValueError` |
-| `_current_mark_price()`, called at the top of every futures `_step()` | `ValueError` |
+| `_current_mark_price()` at the **sizing** call sites in `_execute_fractional_action` / `_execute_trade_if_needed` | `ValueError` |
 | the sizing balance / portfolio checks | `ValueError` |
 | the candle close that prices SL/TP brackets | `ValueError` |
 
-So `except LiveObservationHalt` alone does **not** give you a policy-driven emergency
-close on an unreadable price or balance — it catches the post-bar read and nothing else.
-Catch `ValueError` and `PositionUnknownError` too if you need to cover those. Alpaca and
-Polymarket do not route through this path at all. Closing the gap is #355.
+So `except LiveObservationHalt` covers the two state reads and nothing else. Catch
+`ValueError` and `PositionUnknownError` too if you need the sizing paths. Alpaca and
+Polymarket do not route through this path at all. Closing the rest of the gap is #355.
 
 ```python
 from torchtrade.envs.core.live import LiveObservationHalt
@@ -847,10 +854,16 @@ as requiring an operator to check the account.
 ### What does not halt
 
 Only failures that mean *the venue told us something impossible about our own money* are
-terminal. A transient error is not: every adapter wraps arbitrary failures in
-`RuntimeError("Failed to get account balance: ...")`, so treating that as terminal would
-end an episode — and under `flatten`, close a live position — on a read timeout. Those
-propagate unchanged, as do configuration errors such as a missing feature key. Retry and
-staleness handling are tracked in #295.
+terminal. A transient error is generally not: adapters wrap arbitrary failures in
+`RuntimeError("Failed to get account balance: ...")`, and treating every one of those as
+terminal would end an episode — and under `flatten`, close a live position — on a read
+timeout. Those propagate unchanged, as do configuration errors such as a missing feature
+key.
+
+The mark-price read is the deliberate exception (#394): there a failed read is
+indistinguishable from reading an unusable price, which was already terminal, so it
+raises the same way. Escalating it is safe because the only halt-wrapped caller reaches
+the fetch solely when the account is flat. Retry and staleness handling are tracked
+in #295.
 
 Alpaca and Polymarket do not route through this path at all (#355).

--- a/docs/environments/online.md
+++ b/docs/environments/online.md
@@ -805,29 +805,37 @@ size, exposure and liquidation distance the env has just admitted it cannot veri
 
 So the env **halts**: it raises `LiveObservationHalt` and produces no transition.
 
-**Which reads this covers.** The post-bar state read — the portfolio value and
-observation taken after the bar closes — and the pre-trade state read. Both include the
-observation itself, so one the env refuses to emit (a stale last bar, or one shorter than
-its declared spec) engages the policy like any other unreadable state.
+**Which reads this covers.** Two reads. The **post-bar** read — the portfolio value and
+observation taken after the bar closes — is the only one that carries the observation, so
+an observation the env refuses to emit (a stale last bar, or one shorter than its declared
+spec) engages the policy here and nowhere else. Note the cost under `flatten`: the fetch
+buffer is a fixed candle count, so on a 1-minute timeframe a refused window can mean ~50
+minutes of bad feed, not an outage, and in a multi-timeframe stack the finest timeframe
+decides.
 
-The pre-trade read also covers the mark price: a fetch that fails now raises `ValueError`
-rather than the venue's own type, so `ObservationFailurePolicy` is consulted (#394).
-Before that fix the raw exception escaped and the policy was silently bypassed.
+The **pre-trade** read covers the position status and the mark price. A mark-price fetch
+that fails now raises `ValueError` rather than the venue's own type, so the policy is
+consulted (#394). Before that fix the wrapped `RuntimeError` and the raw SDK exception
+both escaped it — though a non-numeric payload already raised `ValueError` from `float()`
+and was caught, which is why the bypass was intermittent rather than total.
 
-Every *other* venue read still raises its original exception with no latch and no
+`_reset()` reads the observation *outside* the halt, deliberately — routing it through
+would market-flatten on every episode start for an account whose metadata is always blank
+(a Bybit portfolio-margin account blanks `liqPrice`). A reset failure raises bare.
+
+Every *other* venue read also raises its original exception, with no latch and no
 emergency flatten:
 
 | read | raises |
 |---|---|
 | position read at the top of `_step()` (position sync, duplicate-action guard) | `PositionUnknownError` |
-| the initial read inside `_reset()` | `ValueError` |
+| the initial read inside `_reset()` | `ValueError`, or `PositionUnknownError` if the position is the unreadable part |
 | `_current_mark_price()` at the **sizing** call sites in `_execute_fractional_action` / `_execute_trade_if_needed` | `ValueError` |
 | the sizing balance / portfolio checks | `ValueError` |
 | the candle close that prices SL/TP brackets | `ValueError` |
 
 So `except LiveObservationHalt` covers the two state reads and nothing else. Catch
-`ValueError` and `PositionUnknownError` too if you need the sizing paths. Alpaca and
-Polymarket do not route through this path at all. Closing the rest of the gap is #355.
+`ValueError` and `PositionUnknownError` too if you need the sizing paths.
 
 ```python
 from torchtrade.envs.core.live import LiveObservationHalt
@@ -866,4 +874,4 @@ raises the same way. Escalating it is safe because the only halt-wrapped caller 
 the fetch solely when the account is flat. Retry and staleness handling are tracked
 in #295.
 
-Alpaca and Polymarket do not route through this path at all (#355).
+Alpaca and Polymarket do not route through this path at all.

--- a/tests/envs/base_exchange_tests.py
+++ b/tests/envs/base_exchange_tests.py
@@ -287,6 +287,31 @@ class BaseObservationClassTests(ABC):
         # Custom preprocessing has 2 features
         assert observations[key].shape[1] == 2
 
+    @pytest.mark.parametrize("kept", [0, 4], ids=["total-outage", "malformed-burst"])
+    def test_an_observation_shorter_than_the_declared_spec_is_refused(self, kept):
+        """`iloc[-window_size:]` is a silent short read, not an error (#400).
+
+        Preprocessing drops rows, so a burst of malformed candles exceeding the fetch
+        buffer emitted a (4, n) array against a declared (5, n) spec, and reset() and
+        rollout() both SUCCEEDED on it. Empty is the degenerate case, and it surfaced
+        instead as an IndexError from `base_features[-1, 3]` inside the trade path
+        (#397). Here, not per-venue: alpaca hand-rolls this while the four futures
+        venues share one base, which is exactly how a fix lands on some and not others.
+        """
+        def truncating(df):
+            df = df.copy()
+            df["feature_range"] = df["high"] - df["low"]
+            return df.iloc[:kept]
+
+        observer = self.create_observer(
+            symbol="BTC/USD",
+            timeframes=TimeFrame(1, TimeFrameUnit.Minute),
+            window_sizes=5,
+            feature_preprocessing_fn=truncating,
+        )
+        with pytest.raises(ValueError, match="usable candles"):
+            observer.get_observations(return_base_ohlc=True)
+
     # Edge cases
 
     def test_window_size_one(self):

--- a/tests/envs/base_exchange_tests.py
+++ b/tests/envs/base_exchange_tests.py
@@ -287,8 +287,12 @@ class BaseObservationClassTests(ABC):
         # Custom preprocessing has 2 features
         assert observations[key].shape[1] == 2
 
-    @pytest.mark.parametrize("kept", [0, 4], ids=["total-outage", "malformed-burst"])
-    def test_an_observation_shorter_than_the_declared_spec_is_refused(self, kept):
+    @pytest.mark.parametrize("kept,refused", [
+        pytest.param(0, True, id="total-outage"),
+        pytest.param(4, True, id="malformed-burst"),
+        pytest.param(5, False, id="exactly-enough"),
+    ])
+    def test_an_observation_shorter_than_the_declared_spec_is_refused(self, kept, refused):
         """`iloc[-window_size:]` is a silent short read, not an error (#400).
 
         Preprocessing drops rows, so a burst of malformed candles exceeding the fetch
@@ -309,6 +313,10 @@ class BaseObservationClassTests(ABC):
             window_sizes=5,
             feature_preprocessing_fn=truncating,
         )
+        if not refused:  # the boundary: `<` -> `<=` passes the whole suite without it
+            emitted = observer.get_observations(return_base_ohlc=True)
+            assert emitted["base_features"].shape[0] == 5
+            return
         with pytest.raises(ValueError, match="usable candles"):
             observer.get_observations(return_base_ohlc=True)
 

--- a/tests/envs/binance/test_obs_class.py
+++ b/tests/envs/binance/test_obs_class.py
@@ -371,14 +371,3 @@ class TestBinanceSharesTheObservationBase:
         """
         obs = self._obs(self._klines(60), fn=fn).get_observations(return_base_ohlc=True)
         assert obs["base_features"].shape[0] > 0
-
-    def test_an_observation_with_no_usable_candles_is_refused(self):
-        """The stale-bar check cannot see this -- there is no last row to compare.
-
-        Without a separate check a total outage returned a silent (0, n) array, and
-        `base_features[-1, 3]` then raised IndexError from inside the trade path.
-        """
-        with pytest.raises(ValueError, match="no usable candles"):
-            self._obs(
-                self._klines(60), fn=lambda df: _basic_features(df).iloc[0:0]
-            ).get_observations(return_base_ohlc=True)

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -3408,3 +3408,63 @@ def test_an_observer_disagreeing_with_the_config_raises_rather_than_guessing():
         BinanceFuturesTorchTradingEnv(config=config, observer=observer, trader=trader)
 
 
+
+
+@pytest.mark.parametrize("venue_error", [
+    pytest.param(RuntimeError("venue unreachable"), id="wrapped-RuntimeError"),
+    pytest.param(ConnectionError("socket closed"), id="raw-sdk-exception"),
+    pytest.param(KeyError("markPrice"), id="malformed-payload"),
+], )
+@pytest.mark.parametrize("policy", ["halt", "flatten"])
+def test_a_mark_price_that_cannot_be_read_engages_the_failure_policy(venue_error, policy):
+    """`_halting` catches (PositionUnknownError, ValueError), deliberately NOT RuntimeError.
+
+    binance and bitget wrap a mark-price fetch failure in RuntimeError; bybit and okx do
+    not wrap it at all. Either way the raw type escaped `_halting`, so
+    ObservationFailurePolicy was never consulted -- measured BYPASSED under both HALT and
+    FLATTEN on a FLAT account, which is the only branch that re-fetches the mark (#394).
+
+    Flat is also why converting it is safe: FLATTEN has nothing to close, and HALT gets
+    the structured signal orchestration is built to catch.
+    """
+    from torchtrade.envs.core.live import LiveObservationHalt, ObservationFailurePolicy
+    from torchtrade.envs.live.binance.env import (
+        BinanceFuturesTorchTradingEnv,
+        BinanceFuturesTradingEnvConfig,
+    )
+
+    observer = MagicMock()
+    observer.get_keys.return_value = ["1Minute_10"]
+    observer.get_features.return_value = {
+        "observation_features": ["a", "b", "c", "d"], "original_features": []}
+    observer.get_observations.return_value = {
+        "1Minute_10": np.zeros((10, 4), dtype=np.float32)}
+    observer.reset.return_value = None
+
+    trader = MagicMock()
+    trader.get_account_balance.return_value = {
+        "available_balance": 1000.0, "total_margin_balance": 1000.0,
+        "total_wallet_balance": 1000.0,
+    }
+    trader.get_status.return_value = {"position_status": None}  # flat
+    trader.cancel_open_orders.return_value = True
+    trader.close_position.return_value = True
+    trader.get_mark_price.side_effect = venue_error
+
+    config = BinanceFuturesTradingEnvConfig(
+        symbol="BTCUSDT", time_frames=["1m"], window_sizes=[10], execute_on="1m",
+        observation_failure_policy=policy,
+    )
+    with patch("time.sleep"), patch.object(
+        BinanceFuturesTorchTradingEnv, "_wait_for_next_timestamp"
+    ):
+        env = BinanceFuturesTorchTradingEnv(
+            config=config, observer=observer, trader=trader
+        )
+
+    td = env.reset()
+    td["action"] = torch.tensor(1)
+    with pytest.raises(LiveObservationHalt):
+        env.step(td)
+    if config.observation_failure_policy is ObservationFailurePolicy.FLATTEN:
+        trader.close_position.assert_called()

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -1868,13 +1868,13 @@ def test_an_unusable_mark_price_cannot_size_a_trade(source, price):
     pytest.param(KeyError("markPrice"), id="malformed-payload"),
 ])
 def test_a_mark_price_that_cannot_be_read_raises_what_halting_catches(venue_error):
-    """#394: no adapter raised a type `_halting` catches, so the policy was bypassed.
+    """#394: the mark-price fetch raised types `_halting` misses, bypassing the policy.
 
     `_halting` catches (PositionUnknownError, ValueError) and deliberately not
     RuntimeError, which adapters use for timeouts. Failing to READ the mark is the same
     event as reading an unusable one above, so it must raise the same way. The three
-    shapes are three exception families: narrowing the catch to RuntimeError, or to
-    (RuntimeError, OSError), lets one of them escape again.
+    shapes are three exception families: narrowing the catch to RuntimeError lets two
+    escape, to (RuntimeError, OSError) lets one.
     """
     env = SimpleNamespace(
         trader=SimpleNamespace(get_mark_price=MagicMock(side_effect=venue_error)),

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -188,6 +188,10 @@ def test_no_live_env_overrides_shared_method(env_cls, method):
         "_create_trade_info",
         "_handle_close_action",
         "_execute_market_order",
+        # Re-forking either reopens #394 on that venue alone: `_current_mark_price` is
+        # what converts a failed fetch into a type `_halting` catches.
+        "_current_mark_price",
+        "_halting",
     ],
 )
 @pytest.mark.parametrize("env_cls", FUTURES_ENVS, ids=lambda c: c.__name__)
@@ -2584,6 +2588,87 @@ def test_a_reset_on_an_unreadable_position_still_raises_the_bare_exception():
         position_direction_from_status(POSITION_UNKNOWN)
 
 
+def test_an_open_position_never_re_fetches_the_mark_in_the_halt_wrapped_read():
+    """The one fact that makes #394's escalation safe, and nothing pinned it.
+
+    `_current_mark_price` converts ANY fetch failure into a ValueError so `_halting`
+    catches it -- which under FLATTEN means a market close. That is only acceptable
+    because the sole halt-wrapped caller passes `position_status`, so with a position
+    open it reads `position_status.mark_price` and never calls the venue at all.
+
+    Drop the `if position_status:` branch and the suite stays green while a read timeout
+    starts market-closing real positions. Five OTHER call sites do fetch with a position
+    open; they are outside `_halting`, so they crash rather than trade.
+    """
+    from torchtrade.envs.live.binance import env as binance_env
+
+    trader = MagicMock()
+    trader.get_account_balance.return_value = {
+        "available_balance": 1000.0, "total_margin_balance": 1000.0,
+        "total_wallet_balance": 1000.0}
+    trader.cancel_open_orders.return_value = True
+    trader.close_position.return_value = True
+    trader.get_mark_price.side_effect = ConnectionError("venue unreachable")
+    trader.get_status.return_value = {"position_status": SimpleNamespace(
+        mark_price=50000.0, qty=0.5, side="long", entry_price=49000.0,
+        unrealized_pnl=500.0, leverage=5.0, liquidation_price=40000.0)}
+
+    env = _build_env_with(binance_env.BinanceFuturesTorchTradingEnv, binance_env, trader)
+    assert env is not None
+    trader.get_mark_price.reset_mock()
+
+    env._acquire_pre_trade_state()
+    trader.get_mark_price.assert_not_called()
+
+
+@pytest.mark.parametrize("flat_at_reset", [True, False],
+                         ids=["reset-is-not-halt-wrapped", "step-flattens-a-real-position"])
+def test_what_a_short_observation_costs_under_flatten(flat_at_reset):
+    """#400's raise is cheap at reset and expensive mid-episode. Pin both.
+
+    `_reset` calls `_get_observation` UNWRAPPED (`futures_live_base.py:568`), so a config
+    that can never fill its window surfaces as a bare ValueError while flat -- that is the
+    half that makes the escalation acceptable, and nothing drove it before.
+
+    `_acquire_post_bar_state` does wrap it, so the SAME raise mid-episode market-closes an
+    open position under FLATTEN. That cost is opt-in (HALT is the default and leaves the
+    position alone), but it must not become opt-out by accident: the `+50` fetch buffer is
+    a fixed candle count, so on a 1m leg it is ~50 minutes of bad feed, not an outage.
+    """
+    from torchtrade.envs.live.binance import env as binance_env
+
+    trader = MagicMock()
+    trader.get_account_balance.return_value = {
+        "available_balance": 1000.0, "total_margin_balance": 1000.0,
+        "total_wallet_balance": 1000.0}
+    trader.get_mark_price.return_value = 50000.0
+    trader.cancel_open_orders.return_value = True
+    trader.close_position.return_value = True
+    trader.get_status.return_value = {"position_status": None}
+
+    env = _build_env_with(binance_env.BinanceFuturesTorchTradingEnv, binance_env, trader)
+    assert env is not None
+    env.config.observation_failure_policy = ObservationFailurePolicy.FLATTEN
+
+    # The observer now returns a window SHORT of the declared (10, 4) spec.
+    env.observer.get_observations.side_effect = lambda return_base_ohlc=False: (_ for _ in ()
+        ).throw(ValueError("only 4 usable candles for BTCUSDT on 1m, need 10"))
+
+    trader.close_position.reset_mock()
+    if flat_at_reset:
+        with pytest.raises(ValueError) as excinfo:
+            env.reset()
+        assert not isinstance(excinfo.value, LiveObservationHalt), (
+            "reset must NOT route through _halting: a metadata gap would then "
+            "market-flatten on every episode start"
+        )
+        assert trader.close_position.call_count == 0
+    else:
+        with pytest.raises(LiveObservationHalt):
+            env._acquire_post_bar_state()
+        assert trader.close_position.call_count == 1
+
+
 def test_the_pre_trade_tuple_cannot_be_reordered_unnoticed():
     """Eight sites unpack one 4-tuple, and only okx would notice a swap.
 
@@ -2837,23 +2922,15 @@ def test_no_live_env_re_forks_the_shared_accessors():
     """
     from torchtrade.envs.core.live import TorchTradeLiveEnv
 
-    shared = [
-        ("get_account_state", LIVE_ENVS, TorchTradeLiveEnv),
-        ("get_market_data_keys", LIVE_ENVS, TorchTradeLiveEnv),
-        # A venue that re-forks these keeps the #394 bypass: `_current_mark_price` is
-        # what converts a fetch failure into a type `_halting` catches, and the sibling
-        # source grep only reads env.py / env_sltp.py.
-        ("_current_mark_price", FUTURES_ENVS, TorchTradeFuturesLiveEnv),
-        ("_halting", FUTURES_ENVS, TorchTradeFuturesLiveEnv),
-    ]
-    for name, envs, owner in shared:
+    for name in ("get_account_state", "get_market_data_keys"):
         wrong_owner = {
             c.__name__: next(b for b in c.__mro__ if name in b.__dict__).__name__
-            for c in envs
-            if next((b for b in c.__mro__ if name in b.__dict__), None) is not owner
+            for c in LIVE_ENVS
+            if next((b for b in c.__mro__ if name in b.__dict__), None)
+            is not TorchTradeLiveEnv
         }
         assert not wrong_owner, (
-            f"{name} does not resolve to {owner.__name__} on: {wrong_owner}"
+            f"{name} does not resolve to TorchTradeLiveEnv on: {wrong_owner}"
         )
 
 

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -1862,6 +1862,28 @@ def test_an_unusable_mark_price_cannot_size_a_trade(source, price):
         TorchTradeFuturesLiveEnv._current_mark_price(env, position_status)
 
 
+@pytest.mark.parametrize("venue_error", [
+    pytest.param(RuntimeError("venue unreachable"), id="wrapped"),
+    pytest.param(ConnectionError("socket closed"), id="raw-sdk"),
+    pytest.param(KeyError("markPrice"), id="malformed-payload"),
+])
+def test_a_mark_price_that_cannot_be_read_raises_what_halting_catches(venue_error):
+    """#394: no adapter raised a type `_halting` catches, so the policy was bypassed.
+
+    `_halting` catches (PositionUnknownError, ValueError) and deliberately not
+    RuntimeError, which adapters use for timeouts. Failing to READ the mark is the same
+    event as reading an unusable one above, so it must raise the same way. The three
+    shapes are three exception families: narrowing the catch to RuntimeError, or to
+    (RuntimeError, OSError), lets one of them escape again.
+    """
+    env = SimpleNamespace(
+        trader=SimpleNamespace(get_mark_price=MagicMock(side_effect=venue_error)),
+        config=SimpleNamespace(symbol="BTCUSDT"),
+    )
+    with pytest.raises(ValueError, match="could not read the mark price"):
+        TorchTradeFuturesLiveEnv._current_mark_price(env, None)
+
+
 @pytest.mark.parametrize("exchange", ["binance", "bitget", "bybit", "okx"])
 @pytest.mark.parametrize("module", ["env", "env_sltp"])
 def test_no_futures_env_reads_the_mark_price_unvalidated(exchange, module):
@@ -2815,15 +2837,23 @@ def test_no_live_env_re_forks_the_shared_accessors():
     """
     from torchtrade.envs.core.live import TorchTradeLiveEnv
 
-    for name in ("get_account_state", "get_market_data_keys"):
+    shared = [
+        ("get_account_state", LIVE_ENVS, TorchTradeLiveEnv),
+        ("get_market_data_keys", LIVE_ENVS, TorchTradeLiveEnv),
+        # A venue that re-forks these keeps the #394 bypass: `_current_mark_price` is
+        # what converts a fetch failure into a type `_halting` catches, and the sibling
+        # source grep only reads env.py / env_sltp.py.
+        ("_current_mark_price", FUTURES_ENVS, TorchTradeFuturesLiveEnv),
+        ("_halting", FUTURES_ENVS, TorchTradeFuturesLiveEnv),
+    ]
+    for name, envs, owner in shared:
         wrong_owner = {
             c.__name__: next(b for b in c.__mro__ if name in b.__dict__).__name__
-            for c in LIVE_ENVS
-            if next((b for b in c.__mro__ if name in b.__dict__), None)
-            is not TorchTradeLiveEnv
+            for c in envs
+            if next((b for b in c.__mro__ if name in b.__dict__), None) is not owner
         }
         assert not wrong_owner, (
-            f"{name} does not resolve to TorchTradeLiveEnv on: {wrong_owner}"
+            f"{name} does not resolve to {owner.__name__} on: {wrong_owner}"
         )
 
 
@@ -3406,65 +3436,3 @@ def test_an_observer_disagreeing_with_the_config_raises_rather_than_guessing():
         BinanceFuturesTorchTradingEnv, "_wait_for_next_timestamp"
     ), pytest.raises(ValueError, match="zip"):
         BinanceFuturesTorchTradingEnv(config=config, observer=observer, trader=trader)
-
-
-
-
-@pytest.mark.parametrize("venue_error", [
-    pytest.param(RuntimeError("venue unreachable"), id="wrapped-RuntimeError"),
-    pytest.param(ConnectionError("socket closed"), id="raw-sdk-exception"),
-    pytest.param(KeyError("markPrice"), id="malformed-payload"),
-], )
-@pytest.mark.parametrize("policy", ["halt", "flatten"])
-def test_a_mark_price_that_cannot_be_read_engages_the_failure_policy(venue_error, policy):
-    """`_halting` catches (PositionUnknownError, ValueError), deliberately NOT RuntimeError.
-
-    binance and bitget wrap a mark-price fetch failure in RuntimeError; bybit and okx do
-    not wrap it at all. Either way the raw type escaped `_halting`, so
-    ObservationFailurePolicy was never consulted -- measured BYPASSED under both HALT and
-    FLATTEN on a FLAT account, which is the only branch that re-fetches the mark (#394).
-
-    Flat is also why converting it is safe: FLATTEN has nothing to close, and HALT gets
-    the structured signal orchestration is built to catch.
-    """
-    from torchtrade.envs.core.live import LiveObservationHalt, ObservationFailurePolicy
-    from torchtrade.envs.live.binance.env import (
-        BinanceFuturesTorchTradingEnv,
-        BinanceFuturesTradingEnvConfig,
-    )
-
-    observer = MagicMock()
-    observer.get_keys.return_value = ["1Minute_10"]
-    observer.get_features.return_value = {
-        "observation_features": ["a", "b", "c", "d"], "original_features": []}
-    observer.get_observations.return_value = {
-        "1Minute_10": np.zeros((10, 4), dtype=np.float32)}
-    observer.reset.return_value = None
-
-    trader = MagicMock()
-    trader.get_account_balance.return_value = {
-        "available_balance": 1000.0, "total_margin_balance": 1000.0,
-        "total_wallet_balance": 1000.0,
-    }
-    trader.get_status.return_value = {"position_status": None}  # flat
-    trader.cancel_open_orders.return_value = True
-    trader.close_position.return_value = True
-    trader.get_mark_price.side_effect = venue_error
-
-    config = BinanceFuturesTradingEnvConfig(
-        symbol="BTCUSDT", time_frames=["1m"], window_sizes=[10], execute_on="1m",
-        observation_failure_policy=policy,
-    )
-    with patch("time.sleep"), patch.object(
-        BinanceFuturesTorchTradingEnv, "_wait_for_next_timestamp"
-    ):
-        env = BinanceFuturesTorchTradingEnv(
-            config=config, observer=observer, trader=trader
-        )
-
-    td = env.reset()
-    td["action"] = torch.tensor(1)
-    with pytest.raises(LiveObservationHalt):
-        env.step(td)
-    if config.observation_failure_policy is ObservationFailurePolicy.FLATTEN:
-        trader.close_position.assert_called()

--- a/torchtrade/envs/live/alpaca/observation.py
+++ b/torchtrade/envs/live/alpaca/observation.py
@@ -193,10 +193,10 @@ class AlpacaObservationClass:
                 # each guarded by isfinite and `<= 0`. If the newest bar was dropped,
                 # `[-1]` is the PREVIOUS bar and those guards pass on a stale price.
                 #
-                # Here, not per-timeframe: raising in the general read runs under
-                # `_halting`, where FLATTEN emergency-closes a real position -- the
-                # lesson `futures_live_base._current_mark_price` already records. Only
-                # the default fn: a custom one may resample or trim the forming bar.
+                # Here, not per-timeframe. Alpaca has no ObservationFailurePolicy, so
+                # this ends the step rather than flattening -- the futures copy of this
+                # guard carries that cost, see `futures_base_obs`. Only the default fn:
+                # a custom one may resample or trim the forming bar.
                 if self.feature_preprocessing_fn == self._default_preprocessing:
                     _kept = _timestamps_of(processed_df, 'timestamp')
                     _fetched = _timestamps_of(df, 'timestamp')

--- a/torchtrade/envs/live/alpaca/observation.py
+++ b/torchtrade/envs/live/alpaca/observation.py
@@ -176,14 +176,15 @@ class AlpacaObservationClass:
             
             processed_df = self.feature_preprocessing_fn(df)
 
-            # An empty observation is never valid, whatever the preprocessing fn is.
-            # The stale-bar check below cannot see this case -- there is no last row to
-            # compare -- so without it a total outage returned a silent (0, n) array and
-            # `base_features[-1, 3]` raised IndexError from inside the trade path.
-            if processed_df.empty:
+            # `iloc[-window_size:]` is a silent short read, not an error: preprocessing
+            # drops rows, so a burst of malformed candles exceeding the +50 fetch buffer
+            # emitted an array SHORTER than the declared spec and reset()/rollout() both
+            # succeeded (#400). Empty is only its degenerate case -- that one surfaced as
+            # an IndexError from `base_features[-1, 3]` inside the trade path (#397).
+            if len(processed_df) < window_size:
                 raise ValueError(
-                    f"no usable candles for {self.symbol} on "
-                    f"{timeframe.obs_key_freq()} after preprocessing"
+                    f"only {len(processed_df)} usable candles for {self.symbol} on "
+                    f"{timeframe.obs_key_freq()} after preprocessing, need {window_size}"
                 )
 
             # Sliced from the SAME frame as the market data, so row i of each is the

--- a/torchtrade/envs/live/alpaca/observation.py
+++ b/torchtrade/envs/live/alpaca/observation.py
@@ -176,11 +176,10 @@ class AlpacaObservationClass:
             
             processed_df = self.feature_preprocessing_fn(df)
 
-            # `iloc[-window_size:]` is a silent short read, not an error: preprocessing
-            # drops rows, so a burst of malformed candles exceeding the +50 fetch buffer
-            # emitted an array SHORTER than the declared spec and reset()/rollout() both
-            # succeeded (#400). Empty is only its degenerate case -- that one surfaced as
-            # an IndexError from `base_features[-1, 3]` inside the trade path (#397).
+            # A short frame is a silent shape corruption, not an error: `iloc[-w:]` just
+            # returns fewer rows, and reset() and rollout() both succeed on it (#400).
+            # Alpaca has no ObservationFailurePolicy, so this ends the step rather than
+            # flattening, and a config that can never fill the window raises at reset().
             if len(processed_df) < window_size:
                 raise ValueError(
                     f"only {len(processed_df)} usable candles for {self.symbol} on "

--- a/torchtrade/envs/live/shared/futures_base_obs.py
+++ b/torchtrade/envs/live/shared/futures_base_obs.py
@@ -306,14 +306,15 @@ class BaseFuturesObservationClass(ABC):
 
             processed_df = self.feature_preprocessing_fn(df)
 
-            # An empty observation is never valid, whatever the preprocessing fn is.
-            # The stale-bar check below cannot see this case -- there is no last row to
-            # compare -- so without it a total outage returned a silent (0, n) array and
-            # `base_features[-1, 3]` raised IndexError from inside the trade path.
-            if processed_df.empty:
+            # `iloc[-window_size:]` is a silent short read, not an error: preprocessing
+            # drops rows, so a burst of malformed candles exceeding the +50 fetch buffer
+            # emitted an array SHORTER than the declared spec and reset()/rollout() both
+            # succeeded (#400). Empty is only its degenerate case -- that one surfaced as
+            # an IndexError from `base_features[-1, 3]` inside the trade path (#397).
+            if len(processed_df) < window_size:
                 raise ValueError(
-                    f"no usable candles for {self.symbol} on "
-                    f"{timeframe.obs_key_freq()} after preprocessing"
+                    f"only {len(processed_df)} usable candles for {self.symbol} on "
+                    f"{timeframe.obs_key_freq()} after preprocessing, need {window_size}"
                 )
 
             # Sliced from the SAME frame as the market data, so row i of each is the

--- a/torchtrade/envs/live/shared/futures_base_obs.py
+++ b/torchtrade/envs/live/shared/futures_base_obs.py
@@ -306,11 +306,13 @@ class BaseFuturesObservationClass(ABC):
 
             processed_df = self.feature_preprocessing_fn(df)
 
-            # `iloc[-window_size:]` is a silent short read, not an error: preprocessing
-            # drops rows, so a burst of malformed candles exceeding the +50 fetch buffer
-            # emitted an array SHORTER than the declared spec and reset()/rollout() both
-            # succeeded (#400). Empty is only its degenerate case -- that one surfaced as
-            # an IndexError from `base_features[-1, 3]` inside the trade path (#397).
+            # A short frame is a silent shape corruption, not an error: `iloc[-w:]` just
+            # returns fewer rows, and reset() and rollout() both succeed on it (#400).
+            # This raise runs under `_halting`, so FLATTEN closes an OPEN position --
+            # measured, and accepted: a window short of its spec is not a market view,
+            # which is the event FLATTEN exists for. It takes 50 of 60 candles malformed
+            # to get here (the +50 fetch buffer absorbs the rest), and a config that can
+            # NEVER fill the window raises at reset(), flat, with nothing to close.
             if len(processed_df) < window_size:
                 raise ValueError(
                     f"only {len(processed_df)} usable candles for {self.symbol} on "

--- a/torchtrade/envs/live/shared/futures_base_obs.py
+++ b/torchtrade/envs/live/shared/futures_base_obs.py
@@ -308,11 +308,16 @@ class BaseFuturesObservationClass(ABC):
 
             # A short frame is a silent shape corruption, not an error: `iloc[-w:]` just
             # returns fewer rows, and reset() and rollout() both succeed on it (#400).
-            # This raise runs under `_halting`, so FLATTEN closes an OPEN position --
-            # measured, and accepted: a window short of its spec is not a market view,
-            # which is the event FLATTEN exists for. It takes 50 of 60 candles malformed
-            # to get here (the +50 fetch buffer absorbs the rest), and a config that can
-            # NEVER fill the window raises at reset(), flat, with nothing to close.
+            #
+            # Know what this costs before widening it. Under the DEFAULT policy (HALT)
+            # it raises and leaves the position alone. Under FLATTEN it market-closes an
+            # open position -- measured -- and the `+50` fetch buffer is a fixed CANDLE
+            # count, so on a 1m leg 50 bad candles is ~50 MINUTES of degraded feed, not
+            # an outage. In a multi-timeframe stack the finest leg decides, since any one
+            # short leg halts the read. That is opt-in, not free: FLATTEN means "if I
+            # cannot see the market, get flat", and a window short of its spec is not a
+            # market view. A config that can never fill the window raises in `_reset`,
+            # which is not halt-wrapped, so it surfaces flat with nothing to close.
             if len(processed_df) < window_size:
                 raise ValueError(
                     f"only {len(processed_df)} usable candles for {self.symbol} on "

--- a/torchtrade/envs/live/shared/futures_live_base.py
+++ b/torchtrade/envs/live/shared/futures_live_base.py
@@ -224,10 +224,9 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
 
         So flat rows do fetch, but NEVER fatally. The first version of this fix called
         `_current_mark_price()` inside the halt wrapper, where a non-positive or missing
-        mark raises -- and under FLATTEN that emergency-closes a real position (bybit and
-        okx raise RuntimeError, which `_halting` does not even catch). A price that only
-        labels a history row is not worth a market order, so an unavailable mark returns
-        None and the caller records the pre-trade price instead.
+        mark raises -- and under FLATTEN that emergency-closes a real position. A price
+        that only labels a history row is not worth a market order, so an unavailable
+        mark returns None and the caller records the pre-trade price instead.
         """
         def read():
             self._last_observed_mark = None
@@ -266,13 +265,10 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
             try:
                 price = self.trader.get_mark_price()
             except Exception as error:
-                # ValueError, not the venue's own type: `_halting` catches
-                # (PositionUnknownError, ValueError) and deliberately NOT RuntimeError,
-                # which adapters use for timeouts. binance and bitget wrap this in
-                # RuntimeError and bybit and okx do not wrap it at all, so the raw type
-                # escaped and ObservationFailurePolicy was never consulted -- measured
-                # BYPASSED under both HALT and FLATTEN (#394). Failing to READ the mark
-                # is the same event as reading an unusable one, so it raises the same way.
+                # `_halting` catches (PositionUnknownError, ValueError) and deliberately
+                # not RuntimeError; no adapter raised either from here, so the policy was
+                # bypassed (#394). Broad on purpose: the shapes span four SDKs, and any
+                # tuple fails open the first time one adds a type.
                 raise ValueError(
                     f"could not read the mark price for {self.config.symbol}: {error}"
                 ) from error

--- a/torchtrade/envs/live/shared/futures_live_base.py
+++ b/torchtrade/envs/live/shared/futures_live_base.py
@@ -260,7 +260,22 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
         Every venue reads its mark as `float(pos.get("markPrice") or entry_price)`, which
         is 0.0 when both fields are blank.
         """
-        price = position_status.mark_price if position_status else self.trader.get_mark_price()
+        if position_status:
+            price = position_status.mark_price
+        else:
+            try:
+                price = self.trader.get_mark_price()
+            except Exception as error:
+                # ValueError, not the venue's own type: `_halting` catches
+                # (PositionUnknownError, ValueError) and deliberately NOT RuntimeError,
+                # which adapters use for timeouts. binance and bitget wrap this in
+                # RuntimeError and bybit and okx do not wrap it at all, so the raw type
+                # escaped and ObservationFailurePolicy was never consulted -- measured
+                # BYPASSED under both HALT and FLATTEN (#394). Failing to READ the mark
+                # is the same event as reading an unusable one, so it raises the same way.
+                raise ValueError(
+                    f"could not read the mark price for {self.config.symbol}: {error}"
+                ) from error
         if not math.isfinite(price) or price <= 0:
             raise ValueError(f"venue reported an unusable mark price ({price})")
         return price

--- a/torchtrade/envs/live/shared/futures_live_base.py
+++ b/torchtrade/envs/live/shared/futures_live_base.py
@@ -266,9 +266,9 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
                 price = self.trader.get_mark_price()
             except Exception as error:
                 # `_halting` catches (PositionUnknownError, ValueError) and deliberately
-                # not RuntimeError; no adapter raised either from here, so the policy was
-                # bypassed (#394). Broad on purpose: the shapes span four SDKs, and any
-                # tuple fails open the first time one adds a type.
+                # not RuntimeError, which adapters use for timeouts -- so the wrapped and
+                # the raw venue errors both escaped it and the policy was bypassed (#394).
+                # Broad on purpose: any tuple fails open the first time an SDK adds a type.
                 raise ValueError(
                     f"could not read the mark price for {self.config.symbol}: {error}"
                 ) from error


### PR DESCRIPTION
Fixes #394 and #400 — both are the live observation-failure path, and the second is one line from the first.

## #394 — a mark-price fetch failure bypassed `ObservationFailurePolicy`

Reproduced before fixing, on a flat account:

```
HALT     -> RuntimeError: policy BYPASSED
FLATTEN  -> RuntimeError: policy BYPASSED
```

`_halting` catches `(PositionUnknownError, ValueError)` and deliberately **not** `RuntimeError`, because adapters wrap timeouts in it. No adapter raised either type from this call, so whatever the SDK produced escaped and the configured policy was never consulted. Orchestration built around catching `LiveObservationHalt` got an uncontrolled crash instead.

Failing to *read* the mark is the same event as reading an unusable one, and the latter already raises `ValueError` two lines down. So the fetch raises the same way, in the shared base, covering all four venues at once.

**On the safety of converting the type:** `_current_mark_price` itself is *not* flat-gated — five call sites in `binance/env.py`, `bitget/env.py`, `bybit/env.py`, `bybit/env_sltp.py` and `okx/env_sltp.py` fetch the mark with a position open. They are outside `_halting`, so the type change is inert there: an exception propagates uncaught exactly as before, with identical `close_position` counts measured on both sides. The only `_halting`-reachable caller is `_acquire_pre_trade_state`, which passes `position_status` and therefore takes the fetch branch only when flat. `close_position()` *is* invoked under FLATTEN, but every adapter re-reads the venue and returns early when flat, so no market order results.

(An earlier version of this description claimed the branch "only runs when flat", that "bybit and okx don't wrap it at all", and that "FLATTEN has nothing to close". Review measured all three false; the paragraph above is what the measurements actually support.)

## #400 — an observation shorter than the declared spec

`get_observations` slices `iloc[-window_size:]` with no length check. Preprocessing drops rows, so a burst of malformed candles exceeding the `+50` fetch buffer emitted an array shorter than the spec, and `reset()` and `rollout()` both succeeded on it silently.

The existing empty-frame check turns out to be the degenerate case of this one, so `if processed_df.empty` is **replaced** rather than joined. Applied to both copies: the shared futures base and alpaca's hand-rolled one.

## Tests

The #394 test sits at the `_current_mark_price` level next to its sibling, not at env level — the first version asserted `close_position.assert_called()` under FLATTEN, which `close_position_on_init=True` already satisfies at construction. Disabling `_halting`'s flatten dispatch entirely left all six cases green.

All three error shapes are kept because each is a distinct exception family: narrowing the catch to `RuntimeError` fails 2 of 3, to `(RuntimeError, OSError)` fails 1 of 3.

The #400 test goes in `base_exchange_tests.py`, which all five venues inherit. Alpaca's copy had no coverage at all — reverting it alone fails `[malformed-burst]` while `[total-outage]` still passes, which is what proves the new case is load-bearing rather than decorative.

`test_no_live_env_re_forks_the_shared_accessors` now also covers `_current_mark_price` and `_halting`. Verified it catches a re-fork into `base.py`, which the sibling source grep cannot see.

Full suite: **3929 passed, 16 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
