### PR TITLE
refactor(live): one get_observations for all five venues (#288, slice 1)

### DIFF
--- a/tests/envs/alpaca/test_obs_class.py
+++ b/tests/envs/alpaca/test_obs_class.py
@@ -151,7 +151,7 @@ def test_a_malformed_candle_never_reaches_alpaca_base_features(monkeypatch):
         client=MagicMock(),
     )
 
-    def frame_with_a_hole(timeframe):
+    def frame_with_a_hole(timeframe, limit=None):
         n = 60
         df = pd.DataFrame({
             "symbol": ["BTC/USD"] * n,  # alpaca's default preprocessing drops this column
@@ -202,7 +202,7 @@ def test_alpaca_base_features_survive_a_fn_that_leaves_the_timestamp_in_the_inde
             [["BTC/USD"] * n, stamps], names=["symbol", "timestamp"]
         ),
     )
-    observer._fetch_single_timeframe = lambda timeframe: frame
+    observer._fetch_single_timeframe = lambda timeframe, limit=None: frame
 
     observations = observer.get_observations(return_base_ohlc=True)
     assert observations["base_features"].shape == (10, 4)
@@ -231,7 +231,7 @@ def test_alpaca_refuses_a_fn_that_loses_the_timestamp_entirely():
         client=MagicMock(),
     )
     n = 60
-    observer._fetch_single_timeframe = lambda timeframe: pd.DataFrame(
+    observer._fetch_single_timeframe = lambda timeframe, limit=None: pd.DataFrame(
         {"open": np.full(n, 100.0), "high": np.full(n, 101.0),
          "low": np.full(n, 99.0), "close": np.full(n, 100.5),
          "volume": np.full(n, 10.0)},
@@ -268,7 +268,7 @@ def test_alpaca_drops_a_zero_priced_bar_rather_than_emitting_inf():
             names=["symbol", "timestamp"],
         ),
     )
-    observer._fetch_single_timeframe = lambda timeframe: frame
+    observer._fetch_single_timeframe = lambda timeframe, limit=None: frame
 
     observations = observer.get_observations(return_base_ohlc=True)
     for key, array in observations.items():
@@ -298,7 +298,7 @@ def test_alpaca_refuses_a_stale_last_bar():
     n = 60
     close = np.linspace(100.0, 130.0, n)
     close[-1] = 0.0  # the most recent candle is unusable
