### PR TITLE
fix(sltp): mirror short bracket magnitudes instead of swapping the lists

### DIFF
--- a/docs/environments/offline.md
+++ b/docs/environments/offline.md
@@ -191,11 +191,19 @@ Extends `SequentialTradingEnv` with **bracket order risk management**. Supports 
 
 ### Configuration
 
+Short actions **mirror** their long counterpart: action *k* short carries the same risk
+and reward as action *k* long, with the stop above entry and the target below. Before
+#279 the two level lists were swapped rather than negated, so short *k* carried long
+*k*'s risk and reward **exchanged** — with the levels below, long stops were
+{2%, 5%} while short stops were {5%, 10%}, and no short action had a 2% stop at all.
+The action-space size is unchanged, so an SLTP checkpoint trained before that fix loads
+without complaint and trades a different strategy. **Retrain rather than reload.**
+
 ```python
 from torchtrade.envs.offline import SequentialTradingEnvSLTP, SequentialTradingEnvSLTPConfig
 
 config = SequentialTradingEnvSLTPConfig(
-    stoploss_levels=[-0.02, -0.05],
+    stoploss_levels=[-0.02, -0.05],   # magnitudes apply to BOTH directions
     takeprofit_levels=[0.05, 0.10],
     include_hold_action=True,
 

--- a/docs/environments/offline.md
+++ b/docs/environments/offline.md
@@ -193,11 +193,9 @@ Extends `SequentialTradingEnv` with **bracket order risk management**. Supports 
 
 Short actions **mirror** their long counterpart: action *k* short carries the same risk
 and reward as action *k* long, with the stop above entry and the target below. Before
-#279 the two level lists were swapped rather than negated, so short *k* carried long
-*k*'s risk and reward **exchanged** — with the levels below, long stops were
-{2%, 5%} while short stops were {5%, 10%}, and no short action had a 2% stop at all.
-The action-space size is unchanged, so an SLTP checkpoint trained before that fix loads
-without complaint and trades a different strategy. **Retrain rather than reload.**
+#279 the levels were swapped rather than negated, so short *k* carried long *k*'s risk
+and reward exchanged. The action-space size is unchanged either way, so a checkpoint
+trained before that fix loads without complaint. **Retrain rather than reload.**
 
 ```python
 from torchtrade.envs.offline import SequentialTradingEnvSLTP, SequentialTradingEnvSLTPConfig

--- a/tests/envs/binance/test_torch_env_futures_sltp.py
+++ b/tests/envs/binance/test_torch_env_futures_sltp.py
@@ -473,23 +473,6 @@ class TestCombinatoryActionMap:
         assert sl == -0.02
         assert tp == 0.03
 
-    def test_action_map_short_sign_flip(self):
-        """Test that short actions have flipped signs."""
-        from torchtrade.envs.utils.action_maps import create_sltp_action_map as combinatory_action_map
-
-        action_map = combinatory_action_map(
-            stoploss_levels=[-0.02],
-            takeprofit_levels=[0.03],
-            include_short_positions=True
-        )
-
-        # Action 2 should be the short action
-        side, sl, tp = action_map[2]
-        assert side == "short"
-        # For shorts: SL is above entry (positive), TP is below entry (negative)
-        assert sl == 0.03  # From takeprofit_levels (positive values become SL for shorts)
-        assert tp == -0.02  # From stoploss_levels (negative values become TP for shorts)
-
 
 class TestMultipleSteps:
     """Test multiple environment steps."""

--- a/tests/envs/binance/test_torch_env_futures_sltp.py
+++ b/tests/envs/binance/test_torch_env_futures_sltp.py
@@ -286,9 +286,9 @@ class TestBinanceFuturesSLTPTorchTradingEnv:
         with patch.object(env, "_wait_for_next_timestamp"):
             env.reset()
 
-            # Action 5: SHORT with flipped SL/TP
-            # For short: SL above entry, TP below entry
-            action_tuple = ("short", 0.03, -0.02)  # Note: already flipped in action_map
+            # A short tuple as the action map emits it: SL above entry, TP below,
+            # already signed against the position (negated from the levels, #279).
+            action_tuple = ("short", 0.03, -0.02)
             trade_info = env._execute_trade_if_needed(action_tuple)
 
             if trade_info["executed"]:

--- a/tests/envs/binance/test_torch_env_futures_sltp.py
+++ b/tests/envs/binance/test_torch_env_futures_sltp.py
@@ -159,7 +159,7 @@ class TestBinanceFuturesSLTPTorchTradingEnv:
 
     def test_action_map_short_actions(self, env):
         """Test action map short actions."""
-        # Actions 5-8 should be SHORT with flipped SL/TP
+        # Actions 5-8 should be SHORT, with SL/TP negated (#279)
         for i in range(5, 9):
             side, sl, tp = env.action_map[i]
             assert side == "short"

--- a/tests/envs/bitget/test_torch_env_futures_sltp.py
+++ b/tests/envs/bitget/test_torch_env_futures_sltp.py
@@ -173,7 +173,7 @@ class TestBitgetFuturesSLTPTorchTradingEnv:
 
     def test_action_map_short_actions(self, env):
         """Test action map short actions."""
-        # Actions 5-8 should be SHORT with flipped SL/TP
+        # Actions 5-8 should be SHORT, with SL/TP negated (#279)
         for i in range(5, 9):
             side, sl, tp = env.action_map[i]
             assert side == "short"

--- a/tests/envs/offline/test_sequential_sltp.py
+++ b/tests/envs/offline/test_sequential_sltp.py
@@ -1370,8 +1370,8 @@ class TestLiquidationVsBracketOnADoubleBreachBar:
         low = wick_low if wick_low is not None else 100.0
         high = wick_high if wick_high is not None else 100.0
         # action[1] is the stop pct the action map hands the bracket calculator, already
-        # signed per side (negative long, positive short) -- not stoploss_levels[0], which
-        # the map SWAPS with the take-profit for shorts.
+        # signed per side (negative long, positive short) -- not stoploss_levels[0],
+        # which the map NEGATES for shorts.
         price = 100.0 * (1 + action[1]) if stop_wins else getattr(env, armed)
         assert low <= price <= high, (
             f"{armed}={price} sits outside the bar [{low}, {high}] -- this row no "

--- a/tests/envs/offline/test_sequential_sltp.py
+++ b/tests/envs/offline/test_sequential_sltp.py
@@ -129,13 +129,14 @@ class TestSLTPActionSpace:
         }
         assert actual_long_combinations == expected_long_combinations
 