-    observer._fetch_single_timeframe = lambda timeframe: pd.DataFrame(
+    observer._fetch_single_timeframe = lambda timeframe, limit=None: pd.DataFrame(
         {"open": np.full(n, 100.0), "high": np.full(n, 101.0),
          "low": np.full(n, 99.0), "close": close, "volume": np.full(n, 10.0)},
         index=pd.MultiIndex.from_arrays(

--- a/tests/envs/alpaca/test_obs_class.py
+++ b/tests/envs/alpaca/test_obs_class.py
@@ -42,6 +42,19 @@ class TestAlpacaObservationClass(BaseObservationClassTests):
         assert obs.symbol == "BTC/USD"
         assert obs.client is mock_client
 
+    def test_a_daily_timeframe_is_refused_at_construction(self):
+        """The 60-day fetch window cannot fill a daily observation, and says so early.
+
+        This check used to live inside `_fetch_single_timeframe`, so the config built
+        fine and failed on the first fetch -- during `reset()`, on a live account. The
+        shared base calls `_validate_timeframe` from `__init__`, which is where the
+        futures venues have always validated theirs (#288). Untested either way before.
+        """
+        with pytest.raises(ValueError, match="not allowed for daily data"):
+            self.create_observer(
+                symbol="BTC/USD", timeframes=TimeFrame(1, TimeFrameUnit.Day),
+                window_sizes=5)
+
     def test_get_keys_multiple_timeframes(self):
         obs = self.create_observer(
             symbol="BTC/USD",
@@ -96,14 +109,6 @@ class TestAlpacaObservationClass(BaseObservationClassTests):
         key = obs.get_keys()[0]
         assert obs.get_observations()[key].shape[0] == 15
 
-    def test_feature_close_is_pct_change(self):
-        """feature_close is a percentage change (small values around 0)."""
-        obs = self.create_observer(
-            symbol="BTC/USD", timeframes=TimeFrame(1, TimeFrameUnit.Minute), window_sizes=10)
-        key = obs.get_keys()[0]
-        feature_close = obs.get_observations()[key][:, 0]
-        assert np.abs(feature_close).max() < 0.1
-
     def test_different_timeframe_units(self):
         """Hourly timeframe produces the expected key."""
         obs = self.create_observer(
@@ -118,22 +123,6 @@ class TestAlpacaObservationClass(BaseObservationClassTests):
         obs1 = obs.get_observations()[key]
         obs2 = obs.get_observations()[key]
         assert obs1.shape == obs2.shape == (10, 4)
-
-    def test_ohlc_relationship(self):
-        """OHLC high >= low holds in the base features."""
-        obs = self.create_observer(
-            symbol="BTC/USD", timeframes=TimeFrame(1, TimeFrameUnit.Minute), window_sizes=10)
-        base = obs.get_observations(return_base_ohlc=True)["base_features"]
-        highs, lows = base[:, 1], base[:, 2]
-        assert np.all(highs >= lows)
-
-    def test_timestamps_are_ordered(self):
-        """base_timestamps are chronological."""
-        obs = self.create_observer(
-            symbol="BTC/USD", timeframes=TimeFrame(1, TimeFrameUnit.Minute), window_sizes=10)
-        timestamps = obs.get_observations(return_base_ohlc=True)["base_timestamps"]
-        for i in range(len(timestamps) - 1):
-            assert timestamps[i] < timestamps[i + 1]
 
 
 def test_a_malformed_candle_never_reaches_alpaca_base_features(monkeypatch):

--- a/tests/envs/alpaca/test_obs_class.py
+++ b/tests/envs/alpaca/test_obs_class.py
@@ -125,6 +125,46 @@ class TestAlpacaObservationClass(BaseObservationClassTests):
         assert obs1.shape == obs2.shape == (10, 4)
 
 
+def test_a_bar_with_a_null_symbol_but_sound_prices_survives(monkeypatch):
+    """The one deliberate behaviour change in the #288 fold, pinned in both directions.
+
+    `_normalise_frame` drops `symbol` BEFORE the shared dropna, where it used to be
+    dropped after -- so a bar whose metadata came back null and whose OHLCV is intact is
+    kept now and was discarded before. That is the better answer (losing usable bars to a
+    metadata gap is what pushes a window under its spec, #400), but it was a stated
+    change with nothing asserting it: move the drop back after the dropna and no test
+    would have failed.
+    """
+    observer = AlpacaObservationClass(
+        symbol="BTC/USD", timeframes=TimeFrame(1, TimeFrameUnit.Minute),
+        window_sizes=5, client=MockCryptoHistoricalDataClient(num_bars=60))
+
+    def frame_with_a_null_symbol(timeframe, limit=None):
+        n = 60
+        df = pd.DataFrame({
+            "symbol": ["BTC/USD"] * n,
+            "open": np.full(n, 100.0), "high": np.full(n, 101.0),
+            "low": np.full(n, 99.0), "close": np.full(n, 100.5),
+            "volume": np.full(n, 10.0),
+            "timestamp": pd.date_range("2024-01-01", periods=n, freq="1min"),
+        })
+        df.loc[55, "symbol"] = None      # metadata gap, prices intact
+        return df
+
+    monkeypatch.setattr(observer, "_fetch_single_timeframe", frame_with_a_null_symbol)
+    obs = observer.get_observations(return_base_ohlc=True)
+
+    # The window is the last 5 of 60, so bar 55 is INSIDE it. Asserting the row count
+    # cannot distinguish the two orderings -- 59 surviving rows still fill a 5-bar
+    # window. The timestamp is what moves: drop bar 55 and the window shifts back to
+    # include bar 54.
+    kept = pd.to_datetime(obs["base_timestamps"])
+    assert pd.Timestamp("2024-01-01 00:55:00") in set(kept), (
+        f"the null-symbol bar was discarded despite sound prices; window is {list(kept)}"
+    )
+    assert pd.Timestamp("2024-01-01 00:54:00") not in set(kept)
+
+
 def test_a_malformed_candle_never_reaches_alpaca_base_features(monkeypatch):
     """Alpaca already dropped NaN before slicing base_features; nothing tested it.
 

--- a/tests/envs/base_exchange_tests.py
+++ b/tests/envs/base_exchange_tests.py
@@ -337,6 +337,30 @@ class BaseObservationClassTests(ABC):
             self.create_observer(symbol="BTC/USD", timeframes=timeframes,
                                  window_sizes=window_sizes)
 
+    def test_the_shared_preprocessing_semantics_hold(self):
+        """`_default_preprocessing` is one implementation now, so assert it on every venue.
+
+        These three assertions lived only in alpaca's file. That was fine while alpaca
+        owned its own copy; after the fold they cover code all five venues run, and a
+        regression would have shipped silently for the four that had no equivalent (#288).
+        """
+        observer = self.create_observer(
+            symbol="BTC/USD", timeframes=TimeFrame(1, TimeFrameUnit.Minute),
+            window_sizes=10)
+        obs = observer.get_observations(return_base_ohlc=True)
+
+        # feature_close is a pct_change, so it sits near zero rather than near price.
+        assert np.abs(obs[observer.get_keys()[0]][:, 0]).max() < 0.1
+
+        # A column swap in the base_features slice would break high >= low.
+        base = obs["base_features"]
+        assert np.all(base[:, 1] >= base[:, 2])
+
+        # base_timestamps is windowed alongside base_features; a mis-slice reorders it.
+        timestamps = obs["base_timestamps"]
+        assert len(timestamps) == len(base)
+        assert np.all(timestamps[:-1] < timestamps[1:])
+
     def test_this_venue_does_not_re_fork_the_shared_window_logic(self):
         """One `get_observations`, for all five venues (#288).
 
@@ -346,8 +370,8 @@ class BaseObservationClassTests(ABC):
         back, and every behavioural test still passes on the day it happens, because both
         copies are correct at birth.
 
-        `_dummy_frame` is an extension point, not a re-fork: venues return different
-        columns and the base cannot know their dtypes.
+        `_dummy_frame` and `_normalise_frame` are extension points, not re-forks: venues
+        return different columns, and their SDKs hand back different frame shapes.
         """
         from torchtrade.envs.live.shared.base_obs import BaseObservationClass
 
@@ -361,7 +385,7 @@ class BaseObservationClassTests(ABC):
             and not n.startswith("__")
         }
         assert {"get_observations", "_default_preprocessing", "get_features"} <= shared
-        redeclared = (shared & set(vars(venue_cls))) - {"_dummy_frame"}
+        redeclared = (shared & set(vars(venue_cls))) - {"_dummy_frame", "_normalise_frame"}
         assert not redeclared, (
             f"{venue_cls.__name__} re-forks {sorted(redeclared)} instead of sharing "
             f"BaseObservationClass's"

--- a/tests/envs/base_exchange_tests.py
+++ b/tests/envs/base_exchange_tests.py
@@ -361,6 +361,28 @@ class BaseObservationClassTests(ABC):
         assert len(timestamps) == len(base)
         assert np.all(timestamps[:-1] < timestamps[1:])
 
+    def test_preprocessing_does_not_mutate_the_fetched_frame(self):
+        """`_normalise_frame` returns a COPY, and the #399 guard depends on it.
+
+        `_default_preprocessing` drops rows with `inplace=True`, and `get_observations`
+        then compares the processed frame's last timestamp against the FETCHED frame's to
+        refuse a stale bar. Share one object between them and both sides move together,
+        so the comparison can never differ and a stale bar reaches the policy. Measured:
+        returning `df` instead of `df.copy()` passes the entire suite.
+        """
+        observer = self.create_observer(
+            symbol="BTC/USD", timeframes=TimeFrame(1, TimeFrameUnit.Minute),
+            window_sizes=5)
+        fetched = observer._fetch_single_timeframe(observer.time_frames[0], limit=55)
+        before = (len(fetched), list(fetched.columns))
+
+        observer.feature_preprocessing_fn(fetched)
+
+        assert (len(fetched), list(fetched.columns)) == before, (
+            "preprocessing mutated the frame it was handed, so the stale-bar check "
+            "compares an object against itself"
+        )
+
     def test_this_venue_does_not_re_fork_the_shared_window_logic(self):
         """One `get_observations`, for all five venues (#288).
 
@@ -372,6 +394,11 @@ class BaseObservationClassTests(ABC):
 
         `_dummy_frame` and `_normalise_frame` are extension points, not re-forks: venues
         return different columns, and their SDKs hand back different frame shapes.
+
+        Name-based, deliberately: this diffs method NAMES and never reads a body, so a
+        venue that reimplements the pipeline INSIDE one of those two exempted overrides
+        passes. That is a copy-paste-drift guard, not a circumvention guard -- the
+        behavioural tests above are what would catch the reimplementation.
         """
         from torchtrade.envs.live.shared.base_obs import BaseObservationClass
 

--- a/tests/envs/base_exchange_tests.py
+++ b/tests/envs/base_exchange_tests.py
@@ -320,6 +320,36 @@ class BaseObservationClassTests(ABC):
         with pytest.raises(ValueError, match="usable candles"):
             observer.get_observations(return_base_ohlc=True)
 
+    def test_this_venue_does_not_re_fork_the_shared_window_logic(self):
+        """One `get_observations`, for all five venues (#288).
+
+        Alpaca kept a byte-for-byte parallel copy of the window logic until this landed,
+        and each of the last three fixes to it -- row alignment (#395), the stale last bar
+        (#399), the short window (#400) -- had to be pasted into both. A re-fork puts that
+        back, and every behavioural test still passes on the day it happens, because both
+        copies are correct at birth.
+
+        `_dummy_frame` is an extension point, not a re-fork: venues return different
+        columns and the base cannot know their dtypes.
+        """
+        from torchtrade.envs.live.shared.base_obs import BaseObservationClass
+
+        venue_cls = type(self.create_observer(
+            symbol="BTC/USD", timeframes=TimeFrame(1, TimeFrameUnit.Minute),
+            window_sizes=5,
+        ))
+        shared = {
+            n for n, v in vars(BaseObservationClass).items()
+            if callable(v) and not getattr(v, "__isabstractmethod__", False)
+            and not n.startswith("__")
+        }
+        assert {"get_observations", "_default_preprocessing", "get_features"} <= shared
+        redeclared = (shared & set(vars(venue_cls))) - {"_dummy_frame"}
+        assert not redeclared, (
+            f"{venue_cls.__name__} re-forks {sorted(redeclared)} instead of sharing "
+            f"BaseObservationClass's"
+        )
+
     # Edge cases
 
     def test_window_size_one(self):

--- a/tests/envs/base_exchange_tests.py
+++ b/tests/envs/base_exchange_tests.py
@@ -320,6 +320,23 @@ class BaseObservationClassTests(ABC):
         with pytest.raises(ValueError, match="usable candles"):
             observer.get_observations(return_base_ohlc=True)
 
+    @pytest.mark.parametrize("timeframes,window_sizes", [
+        (TimeFrame(1, TimeFrameUnit.Minute), [10, 20]),
+        ([TimeFrame(1, TimeFrameUnit.Minute), TimeFrame(5, TimeFrameUnit.Minute)], 10),
+    ], ids=["one-timeframe-two-windows", "two-timeframes-one-window"])
+    def test_a_length_mismatch_raises_instead_of_truncating(self, timeframes, window_sizes):
+        """`zip()` truncates, so a mismatch used to become a SHORTER observation set.
+
+        Alpaca checked only when BOTH arguments were already lists, so passing one of
+        each normalised to lists of different length and then silently lost a timeframe
+        in `get_keys()` -- the policy trains on a window it was not configured for. The
+        futures venues always checked unconditionally; folding onto the shared base is
+        what made alpaca agree (#288).
+        """
+        with pytest.raises(ValueError, match="same length"):
+            self.create_observer(symbol="BTC/USD", timeframes=timeframes,
+                                 window_sizes=window_sizes)
+
     def test_this_venue_does_not_re_fork_the_shared_window_logic(self):
         """One `get_observations`, for all five venues (#288).
 

--- a/tests/envs/binance/test_obs_class.py
+++ b/tests/envs/binance/test_obs_class.py
@@ -143,7 +143,9 @@ def _basic_features(df):
 class TestBinanceSharesTheObservationBase:
     """binance was the last FUTURES venue with a parallel observation class (#289).
 
-    alpaca still hand-rolls its own; it is spot, so outside this issue's scope.
+    alpaca folded onto the shared BaseObservationClass in #288; this guard stays
+    futures-only because _fetch_single_timeframe is concrete one level down, and
+    base_exchange_tests.py covers all five venues at the BaseObservationClass level.
     """
 
     @staticmethod

--- a/tests/envs/binance/test_obs_class.py
+++ b/tests/envs/binance/test_obs_class.py
@@ -176,8 +176,14 @@ class TestBinanceSharesTheObservationBase:
         `get_features` a property drops it from a callable filter), and a merely non-empty
         check would still pass.
         """
+        # Over the MRO, not one class's __dict__: the window logic now lives on
+        # BaseObservationClass and only the kline half on BaseFuturesObservationClass
+        # (#288). A __dict__-scoped set silently stopped covering `get_observations` the
+        # moment it was hoisted, which is how this guard would have gone quiet.
         shared = {
-            n for n, v in vars(BaseFuturesObservationClass).items()
+            n for klass in BaseFuturesObservationClass.__mro__
+            if klass.__module__.startswith("torchtrade.")
+            for n, v in vars(klass).items()
             if callable(v) and not getattr(v, "__isabstractmethod__", False)
             and not n.startswith("__")
         }

--- a/torchtrade/envs/live/alpaca/observation.py
+++ b/torchtrade/envs/live/alpaca/observation.py
@@ -75,8 +75,12 @@ class AlpacaObservationClass(BaseObservationClass):
     def _normalise_frame(self, df: pd.DataFrame) -> pd.DataFrame:
         """The SDK hands back a (symbol, timestamp) MultiIndex and a constant `symbol`.
 
-        Dropped before the shared `dropna`, so a row with a null symbol but sound OHLCV
-        now survives (#288 review).
+        Dropped BEFORE the shared dropna/drop_duplicates, where it used to go after. Safe
+        only because `symbol: str` means one symbol per observer: with the column gone,
+        two bars alike in every OHLCV field but differing in symbol would dedupe to one.
+        Revisit this ordering before any multi-symbol support. (A row with a null symbol
+        and sound OHLCV also survives now, which is the better answer -- losing a usable
+        bar to a gap in metadata is what pushes a window under its spec, #400.)
         """
         return df.reset_index().drop(columns=["symbol"])
 

--- a/torchtrade/envs/live/alpaca/observation.py
+++ b/torchtrade/envs/live/alpaca/observation.py
@@ -38,9 +38,6 @@ class AlpacaObservationClass(BaseObservationClass):
             feature_preprocessing_fn: Optional custom preprocessing function that takes a DataFrame
                                    and returns a DataFrame with feature columns
             client: Optional pre-configured CryptoHistoricalDataClient for dependency injection (useful for testing)
-
-        `timeframes`, not the base's `time_frames`: the spelling is public and renaming it
-        would break every existing alpaca config for no behavioural gain.
         """
         self.default_lookback = 60
         super().__init__(
@@ -65,12 +62,7 @@ class AlpacaObservationClass(BaseObservationClass):
         return "timestamp"
 
     def _fetch_single_timeframe(self, timeframe: TimeFrame, limit: int = None) -> pd.DataFrame:
-        """A date RANGE, not a bar count, so `limit` has nothing to bind to.
-
-        That is why the short-window refusal in `get_observations` matters more here than
-        on the futures venues: they over-fetch by a fixed +50 bars, and this fetches
-        whatever 60 days happens to contain (#400).
-        """
+        """A date RANGE, not a bar count, so `limit` has nothing to bind to."""
         now = datetime.now(ZoneInfo("America/New_York"))
         request = CryptoBarsRequest(
             symbol_or_symbols=self.symbol,
@@ -83,20 +75,14 @@ class AlpacaObservationClass(BaseObservationClass):
     def _normalise_frame(self, df: pd.DataFrame) -> pd.DataFrame:
         """The SDK hands back a (symbol, timestamp) MultiIndex and a constant `symbol`.
 
-        Dropped BEFORE the shared `dropna`, where it used to be dropped after. For a
-        single-symbol request the column is constant and the surviving rows are the same
-        either way -- measured. The one input that differs is a row whose `symbol` is
-        null: it used to be discarded, and now survives if its OHLCV is intact. That is
-        the better answer. Losing a usable bar to a gap in a METADATA column is the
-        over-eager row removal #400 exists to catch, and `symbol` is a field this class
-        already knows the value of -- it is the one it asked for.
+        Dropped before the shared `dropna`, so a row with a null symbol but sound OHLCV
+        now survives (#288 review).
         """
         return df.reset_index().drop(columns=["symbol"])
 
     def _dummy_frame(self, window_size: int) -> pd.DataFrame:
-        """Carries `symbol` because `_normalise_frame` drops it -- the dummy has to have
-        the shape real data has, or `get_features` measures a frame the venue never
-        produces (the dtype-fidelity lesson from binance's #289 fold)."""
+        """Carries `symbol` because `_normalise_frame` drops it: the dummy has to have
+        the shape real data has, or `get_features` measures a frame that never occurs."""
         df = super()._dummy_frame(window_size)
         df.insert(0, "symbol", [self.symbol] * window_size)
         return df
@@ -120,81 +106,3 @@ class AlpacaObservationClass(BaseObservationClass):
             raise ValueError(f"No data available for {self.symbol}")
 
         return float(df['close'].iloc[-1])
-
-
-# Example usage:
-if __name__ == "__main__":
-    # Note: Examples now use custom TimeFrame from torchtrade.envs.timeframe
-    # instead of Alpaca's TimeFrame class
-
-    # Single timeframe example
-    print("Testing single timeframe...")
-    window_size = 10
-    observer = AlpacaObservationClass(
-        symbol="BTC/USD",
-        timeframes=TimeFrame(15, TimeFrameUnit.Minute),
-        window_sizes=window_size,
-    )
-    expected_keys = observer.get_keys()
-    observations = observer.get_observations()
-    #features = observer.get_features()
-
-    assert set(observations.keys()) == set(expected_keys), "Keys don't match expected keys"
-    # Default preprocessing has 4 features: feature_close, feature_open, feature_high, feature_low
-    assert observations[expected_keys[0]].shape == (window_size, 4), \
-        f"Expected shape (10, 4) for default features, got {observations[expected_keys[0]].shape}"
-    print("Single timeframe test passed!")
-
-    # Example with multiple timeframes and window sizes
-    print("\nTesting multiple timeframes...")
-    window_sizes = [10, 20]
-    observer = AlpacaObservationClass(
-        symbol="BTC/USD",
-        timeframes=[
-            TimeFrame(15, TimeFrameUnit.Minute),
-            TimeFrame(1, TimeFrameUnit.Hour)
-        ],
-        window_sizes=window_sizes
-    )
-
-    expected_keys = observer.get_keys()
-    print("Expected keys:", expected_keys)
-    observations = observer.get_observations()
-    #features = observer.get_features()
-
-    assert set(observations.keys()) == set(expected_keys), "Keys don't match expected keys"
-    assert len(observations) == 2, "Expected exactly 2 observations"
-
-    # Check shapes for each timeframe/window combination
-    expected_shapes = { key: (w, 4) for key, w in zip(expected_keys, window_sizes)
-    }
-
-    for key, expected_shape in expected_shapes.items():
-        assert observations[key].shape == expected_shape, \
-            f"Shape mismatch for {key}: expected {expected_shape}, got {observations[key].shape}"
-    print("Multiple timeframes test passed!")
-
-    # Custom preprocessing example
-    print("\nTesting custom preprocessing...")
-    def custom_preprocessing(df):
-        df = df.reset_index()
-        df.dropna(inplace=True)
-        df["feature_volatility"] = df["high"] - df["low"]
-        df["feature_volume_ma"] = df["volume"].rolling(window=3).mean()
-        df.dropna(inplace=True)  # Drop NaN values from rolling window
-        return df
-
-    observer_custom = AlpacaObservationClass(
-        symbol="BTC/USD",
-        timeframes=TimeFrame(15, TimeFrameUnit.Minute),
-        window_sizes=10,
-        feature_preprocessing_fn=custom_preprocessing,
-    )
-
-    observations_custom = observer_custom.get_observations()
-    key = observer_custom.get_keys()[0]
-    #features_custom = observer_custom.get_features()
-    # Custom preprocessing has 2 features and loses 2 rows due to rolling window
-    assert observations_custom[key].shape == (8, 2), \
-        f"Expected shape (8, 2) for custom features, got {observations_custom[key].shape}"
-    print("Custom preprocessing test passed!")

--- a/torchtrade/envs/live/alpaca/observation.py
+++ b/torchtrade/envs/live/alpaca/observation.py
@@ -1,9 +1,8 @@
 """Alpaca crypto bars, on the shared observation base."""
 
-from typing import List, Union, Callable, Dict, Optional
+from typing import List, Union, Callable, Optional
 from datetime import datetime, timedelta
 from zoneinfo import ZoneInfo
-import numpy as np
 import pandas as pd
 from torchtrade.envs.live.shared.base_obs import BaseObservationClass
 from torchtrade.envs.utils.timeframe import TimeFrame, TimeFrameUnit, timeframe_to_alpaca
@@ -78,9 +77,7 @@ class AlpacaObservationClass(BaseObservationClass):
         Dropped BEFORE the shared dropna/drop_duplicates, where it used to go after. Safe
         only because `symbol: str` means one symbol per observer: with the column gone,
         two bars alike in every OHLCV field but differing in symbol would dedupe to one.
-        Revisit this ordering before any multi-symbol support. (A row with a null symbol
-        and sound OHLCV also survives now, which is the better answer -- losing a usable
-        bar to a gap in metadata is what pushes a window under its spec, #400.)
+        Revisit this ordering before any multi-symbol support.
         """
         return df.reset_index().drop(columns=["symbol"])
 

--- a/torchtrade/envs/live/alpaca/observation.py
+++ b/torchtrade/envs/live/alpaca/observation.py
@@ -81,7 +81,16 @@ class AlpacaObservationClass(BaseObservationClass):
         return self.client.get_crypto_bars(request).df
 
     def _normalise_frame(self, df: pd.DataFrame) -> pd.DataFrame:
-        """The SDK hands back a (symbol, timestamp) MultiIndex and a constant `symbol`."""
+        """The SDK hands back a (symbol, timestamp) MultiIndex and a constant `symbol`.
+
+        Dropped BEFORE the shared `dropna`, where it used to be dropped after. For a
+        single-symbol request the column is constant and the surviving rows are the same
+        either way -- measured. The one input that differs is a row whose `symbol` is
+        null: it used to be discarded, and now survives if its OHLCV is intact. That is
+        the better answer. Losing a usable bar to a gap in a METADATA column is the
+        over-eager row removal #400 exists to catch, and `symbol` is a field this class
+        already knows the value of -- it is the one it asked for.
+        """
         return df.reset_index().drop(columns=["symbol"])
 
     def _dummy_frame(self, window_size: int) -> pd.DataFrame:

--- a/torchtrade/envs/live/alpaca/observation.py
+++ b/torchtrade/envs/live/alpaca/observation.py
@@ -1,33 +1,23 @@
+"""Alpaca crypto bars, on the shared observation base."""
+
 from typing import List, Union, Callable, Dict, Optional
 from datetime import datetime, timedelta
 from zoneinfo import ZoneInfo
 import numpy as np
 import pandas as pd
+from torchtrade.envs.live.shared.base_obs import BaseObservationClass
 from torchtrade.envs.utils.timeframe import TimeFrame, TimeFrameUnit, timeframe_to_alpaca
 from alpaca.data.requests import CryptoBarsRequest
 from alpaca.data.historical.crypto import CryptoHistoricalDataClient
 
-def _timestamps_of(df, column):
-    """Timestamps for `df`'s rows, from the column or the index.
 
-    `feature_preprocessing_fn` is public and may leave the timestamp in the index --
-    alpaca's SDK returns a (symbol, timestamp) MultiIndex and a custom fn need not call
-    reset_index. Reading the column unconditionally regressed that path to a KeyError.
+class AlpacaObservationClass(BaseObservationClass):
+    """Spot crypto bars from alpaca.
+
+    Everything about the WINDOW is inherited. This class is the part alpaca does
+    differently: it fetches a date RANGE rather than a bar count, and its SDK returns a
+    frame with a (symbol, timestamp) MultiIndex instead of a list of klines.
     """
-    if column in df.columns:
-        return df[column].values
-    if column in (df.index.names or []):
-        return df.index.get_level_values(column).values
-    raise KeyError(
-        f"feature_preprocessing_fn returned a frame with no {column!r} column or index "
-        f"level; base_features cannot be timestamped"
-    )
-
-
-class AlpacaObservationClass:
-
-    def reset(self) -> None:
-        """No-op; see BaseFuturesObservationClass.reset (#278)."""
 
     def __init__(
         self,
@@ -48,178 +38,59 @@ class AlpacaObservationClass:
             feature_preprocessing_fn: Optional custom preprocessing function that takes a DataFrame
                                    and returns a DataFrame with feature columns
             client: Optional pre-configured CryptoHistoricalDataClient for dependency injection (useful for testing)
+
+        `timeframes`, not the base's `time_frames`: the spelling is public and renaming it
+        would break every existing alpaca config for no behavioural gain.
         """
-        self.symbol = symbol
-        self.timeframes = (
-            [timeframes] if isinstance(timeframes, TimeFrame) else timeframes
-        )
-        self.window_sizes = (
-            [window_sizes] if isinstance(window_sizes, int) else window_sizes
-        )
         self.default_lookback = 60
-        # Validate that timeframes and window_sizes have matching lengths when both are lists
-        if isinstance(timeframes, list) and isinstance(window_sizes, list):
-            if len(self.timeframes) != len(self.window_sizes):
-                raise ValueError("If both timeframes and window_sizes are lists, they must have the same length")
-
-        self.feature_preprocessing_fn = (
-            feature_preprocessing_fn or self._default_preprocessing
+        super().__init__(
+            symbol=symbol,
+            time_frames=timeframes,
+            window_sizes=window_sizes,
+            feature_preprocessing_fn=feature_preprocessing_fn,
+            client=client,
         )
-        self.client = client if client is not None else CryptoHistoricalDataClient()
 
-    def _default_preprocessing(self, df: pd.DataFrame) -> pd.DataFrame:
-        """Default preprocessing function if none is provided."""
-        df = df.reset_index()
-        df.dropna(inplace=True)
-        df.drop_duplicates(inplace=True)
-        df = df.drop(columns=["symbol"])
+    def _create_client(self) -> object:
+        return CryptoHistoricalDataClient()
 
-        # Generating base features
-        # TODO: should those be unnormalized?
-        df["feature_close"] = df["close"].pct_change().fillna(0)
-        df["feature_open"] = df["open"] / df["close"]
-        df["feature_high"] = df["high"] / df["close"]
-        df["feature_low"] = df["low"] / df["close"]
-        df.dropna(inplace=True)
-        # dropna removes NaN but NOT inf, and a zero close produces it twice over:
-        # `open/close` on the zero bar itself, and `close.pct_change()` on the next one.
-        # inf then reaches the policy's observation tensor (#398).
-        df = df[np.isfinite(df.select_dtypes(include=[np.number])).all(axis=1)]
-        return df
-
-    def _get_numpy_obs(self, df: pd.DataFrame, columns: List[str] = None) -> np.ndarray:
-        """Convert specified columns to numpy array."""
-        if columns is None:
-            columns = [col for col in df.columns if "feature" in col]
-        if not columns:
-            raise ValueError(f"No columns found in preprocessed DataFrame matching: {columns}")
-        return np.array(df[columns], dtype=np.float32)
-
-    def _fetch_single_timeframe(
-        self, timeframe: TimeFrame #, window_size: int
-    ) -> pd.DataFrame:
-        """Fetch and preprocess data for a single timeframe.
-
-        Args:
-            timeframe: Custom TimeFrame object
-
-        Returns:
-            DataFrame with OHLCV data
-        """
+    def _validate_timeframe(self, timeframe: TimeFrame) -> None:
+        """The 60-day fetch window cannot fill a daily-bar observation."""
         if timeframe.unit == TimeFrameUnit.Day and self.default_lookback > 30:
-            raise ValueError("Default lookback is greater than 30 days, which is not allowed for daily data")
+            raise ValueError(
+                "Default lookback is greater than 30 days, which is not allowed for daily data"
+            )
 
-        # Convert custom TimeFrame to Alpaca TimeFrame for API calls
-        alpaca_timeframe = timeframe_to_alpaca(timeframe)
+    def _get_timestamp_column(self) -> str:
+        return "timestamp"
 
+    def _fetch_single_timeframe(self, timeframe: TimeFrame, limit: int = None) -> pd.DataFrame:
+        """A date RANGE, not a bar count, so `limit` has nothing to bind to.
+
+        That is why the short-window refusal in `get_observations` matters more here than
+        on the futures venues: they over-fetch by a fixed +50 bars, and this fetches
+        whatever 60 days happens to contain (#400).
+        """
         now = datetime.now(ZoneInfo("America/New_York"))
         request = CryptoBarsRequest(
             symbol_or_symbols=self.symbol,
-            timeframe=alpaca_timeframe,
-            start=now - timedelta(days=self.default_lookback), # TODO: this is critical
+            timeframe=timeframe_to_alpaca(timeframe),
+            start=now - timedelta(days=self.default_lookback),
             end=now,
-            #limit=window_size
         )
         return self.client.get_crypto_bars(request).df
 
-    def get_keys(self) -> List[str]:
-        """
-        Get the list of keys that will be present in the observations dictionary.
+    def _normalise_frame(self, df: pd.DataFrame) -> pd.DataFrame:
+        """The SDK hands back a (symbol, timestamp) MultiIndex and a constant `symbol`."""
+        return df.reset_index().drop(columns=["symbol"])
 
-        Returns:
-            List of strings formatted as '{timeframe}_{window_size}'
-            (e.g., '5Minute_10', '1Hour_20')
-        """
-        return [
-            f"{tf.obs_key_freq()}_{ws}"
-            for tf, ws in zip(self.timeframes, self.window_sizes)
-        ]
-
-    def get_features(self) -> Dict[str, List[str]]:
-        """Returns a dictionary with the observation features and the original features."""
-        def get_dummy_data(window_size: int):
-            df = pd.DataFrame()
-            df["symbol"] = [self.symbol]*window_size
-            df["open"] = np.random.rand(window_size)
-            df["high"] = np.random.rand(window_size)
-            df["low"] = np.random.rand(window_size)
-            df["close"] = np.random.rand(window_size)
-            df["volume"] = np.random.rand(window_size)
-            return df
-        # TODO: we could do this for all window sizes in case we have different processings per time frame
-        #features = []
-        #for window_size in self.window_sizes:
-            #dummy_df = get_dummy_data(window_size)
-            #features.extend([f for f in self.feature_preprocessing_fn(dummy_df).columns if "feature" in f])
-        dummy_df = self.feature_preprocessing_fn(get_dummy_data(self.window_sizes[0]))
-        observation_features = [f for f in dummy_df.columns if "feature" in f]
-        original_features = [f for f in dummy_df.columns if "feature" not in f]
-        return {"observation_features": observation_features, "original_features": original_features}
-
-    def get_observations(self, return_base_ohlc: bool = False) -> Dict[str, np.ndarray]:
-        """
-        Fetch and process observations for all specified timeframes and window sizes.
-
-        Args:
-            return_base_ohlc: If True, includes the raw OHLC data from the first timeframe
-                            in the observations dictionary under the 'base_features' key.
-
-        Returns:
-            Dictionary with keys formatted as '{timeframe}_{window_size}' and numpy array values.
-            If return_base_ohlc is True, includes 'base_features'and 'base_timestamps' keys with raw OHLC and timestamp data.
-        """
-        observations = {}
-
-        for timeframe, window_size in zip(self.timeframes, self.window_sizes):
-            key = f"{timeframe.obs_key_freq()}_{window_size}"
-            df = self._fetch_single_timeframe(timeframe)
-            
-            processed_df = self.feature_preprocessing_fn(df)
-
-            # A short frame is a silent shape corruption, not an error: `iloc[-w:]` just
-            # returns fewer rows, and reset() and rollout() both succeed on it (#400).
-            # Alpaca has no ObservationFailurePolicy, so this ends the step rather than
-            # flattening, and a config that can never fill the window raises at reset().
-            if len(processed_df) < window_size:
-                raise ValueError(
-                    f"only {len(processed_df)} usable candles for {self.symbol} on "
-                    f"{timeframe.obs_key_freq()} after preprocessing, need {window_size}"
-                )
-
-            # Sliced from the SAME frame as the market data, so row i of each is the
-            # same bar by construction (#395). Windowed to the (window, 4) spec (#69).
-            if return_base_ohlc and timeframe == self.timeframes[0]:
-                # `base_features[-1, 3]` is the current price at three SLTP call sites,
-                # each guarded by isfinite and `<= 0`. If the newest bar was dropped,
-                # `[-1]` is the PREVIOUS bar and those guards pass on a stale price.
-                #
-                # Here, not per-timeframe. Alpaca has no ObservationFailurePolicy, so
-                # this ends the step rather than flattening -- the futures copy of this
-                # guard carries that cost, see `futures_base_obs`. Only the default fn:
-                # a custom one may resample or trim the forming bar.
-                if self.feature_preprocessing_fn == self._default_preprocessing:
-                    _kept = _timestamps_of(processed_df, 'timestamp')
-                    _fetched = _timestamps_of(df, 'timestamp')
-                    if len(_fetched) and _kept[-1] != _fetched[-1]:
-                        raise ValueError(
-                            f"most recent candle for {self.symbol} on "
-                            f"{timeframe.obs_key_freq()} did not survive preprocessing; "
-                            f"refusing an observation whose last bar is stale"
-                        )
-
-                observations['base_features'] = self._get_numpy_obs(
-                    processed_df,
-                    columns=['open', 'high', 'low', 'close']
-                )[-window_size:]
-                observations['base_timestamps'] = _timestamps_of(
-                    processed_df, 'timestamp'
-                )[-window_size:]
-
-            # apply window size
-            processed_df = processed_df.iloc[-window_size:]
-            observations[key] = self._get_numpy_obs(processed_df)
-
-        return observations
+    def _dummy_frame(self, window_size: int) -> pd.DataFrame:
+        """Carries `symbol` because `_normalise_frame` drops it -- the dummy has to have
+        the shape real data has, or `get_features` measures a frame the venue never
+        produces (the dtype-fidelity lesson from binance's #289 fold)."""
+        df = super()._dummy_frame(window_size)
+        df.insert(0, "symbol", [self.symbol] * window_size)
+        return df
 
     def get_current_price(self) -> float:
         """
@@ -231,16 +102,14 @@ class AlpacaObservationClass:
         Returns:
             float: Most recent close price from the first timeframe
         """
-        if not self.timeframes:
+        if not self.time_frames:
             raise ValueError("No timeframes configured")
 
-        # Fetch data from the first timeframe
-        df = self._fetch_single_timeframe(self.timeframes[0])
+        df = self._fetch_single_timeframe(self.time_frames[0])
 
         if df.empty:
             raise ValueError(f"No data available for {self.symbol}")
 
-        # Return the most recent close price
         return float(df['close'].iloc[-1])
 
 

--- a/torchtrade/envs/live/shared/base_obs.py
+++ b/torchtrade/envs/live/shared/base_obs.py
@@ -15,9 +15,7 @@ class BaseObservationClass(ABC):
     Everything a venue can get wrong about the WINDOW lives here: which rows survive
     preprocessing, that base_features is sliced from the same frame as the market data
     (#395), that the newest bar is not stale (#399), and that the window is not shorter
-    than the declared spec (#400). Alpaca kept a parallel copy of all of it, and each
-    of those three fixes had to be pasted into both -- which is the pattern #288 exists
-    to end.
+    than the declared spec (#400).
 
     A subclass supplies the bars (`_fetch_single_timeframe`) and says how its SDK
     hands them over (`_normalise_frame`, `_get_timestamp_column`).
@@ -125,14 +123,13 @@ class BaseObservationClass(ABC):
         `get_observations` (#400).
         """
 
-    @abstractmethod
     def _normalise_frame(self, df: pd.DataFrame) -> pd.DataFrame:
         """A private copy of `df` in the shape the rest of this class expects.
 
-        Exists because SDKs disagree about what they hand back: a plain frame needs only
-        a copy, while alpaca's arrives with a (symbol, timestamp) MultiIndex and a
-        constant `symbol` column. Must not mutate the argument.
+        Overridable because SDKs disagree about what they hand back: a copy is enough for
+        a plain frame, while alpaca's arrives with a (symbol, timestamp) MultiIndex.
         """
+        return df.copy()
 
     def _default_preprocessing(self, df: pd.DataFrame) -> pd.DataFrame:
         """Default preprocessing function if none is provided."""

--- a/torchtrade/envs/live/shared/base_obs.py
+++ b/torchtrade/envs/live/shared/base_obs.py
@@ -1,0 +1,302 @@
+"""Venue-agnostic observation base: the window the policy actually sees."""
+
+from abc import ABC, abstractmethod
+from typing import List, Union, Callable, Dict, Optional
+import numpy as np
+import pandas as pd
+
+from torchtrade.envs.utils.timeframe import TimeFrame
+
+
+class BaseObservationClass(ABC):
+    """
+    Multi-timeframe market observations, independent of how the bars are fetched.
+
+    Everything a venue can get wrong about the WINDOW lives here: which rows survive
+    preprocessing, that base_features is sliced from the same frame as the market data
+    (#395), that the newest bar is not stale (#399), and that the window is not shorter
+    than the declared spec (#400). Alpaca kept a parallel copy of all of it, and each
+    of those three fixes had to be pasted into both -- which is the pattern #288 exists
+    to end.
+
+    A subclass supplies the bars (`_fetch_single_timeframe`) and says how its SDK
+    hands them over (`_normalise_frame`, `_get_timestamp_column`).
+    """
+
+    def reset(self) -> None:
+        """Rewind to the start of an episode. A live observer has nothing to rewind.
+
+        Declared so the envs can call it unconditionally (#278): ReplayObserver overrides
+        it to rewind the sampler and the simulated executor, and before this existed
+        nothing but a test ever called it -- so under a collector, episode 2 continued
+        mid-stream with episode 1's balance and an inherited position whose brackets had
+        been cancelled. A `hasattr` guard at the call site would be fail-open: an observer
+        that renamed the method would silently stop rewinding.
+
+        The bankruptcy baseline is deliberately NOT re-captured here. Rebasing it per
+        episode removes the cross-episode drawdown circuit breaker on a live account,
+        which persists between episodes -- and on replay it is a no-op, because the
+        executor rewinds to the same initial_balance every time.
+        """
+
+    def __init__(
+        self,
+        symbol: str,
+        time_frames: Union[List[TimeFrame], TimeFrame],
+        window_sizes: Union[List[int], int] = 10,
+        feature_preprocessing_fn: Optional[Callable] = None,
+        client: Optional[object] = None,
+        demo: bool = True,
+    ):
+        """
+        Initialize the observation class.
+
+        Args:
+            symbol: Trading symbol (e.g., "BTCUSDT")
+            time_frames: Single TimeFrame or list of TimeFrame objects
+            window_sizes: Single integer or list of integers specifying window sizes.
+                         If a list is provided, it must have the same length as time_frames.
+            feature_preprocessing_fn: Optional custom preprocessing function that takes a DataFrame
+                                     and returns a DataFrame with feature columns
+            client: Optional pre-configured client for dependency injection (useful for testing)
+            demo: Whether to use demo/testnet environment (default: True)
+        """
+        # Store symbol as-is (provider-specific normalization happens in subclasses)
+        self.symbol = symbol
+
+        # Normalize time_frames and window_sizes to lists
+        self.time_frames = [time_frames] if isinstance(time_frames, TimeFrame) else time_frames
+        self.window_sizes = [window_sizes] if isinstance(window_sizes, int) else window_sizes
+        self.demo = demo
+
+        # Validate time_frames
+        for tf in self.time_frames:
+            self._validate_timeframe(tf)
+
+        # Validate that time_frames and window_sizes have matching lengths
+        if len(self.time_frames) != len(self.window_sizes):
+            raise ValueError("time_frames and window_sizes must have the same length")
+
+        self.feature_preprocessing_fn = feature_preprocessing_fn or self._default_preprocessing
+
+        # Initialize client (provider-specific)
+        self.client = client if client is not None else self._create_client()
+
+    @abstractmethod
+    def _create_client(self) -> object:
+        """
+        Create provider-specific API client.
+
+        Returns:
+            Initialized API client for the provider
+        """
+        pass
+    @abstractmethod
+    def _validate_timeframe(self, timeframe: TimeFrame) -> None:
+        """
+        Validate that a timeframe is supported by this provider.
+
+        Args:
+            timeframe: TimeFrame object to validate
+
+        Raises:
+            ValueError: If timeframe is not supported
+        """
+        pass
+    @abstractmethod
+    def _get_timestamp_column(self) -> str:
+        """
+        Get the name of the primary timestamp column for base observations.
+
+        Returns:
+            Column name (e.g., "timestamp" for Bitget, "open_time" for Binance)
+        """
+        pass
+
+    # Common methods (shared across all providers)
+
+    @abstractmethod
+    def _fetch_single_timeframe(self, timeframe: TimeFrame, limit: int = None) -> pd.DataFrame:
+        """Bars for one timeframe, oldest first, as a DataFrame.
+
+        `limit` is a row count the caller wants available BEFORE preprocessing drops any.
+        A venue that fetches by date range instead may ignore it, but then nothing bounds
+        how many rows preprocessing can drop -- see the short-window refusal in
+        `get_observations` (#400).
+        """
+
+    @abstractmethod
+    def _normalise_frame(self, df: pd.DataFrame) -> pd.DataFrame:
+        """A private copy of `df` in the shape the rest of this class expects.
+
+        Exists because SDKs disagree about what they hand back: a plain frame needs only
+        a copy, while alpaca's arrives with a (symbol, timestamp) MultiIndex and a
+        constant `symbol` column. Must not mutate the argument.
+        """
+
+    def _default_preprocessing(self, df: pd.DataFrame) -> pd.DataFrame:
+        """Default preprocessing function if none is provided."""
+        df = self._normalise_frame(df)
+        df.dropna(inplace=True)
+        df.drop_duplicates(inplace=True)
+
+        # Generating base features (normalized)
+        df["feature_close"] = df["close"].pct_change().fillna(0)
+        df["feature_open"] = df["open"] / df["close"]
+        df["feature_high"] = df["high"] / df["close"]
+        df["feature_low"] = df["low"] / df["close"]
+        df.dropna(inplace=True)
+        # dropna removes NaN but NOT inf, and a zero close produces it twice over:
+        # `open/close` on the zero bar itself, and `close.pct_change()` on the next one.
+        # inf then reaches the policy's observation tensor (#398).
+        df = df[np.isfinite(df.select_dtypes(include=[np.number])).all(axis=1)]
+        return df
+
+    @staticmethod
+    def _timestamps_of(df: pd.DataFrame, column: str) -> np.ndarray:
+        """Timestamps for `df`'s rows, from the column or the index.
+
+        `feature_preprocessing_fn` is public and may return the timestamp either way. The
+        alpaca observer got this in #397; the futures half was lost before that commit
+        landed, so reading the column unconditionally still raised KeyError here for a fn
+        that sets it as an index.
+        """
+        if column in df.columns:
+            return df[column].values
+        if column in (df.index.names or []):
+            return df.index.get_level_values(column).values
+        # Not a silent `df.index.values`: that hands back positions as timestamps for a
+        # frame whose OHLC came from real bars. Validate at the boundary.
+        raise KeyError(
+            f"feature_preprocessing_fn returned a frame with no {column!r} column or "
+            f"index level; base_features cannot be timestamped"
+        )
+
+    def _get_numpy_obs(self, df: pd.DataFrame, columns: List[str] = None) -> np.ndarray:
+        """Convert specified columns to numpy array."""
+        if columns is None:
+            columns = [col for col in df.columns if "feature" in col]
+        if not columns:
+            raise ValueError(f"No columns found in preprocessed DataFrame matching: {columns}")
+        return np.array(df[columns], dtype=np.float32)
+
+    def get_keys(self) -> List[str]:
+        """
+        Get the list of keys that will be present in the observations dictionary.
+
+        Returns:
+            List of strings formatted as '{timeframe}_{window_size}'
+            (e.g., '5Minute_10', '1Hour_20')
+        """
+        return [
+            f"{tf.obs_key_freq()}_{ws}"
+            for tf, ws in zip(self.time_frames, self.window_sizes)
+        ]
+
+    def _dummy_frame(self, window_size: int) -> pd.DataFrame:
+        """A frame standing in for this venue's parsed klines, to count feature columns.
+
+        A method rather than a column tuple because DTYPE MATTERS: binance's `trades` is
+        int64 in real klines, and a names-only tuple made it a float, so a fn branching
+        on `is_integer_dtype(...)` took a different branch here than on live data.
+        `get_features()` then reported a width the observation did not have -- and that
+        width IS the spec `BinanceOHLCVTransform` builds, so it surfaced at
+        `check_env_specs`.
+
+        MAGNITUDES are NOT faithful and a fn branching on one will still diverge: dummy
+        values are `rand()` in [0, 1) and `trades` averages ~55 against a live ~1500.
+        Unbounded to chase, so it is stated rather than fixed.
+
+        Overridable because the venues do not return the same columns: binance klines
+        carry quote_volume, trades and the taker-buy fields, and against an OHLCV-only
+        frame a fn reading them raises KeyError. The timestamp columns are omitted on
+        every venue, so a fn deriving a time-of-day feature raises too.
+        """
+        return pd.DataFrame({
+            col: np.random.rand(window_size)
+            for col in ("open", "high", "low", "close", "volume")
+        })
+
+    def get_features(self) -> Dict[str, List[str]]:
+        """Returns a dictionary with the observation features and the original features."""
+        dummy_df = self.feature_preprocessing_fn(self._dummy_frame(self.window_sizes[0]))
+        observation_features = [f for f in dummy_df.columns if "feature" in f]
+        original_features = [f for f in dummy_df.columns if "feature" not in f]
+        return {"observation_features": observation_features, "original_features": original_features}
+
+    def get_observations(self, return_base_ohlc: bool = False) -> Dict[str, np.ndarray]:
+        """
+        Fetch and process observations for all specified timeframes and window sizes.
+
+        Args:
+            return_base_ohlc: If True, adds 'base_features' -- the preprocessing fn's
+                            open/high/low/close for the first timeframe, sliced to the same
+                            rows as the market data. A fn that drops or rescales those
+                            columns changes what the SLTP envs read as the current price.
+
+        Returns:
+            Dictionary with keys formatted as '{timeframe}_{window_size}' and numpy array values.
+            If return_base_ohlc is True, includes 'base_features' and 'base_timestamps' keys.
+        """
+        observations = {}
+
+        for timeframe, window_size in zip(self.time_frames, self.window_sizes):
+            key = f"{timeframe.obs_key_freq()}_{window_size}"
+            # Fetch extra data for preprocessing (rolling windows may need more)
+            df = self._fetch_single_timeframe(timeframe, limit=window_size + 50)
+
+            processed_df = self.feature_preprocessing_fn(df)
+
+            # A short frame is a silent shape corruption, not an error: `iloc[-w:]` just
+            # returns fewer rows, and reset() and rollout() both succeed on it (#400).
+            #
+            # Know what this costs before widening it. Under the DEFAULT policy (HALT)
+            # it raises and leaves the position alone. Under FLATTEN it market-closes an
+            # open position -- measured -- and the `+50` fetch buffer is a fixed CANDLE
+            # count, so on a 1m leg 50 bad candles is ~50 MINUTES of degraded feed, not
+            # an outage. In a multi-timeframe stack the finest leg decides, since any one
+            # short leg halts the read. That is opt-in, not free: FLATTEN means "if I
+            # cannot see the market, get flat", and a window short of its spec is not a
+            # market view. A config that can never fill the window raises in `_reset`,
+            # which is not halt-wrapped, so it surfaces flat with nothing to close.
+            if len(processed_df) < window_size:
+                raise ValueError(
+                    f"only {len(processed_df)} usable candles for {self.symbol} on "
+                    f"{timeframe.obs_key_freq()} after preprocessing, need {window_size}"
+                )
+
+            # Sliced from the SAME frame as the market data, so row i of each is the
+            # same bar by construction -- for a custom preprocessing fn too. Do NOT
+            # re-derive the row selection here: every partial copy of it desynced (#395).
+            if return_base_ohlc and timeframe == self.time_frames[0]:
+                # `base_features[-1, 3]` is the current price at three SLTP call sites,
+                # each guarded by isfinite and `<= 0`. If the newest bar was dropped,
+                # `[-1]` is the PREVIOUS bar and those guards pass on a stale price.
+                #
+                # Here, not per-timeframe: raising in the general read runs under
+                # `_halting`, where FLATTEN emergency-closes a real position -- the
+                # lesson `futures_live_base._current_mark_price` already records. Only
+                # the default fn: a custom one may resample or trim the forming bar.
+                if self.feature_preprocessing_fn == self._default_preprocessing:
+                    _kept = self._timestamps_of(processed_df, self._get_timestamp_column())
+                    _fetched = self._timestamps_of(df, self._get_timestamp_column())
+                    if len(_fetched) and _kept[-1] != _fetched[-1]:
+                        raise ValueError(
+                            f"most recent candle for {self.symbol} on "
+                            f"{timeframe.obs_key_freq()} did not survive preprocessing; "
+                            f"refusing an observation whose last bar is stale"
+                        )
+
+                observations['base_features'] = self._get_numpy_obs(
+                    processed_df,
+                    columns=['open', 'high', 'low', 'close']
+                )[-window_size:]
+                observations['base_timestamps'] = self._timestamps_of(
+                    processed_df, self._get_timestamp_column()
+                )[-window_size:]
+
+            # Apply window size
+            processed_df = processed_df.iloc[-window_size:]
+            observations[key] = self._get_numpy_obs(processed_df)
+
+        return observations

--- a/torchtrade/envs/live/shared/futures_base_obs.py
+++ b/torchtrade/envs/live/shared/futures_base_obs.py
@@ -1,103 +1,21 @@
 """Base observation class for futures exchanges."""
 
-from abc import ABC, abstractmethod
-from typing import List, Union, Callable, Dict, Optional
-import numpy as np
+from abc import abstractmethod
+
 import pandas as pd
 
+from torchtrade.envs.live.shared.base_obs import BaseObservationClass
 from torchtrade.envs.utils.timeframe import TimeFrame
 
 
-class BaseFuturesObservationClass(ABC):
+class BaseFuturesObservationClass(BaseObservationClass):
     """
-    Base observation class for fetching market data from futures exchanges.
+    Market data from a futures exchange's kline endpoint.
 
-    Provides common functionality for multi-timeframe observations with custom
-    feature preprocessing. Provider-specific implementations (Bitget, Binance, etc.)
-    only need to implement data fetching and parsing logic.
+    The window logic lives in `BaseObservationClass`; what is left here is the shape of a
+    kline API -- fetch a raw list, parse it, name the interval -- which the four futures
+    venues share and alpaca does not have at all.
     """
-
-    def reset(self) -> None:
-        """Rewind to the start of an episode. A live observer has nothing to rewind.
-
-        Declared so the envs can call it unconditionally (#278): ReplayObserver overrides
-        it to rewind the sampler and the simulated executor, and before this existed
-        nothing but a test ever called it -- so under a collector, episode 2 continued
-        mid-stream with episode 1's balance and an inherited position whose brackets had
-        been cancelled. A `hasattr` guard at the call site would be fail-open: an observer
-        that renamed the method would silently stop rewinding.
-
-        The bankruptcy baseline is deliberately NOT re-captured here. Rebasing it per
-        episode removes the cross-episode drawdown circuit breaker on a live account,
-        which persists between episodes -- and on replay it is a no-op, because the
-        executor rewinds to the same initial_balance every time.
-        """
-
-    def __init__(
-        self,
-        symbol: str,
-        time_frames: Union[List[TimeFrame], TimeFrame],
-        window_sizes: Union[List[int], int] = 10,
-        feature_preprocessing_fn: Optional[Callable] = None,
-        client: Optional[object] = None,
-        demo: bool = True,
-    ):
-        """
-        Initialize the observation class.
-
-        Args:
-            symbol: Trading symbol (e.g., "BTCUSDT")
-            time_frames: Single TimeFrame or list of TimeFrame objects
-            window_sizes: Single integer or list of integers specifying window sizes.
-                         If a list is provided, it must have the same length as time_frames.
-            feature_preprocessing_fn: Optional custom preprocessing function that takes a DataFrame
-                                     and returns a DataFrame with feature columns
-            client: Optional pre-configured client for dependency injection (useful for testing)
-            demo: Whether to use demo/testnet environment (default: True)
-        """
-        # Store symbol as-is (provider-specific normalization happens in subclasses)
-        self.symbol = symbol
-
-        # Normalize time_frames and window_sizes to lists
-        self.time_frames = [time_frames] if isinstance(time_frames, TimeFrame) else time_frames
-        self.window_sizes = [window_sizes] if isinstance(window_sizes, int) else window_sizes
-        self.demo = demo
-
-        # Validate time_frames
-        for tf in self.time_frames:
-            self._validate_timeframe(tf)
-
-        # Validate that time_frames and window_sizes have matching lengths
-        if len(self.time_frames) != len(self.window_sizes):
-            raise ValueError("time_frames and window_sizes must have the same length")
-
-        self.feature_preprocessing_fn = feature_preprocessing_fn or self._default_preprocessing
-
-        # Initialize client (provider-specific)
-        self.client = client if client is not None else self._create_client()
-
-    @abstractmethod
-    def _create_client(self) -> object:
-        """
-        Create provider-specific API client.
-
-        Returns:
-            Initialized API client for the provider
-        """
-        pass
-
-    @abstractmethod
-    def _validate_timeframe(self, timeframe: TimeFrame) -> None:
-        """
-        Validate that a timeframe is supported by this provider.
-
-        Args:
-            timeframe: TimeFrame object to validate
-
-        Raises:
-            ValueError: If timeframe is not supported
-        """
-        pass
 
     @abstractmethod
     def _fetch_klines(self, symbol: str, interval: str, limit: int) -> list:
@@ -113,7 +31,6 @@ class BaseFuturesObservationClass(ABC):
             Raw kline data from the API
         """
         pass
-
     @abstractmethod
     def _parse_klines(self, raw_klines: list) -> pd.DataFrame:
         """
@@ -134,7 +51,6 @@ class BaseFuturesObservationClass(ABC):
             DataFrame with standardized OHLCV columns
         """
         pass
-
     @abstractmethod
     def _convert_timeframe(self, timeframe: TimeFrame) -> str:
         """
@@ -147,69 +63,10 @@ class BaseFuturesObservationClass(ABC):
             Provider-specific interval string (e.g., "1H" for Bitget, "1h" for Binance)
         """
         pass
-
     @abstractmethod
     def _get_default_lookback(self) -> int:
         """Get the default number of candles to fetch."""
         pass
-
-    @abstractmethod
-    def _get_timestamp_column(self) -> str:
-        """
-        Get the name of the primary timestamp column for base observations.
-
-        Returns:
-            Column name (e.g., "timestamp" for Bitget, "open_time" for Binance)
-        """
-        pass
-
-    # Common methods (shared across all providers)
-
-    def _default_preprocessing(self, df: pd.DataFrame) -> pd.DataFrame:
-        """Default preprocessing function if none is provided."""
-        df = df.copy()
-        df.dropna(inplace=True)
-        df.drop_duplicates(inplace=True)
-
-        # Generating base features (normalized)
-        df["feature_close"] = df["close"].pct_change().fillna(0)
-        df["feature_open"] = df["open"] / df["close"]
-        df["feature_high"] = df["high"] / df["close"]
-        df["feature_low"] = df["low"] / df["close"]
-        df.dropna(inplace=True)
-        # dropna removes NaN but NOT inf, and a zero close produces it twice over:
-        # `open/close` on the zero bar itself, and `close.pct_change()` on the next one.
-        # inf then reaches the policy's observation tensor (#398).
-        df = df[np.isfinite(df.select_dtypes(include=[np.number])).all(axis=1)]
-        return df
-
-    @staticmethod
-    def _timestamps_of(df: pd.DataFrame, column: str) -> np.ndarray:
-        """Timestamps for `df`'s rows, from the column or the index.
-
-        `feature_preprocessing_fn` is public and may return the timestamp either way. The
-        alpaca observer got this in #397; the futures half was lost before that commit
-        landed, so reading the column unconditionally still raised KeyError here for a fn
-        that sets it as an index.
-        """
-        if column in df.columns:
-            return df[column].values
-        if column in (df.index.names or []):
-            return df.index.get_level_values(column).values
-        # Not a silent `df.index.values`: that hands back positions as timestamps for a
-        # frame whose OHLC came from real bars. Validate at the boundary.
-        raise KeyError(
-            f"feature_preprocessing_fn returned a frame with no {column!r} column or "
-            f"index level; base_features cannot be timestamped"
-        )
-
-    def _get_numpy_obs(self, df: pd.DataFrame, columns: List[str] = None) -> np.ndarray:
-        """Convert specified columns to numpy array."""
-        if columns is None:
-            columns = [col for col in df.columns if "feature" in col]
-        if not columns:
-            raise ValueError(f"No columns found in preprocessed DataFrame matching: {columns}")
-        return np.array(df[columns], dtype=np.float32)
 
     def _fetch_single_timeframe(self, timeframe: TimeFrame, limit: int = None) -> pd.DataFrame:
         """Fetch and preprocess data for a single timeframe."""
@@ -239,123 +96,6 @@ class BaseFuturesObservationClass(ABC):
         except Exception as e:
             raise RuntimeError(f"Failed to fetch candles for {self.symbol} on {timeframe.obs_key_freq()}: {str(e)}")
 
-    def get_keys(self) -> List[str]:
-        """
-        Get the list of keys that will be present in the observations dictionary.
-
-        Returns:
-            List of strings formatted as '{timeframe}_{window_size}'
-            (e.g., '5Minute_10', '1Hour_20')
-        """
-        return [
-            f"{tf.obs_key_freq()}_{ws}"
-            for tf, ws in zip(self.time_frames, self.window_sizes)
-        ]
-
-    def _dummy_frame(self, window_size: int) -> pd.DataFrame:
-        """A frame standing in for this venue's parsed klines, to count feature columns.
-
-        A method rather than a column tuple because DTYPE MATTERS: binance's `trades` is
-        int64 in real klines, and a names-only tuple made it a float, so a fn branching
-        on `is_integer_dtype(...)` took a different branch here than on live data.
-        `get_features()` then reported a width the observation did not have -- and that
-        width IS the spec `BinanceOHLCVTransform` builds, so it surfaced at
-        `check_env_specs`.
-
-        MAGNITUDES are NOT faithful and a fn branching on one will still diverge: dummy
-        values are `rand()` in [0, 1) and `trades` averages ~55 against a live ~1500.
-        Unbounded to chase, so it is stated rather than fixed.
-
-        Overridable because the venues do not return the same columns: binance klines
-        carry quote_volume, trades and the taker-buy fields, and against an OHLCV-only
-        frame a fn reading them raises KeyError. The timestamp columns are omitted on
-        every venue, so a fn deriving a time-of-day feature raises too.
-        """
-        return pd.DataFrame({
-            col: np.random.rand(window_size)
-            for col in ("open", "high", "low", "close", "volume")
-        })
-
-    def get_features(self) -> Dict[str, List[str]]:
-        """Returns a dictionary with the observation features and the original features."""
-        dummy_df = self.feature_preprocessing_fn(self._dummy_frame(self.window_sizes[0]))
-        observation_features = [f for f in dummy_df.columns if "feature" in f]
-        original_features = [f for f in dummy_df.columns if "feature" not in f]
-        return {"observation_features": observation_features, "original_features": original_features}
-
-    def get_observations(self, return_base_ohlc: bool = False) -> Dict[str, np.ndarray]:
-        """
-        Fetch and process observations for all specified timeframes and window sizes.
-
-        Args:
-            return_base_ohlc: If True, adds 'base_features' -- the preprocessing fn's
-                            open/high/low/close for the first timeframe, sliced to the same
-                            rows as the market data. A fn that drops or rescales those
-                            columns changes what the SLTP envs read as the current price.
-
-        Returns:
-            Dictionary with keys formatted as '{timeframe}_{window_size}' and numpy array values.
-            If return_base_ohlc is True, includes 'base_features' and 'base_timestamps' keys.
-        """
-        observations = {}
-
-        for timeframe, window_size in zip(self.time_frames, self.window_sizes):
-            key = f"{timeframe.obs_key_freq()}_{window_size}"
-            # Fetch extra data for preprocessing (rolling windows may need more)
-            df = self._fetch_single_timeframe(timeframe, limit=window_size + 50)
-
-            processed_df = self.feature_preprocessing_fn(df)
-
-            # A short frame is a silent shape corruption, not an error: `iloc[-w:]` just
-            # returns fewer rows, and reset() and rollout() both succeed on it (#400).
-            #
-            # Know what this costs before widening it. Under the DEFAULT policy (HALT)
-            # it raises and leaves the position alone. Under FLATTEN it market-closes an
-            # open position -- measured -- and the `+50` fetch buffer is a fixed CANDLE
-            # count, so on a 1m leg 50 bad candles is ~50 MINUTES of degraded feed, not
-            # an outage. In a multi-timeframe stack the finest leg decides, since any one
-            # short leg halts the read. That is opt-in, not free: FLATTEN means "if I
-            # cannot see the market, get flat", and a window short of its spec is not a
-            # market view. A config that can never fill the window raises in `_reset`,
-            # which is not halt-wrapped, so it surfaces flat with nothing to close.
-            if len(processed_df) < window_size:
-                raise ValueError(
-                    f"only {len(processed_df)} usable candles for {self.symbol} on "
-                    f"{timeframe.obs_key_freq()} after preprocessing, need {window_size}"
-                )
-
-            # Sliced from the SAME frame as the market data, so row i of each is the
-            # same bar by construction -- for a custom preprocessing fn too. Do NOT
-            # re-derive the row selection here: every partial copy of it desynced (#395).
-            if return_base_ohlc and timeframe == self.time_frames[0]:
-                # `base_features[-1, 3]` is the current price at three SLTP call sites,
-                # each guarded by isfinite and `<= 0`. If the newest bar was dropped,
-                # `[-1]` is the PREVIOUS bar and those guards pass on a stale price.
-                #
-                # Here, not per-timeframe: raising in the general read runs under
-                # `_halting`, where FLATTEN emergency-closes a real position -- the
-                # lesson `futures_live_base._current_mark_price` already records. Only
-                # the default fn: a custom one may resample or trim the forming bar.
-                if self.feature_preprocessing_fn == self._default_preprocessing:
-                    _kept = self._timestamps_of(processed_df, self._get_timestamp_column())
-                    _fetched = self._timestamps_of(df, self._get_timestamp_column())
-                    if len(_fetched) and _kept[-1] != _fetched[-1]:
-                        raise ValueError(
-                            f"most recent candle for {self.symbol} on "
-                            f"{timeframe.obs_key_freq()} did not survive preprocessing; "
-                            f"refusing an observation whose last bar is stale"
-                        )
-
-                observations['base_features'] = self._get_numpy_obs(
-                    processed_df,
-                    columns=['open', 'high', 'low', 'close']
-                )[-window_size:]
-                observations['base_timestamps'] = self._timestamps_of(
-                    processed_df, self._get_timestamp_column()
-                )[-window_size:]
-
-            # Apply window size
-            processed_df = processed_df.iloc[-window_size:]
-            observations[key] = self._get_numpy_obs(processed_df)
-
-        return observations
+    def _normalise_frame(self, df: pd.DataFrame) -> pd.DataFrame:
+        """`_parse_klines` already returns a plain frame, so a copy is the whole job."""
+        return df.copy()

--- a/torchtrade/envs/live/shared/futures_base_obs.py
+++ b/torchtrade/envs/live/shared/futures_base_obs.py
@@ -95,7 +95,3 @@ class BaseFuturesObservationClass(BaseObservationClass):
 
         except Exception as e:
             raise RuntimeError(f"Failed to fetch candles for {self.symbol} on {timeframe.obs_key_freq()}: {str(e)}")
-
-    def _normalise_frame(self, df: pd.DataFrame) -> pd.DataFrame:
-        """`_parse_klines` already returns a plain frame, so a copy is the whole job."""
-        return df.copy()


### PR DESCRIPTION
Refs #288 — first slice, biggest first.

## What was duplicated

Alpaca kept a parallel copy of the entire observation window pipeline. Normalising the three naming differences, the two `get_observations` implementations differed by **one real line**:

```
-  df = self._fetch_single_timeframe(timeframe)
+  df = self._fetch_single_timeframe(timeframe, limit=window_size + 50)
```

Everything else in that 64-line method was docstring prose. `_default_preprocessing` differed by two alpaca SDK-shape lines.

**That copy has cost three times running.** Row alignment (#395), the stale last bar (#398/#399), and the short window (#400) each had to be pasted into both halves. Alpaca's half of #397 had **zero** test coverage until #401 added a shared one — deleting its `dropna` failed no tests at all.

## The split, measured rather than assumed

Of the seven abstract hooks on the futures base, the window logic calls only **three** (`_create_client`, `_validate_timeframe`, `_get_timestamp_column`). The boundary follows what the code needs:

| module | holds | lines |
|---|---|---|
| `shared/base_obs.py` *(new)* | the window pipeline; abstract `_fetch_single_timeframe` + the three above | **299** |
| `shared/futures_base_obs.py` | the four kline hooks and the kline-based fetch | 361 → **97** |
| `alpaca/observation.py` | a date-RANGE fetch and the MultiIndex undo | 321 → **109** |

The four futures venues are untouched — same class name, same module, same abstract contract. `timeframes=` stays alpaca's public kwarg and maps to `time_frames` inside `__init__`.

## Three deviations from behaviour-identical, all deliberate, all now tested

Everything else was verified identical by **hashing `get_observations` output** across all five venues, re-driving all four recent fixes with crafted malformed frames, and running a real env rollout — branch vs main.

1. **Length mismatch now raises at construction.** On main, `timeframes=<one TimeFrame>, window_sizes=[10, 20]` is *accepted* and `get_keys()` silently truncates via `zip()` — the policy trains on a window it wasn't configured for.
2. **A daily timeframe is refused at construction**, not on the first fetch — which previously happened during `reset()`, on a live account.
3. **`symbol` is dropped before the shared `dropna`.** A bar whose metadata came back null but whose OHLCV is sound now survives; losing usable bars to a metadata gap is what pushes a window under its spec. @CharlieHelps found the other side of this boundary: two bars alike in every OHLCV field but differing in *symbol* would now collapse to one. That's outside the `symbol: str` single-symbol contract, and it's recorded at the seam as a constraint on any future multi-symbol work.

## What the review rounds found in my own work

- **The test I added to pin deviation 3 could not fail.** It asserted a row count, and with 60 bars fetched for a 5-bar window, dropping one row still fills the window. It asserts the timestamp now, and fails under main's ordering.
- **`df.copy()` in `_normalise_frame` is load-bearing and nothing guarded it.** Preprocessing drops rows `inplace=True`, and the #399 stale-bar check compares the processed frame against the fetched one — share one object and the comparison can never differ, so a stale bar reaches the policy. Returning `df` instead passed all 3999 tests. Now fails 4 of 5 venues.
- **A coverage skew the fold created.** Three tests asserting shared preprocessing lived only in alpaca's file; the other four venues ran that code with no equivalent. Promoted — swapping high/low in the slice now fails 5 of 5 instead of 1.
- **A guard my own change silenced.** `test_no_venue_reimplements_the_shared_base` read one class's `__dict__`, so hoisting `get_observations` dropped it from the guarded set. It walks the MRO now.
- **A 74-line `__main__` block making live Alpaca network calls**, and dead `numpy`/`Dict` imports left by the move.

Net **+515/−558**. Full suite: **4004 passed, 16 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