-        # Check short combinations have swapped SL/TP (issue #149)
+        # Shorts NEGATE rather than swap, so short k mirrors long k (#279). Sides are
+        # unchanged from #149: SL above entry (positive), TP below (negative).
         if trading_mode != 1:  # futures
             expected_short_combinations = {
-                ("short", 0.03, -0.02),   # tp_pct -> sl_pct, sl_pct -> tp_pct
-                ("short", 0.10, -0.02),
-                ("short", 0.03, -0.05),
-                ("short", 0.10, -0.05),
+                ("short", 0.02, -0.03),
+                ("short", 0.02, -0.10),
+                ("short", 0.05, -0.03),
+                ("short", 0.05, -0.10),
             }
             actual_short_combinations = {
                 v for v in env.action_map.values() if v[0] == "short"
@@ -1307,9 +1308,10 @@ class TestLiquidationVsBracketOnADoubleBreachBar:
         # survived, and the understatement grew with leverage.
         assert env.balance == pytest.approx(0.0)
 
-    # The action tuple is spelled out rather than derived: create_sltp_action_map
-    # stores a short as ("short", tp, sl) -- the pair swapped, not negated -- so a
-    # derived tuple raises KeyError rather than opening the wrong position.
+    # The action tuple is spelled out rather than derived, so a mismatch raises KeyError
+    # rather than silently opening a different position. Since #279 a short NEGATES its
+    # levels instead of swapping them, so each short row now carries the same level
+    # lists as the long row it mirrors.
     @pytest.mark.parametrize(
         "action,stoploss_levels,takeprofit_levels,wick_low,wick_high,armed,expected_balance", [
             # 10x long: liquidation 90.4, SL 95, low 88 breaches both.
@@ -1317,7 +1319,7 @@ class TestLiquidationVsBracketOnADoubleBreachBar:
             # 10x short: liquidation 109.6, SL 105, high 112 breaches both. The short
             # branches of _check_liquidation, _check_sltp_trigger and
             # _execute_liquidation are all separate code from the long ones.
-            (("short", 0.05, -0.50), [-0.50], [0.05], None, 112.0, "stop_loss", 5000.0),
+            (("short", 0.05, -0.50), [-0.05], [0.50], None, 112.0, "stop_loss", 5000.0),
             # 10x long: liquidation 90.4 on the low, TP 150 on the high. The SL is put
             # at 50, outside the bar, so the documented SL-before-TP bias cannot mask
             # the TP.
@@ -1325,7 +1327,7 @@ class TestLiquidationVsBracketOnADoubleBreachBar:
             # 10x short: liquidation 109.6 on the high, TP 90 on the low, SL 150
             # outside the bar. Only a mutation scoped to BOTH short and tp reaches
             # this one, which is why it is the quadrant that stayed hidden longest.
-            (("short", 0.50, -0.10), [-0.10], [0.50], 88.0, 112.0, "take_profit", 400.0),
+            (("short", 0.50, -0.10), [-0.50], [0.10], 88.0, 112.0, "take_profit", 400.0),
         ],
         ids=["long-stop", "short-stop", "long-take-profit", "short-take-profit"],
     )
@@ -1424,8 +1426,9 @@ def test_a_deeper_gap_never_leaves_the_account_richer(side, gaps):
     sl, tp = -0.05, 0.50
     balances = [
         _run_sltp(
-            # Shorts carry the pair swapped in the action map (see #279).
-            [HOLD] * 5 + [(side, sl, tp) if side == "long" else (side, tp, sl)] + [HOLD] * 4,
+            # A short stores its levels negated, not swapped (#279): SL above entry,
+            # TP below, same magnitudes as the long.
+            [HOLD] * 5 + [(side, sl, tp) if side == "long" else (side, -sl, -tp)] + [HOLD] * 4,
             leverage=10, sl_levels=[sl], tp_levels=[tp],
             wick_low=g if side == "long" else None,
             wick_high=g if side == "short" else None,
@@ -1457,7 +1460,7 @@ def test_every_gap_past_bankruptcy_costs_exactly_the_posted_margin(side, wick, d
     """
     def run(open_price, low_or_high):
         return _run_sltp(
-            [HOLD] * 5 + [(side, -0.05, 0.50) if side == "long" else (side, 0.50, -0.05)] + [HOLD] * 4,
+            [HOLD] * 5 + [(side, -0.05, 0.50) if side == "long" else (side, 0.05, -0.50)] + [HOLD] * 4,
             leverage=10, sl_levels=[-0.05], tp_levels=[0.50],
             wick_low=low_or_high if side == "long" else None,
             wick_high=low_or_high if side == "short" else None,

--- a/tests/envs/offline/test_vec_sltp_scalar_equivalence.py
+++ b/tests/envs/offline/test_vec_sltp_scalar_equivalence.py
@@ -604,11 +604,12 @@ class TestSLTPScalarVecEquivalencePriority:
             ("long", [-0.15], [0.50], 84.0, None, None, "liquidation"),    # stop 85, beyond
             ("long", [-0.05], [0.50], 85.0, None, 85.0, "liquidation"),    # gapped past it
             ("long", [-0.50], [0.10], 88.0, 112.0, None, "liquidation"),   # take-profit loses
-            # 10x SHORT at 100, liquidation 109.6. Every short branch is separate code,
-            # and a vec-only short regression is what this file exists to catch. Since
-            # #279 a short negates its levels, so these mirror the long rows exactly --
-            # and note only the first row FAILED when the swap went: the other two kept
-            # passing with their stop moved to 150, i.e. liquidating for the wrong reason.
+            # 10x SHORT at 100, liquidation 109.6. Every short branch is separate code.
+            # Since #279 a short negates its levels, so these mirror the long rows.
+            # Only the FIRST row discriminates that fix: reintroduce the swap and the
+            # other two still pass, because liquidation fires wherever the wrongly moved
+            # stop lands. They earn their place on exit-PRIORITY parity (#298, #300),
+            # which is this file's subject -- not on #279.
             ("short", [-0.05], [0.50], None, 112.0, None, "sltp_sl"),      # stop 105, inside
             ("short", [-0.15], [0.50], None, 116.0, None, "liquidation"),  # stop 115, beyond
             ("short", [-0.05], [0.50], None, 115.0, 115.0, "liquidation"), # gapped past it

--- a/tests/envs/offline/test_vec_sltp_scalar_equivalence.py
+++ b/tests/envs/offline/test_vec_sltp_scalar_equivalence.py
@@ -605,10 +605,13 @@ class TestSLTPScalarVecEquivalencePriority:
             ("long", [-0.05], [0.50], 85.0, None, 85.0, "liquidation"),    # gapped past it
             ("long", [-0.50], [0.10], 88.0, 112.0, None, "liquidation"),   # take-profit loses
             # 10x SHORT at 100, liquidation 109.6. Every short branch is separate code,
-            # and a vec-only short regression is what this file exists to catch.
-            ("short", [-0.50], [0.05], None, 112.0, None, "sltp_sl"),      # stop 105, inside
-            ("short", [-0.50], [0.15], None, 116.0, None, "liquidation"),  # stop 115, beyond
-            ("short", [-0.50], [0.05], None, 115.0, 115.0, "liquidation"), # gapped past it
+            # and a vec-only short regression is what this file exists to catch. Since
+            # #279 a short negates its levels, so these mirror the long rows exactly --
+            # and note only the first row FAILED when the swap went: the other two kept
+            # passing with their stop moved to 150, i.e. liquidating for the wrong reason.
+            ("short", [-0.05], [0.50], None, 112.0, None, "sltp_sl"),      # stop 105, inside
+            ("short", [-0.15], [0.50], None, 116.0, None, "liquidation"),  # stop 115, beyond
+            ("short", [-0.05], [0.50], None, 115.0, 115.0, "liquidation"), # gapped past it
         ],
         ids=["long-stop-inside", "long-stop-beyond", "long-gapped", "long-take-profit",
              "short-stop-inside", "short-stop-beyond", "short-gapped"],

--- a/tests/envs/test_sltp_short_symmetry_279.py
+++ b/tests/envs/test_sltp_short_symmetry_279.py
@@ -80,7 +80,8 @@ def test_a_side_the_bracket_calculator_does_not_know_is_refused(side):
     The percentages arrive already oriented against the position, so passing "flat" or a
     miscapitalised "Long" would price a bracket off the OTHER direction's numbers and
     return silently. Nothing exercised this: collapsing the two per-side functions left
-    the check as the only thing `side` still does, and deleting it kept 861 tests green.
+    the check as the only thing `side` still does, and deleting it left the other 3974
+    tests green.
     """
     with pytest.raises(ValueError, match="Invalid side"):
         calculate_bracket_prices(side, 100.0, -0.02, 0.05)
@@ -93,27 +94,49 @@ ALPACA_SLTP_KWARGS = dict(symbol="BTC/USD", time_frames=["1m"], window_sizes=[10
 
 
 def _sltp_configs():
-    """Every config that feeds create_sltp_action_map, offline and live."""
+    """The DISTINCT __post_init__ implementations that guard the levels.
+
+    Binance/Bitget/Bybit/OKX all inherit `BaseFuturesSLTPConfig.__post_init__` unchanged,
+    so running four of them is the same bytecode relabelled four times. Binance stands in
+    for the shared base; `test_no_futures_sltp_config_reforks_the_level_guard` below is
+    what keeps the other three honest, and it costs an identity check rather than a
+    construction.
+    """
     from torchtrade.envs.offline import SequentialTradingEnvSLTPConfig
     from torchtrade.envs.offline.vectorized_sequential_sltp import (
         VectorizedSequentialTradingEnvSLTPConfig)
     from torchtrade.envs.live.binance.env_sltp import BinanceFuturesSLTPTradingEnvConfig
-    from torchtrade.envs.live.bitget.env_sltp import BitgetFuturesSLTPTradingEnvConfig
-    from torchtrade.envs.live.bybit.env_sltp import BybitFuturesSLTPTradingEnvConfig
-    from torchtrade.envs.live.okx.env_sltp import OKXFuturesSLTPTradingEnvConfig
     from torchtrade.envs.live.alpaca.env_sltp import AlpacaSLTPTradingEnvConfig
     return [
         (SequentialTradingEnvSLTPConfig, {}),
         (VectorizedSequentialTradingEnvSLTPConfig, {}),
         (BinanceFuturesSLTPTradingEnvConfig, LIVE_SLTP_KWARGS),
-        (BitgetFuturesSLTPTradingEnvConfig, LIVE_SLTP_KWARGS),
-        (BybitFuturesSLTPTradingEnvConfig, LIVE_SLTP_KWARGS),
-        (OKXFuturesSLTPTradingEnvConfig, LIVE_SLTP_KWARGS),
         # Long-only, so it never reaches the negation -- but a positive stop level
         # inverts its LONG bracket just the same, and its guard was the one the first
         # version of this list forgot, which the mutation caught.
         (AlpacaSLTPTradingEnvConfig, ALPACA_SLTP_KWARGS),
     ]
+
+
+@pytest.mark.parametrize("venue", ["bitget", "bybit", "okx"])
+def test_no_futures_sltp_config_reforks_the_level_guard(venue):
+    """The three venues the parametrization above drops, held by identity instead.
+
+    They are covered only because they inherit `BaseFuturesSLTPConfig.__post_init__`. A
+    venue that declares its own would silently stop validating its levels while every
+    other test stayed green -- the re-fork shape this repo has shipped three times.
+    """
+    import importlib
+    from torchtrade.envs.live.shared.sltp_config import BaseFuturesSLTPConfig
+
+    module = importlib.import_module(f"torchtrade.envs.live.{venue}.env_sltp")
+    config_cls = next(v for k, v in vars(module).items()
+                      if k.endswith("Config") and hasattr(v, "__dataclass_fields__")
+                      and v.__module__ == module.__name__)
+    assert config_cls.__post_init__ is BaseFuturesSLTPConfig.__post_init__, (
+        f"{config_cls.__name__} re-forks __post_init__, so validate_sltp_levels no "
+        f"longer provably runs for it"
+    )
 
 
 @pytest.mark.parametrize("levels,message", [

--- a/tests/envs/test_sltp_short_symmetry_279.py
+++ b/tests/envs/test_sltp_short_symmetry_279.py
@@ -1,4 +1,4 @@
-"""Short action k is not the mirror of long action k, and it never is (#279)."""
+"""Short action k is the mirror of long action k -- same risk, same reward (#279)."""
 
 import pytest
 
@@ -23,21 +23,20 @@ def _geometry(side, sl_pct, tp_pct):
 
 @pytest.mark.parametrize("stoploss,takeprofit", [
     ([-0.025, -0.05, -0.1], [0.05, 0.1, 0.2]),
-    # Symmetric-LOOKING, and still inverted. An earlier version of this test asserted
-    # this case was fine, because it compared magnitude SETS -- which are equal here --
-    # rather than pairing index against index. Long k=1 risks 5% to make 10%; short k=1
-    # risks 10% to make 5%.
+    # Symmetric-LOOKING, and it was still inverted before the fix: comparing magnitude
+    # SETS passes here, because they are equal. Only pairing index against index sees it.
     ([-0.05, -0.1], [0.05, 0.1]),
     # Asymmetric lengths: the relationship is an identity, not an artefact of equal-sized
     # lists -- both halves consume the same product(), so the nth pair always matches.
     ([-0.02, -0.05], [0.03, 0.06, 0.12]),
 ])
-def test_short_k_has_the_risk_and_reward_of_long_k_exchanged(stoploss, takeprofit):
+def test_short_k_mirrors_long_k(stoploss, takeprofit):
     """Measured through calculate_bracket_prices, not by reading the tuple.
 
-    The tuple is `("short", tp, sl)`, and nothing downstream negates it -- the short
-    bracket helper applies `entry * (1 + pct)` directly -- so the swap survives all the
-    way to the prices the venue receives.
+    The map was built by SWAPPING the two lists, which puts the sides right and the
+    magnitudes wrong: short k carried long k's risk and reward exchanged. It negates now.
+    Nothing downstream re-negates -- the bracket helper applies `entry * (1 + pct)`
+    directly -- so what this asserts is what the venue receives.
     """
     action_map = create_sltp_action_map(stoploss, takeprofit, include_short_positions=True)
     longs = [v for v in action_map.values() if v[0] == "long"]
@@ -50,23 +49,21 @@ def test_short_k_has_the_risk_and_reward_of_long_k_exchanged(stoploss, takeprofi
             f"action {k}: a stop on the wrong side of entry (long {long_risk:.4f}, "
             f"short {short_risk:.4f}) -- the bracket is inverted, not merely exchanged"
         )
-        assert (short_risk, short_reward) == pytest.approx((long_reward, long_risk)), (
+        assert (short_risk, short_reward) == pytest.approx((long_risk, long_reward)), (
             f"action {k}: long is {long_risk:.4f}/{long_reward:.4f}, short is "
-            f"{short_risk:.4f}/{short_reward:.4f} -- expected the exchange of the long's"
+            f"{short_risk:.4f}/{short_reward:.4f} -- expected the same geometry"
         )
 
 
-def test_no_short_action_offers_the_tightest_long_stop():
-    """The consequence that matters: a geometry available to longs is unreachable short."""
+def test_every_long_geometry_is_reachable_short():
+    """The consequence that mattered: no short action had a 2.5% stop anywhere."""
     action_map = create_sltp_action_map(
         [-0.025, -0.05, -0.1], [0.05, 0.1, 0.2], include_short_positions=True
     )
     long_stops = {round(_geometry(*v)[0], 6) for v in action_map.values() if v[0] == "long"}
     short_stops = {round(_geometry(*v)[0], 6) for v in action_map.values() if v[0] == "short"}
 
-    assert 0.025 in long_stops and 0.025 not in short_stops
-    assert long_stops == {0.025, 0.05, 0.1}
-    assert short_stops == {0.05, 0.1, 0.2}
+    assert long_stops == short_stops == {0.025, 0.05, 0.1}
 
 
 def test_an_empty_level_list_still_builds_a_hold_only_map():

--- a/tests/envs/test_sltp_short_symmetry_279.py
+++ b/tests/envs/test_sltp_short_symmetry_279.py
@@ -71,3 +71,51 @@ def test_an_empty_level_list_still_builds_a_hold_only_map():
     assert create_sltp_action_map([], [0.05], include_short_positions=True) == {
         0: (None, None, None)
     }
+
+
+LIVE_SLTP_KWARGS = dict(symbol="BTCUSDT", time_frames=["1m"], window_sizes=[10],
+                        execute_on="1m")
+ALPACA_SLTP_KWARGS = dict(symbol="BTC/USD", time_frames=["1m"], window_sizes=[10],
+                          execute_on="1m")
+
+
+def _sltp_configs():
+    """Every config that feeds create_sltp_action_map, offline and live."""
+    from torchtrade.envs.offline import SequentialTradingEnvSLTPConfig
+    from torchtrade.envs.offline.vectorized_sequential_sltp import (
+        VectorizedSequentialTradingEnvSLTPConfig)
+    from torchtrade.envs.live.binance.env_sltp import BinanceFuturesSLTPTradingEnvConfig
+    from torchtrade.envs.live.bitget.env_sltp import BitgetFuturesSLTPTradingEnvConfig
+    from torchtrade.envs.live.bybit.env_sltp import BybitFuturesSLTPTradingEnvConfig
+    from torchtrade.envs.live.okx.env_sltp import OKXFuturesSLTPTradingEnvConfig
+    from torchtrade.envs.live.alpaca.env_sltp import AlpacaSLTPTradingEnvConfig
+    return [
+        (SequentialTradingEnvSLTPConfig, {}),
+        (VectorizedSequentialTradingEnvSLTPConfig, {}),
+        (BinanceFuturesSLTPTradingEnvConfig, LIVE_SLTP_KWARGS),
+        (BitgetFuturesSLTPTradingEnvConfig, LIVE_SLTP_KWARGS),
+        (BybitFuturesSLTPTradingEnvConfig, LIVE_SLTP_KWARGS),
+        (OKXFuturesSLTPTradingEnvConfig, LIVE_SLTP_KWARGS),
+        # Long-only, so it never reaches the negation -- but a positive stop level
+        # inverts its LONG bracket just the same, and its guard was the one the first
+        # version of this list forgot, which the mutation caught.
+        (AlpacaSLTPTradingEnvConfig, ALPACA_SLTP_KWARGS),
+    ]
+
+
+@pytest.mark.parametrize("levels,message", [
+    (dict(stoploss_levels=[0.02], takeprofit_levels=[0.05]), "must be negative"),
+    (dict(stoploss_levels=[-0.02], takeprofit_levels=[-0.05]), "must be positive"),
+], ids=["positive-stoploss", "negative-takeprofit"])
+def test_every_sltp_config_rejects_levels_that_would_invert_the_bracket(levels, message):
+    """The sign convention is what the negation rests on, so it is validated, not assumed.
+
+    `("short", -sl, -tp)` puts each leg on the correct side of entry only because stops
+    are negative and targets positive. A positive stop level inverts the LONG bracket
+    too -- a stop ABOVE entry, exiting on a favourable move. Both offline envs raised
+    here already; the four live futures configs and alpaca's did not, and they are the
+    ones that pass include_short_positions=True.
+    """
+    for config_cls, extra in _sltp_configs():
+        with pytest.raises(ValueError, match=message):
+            config_cls(**extra, **levels)

--- a/tests/envs/test_sltp_short_symmetry_279.py
+++ b/tests/envs/test_sltp_short_symmetry_279.py
@@ -73,6 +73,19 @@ def test_an_empty_level_list_still_builds_a_hold_only_map():
     }
 
 
+@pytest.mark.parametrize("side", ["Long", "flat", "", None], ids=str)
+def test_a_side_the_bracket_calculator_does_not_know_is_refused(side):
+    """One formula now serves both sides, so `side` only guards the caller's intent.
+
+    The percentages arrive already oriented against the position, so passing "flat" or a
+    miscapitalised "Long" would price a bracket off the OTHER direction's numbers and
+    return silently. Nothing exercised this: collapsing the two per-side functions left
+    the check as the only thing `side` still does, and deleting it kept 861 tests green.
+    """
+    with pytest.raises(ValueError, match="Invalid side"):
+        calculate_bracket_prices(side, 100.0, -0.02, 0.05)
+
+
 LIVE_SLTP_KWARGS = dict(symbol="BTCUSDT", time_frames=["1m"], window_sizes=[10],
                         execute_on="1m")
 ALPACA_SLTP_KWARGS = dict(symbol="BTC/USD", time_frames=["1m"], window_sizes=[10],
@@ -107,7 +120,11 @@ def _sltp_configs():
     (dict(stoploss_levels=[0.02], takeprofit_levels=[0.05]), "must be negative"),
     (dict(stoploss_levels=[-0.02], takeprofit_levels=[-0.05]), "must be positive"),
 ], ids=["positive-stoploss", "negative-takeprofit"])
-def test_every_sltp_config_rejects_levels_that_would_invert_the_bracket(levels, message):
+@pytest.mark.parametrize("config_cls,extra", _sltp_configs(),
+                         ids=lambda v: v.__name__ if isinstance(v, type) else "")
+def test_every_sltp_config_rejects_levels_that_would_invert_the_bracket(
+    config_cls, extra, levels, message
+):
     """The sign convention is what the negation rests on, so it is validated, not assumed.
 
     `("short", -sl, -tp)` puts each leg on the correct side of entry only because stops
@@ -115,7 +132,10 @@ def test_every_sltp_config_rejects_levels_that_would_invert_the_bracket(levels, 
     too -- a stop ABOVE entry, exiting on a favourable move. Both offline envs raised
     here already; the four live futures configs and alpaca's did not, and they are the
     ones that pass include_short_positions=True.
+
+    Parametrized over the configs rather than looping: a loop stops at the first failure
+    and names no venue, and the first version of this list silently omitted alpaca --
+    mutating alpaca's guard left every case green.
     """
-    for config_cls, extra in _sltp_configs():
-        with pytest.raises(ValueError, match=message):
-            config_cls(**extra, **levels)
+    with pytest.raises(ValueError, match=message):
+        config_cls(**extra, **levels)

--- a/torchtrade/envs/core/common.py
+++ b/torchtrade/envs/core/common.py
@@ -40,6 +40,28 @@ def validate_position_sizing(
             raise ValueError(f"quantity_per_trade must be positive, got {quantity_per_trade}")
 
 
+def validate_sltp_levels(stoploss_levels, takeprofit_levels) -> None:
+    """Reject SL/TP levels whose sign would invert the bracket.
+
+    The action map NEGATES these for shorts (#279), so the sign convention is what puts
+    each leg on the correct side of entry. A positive stop level silently places a LONG's
+    stop above entry -- an inverted bracket that exits on a favourable move.
+
+    Both offline SLTP envs already raised here; the four live futures configs and alpaca's
+    did not, and they are the ones passing include_short_positions=True.
+    """
+    for sl in stoploss_levels:
+        if sl >= 0:
+            raise ValueError(
+                f"Stop-loss levels must be negative (e.g., -0.05 for 5% loss), got {sl}"
+            )
+    for tp in takeprofit_levels:
+        if tp <= 0:
+            raise ValueError(
+                f"Take-profit levels must be positive (e.g., 0.1 for 10% profit), got {tp}"
+            )
+
+
 def validate_trade_mode(trade_mode: str) -> str:
     """
     Validate trade_mode configuration parameter.

--- a/torchtrade/envs/live/alpaca/env_sltp.py
+++ b/torchtrade/envs/live/alpaca/env_sltp.py
@@ -9,7 +9,11 @@ import torch
 logger = logging.getLogger(__name__)
 from torchtrade.envs.core.state import position_qty_from_status
 from torchtrade.envs.utils.timeframe import TimeFrame, TimeFrameUnit
-from torchtrade.envs.core.common import validate_trade_mode, validate_position_sizing
+from torchtrade.envs.core.common import (
+    validate_position_sizing,
+    validate_sltp_levels,
+    validate_trade_mode,
+)
 from torchtrade.envs.live.alpaca.utils import normalize_alpaca_timeframe_config
 from torchtrade.envs.live.alpaca.observation import AlpacaObservationClass
 from torchtrade.envs.live.alpaca.order_executor import AlpacaOrderClass, TradeMode
@@ -54,6 +58,7 @@ class AlpacaSLTPTradingEnvConfig:
 
     def __post_init__(self):
         self.trade_mode = validate_trade_mode(self.trade_mode)
+        validate_sltp_levels(self.stoploss_levels, self.takeprofit_levels)
         if self.trade_mode == "quantity":
             raise ValueError(
                 "trade_mode='quantity' is not supported for Alpaca SLTP -- its bracket "

--- a/torchtrade/envs/live/bitget/env_sltp.py
+++ b/torchtrade/envs/live/bitget/env_sltp.py
@@ -348,7 +348,7 @@ class BitgetFuturesSLTPTorchTradingEnv(SLTPMixin, BitgetBaseTorchTradingEnv):
         elif side == "short":
             # Open SHORT with SL/TP bracket order
             # Use helper to calculate correct SL/TP for shorts
-            # The action_map already swaps SL/TP for shorts, helper handles this correctly
+            # The action_map already negates SL/TP for shorts, helper handles this correctly
             stop_loss_price, take_profit_price = calculate_bracket_prices(
                 "short", current_price, stop_loss_pct, take_profit_pct
             )

--- a/torchtrade/envs/live/shared/sltp_config.py
+++ b/torchtrade/envs/live/shared/sltp_config.py
@@ -6,6 +6,7 @@ from typing import List, Optional, Tuple, Union
 from torchtrade.envs.core.common import (
     TradeMode,
     validate_position_sizing,
+    validate_sltp_levels,
     validate_trade_mode,
 )
 from torchtrade.envs.core.live import ObservationFailurePolicy
@@ -55,6 +56,7 @@ class BaseFuturesSLTPConfig:
             self.observation_failure_policy
         )
         self.trade_mode = validate_trade_mode(self.trade_mode)
+        validate_sltp_levels(self.stoploss_levels, self.takeprofit_levels)
         validate_position_sizing(
             self.trade_mode, self.position_fraction, self.quantity_per_trade
         )

--- a/torchtrade/envs/offline/sequential_sltp.py
+++ b/torchtrade/envs/offline/sequential_sltp.py
@@ -33,8 +33,7 @@ from torchtrade.envs.core.state import (
     binarize_action_type,
 )
 from torchtrade.envs.utils.sltp_helpers import (
-    calculate_long_bracket_prices,
-    calculate_short_bracket_prices,
+    calculate_bracket_prices,
     stop_fill_price,
 )
 from torchtrade.envs.utils.action_maps import create_sltp_action_map
@@ -578,15 +577,9 @@ class SequentialTradingEnvSLTP(SequentialTradingEnv):
         # Calculate liquidation price (futures only)
         self.liquidation_price = self._calculate_liquidation_price(execution_price, self.position.position_size)
 
-        # Set SLTP brackets using helper functions
-        if side == "long":
-            self.stop_loss, self.take_profit = calculate_long_bracket_prices(
-                execution_price, sl_pct, tp_pct
-            )
-        else:  # short
-            self.stop_loss, self.take_profit = calculate_short_bracket_prices(
-                execution_price, sl_pct, tp_pct
-            )
+        self.stop_loss, self.take_profit = calculate_bracket_prices(
+            side, execution_price, sl_pct, tp_pct
+        )
 
         return {"executed": True, "side": side, "fee_paid": fee, "liquidated": False}
 

--- a/torchtrade/envs/offline/sequential_sltp.py
+++ b/torchtrade/envs/offline/sequential_sltp.py
@@ -27,6 +27,7 @@ from torchtrade.envs.offline.sequential import (
     SequentialTradingEnvConfig,
 )
 from torchtrade.envs.core.common import TradeMode, validate_trade_mode, validate_position_sizing
+from torchtrade.envs.core.common import validate_sltp_levels
 from torchtrade.envs.core.state import (
     advance_hold_counter_from_size,
     binarize_action_type,
@@ -81,16 +82,7 @@ class SequentialTradingEnvSLTPConfig(SequentialTradingEnvConfig):
             self.takeprofit_levels = list(self.takeprofit_levels)
 
         # Validate SL/TP levels
-        for sl in self.stoploss_levels:
-            if sl >= 0:
-                raise ValueError(
-                    f"Stop-loss levels must be negative (e.g., -0.05 for 5% loss), got {sl}"
-                )
-        for tp in self.takeprofit_levels:
-            if tp <= 0:
-                raise ValueError(
-                    f"Take-profit levels must be positive (e.g., 0.1 for 10% profit), got {tp}"
-                )
+        validate_sltp_levels(self.stoploss_levels, self.takeprofit_levels)
 
 
 class SequentialTradingEnvSLTP(SequentialTradingEnv):
@@ -152,12 +144,12 @@ class SequentialTradingEnvSLTP(SequentialTradingEnv):
         self.include_close_action = config.include_close_action
 
         # Build action map for SLTP
-        self.action_map = self._build_action_map(
-            config.stoploss_levels,
-            config.takeprofit_levels,
-            config.include_hold_action,
-            config.include_close_action,
-            allow_short=(config.leverage > 1),  # Futures mode: leverage > 1
+        self.action_map = create_sltp_action_map(
+            stoploss_levels=config.stoploss_levels,
+            takeprofit_levels=config.takeprofit_levels,
+            include_short_positions=(config.leverage > 1),  # Futures mode
+            include_hold_action=config.include_hold_action,
+            include_close_action=config.include_close_action,
         )
 
         # Temporarily set action_levels to a dummy list for parent initialization
@@ -185,27 +177,6 @@ class SequentialTradingEnvSLTP(SequentialTradingEnv):
 
         # Convert action_map to tuple for O(1) indexed lookup (performance optimization)
         self._action_tuple = tuple(self.action_map[i] for i in range(len(self.action_map)))
-
-    def _build_action_map(
-        self,
-        stoploss_levels: List[float],
-        takeprofit_levels: List[float],
-        include_hold_action: bool,
-        include_close_action: bool,
-        allow_short: bool,
-    ) -> Dict[int, Tuple]:
-        """Build action map for SLTP environment.
-
-        Delegates to the shared create_sltp_action_map to ensure consistent
-        SL/TP swapping for short positions across live and offline environments.
-        """
-        return create_sltp_action_map(
-            stoploss_levels=stoploss_levels,
-            takeprofit_levels=takeprofit_levels,
-            include_short_positions=allow_short,
-            include_hold_action=include_hold_action,
-            include_close_action=include_close_action,
-        )
 
     def _reset_position_state(self):
         """Reset position tracking state including SLTP-specific state."""

--- a/torchtrade/envs/offline/sequential_sltp.py
+++ b/torchtrade/envs/offline/sequential_sltp.py
@@ -26,8 +26,7 @@ from torchtrade.envs.offline.sequential import (
     SequentialTradingEnv,
     SequentialTradingEnvConfig,
 )
-from torchtrade.envs.core.common import TradeMode, validate_trade_mode, validate_position_sizing
-from torchtrade.envs.core.common import validate_sltp_levels
+from torchtrade.envs.core.common import TradeMode, validate_trade_mode, validate_position_sizing, validate_sltp_levels
 from torchtrade.envs.core.state import (
     advance_hold_counter_from_size,
     binarize_action_type,

--- a/torchtrade/envs/offline/vectorized_sequential_sltp.py
+++ b/torchtrade/envs/offline/vectorized_sequential_sltp.py
@@ -472,7 +472,7 @@ class VectorizedSequentialTradingEnvSLTP(VectorizedSequentialTradingEnv):
                 # Set bracket prices: entry * (1 + pct)
                 # E.g. Long entry=100, sl_pct=-0.05 → sl_price=95
                 # E.g. Short entry=100, sl_pct=+0.05 → sl_price=105
-                # (create_sltp_action_map already swaps pcts for shorts)
+                # (create_sltp_action_map already negates pcts for shorts)
                 self._sl_prices[final_open] = (
                     trade_prices * (1 + sl_pcts)
                 )[final_open]

--- a/torchtrade/envs/offline/vectorized_sequential_sltp.py
+++ b/torchtrade/envs/offline/vectorized_sequential_sltp.py
@@ -21,8 +21,7 @@ import torch
 from tensordict import TensorDictBase
 from torchrl.data import Categorical
 
-from torchtrade.envs.core.common import TradeMode, validate_trade_mode, validate_position_sizing
-from torchtrade.envs.core.common import validate_sltp_levels
+from torchtrade.envs.core.common import TradeMode, validate_trade_mode, validate_position_sizing, validate_sltp_levels
 from torchtrade.envs.offline.vectorized_sequential import (
     MONEY_DTYPE,
     VectorizedSequentialTradingEnv,

--- a/torchtrade/envs/offline/vectorized_sequential_sltp.py
+++ b/torchtrade/envs/offline/vectorized_sequential_sltp.py
@@ -22,6 +22,7 @@ from tensordict import TensorDictBase
 from torchrl.data import Categorical
 
 from torchtrade.envs.core.common import TradeMode, validate_trade_mode, validate_position_sizing
+from torchtrade.envs.core.common import validate_sltp_levels
 from torchtrade.envs.offline.vectorized_sequential import (
     MONEY_DTYPE,
     VectorizedSequentialTradingEnv,
@@ -64,16 +65,7 @@ class VectorizedSequentialTradingEnvSLTPConfig(VectorizedSequentialTradingEnvCon
 
         super().__post_init__()
 
-        for sl in self.stoploss_levels:
-            if sl >= 0:
-                raise ValueError(
-                    f"Stop-loss levels must be negative (e.g., -0.05 for 5% loss), got {sl}"
-                )
-        for tp in self.takeprofit_levels:
-            if tp <= 0:
-                raise ValueError(
-                    f"Take-profit levels must be positive (e.g., 0.1 for 10% profit), got {tp}"
-                )
+        validate_sltp_levels(self.stoploss_levels, self.takeprofit_levels)
 
 
 class VectorizedSequentialTradingEnvSLTP(VectorizedSequentialTradingEnv):

--- a/torchtrade/envs/utils/README.md
+++ b/torchtrade/envs/utils/README.md
@@ -60,10 +60,12 @@ adds that many again for the short side.
 above entry and the target below with the same magnitudes. Until
 [#279](https://github.com/TorchTrade/torchtrade/issues/279) the two lists were *swapped*
 instead, which got the sides right and the magnitudes wrong — short *k* carried long
-*k*'s risk and reward exchanged, so with `stoploss_levels=(-0.025, -0.05, -0.1)` long
-stops were {2.5, 5, 10}% while short stops were {5, 10, 20}% and no short action had a
-2.5% stop. The action-space size is unchanged either way, so a checkpoint trained before
-that fix loads without complaint and trades a different strategy.
+*k*'s risk and reward exchanged. With `stoploss_levels=(-0.025, -0.05, -0.1)` and
+`takeprofit_levels=(0.05, 0.1, 0.2)`, long stops were {2.5, 5, 10}% while short stops
+were {5, 10, 20}% and no short action had a 2.5% stop. The action-space size is unchanged
+either way, so a checkpoint trained before that fix loads without complaint — and where
+the two magnitudes differ, it then trades a different strategy. Where every pair has
+`tp == -sl` the maps are identical, as they are for any long-only config.
 
 **Example:**
 ```python

--- a/torchtrade/envs/utils/README.md
+++ b/torchtrade/envs/utils/README.md
@@ -63,9 +63,9 @@ instead, which got the sides right and the magnitudes wrong — short *k* carrie
 *k*'s risk and reward exchanged. With `stoploss_levels=(-0.025, -0.05, -0.1)` and
 `takeprofit_levels=(0.05, 0.1, 0.2)`, long stops were {2.5, 5, 10}% while short stops
 were {5, 10, 20}% and no short action had a 2.5% stop. The action-space size is unchanged
-either way, so a checkpoint trained before that fix loads without complaint — and where
-the two magnitudes differ, it then trades a different strategy. Where every pair has
-`tp == -sl` the maps are identical, as they are for any long-only config.
+either way, so a checkpoint trained before that fix loads without complaint and trades a
+different strategy. Retrain — equal magnitude *sets* are not an exemption, since the same
+tuples land at permuted indices and the index is what the policy emits.
 
 **Example:**
 ```python

--- a/torchtrade/envs/utils/README.md
+++ b/torchtrade/envs/utils/README.md
@@ -56,30 +56,14 @@ Neither is a BUY/SELL/HOLD map. Index 0 is the flat/no-bracket action; the long 
 `len(sl) * len(tp)` entries, and `create_sltp_action_map(..., include_short_positions=True)`
 adds that many again for the short side.
 
-**A short action is never the mirror of its long counterpart** — it is the mirror with
-risk and reward exchanged. This is unconditional: both halves iterate the same
-`product(stoploss_levels, takeprofit_levels)`, so the *n*th long and the *n*th short
-always carry the same magnitude pair the other way round. It is only *invisible* when
-every magnitude is equal.
-
-With `stoploss_levels=(-0.025, -0.05, -0.1)` and `takeprofit_levels=(0.05, 0.1, 0.2)` at
-entry 100 — note the map index, since index 0 is HOLD and the short block starts at 10:
-
-| action | tuple | risk / reward |
-|---|---|---|
-| 1 (1st long) | `(-0.025, 0.05)` | 2.5% / 5% |
-| 10 (1st short) | `(0.05, -0.025)` | **5% / 2.5%** |
-| 3 (3rd long) | `(-0.025, 0.2)` | 2.5% / 20% |
-| 12 (3rd short) | `(0.2, -0.025)` | **20% / 2.5%** |
-
-Long stops are {2.5, 5, 10}%; short stops are {5, 10, 20}%. **No short action has a 2.5%
-stop.** A policy that learned "tight stop, wide target" gets the opposite geometry the
-moment it goes short.
-
-Whether to mirror the magnitudes instead is
-[#279](https://github.com/TorchTrade/torchtrade/issues/279), deliberately open: the fix
-leaves the action-space size unchanged while changing what every short index means, so a
-trained checkpoint would load without complaint and trade a different strategy.
+**Short action *k* mirrors long action *k***: the levels are negated, so the stop sits
+above entry and the target below with the same magnitudes. Until
+[#279](https://github.com/TorchTrade/torchtrade/issues/279) the two lists were *swapped*
+instead, which got the sides right and the magnitudes wrong — short *k* carried long
+*k*'s risk and reward exchanged, so with `stoploss_levels=(-0.025, -0.05, -0.1)` long
+stops were {2.5, 5, 10}% while short stops were {5, 10, 20}% and no short action had a
+2.5% stop. The action-space size is unchanged either way, so a checkpoint trained before
+that fix loads without complaint and trades a different strategy.
 
 **Example:**
 ```python

--- a/torchtrade/envs/utils/__init__.py
+++ b/torchtrade/envs/utils/__init__.py
@@ -19,8 +19,6 @@ from torchtrade.envs.utils.action_maps import (
 )
 from torchtrade.envs.utils.sltp_helpers import (
     calculate_bracket_prices,
-    calculate_long_bracket_prices,
-    calculate_short_bracket_prices,
 )
 from torchtrade.envs.utils.sltp_mixin import SLTPMixin
 from torchtrade.envs.utils.fractional_sizing import (
@@ -48,8 +46,6 @@ __all__ = [
     "create_alpaca_sltp_action_map",
     # SL/TP helpers
     "calculate_bracket_prices",
-    "calculate_long_bracket_prices",
-    "calculate_short_bracket_prices",
     "SLTPMixin",
     # Position sizing
     "PositionCalculationParams",

--- a/torchtrade/envs/utils/action_maps.py
+++ b/torchtrade/envs/utils/action_maps.py
@@ -59,10 +59,11 @@ def create_sltp_action_map(
 
         This SWAPPED the two lists until #279, which got the sides right and the
         magnitudes wrong. The action-space size never changed, so a checkpoint trained
-        before that fix loads without complaint -- and where the stop and target
-        magnitudes DIFFER it then trades a different strategy. Where every pair has
-        ``tp == -sl`` the two maps are identical, as they are for any long-only config.
-        Retrain unless you can show your levels fall in that identical case.
+        before that fix loads without complaint and trades a different strategy.
+        Retrain. Equal magnitude SETS are not an exemption: with two levels each way the
+        old and new maps hold the same four short tuples at PERMUTED indices, and the
+        index is what the policy emits. Only a long-only config, or a single stop and
+        target of equal size, leaves the map untouched.
     """
     action_map = {}
     idx = 0

--- a/torchtrade/envs/utils/action_maps.py
+++ b/torchtrade/envs/utils/action_maps.py
@@ -58,9 +58,11 @@ def create_sltp_action_map(
         target. Short action k is then the exact mirror of long action k.
 
         This SWAPPED the two lists until #279, which got the sides right and the
-        magnitudes wrong. Only short indices changed meaning and the action-space size
-        did not, so a checkpoint trained before that fix loads without complaint and
-        trades a different strategy. Retrain rather than reload.
+        magnitudes wrong. The action-space size never changed, so a checkpoint trained
+        before that fix loads without complaint -- and where the stop and target
+        magnitudes DIFFER it then trades a different strategy. Where every pair has
+        ``tp == -sl`` the two maps are identical, as they are for any long-only config.
+        Retrain unless you can show your levels fall in that identical case.
     """
     action_map = {}
     idx = 0

--- a/torchtrade/envs/utils/action_maps.py
+++ b/torchtrade/envs/utils/action_maps.py
@@ -26,7 +26,7 @@ def create_sltp_action_map(
     Args:
         stoploss_levels: List of stop-loss percentages (typically negative, e.g., -0.02 = -2%)
         takeprofit_levels: List of take-profit percentages (typically positive, e.g., 0.05 = 5%)
-        include_short_positions: If True, include short position actions with swapped SL/TP
+        include_short_positions: If True, include short position actions, with SL/TP negated
         include_hold_action: If True, action 0 = HOLD (default: True)
         include_close_action: If True, add CLOSE action to exit positions (default: False for SLTP)
 
@@ -49,27 +49,18 @@ def create_sltp_action_map(
         ('close', None, None)
         >>> action_map[2]  # Long
         ('long', -0.02, 0.03)
-        >>> action_map[3]  # Short (SL/TP swapped)
-        ('short', 0.03, -0.02)
+        >>> action_map[3]  # Short: levels negated, so it mirrors action_map[2]
+        ('short', 0.02, -0.03)
 
     Note:
         For short positions SL must be above entry (positive %) and TP below entry
         (negative %), so the levels are NEGATED: ``-sl`` becomes the stop and ``-tp`` the
         target. Short action k is then the exact mirror of long action k.
 
-        It used to SWAP the two lists instead. That puts the sides right and the
-        magnitudes wrong, because both halves iterate the same
-        ``product(stoploss_levels, takeprofit_levels)`` -- so the nth short carried the
-        nth long's risk and reward exchanged, unconditionally, and visibly only when the
-        magnitudes differed. With ``stoploss_levels=(-0.025, -0.05, -0.1)`` and
-        ``takeprofit_levels=(0.05, 0.1, 0.2)`` long stops were {2.5, 5, 10}% while short
-        stops were {5, 10, 20}%: no short action had a 2.5% stop anywhere in the space,
-        so a policy that learned "tight stop, wide target" got the opposite geometry the
-        moment it went short (#279).
-
-        The action-space SIZE is unchanged (19 actions either way) and only short indices
-        change MEANING, so an SLTP checkpoint trained before this loads without complaint
-        and trades a different strategy. Retrain rather than reload.
+        This SWAPPED the two lists until #279, which got the sides right and the
+        magnitudes wrong. Only short indices changed meaning and the action-space size
+        did not, so a checkpoint trained before that fix loads without complaint and
+        trades a different strategy. Retrain rather than reload.
     """
     action_map = {}
     idx = 0

--- a/torchtrade/envs/utils/action_maps.py
+++ b/torchtrade/envs/utils/action_maps.py
@@ -53,35 +53,23 @@ def create_sltp_action_map(
         ('short', 0.03, -0.02)
 
     Note:
-        For short positions, SL must be above entry (positive %) and TP below entry
-        (negative %), so we swap: takeprofit_levels -> stop_loss and stoploss_levels ->
-        take_profit.
+        For short positions SL must be above entry (positive %) and TP below entry
+        (negative %), so the levels are NEGATED: ``-sl`` becomes the stop and ``-tp`` the
+        target. Short action k is then the exact mirror of long action k.
 
-    Warning:
-        That swap reuses the opposite list's MAGNITUDES, so a short action is never the
-        mirror of its long counterpart -- it is the mirror with risk and reward
-        exchanged. This is unconditional: both halves iterate the same
-        ``product(stoploss_levels, takeprofit_levels)``, so the nth long and the nth
-        short always carry the same magnitude pair the other way round. It is only
-        INVISIBLE when every magnitude is equal.
+        It used to SWAP the two lists instead. That puts the sides right and the
+        magnitudes wrong, because both halves iterate the same
+        ``product(stoploss_levels, takeprofit_levels)`` -- so the nth short carried the
+        nth long's risk and reward exchanged, unconditionally, and visibly only when the
+        magnitudes differed. With ``stoploss_levels=(-0.025, -0.05, -0.1)`` and
+        ``takeprofit_levels=(0.05, 0.1, 0.2)`` long stops were {2.5, 5, 10}% while short
+        stops were {5, 10, 20}%: no short action had a 2.5% stop anywhere in the space,
+        so a policy that learned "tight stop, wide target" got the opposite geometry the
+        moment it went short (#279).
 
-        With ``stoploss_levels=(-0.025, -0.05, -0.1)`` and
-        ``takeprofit_levels=(0.05, 0.1, 0.2)`` at entry 100, pairing the nth long with
-        the nth short (actions 1 and 10, then 3 and 12):
-
-        - long 1 = ``(-0.025, 0.05)``  -> risk 2.5%, reward 5%
-        - short 10 = ``(0.05, -0.025)`` -> risk 5%, reward 2.5%
-        - long 3 = ``(-0.025, 0.2)``   -> risk 2.5%, reward 20%
-        - short 12 = ``(0.2, -0.025)``  -> risk 20%, reward 2.5%
-
-        Long stops are {2.5, 5, 10}% and short stops are {5, 10, 20}%: no short action
-        has a 2.5% stop anywhere in the space. A policy that learned "tight stop, wide
-        target" gets the opposite geometry the moment it goes short.
-
-        Whether to mirror the magnitudes instead is #279, and it is deliberately open:
-        the fix leaves the action-space SIZE unchanged (19 actions either way) while
-        changing what every short index MEANS, so a trained checkpoint would load without
-        complaint and trade a different strategy.
+        The action-space SIZE is unchanged (19 actions either way) and only short indices
+        change MEANING, so an SLTP checkpoint trained before this loads without complaint
+        and trades a different strategy. Retrain rather than reload.
     """
     action_map = {}
     idx = 0
@@ -104,9 +92,11 @@ def create_sltp_action_map(
     # Short positions with SL/TP combinations (if enabled)
     if include_short_positions:
         for sl, tp in product(stoploss_levels, takeprofit_levels):
-            # For shorts: SL is above entry (positive), TP is below entry (negative)
-            # We swap: takeprofit_levels (positive) -> SL, stoploss_levels (negative) -> TP
-            action_map[idx] = ("short", tp, sl)
+            # Negate, do not swap. Shorts need SL above entry (positive) and TP below
+            # (negative), which a swap also produces -- but it takes the magnitudes from
+            # the OTHER list, so the nth short carried the nth long's risk and reward
+            # exchanged (#279). Negating keeps the sides and mirrors the geometry.
+            action_map[idx] = ("short", -sl, -tp)
             idx += 1
 
     return action_map

--- a/torchtrade/envs/utils/sltp_helpers.py
+++ b/torchtrade/envs/utils/sltp_helpers.py
@@ -36,9 +36,9 @@ def calculate_short_bracket_prices(entry_price: float, sl_pct: float, tp_pct: fl
     - Stop loss must be ABOVE entry (loss when price rises)
     - Take profit must be BELOW entry (profit when price falls)
 
-    IMPORTANT: The action_map already swaps SL/TP for shorts, so:
-    - sl_pct will be POSITIVE (from the original tp_pct)
-    - tp_pct will be NEGATIVE (from the original sl_pct)
+    IMPORTANT: The action_map already negates SL/TP for shorts (#279), so:
+    - sl_pct will be POSITIVE (it is -stoploss_level)
+    - tp_pct will be NEGATIVE (it is -takeprofit_level)
 
     Args:
         entry_price: Entry price for the position
@@ -53,7 +53,7 @@ def calculate_short_bracket_prices(entry_price: float, sl_pct: float, tp_pct: fl
         >>> calculate_short_bracket_prices(50000, 0.03, -0.02)
         (51500.0, 49000.0)  # SL 3% above, TP 2% below
     """
-    # For shorts, action_map has already swapped the percentages
+    # For shorts, action_map has already negated the percentages
     # sl_pct is positive (above entry), tp_pct is negative (below entry)
     stop_loss = entry_price * (1 + sl_pct)
     take_profit = entry_price * (1 + tp_pct)

--- a/torchtrade/envs/utils/sltp_helpers.py
+++ b/torchtrade/envs/utils/sltp_helpers.py
@@ -3,74 +3,23 @@
 from typing import Tuple
 
 
-def calculate_long_bracket_prices(entry_price: float, sl_pct: float, tp_pct: float) -> Tuple[float, float]:
-    """
-    Calculate SL/TP prices for long positions.
-
-    For long positions:
-    - Stop loss must be BELOW entry (loss when price falls)
-    - Take profit must be ABOVE entry (profit when price rises)
-
-    Args:
-        entry_price: Entry price for the position
-        sl_pct: Stop loss percentage (negative, e.g., -0.02 for 2% below entry)
-        tp_pct: Take profit percentage (positive, e.g., 0.05 for 5% above entry)
-
-    Returns:
-        Tuple of (stop_loss_price, take_profit_price)
-
-    Example:
-        >>> calculate_long_bracket_prices(50000, -0.02, 0.05)
-        (49000.0, 52500.0)  # SL 2% below, TP 5% above
-    """
-    stop_loss = entry_price * (1 + sl_pct)
-    take_profit = entry_price * (1 + tp_pct)
-    return stop_loss, take_profit
-
-
-def calculate_short_bracket_prices(entry_price: float, sl_pct: float, tp_pct: float) -> Tuple[float, float]:
-    """
-    Calculate SL/TP prices for short positions.
-
-    For short positions:
-    - Stop loss must be ABOVE entry (loss when price rises)
-    - Take profit must be BELOW entry (profit when price falls)
-
-    IMPORTANT: The action_map already negates SL/TP for shorts (#279), so:
-    - sl_pct will be POSITIVE (it is -stoploss_level)
-    - tp_pct will be NEGATIVE (it is -takeprofit_level)
-
-    Args:
-        entry_price: Entry price for the position
-        sl_pct: Stop loss percentage from action_map (positive, e.g., 0.03 for 3% above entry)
-        tp_pct: Take profit percentage from action_map (negative, e.g., -0.02 for 2% below entry)
-
-    Returns:
-        Tuple of (stop_loss_price, take_profit_price)
-
-    Example:
-        >>> # Action map provides: sl_pct=0.03, tp_pct=-0.02 for shorts
-        >>> calculate_short_bracket_prices(50000, 0.03, -0.02)
-        (51500.0, 49000.0)  # SL 3% above, TP 2% below
-    """
-    # For shorts, action_map has already negated the percentages
-    # sl_pct is positive (above entry), tp_pct is negative (below entry)
-    stop_loss = entry_price * (1 + sl_pct)
-    take_profit = entry_price * (1 + tp_pct)
-    return stop_loss, take_profit
-
-
 def calculate_bracket_prices(side: str, entry_price: float, sl_pct: float, tp_pct: float) -> Tuple[float, float]:
-    """
-    Calculate SL/TP prices for either long or short positions.
+    """Bracket prices for a long or short, from percentages the action map already signed.
 
-    Convenience function that dispatches to the appropriate calculator based on side.
+    One formula for both sides: the action map hands over percentages already oriented
+    against the position (long -0.02/+0.05, short +0.02/-0.05), so `entry * (1 + pct)`
+    puts each leg on the correct side without a per-side branch. There were two
+    byte-identical functions here whose only job was to document the SWAP the map used
+    to apply to shorts; #279 negates instead, so the pair had nothing left to say.
+
+    `side` is still validated -- a typo would otherwise price a bracket off percentages
+    meant for the other direction.
 
     Args:
         side: Position side ("long" or "short")
         entry_price: Entry price for the position
-        sl_pct: Stop loss percentage from action_map
-        tp_pct: Take profit percentage from action_map
+        sl_pct: Stop loss percentage from action_map (negative long, positive short)
+        tp_pct: Take profit percentage from action_map (positive long, negative short)
 
     Returns:
         Tuple of (stop_loss_price, take_profit_price)
@@ -81,15 +30,12 @@ def calculate_bracket_prices(side: str, entry_price: float, sl_pct: float, tp_pc
     Example:
         >>> calculate_bracket_prices("long", 50000, -0.02, 0.05)
         (49000.0, 52500.0)
-        >>> calculate_bracket_prices("short", 50000, 0.03, -0.02)
-        (51500.0, 49000.0)
+        >>> calculate_bracket_prices("short", 50000, 0.02, -0.05)
+        (51000.0, 47500.0)
     """
-    if side == "long":
-        return calculate_long_bracket_prices(entry_price, sl_pct, tp_pct)
-    elif side == "short":
-        return calculate_short_bracket_prices(entry_price, sl_pct, tp_pct)
-    else:
+    if side not in ("long", "short"):
         raise ValueError(f"Invalid side: {side}. Must be 'long' or 'short'.")
+    return entry_price * (1 + sl_pct), entry_price * (1 + tp_pct)
 
 
 def stop_fill_price(stop_price: float, open_price: float, is_long: bool) -> float:


### PR DESCRIPTION
Fixes #279.

Shorts were built as `("short", tp, sl)` — sides right, **magnitudes wrong**. Both halves iterate the same `product(stoploss_levels, takeprofit_levels)`, so the nth short carried the nth long's risk and reward exchanged:

```
long  1: risk 2.5%  reward  5.0%      short 10: risk  5.0%  reward 2.5%
long  3: risk 2.5%  reward 20.0%      short 12: risk 20.0%  reward 2.5%
```

Long stops were {2.5, 5, 10}% and short stops {5, 10, 20}% — **no short action had a 2.5% stop anywhere**. Now `("short", -sl, -tp)`. Measured end-to-end through a real fill, entry 100.40:

| | long SL / TP | short SL / TP |
|---|---|---|
| main | 97.892464 / 105.422653 | **105.422653 / 97.892464** |
| this PR | 97.892464 / 105.422653 | **102.912590 / 95.382401** |

Main's short prices are literally the long row's two numbers swapped. That is #279 in one line.

## Breaking, deliberately

**Retrain — do not reload.** The action-space size is identical in all 128 config combinations swept, so a pre-fix checkpoint loads with no error and trades a different strategy. Equal magnitude *sets* are **not** an exemption: with `stoploss_levels=[-0.05,-0.1]`, `takeprofit_levels=[0.05,0.1]` the old and new maps hold the same four short tuples at **permuted indices** (6 and 7 swap meaning), and the index is what the policy emits. Only a long-only config, or a single stop and target of equal size, leaves the map untouched.

Per @CharlieHelps, a version stamp or action-map checksum is the right long-term answer but spans save/load formats and belongs in its own design change.

## Also in this PR

**A live boundary was open.** `BinanceFuturesSLTPTradingEnvConfig(stoploss_levels=(0.02,), …)` was *accepted* — only the two offline configs validated signs. A positive stop level silently inverts the **long** bracket (stop above entry). `validate_sltp_levels` now holds that boundary for all seven config classes from one place, replacing two hand-rolled copies. `abs()` was rejected: it would immunize the short leg while leaving the long leg inverted.

**Three bracket calculators became one.** `calculate_long_bracket_prices` / `calculate_short_bracket_prices` had statement-identical bodies and existed only to narrate the swap; with no swap they had nothing left to say. Verified a pure refactor across 2250 input combinations — bit-identical, error strings included.

## What the review rounds corrected in my own work

Recorded because the process is the interesting part:

- **A vacuous test.** The first FLATTEN-style assertion pattern recurred: 8 of 14 config-guard cases ran identical bytecode, because all four futures venues inherit `BaseFuturesSLTPConfig.__post_init__`. Replaced with one representative plus an identity guard.
- **Two of three re-derived rows still don't discriminate the bug** — liquidation fires wherever the wrongly-moved stop lands. They earn their place on exit-priority parity (#298/#300), and the comment now says so instead of implying otherwise.
- **A doctest that returned the wrong answer**, and `torchtrade/envs/utils/README.md` asserting in bold the *opposite* of the shipped code while citing #279 as "deliberately open".
- **The checkpoint-compatibility claim took three attempts** — unconditional, then over-generous, then precise. Set equality was the wrong relation; index-wise equality is.

Reverting the fix fails **10**. Full suite: **3975 passed, 16 skipped**. Net **+293/−314** — a semantic fix that removes more than it adds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
