### PR TITLE
refactor(live): delete an unreachable hook, and give the margin field one name

### DIFF
--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -183,7 +183,6 @@ bankrupt_threshold: 0.1
 include_base_features: false
 max_traj_length: null
 random_start: true
-margin_mode: isolated
 maintenance_margin_rate: 0.004
 seed: 0
 train_envs: 5
@@ -213,7 +212,6 @@ bankrupt_threshold: 0.1
 include_base_features: false
 max_traj_length: null
 random_start: true
-margin_mode: isolated
 maintenance_margin_rate: 0.004
 seed: 0
 train_envs: 10

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -183,7 +183,7 @@ bankrupt_threshold: 0.1
 include_base_features: false
 max_traj_length: null
 random_start: true
-margin_type: isolated
+margin_mode: isolated
 maintenance_margin_rate: 0.004
 seed: 0
 train_envs: 5
@@ -213,7 +213,7 @@ bankrupt_threshold: 0.1
 include_base_features: false
 max_traj_length: null
 random_start: true
-margin_type: isolated
+margin_mode: isolated
 maintenance_margin_rate: 0.004
 seed: 0
 train_envs: 10

--- a/examples/online_rl/dqn/env/sequential.yaml
+++ b/examples/online_rl/dqn/env/sequential.yaml
@@ -13,7 +13,6 @@ bankrupt_threshold: 0.1
 include_base_features: false
 max_traj_length: null
 random_start: true
-margin_type: isolated
 maintenance_margin_rate: 0.004
 exp_name: ${logger.exp_name}
 seed: 0

--- a/examples/online_rl/dqn/env/sequential_sltp.yaml
+++ b/examples/online_rl/dqn/env/sequential_sltp.yaml
@@ -17,7 +17,6 @@ bankrupt_threshold: 0.1
 include_base_features: false
 max_traj_length: null
 random_start: true
-margin_type: isolated
 maintenance_margin_rate: 0.004
 exp_name: ${logger.exp_name}
 seed: 0

--- a/examples/online_rl/dsac/env/sequential.yaml
+++ b/examples/online_rl/dsac/env/sequential.yaml
@@ -13,7 +13,6 @@ bankrupt_threshold: 0.1
 include_base_features: false
 max_traj_length: null
 random_start: true
-margin_type: isolated
 maintenance_margin_rate: 0.004
 exp_name: ${logger.exp_name}
 seed: 0

--- a/examples/online_rl/dsac/env/sequential_sltp.yaml
+++ b/examples/online_rl/dsac/env/sequential_sltp.yaml
@@ -17,7 +17,6 @@ bankrupt_threshold: 0.1
 include_base_features: false
 max_traj_length: null
 random_start: true
-margin_type: isolated
 maintenance_margin_rate: 0.004
 exp_name: ${logger.exp_name}
 seed: 0

--- a/examples/online_rl/iql/env/sequential.yaml
+++ b/examples/online_rl/iql/env/sequential.yaml
@@ -13,7 +13,6 @@ bankrupt_threshold: 0.1
 include_base_features: false
 max_traj_length: null
 random_start: true
-margin_type: isolated
 maintenance_margin_rate: 0.004
 exp_name: ${logger.exp_name}
 seed: 0

--- a/examples/online_rl/iql/env/sequential_sltp.yaml
+++ b/examples/online_rl/iql/env/sequential_sltp.yaml
@@ -17,7 +17,6 @@ bankrupt_threshold: 0.1
 include_base_features: false
 max_traj_length: null
 random_start: true
-margin_type: isolated
 maintenance_margin_rate: 0.004
 exp_name: ${logger.exp_name}
 seed: 0

--- a/examples/online_rl/ppo/env/sequential.yaml
+++ b/examples/online_rl/ppo/env/sequential.yaml
@@ -13,7 +13,6 @@ bankrupt_threshold: 0.1
 include_base_features: false
 max_traj_length: null
 random_start: true
-margin_type: isolated
 maintenance_margin_rate: 0.004
 exp_name: ${logger.exp_name}
 seed: 0

--- a/examples/online_rl/ppo/env/sequential_sltp.yaml
+++ b/examples/online_rl/ppo/env/sequential_sltp.yaml
@@ -17,7 +17,6 @@ bankrupt_threshold: 0.1
 include_base_features: false
 max_traj_length: null
 random_start: true
-margin_type: isolated
 maintenance_margin_rate: 0.004
 exp_name: ${logger.exp_name}
 seed: 0

--- a/examples/online_rl/ppo_chronos/env/sequential.yaml
+++ b/examples/online_rl/ppo_chronos/env/sequential.yaml
@@ -13,7 +13,6 @@ bankrupt_threshold: 0.1
 include_base_features: false
 max_traj_length: null
 random_start: true
-margin_type: isolated
 maintenance_margin_rate: 0.004
 exp_name: ${logger.exp_name}
 seed: 0

--- a/examples/online_rl/ppo_chronos/env/sequential_sltp.yaml
+++ b/examples/online_rl/ppo_chronos/env/sequential_sltp.yaml
@@ -16,7 +16,6 @@ bankrupt_threshold: 0.1
 include_base_features: false
 max_traj_length: null
 random_start: true
-margin_type: isolated
 maintenance_margin_rate: 0.004
 exp_name: ${logger.exp_name}
 seed: 0

--- a/examples/online_rl/ppo_vectorized/env/vectorized_sequential.yaml
+++ b/examples/online_rl/ppo_vectorized/env/vectorized_sequential.yaml
@@ -14,7 +14,6 @@ bankrupt_threshold: 0.1
 include_base_features: false
 max_traj_length: null
 random_start: true
-margin_type: isolated
 maintenance_margin_rate: 0.004
 exp_name: ${logger.exp_name}
 seed: 0

--- a/tests/envs/base_exchange_tests.py
+++ b/tests/envs/base_exchange_tests.py
@@ -5,7 +5,6 @@
   test_torch_env_futures*.py, so the flip contract has one body and five kills.
 """
 
-from dataclasses import fields
 
 import pytest
 import numpy as np

--- a/tests/envs/base_exchange_tests.py
+++ b/tests/envs/base_exchange_tests.py
@@ -457,15 +457,15 @@ def assert_a_direct_flip_does_not_age_the_new_position(
     change and reset hold_counter itself (PR #245 / SLTPMixin), masking the bug: the test goes
     vacuous. Two of these passed on the buggy code before I found that.
     """
-    # Built positionally because the four dataclasses differ only in the NAME of field 8
-    # (margin_mode on binance, margin_mode elsewhere). The only field this test actually reads
-    # is qty -- everything else is inert filler -- so that is the one thing worth pinning.
-    assert [f.name for f in fields(PositionStatus)][0] == "qty"
-
+    # Keyword-built: since #289 every venue's PositionStatus has the same field names, so
+    # the positional form this used to need (they differed only in field 8's spelling) is
+    # gone. Only qty is read; the rest is inert filler.
     def pos(qty):
         liq = 45000.0 if qty > 0 else 55000.0     # shorts liquidate ABOVE the mark
         return {"position_status": PositionStatus(
-            qty, 500.0, 50000.0, 0.0, 0.0, 50000.0, 5, "isolated", liq)}
+            qty=qty, notional_value=500.0, entry_price=50000.0, unrealized_pnl=0.0,
+            unrealized_pnl_pct=0.0, mark_price=50000.0, leverage=5,
+            margin_mode="isolated", liquidation_price=liq)}
 
     with patch.object(env, "_wait_for_next_timestamp"):
         trader.get_status = MagicMock(return_value=pos(0.01))

--- a/tests/envs/base_exchange_tests.py
+++ b/tests/envs/base_exchange_tests.py
@@ -458,7 +458,7 @@ def assert_a_direct_flip_does_not_age_the_new_position(
     vacuous. Two of these passed on the buggy code before I found that.
     """
     # Built positionally because the four dataclasses differ only in the NAME of field 8
-    # (margin_type on binance, margin_mode elsewhere). The only field this test actually reads
+    # (margin_mode on binance, margin_mode elsewhere). The only field this test actually reads
     # is qty -- everything else is inert filler -- so that is the one thing worth pinning.
     assert [f.name for f in fields(PositionStatus)][0] == "qty"
 

--- a/tests/envs/binance/test_futures_order_executor.py
+++ b/tests/envs/binance/test_futures_order_executor.py
@@ -416,7 +416,7 @@ class TestPositionStatusDataclass:
             unrealized_pnl_pct=0.002,
             mark_price=50100.0,
             leverage=10,
-            margin_type="isolated",
+            margin_mode="isolated",
             liquidation_price=45000.0,
         )
 

--- a/tests/envs/binance/test_torch_env_futures.py
+++ b/tests/envs/binance/test_torch_env_futures.py
@@ -326,7 +326,7 @@ class TestBinanceFuturesTorchTradingEnv:
             mock_trader.get_status = MagicMock(return_value={"position_status": PositionStatus(
                 qty=filled, notional_value=500.0, entry_price=50000.0, unrealized_pnl=0.0,
                 unrealized_pnl_pct=0.0, mark_price=50000.0, leverage=5,
-                margin_type="isolated", liquidation_price=45000.0,
+                margin_mode="isolated", liquidation_price=45000.0,
             )})
             mock_trader.trade.reset_mock()
             env.step(TensorDict({"action": torch.tensor(long_idx)}, batch_size=()))
@@ -351,7 +351,7 @@ class TestBinanceFuturesTorchTradingEnv:
         mock_trader.get_status = MagicMock(return_value={"position_status": PositionStatus(
             qty=1e-12, notional_value=500.0, entry_price=47500.0, unrealized_pnl=26.3,
             unrealized_pnl_pct=0.0526, mark_price=50000.0, leverage=20,
-            margin_type="isolated", liquidation_price=48000.0,
+            margin_mode="isolated", liquidation_price=48000.0,
         )})
 
         with patch.object(env, "_wait_for_next_timestamp"):
@@ -391,7 +391,7 @@ class TestBinanceFuturesTorchTradingEnv:
         mock_trader.get_status = MagicMock(return_value={"position_status": PositionStatus(
             qty=0.01, notional_value=500.0, entry_price=47500.0, unrealized_pnl=26.3,
             unrealized_pnl_pct=0.0526, mark_price=50000.0, leverage=20,  # NOT the config's 5
-            margin_type="isolated", liquidation_price=45000.0,
+            margin_mode="isolated", liquidation_price=45000.0,
         )})
 
         with patch.object(env, "_wait_for_next_timestamp"):
@@ -444,7 +444,7 @@ class TestBinanceFuturesTorchTradingEnv:
         mock_trader.get_status = MagicMock(return_value={"position_status": PositionStatus(
             qty=qty, notional_value=50.1, entry_price=50000.0, unrealized_pnl=0.1,
             unrealized_pnl_pct=0.002, mark_price=50100.0, leverage=10,
-            margin_type="isolated", liquidation_price=liq_price,
+            margin_mode="isolated", liquidation_price=liq_price,
         )})
         with patch.object(env, "_wait_for_next_timestamp"):
             td = env.reset()
@@ -468,7 +468,7 @@ class TestBinanceFuturesTorchTradingEnv:
         mock_trader.get_status = MagicMock(return_value={"position_status": PositionStatus(
             qty=0.011, notional_value=550.0, entry_price=50000.0, unrealized_pnl=100.0,
             unrealized_pnl_pct=0.02, mark_price=50000.0, leverage=10,
-            margin_type="isolated", liquidation_price=45000.0,
+            margin_mode="isolated", liquidation_price=45000.0,
         )})
         with patch.object(env, "_wait_for_next_timestamp"):
             td = env.reset()
@@ -490,7 +490,7 @@ class TestBinanceFuturesTorchTradingEnv:
             return {"position_status": PositionStatus(
                 qty=qty, notional_value=500.0, entry_price=50000.0, unrealized_pnl=0.0,
                 unrealized_pnl_pct=0.0, mark_price=50000.0, leverage=5,
-                margin_type="isolated", liquidation_price=45000.0,
+                margin_mode="isolated", liquidation_price=45000.0,
             )} if qty else {"position_status": None}
 
         with patch.object(env, "_wait_for_next_timestamp"):
@@ -523,7 +523,7 @@ class TestBinanceFuturesTorchTradingEnv:
             return {"position_status": PositionStatus(
                 qty=qty, notional_value=500.0, entry_price=50000.0, unrealized_pnl=0.0,
                 unrealized_pnl_pct=0.0, mark_price=50000.0, leverage=5,
-                margin_type="isolated", liquidation_price=45000.0,
+                margin_mode="isolated", liquidation_price=45000.0,
             )} if qty else {"position_status": None}
 
         with patch.object(env, "_wait_for_next_timestamp"):
@@ -551,18 +551,18 @@ class TestBinanceFuturesTradingEnvConfig:
     def test_custom_config(self):
         """Test custom configuration."""
         from torchtrade.envs.live.binance.env import BinanceFuturesTradingEnvConfig
-        from torchtrade.envs.live.binance.order_executor import MarginType
+        from torchtrade.envs.live.binance.order_executor import MarginMode
 
         config = BinanceFuturesTradingEnvConfig(
             symbol="ETHUSDT",
             leverage=10,
-            margin_type=MarginType.CROSSED,
+            margin_mode=MarginMode.CROSSED,
             demo=False,
         )
 
         assert config.symbol == "ETHUSDT"
         assert config.leverage == 10
-        assert config.margin_type == MarginType.CROSSED
+        assert config.margin_mode == MarginMode.CROSSED
         assert config.demo is False
 
 

--- a/tests/envs/offline/test_offline_config_has_no_dead_fields_289.py
+++ b/tests/envs/offline/test_offline_config_has_no_dead_fields_289.py
@@ -106,19 +106,31 @@ def test_every_offline_config_field_is_read_somewhere(config_cls):
     )
 
 
-@pytest.mark.parametrize("config_cls", [
-    SequentialTradingEnvConfig, SequentialTradingEnvSLTPConfig, OneStepTradingEnvConfig,
-], ids=lambda c: c.__name__)
-@pytest.mark.parametrize("kwargs,match", [
-    ({"include_base_features": True}, "not implemented for the offline"),
-    ({"margin_mode": MarginMode.CROSSED}, "not implemented for the offline"),
-])
-def test_a_flag_the_offline_envs_ignore_is_rejected(config_cls, kwargs, match):
-    """Every config that inherits the validation, not just Sequential.
+# Paired explicitly, not derived from `dataclasses.fields`: the vectorized configs carry
+# `margin_mode` but not `include_base_features`, and a presence-derived list would drop a
+# case silently the day a field moves. Every config that HAS the flag is listed against it.
+REJECTED_FLAG_CASES = [
+    (SequentialTradingEnvConfig, {"include_base_features": True}),
+    (SequentialTradingEnvSLTPConfig, {"include_base_features": True}),
+    (OneStepTradingEnvConfig, {"include_base_features": True}),
+    (SequentialTradingEnvConfig, {"margin_mode": MarginMode.CROSSED}),
+    (SequentialTradingEnvSLTPConfig, {"margin_mode": MarginMode.CROSSED}),
+    (OneStepTradingEnvConfig, {"margin_mode": MarginMode.CROSSED}),
+    # The two the guard was ADDED for, and the two it was not tested on: removing
+    # `validate_offline_margin_mode` from the vectorized config passed all 4013 tests.
+    (VectorizedSequentialTradingEnvConfig, {"margin_mode": MarginMode.CROSSED}),
+    (VectorizedSequentialTradingEnvSLTPConfig, {"margin_mode": MarginMode.CROSSED}),
+]
+
+
+@pytest.mark.parametrize("config_cls,kwargs", REJECTED_FLAG_CASES,
+                         ids=lambda v: v.__name__ if isinstance(v, type) else next(iter(v)))
+def test_a_flag_the_offline_envs_ignore_is_rejected(config_cls, kwargs):
+    """Every config that HAS the flag, not just the ones that inherit one validator.
 
     Both defaulted to the value the envs actually implement, so the wrong setting was
     accepted and ignored -- a policy configured for cross margin trained against
     isolated liquidation prices with nothing saying so.
     """
-    with pytest.raises(ValueError, match=match):
+    with pytest.raises(ValueError, match="not implemented for the offline"):
         config_cls(**kwargs)

--- a/tests/envs/offline/test_offline_config_has_no_dead_fields_289.py
+++ b/tests/envs/offline/test_offline_config_has_no_dead_fields_289.py
@@ -6,7 +6,7 @@ import pathlib
 
 import pytest
 
-from torchtrade.envs.core.common_types import MarginType
+from torchtrade.envs.core.common_types import MarginMode
 
 from torchtrade.envs.offline import (
     OneStepTradingEnvConfig,
@@ -43,7 +43,7 @@ DESCRIPTIVE_FIELDS = {"symbol"}
 # __post_init__ REJECTS any value other than the implemented one, so they cannot be set
 # and ignored. `test_a_flag_the_offline_envs_ignore_is_rejected` proves that, which is
 # what earns the exemption; being listed here is not enough on its own.
-REJECTED_FIELDS = {"include_base_features", "margin_type"}
+REJECTED_FIELDS = {"include_base_features", "margin_mode"}
 
 
 def _names_read_offline() -> set:
@@ -57,7 +57,7 @@ def _names_read_offline() -> set:
       raise that names a field permanently disarms the guard for it. That is exactly
       backwards: the raise exists because the field is dead.
     - A match anywhere in the concatenated sources cleared the field on every config, so
-      `margin_type` -- copied once in sequential.py and read nowhere -- was exempt on all
+      `margin_mode` -- copied once in sequential.py and read nowhere -- was exempt on all
       five.
     """
     class _StripPostInit(ast.NodeTransformer):
@@ -86,10 +86,10 @@ def _names_read_offline() -> set:
 
 @pytest.mark.parametrize("config_cls", CONFIGS, ids=lambda c: c.__name__)
 def test_every_offline_config_field_is_read_somewhere(config_cls):
-    """`include_base_features` and `margin_type` both sat here with ZERO readers.
+    """`include_base_features` and `margin_mode` both sat here with ZERO readers.
 
     Setting either did nothing, silently: `include_base_features=True` promised an
-    observation that was never emitted, and `margin_type=CROSSED` promised cross-margin
+    observation that was never emitted, and `margin_mode=CROSSED` promised cross-margin
     liquidation while `_liquidation_price` calls `isolated_liquidation_price`
     unconditionally. Both now raise; this keeps the next one from being added quietly.
     """
@@ -111,7 +111,7 @@ def test_every_offline_config_field_is_read_somewhere(config_cls):
 ], ids=lambda c: c.__name__)
 @pytest.mark.parametrize("kwargs,match", [
     ({"include_base_features": True}, "not implemented for the offline"),
-    ({"margin_type": MarginType.CROSSED}, "not implemented for the offline"),
+    ({"margin_mode": MarginMode.CROSSED}, "not implemented for the offline"),
 ])
 def test_a_flag_the_offline_envs_ignore_is_rejected(config_cls, kwargs, match):
     """Every config that inherits the validation, not just Sequential.

--- a/tests/envs/test_executor_helpers_288.py
+++ b/tests/envs/test_executor_helpers_288.py
@@ -170,3 +170,33 @@ def test_every_position_status_spells_the_margin_field_the_same_way(venue, modul
     assert "margin_mode" in names and "margin_type" not in names, (
         f"{venue} PositionStatus spells it {names & {'margin_mode', 'margin_type'}}"
     )
+
+
+def test_the_package_exports_do_not_shadow_one_margin_enum_with_another():
+    """Four venues, four DIFFERENT margin enums, one name -- so exports must not collide.
+
+    The values are API wire strings and deliberately differ: core/binance `ISOLATED`,
+    bitget and bybit `isolated`, okx `cross` where the others say `crossed`. okx was
+    already aliased `OKXMarginMode` for exactly this reason; renaming binance's
+    `MarginType` to `MarginMode` (#289) walked it into the same trap, and for a while
+    `torchtrade.envs.MarginMode` resolved to BYBIT's -- so a binance config built from
+    the package export would have sent `marginType='crossed'` to an API expecting
+    `'CROSSED'`.
+
+    No test covered the export surface, which is why the whole suite passed on it.
+    """
+    import torchtrade.envs as envs
+    import torchtrade.envs.live as live
+
+    assert envs.MarginMode.__module__ == "torchtrade.envs.core.common_types", (
+        f"torchtrade.envs.MarginMode resolves to {envs.MarginMode.__module__}; the "
+        f"offline configs validate against core's, so a venue enum here rejects them"
+    )
+    assert envs.MarginMode.ISOLATED.value == "ISOLATED"
+    assert live.MarginMode.__module__.endswith("bybit.order_executor")
+    for module in (envs, live):
+        for name in ("MarginMode", "PositionMode"):
+            assert getattr(module, "__all__", []).count(name) <= 1, (
+                f"{module.__name__}.__all__ lists {name} twice; the second import wins "
+                f"silently and the wire value changes with it"
+            )

--- a/tests/envs/test_executor_helpers_288.py
+++ b/tests/envs/test_executor_helpers_288.py
@@ -172,18 +172,20 @@ def test_every_position_status_spells_the_margin_field_the_same_way(venue, modul
     )
 
 
-def test_the_package_exports_do_not_shadow_one_margin_enum_with_another():
-    """Four venues, four DIFFERENT margin enums, one name -- so exports must not collide.
+def test_no_unqualified_margin_enum_is_exported_from_the_live_namespace():
+    """Four venues, four DIFFERENT margin enums, one class name.
 
     The values are API wire strings and deliberately differ: core/binance `ISOLATED`,
-    bitget and bybit `isolated`, okx `cross` where the others say `crossed`. okx was
-    already aliased `OKXMarginMode` for exactly this reason; renaming binance's
-    `MarginType` to `MarginMode` (#289) walked it into the same trap, and for a while
-    `torchtrade.envs.MarginMode` resolved to BYBIT's -- so a binance config built from
-    the package export would have sent `marginType='crossed'` to an API expecting
-    `'CROSSED'`.
+    bitget and bybit `isolated`, okx `cross` where the others say `crossed`. So an
+    unqualified `MarginMode` at a namespace covering all four sends the wrong case to
+    whichever venue it did not come from -- measured, `marginType='isolated'` reaching an
+    API that wants `'ISOLATED'`.
 
-    No test covered the export surface, which is why the whole suite passed on it.
+    okx was aliased for this reason long before #289; renaming binance's `MarginType` to
+    `MarginMode` put a THIRD claimant on the name and made `torchtrade.envs.MarginMode`
+    resolve to bybit's. Nothing covered the export surface, so the whole suite passed on
+    it. Every venue enum is qualified here now; the bare name belongs to core, which is
+    what the offline configs validate against.
     """
     import torchtrade.envs as envs
     import torchtrade.envs.live as live
@@ -192,11 +194,15 @@ def test_the_package_exports_do_not_shadow_one_margin_enum_with_another():
         f"torchtrade.envs.MarginMode resolves to {envs.MarginMode.__module__}; the "
         f"offline configs validate against core's, so a venue enum here rejects them"
     )
-    assert envs.MarginMode.ISOLATED.value == "ISOLATED"
-    assert live.MarginMode.__module__.endswith("bybit.order_executor")
-    for module in (envs, live):
-        for name in ("MarginMode", "PositionMode"):
-            assert getattr(module, "__all__", []).count(name) <= 1, (
-                f"{module.__name__}.__all__ lists {name} twice; the second import wins "
-                f"silently and the wire value changes with it"
-            )
+    assert not hasattr(live, "MarginMode"), (
+        "torchtrade.envs.live exports an unqualified MarginMode; four venues claim that "
+        "name with incompatible wire values, so it must be aliased per venue"
+    )
+    assert not hasattr(live, "PositionMode"), "same, for PositionMode"
+    assert live.BybitMarginMode.ISOLATED.value == "isolated"
+    assert live.OKXMarginMode.CROSS.value == "cross"
+    assert len(live.__all__) == len(set(live.__all__)), (
+        f"duplicate names in torchtrade.envs.live.__all__: the second import wins "
+        f"silently and the wire value changes with it -- "
+        f"{sorted(n for n in live.__all__ if live.__all__.count(n) > 1)}"
+    )

--- a/tests/envs/test_executor_helpers_288.py
+++ b/tests/envs/test_executor_helpers_288.py
@@ -143,3 +143,35 @@ def test_the_executor_trade_surface_advertises_nothing_it_cannot_do(executor):
         f"{executor.__name__}.trade advertises position_side again; it is driven by the "
         f"venue-level position_mode config, and these three have no such config"
     )
+
+
+def test_every_venue_spells_the_margin_field_the_same_way():
+    """binance called it `margin_type` while the other three called it `margin_mode`.
+
+    One concept, two spellings, on configs and on the shared-in-name-only PositionStatus
+    -- so exchange-agnostic config code could not set it, and replay carried BOTH fields
+    to satisfy both readers (#289). The VALUES stay venue-specific: they are API strings,
+    and okx's is `cross` where bitget's and bybit's are `crossed`.
+    """
+    import dataclasses, importlib
+
+    for venue in ("binance", "bitget", "bybit", "okx"):
+        config_cls = getattr(importlib.import_module(f"torchtrade.envs.live.{venue}.env"),
+                             {"binance": "BinanceFuturesTradingEnvConfig",
+                              "bitget": "BitgetFuturesTradingEnvConfig",
+                              "bybit": "BybitFuturesTradingEnvConfig",
+                              "okx": "OKXFuturesTradingEnvConfig"}[venue])
+        names = {f.name for f in dataclasses.fields(config_cls)}
+        assert "margin_mode" in names, f"{venue} config lost margin_mode"
+        assert "margin_type" not in names, f"{venue} config reintroduced margin_type"
+
+    for venue, module in (("binance", "torchtrade.envs.live.binance.order_executor"),
+                          ("bitget", "torchtrade.envs.live.bitget.order_executor"),
+                          ("bybit", "torchtrade.envs.live.bybit.order_executor"),
+                          ("okx", "torchtrade.envs.live.okx.order_executor"),
+                          ("replay", "torchtrade.envs.replay.order_executor")):
+        status = getattr(importlib.import_module(module), "PositionStatus")
+        names = {f.name for f in dataclasses.fields(status)}
+        assert "margin_mode" in names and "margin_type" not in names, (
+            f"{venue} PositionStatus spells the margin field {names & {'margin_mode', 'margin_type'}}"
+        )

--- a/tests/envs/test_executor_helpers_288.py
+++ b/tests/envs/test_executor_helpers_288.py
@@ -145,33 +145,28 @@ def test_the_executor_trade_surface_advertises_nothing_it_cannot_do(executor):
     )
 
 
-def test_every_venue_spells_the_margin_field_the_same_way():
-    """binance called it `margin_type` while the other three called it `margin_mode`.
+POSITION_STATUS_CLASSES = [
+    ("binance", "torchtrade.envs.live.binance.order_executor"),
+    ("bitget", "torchtrade.envs.live.bitget.order_executor"),
+    ("bybit", "torchtrade.envs.live.bybit.order_executor"),
+    ("okx", "torchtrade.envs.live.okx.order_executor"),
+    ("replay", "torchtrade.envs.replay.order_executor"),
+]
 
-    One concept, two spellings, on configs and on the shared-in-name-only PositionStatus
-    -- so exchange-agnostic config code could not set it, and replay carried BOTH fields
-    to satisfy both readers (#289). The VALUES stay venue-specific: they are API strings,
-    and okx's is `cross` where bitget's and bybit's are `crossed`.
+
+@pytest.mark.parametrize("venue,module", POSITION_STATUS_CLASSES, ids=lambda v: v)
+def test_every_position_status_spells_the_margin_field_the_same_way(venue, module):
+    """Five PositionStatus dataclasses, one field name (#289).
+
+    The configs are guarded in `test_live_env_base.py`; this is the other half. Replay's
+    carried BOTH `margin_type` and `margin_mode` as separate fields to satisfy binance's
+    readers and everyone else's -- a duplicate that only surfaced because the rename made
+    the two names collide into a SyntaxError.
     """
     import dataclasses, importlib
 
-    for venue in ("binance", "bitget", "bybit", "okx"):
-        config_cls = getattr(importlib.import_module(f"torchtrade.envs.live.{venue}.env"),
-                             {"binance": "BinanceFuturesTradingEnvConfig",
-                              "bitget": "BitgetFuturesTradingEnvConfig",
-                              "bybit": "BybitFuturesTradingEnvConfig",
-                              "okx": "OKXFuturesTradingEnvConfig"}[venue])
-        names = {f.name for f in dataclasses.fields(config_cls)}
-        assert "margin_mode" in names, f"{venue} config lost margin_mode"
-        assert "margin_type" not in names, f"{venue} config reintroduced margin_type"
-
-    for venue, module in (("binance", "torchtrade.envs.live.binance.order_executor"),
-                          ("bitget", "torchtrade.envs.live.bitget.order_executor"),
-                          ("bybit", "torchtrade.envs.live.bybit.order_executor"),
-                          ("okx", "torchtrade.envs.live.okx.order_executor"),
-                          ("replay", "torchtrade.envs.replay.order_executor")):
-        status = getattr(importlib.import_module(module), "PositionStatus")
-        names = {f.name for f in dataclasses.fields(status)}
-        assert "margin_mode" in names and "margin_type" not in names, (
-            f"{venue} PositionStatus spells the margin field {names & {'margin_mode', 'margin_type'}}"
-        )
+    status = getattr(importlib.import_module(module), "PositionStatus")
+    names = {f.name for f in dataclasses.fields(status)}
+    assert "margin_mode" in names and "margin_type" not in names, (
+        f"{venue} PositionStatus spells it {names & {'margin_mode', 'margin_type'}}"
+    )

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -3094,10 +3094,14 @@ from torchtrade.envs.offline.sequential_sltp import SequentialTradingEnvSLTPConf
 from torchtrade.envs.offline.vectorized_sequential_sltp import (
     VectorizedSequentialTradingEnvSLTPConfig,
 )
-from torchtrade.envs.live.binance import BinanceFuturesSLTPTradingEnvConfig
-from torchtrade.envs.live.bitget import BitgetFuturesSLTPTradingEnvConfig
-from torchtrade.envs.live.bybit import BybitFuturesSLTPTradingEnvConfig
-from torchtrade.envs.live.okx import OKXFuturesSLTPTradingEnvConfig
+from torchtrade.envs.live.binance import (
+    BinanceFuturesSLTPTradingEnvConfig, BinanceFuturesTradingEnvConfig)
+from torchtrade.envs.live.bitget import (
+    BitgetFuturesSLTPTradingEnvConfig, BitgetFuturesTradingEnvConfig)
+from torchtrade.envs.live.bybit import (
+    BybitFuturesSLTPTradingEnvConfig, BybitFuturesTradingEnvConfig)
+from torchtrade.envs.live.okx import (
+    OKXFuturesSLTPTradingEnvConfig, OKXFuturesTradingEnvConfig)
 from torchtrade.envs.live.shared.sltp_config import BaseFuturesSLTPConfig
 
 SLTP_CONFIGS = [
@@ -3157,22 +3161,17 @@ def test_hoisting_a_default_did_not_change_it(config_cls):
     assert {f: getattr(config, f) for f in SHARED_DEFAULTS} == SHARED_DEFAULTS
 
 
-def _margin_bearing_configs():
-    """Both variants per venue. The SLTP-only list let a base config drift unseen."""
-    import importlib
-    out = []
-    for venue, base, sltp in (
-        ("binance", "BinanceFuturesTradingEnvConfig", "BinanceFuturesSLTPTradingEnvConfig"),
-        ("bitget", "BitgetFuturesTradingEnvConfig", "BitgetFuturesSLTPTradingEnvConfig"),
-        ("bybit", "BybitFuturesTradingEnvConfig", "BybitFuturesSLTPTradingEnvConfig"),
-        ("okx", "OKXFuturesTradingEnvConfig", "OKXFuturesSLTPTradingEnvConfig"),
-    ):
-        out.append(getattr(importlib.import_module(f"torchtrade.envs.live.{venue}.env"), base))
-        out.append(getattr(importlib.import_module(f"torchtrade.envs.live.{venue}.env_sltp"), sltp))
-    return out
+# Both variants per venue: the SLTP-only list let a base config drift unseen. Imported
+# classes, not names resolved at runtime -- a string table re-targets silently.
+MARGIN_BEARING_CONFIGS = [
+    BinanceFuturesTradingEnvConfig, BinanceFuturesSLTPTradingEnvConfig,
+    BitgetFuturesTradingEnvConfig, BitgetFuturesSLTPTradingEnvConfig,
+    BybitFuturesTradingEnvConfig, BybitFuturesSLTPTradingEnvConfig,
+    OKXFuturesTradingEnvConfig, OKXFuturesSLTPTradingEnvConfig,
+]
 
 
-@pytest.mark.parametrize("config_cls", _margin_bearing_configs(), ids=lambda c: c.__name__)
+@pytest.mark.parametrize("config_cls", MARGIN_BEARING_CONFIGS, ids=lambda c: c.__name__)
 def test_every_venue_spells_the_margin_field_the_same_way(config_cls):
     """#289's call was made: one spelling, `margin_mode`, on all four venues.
 

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -1338,7 +1338,7 @@ def test_isolated_missing_liquidation_price_does_not_require_account_maintenance
 
 
 @pytest.mark.parametrize("field,label", [
-    ("margin_type", "CROSSED"),  # Binance
+    ("margin_mode", "CROSSED"),  # Binance
     ("margin_mode", "cross"),    # OKX
     ("margin_mode", "crossed"),  # Bitget
 ], ids=["binance", "okx", "bitget"])
@@ -3159,16 +3159,16 @@ def test_hoisting_a_default_did_not_change_it(config_cls):
 
 @pytest.mark.parametrize("config_cls,margin_field", [
     pytest.param(c, m, id=c.__name__) for c, m in [
-        (BinanceFuturesSLTPTradingEnvConfig, "margin_type"),
+        (BinanceFuturesSLTPTradingEnvConfig, "margin_mode"),
         (BitgetFuturesSLTPTradingEnvConfig, "margin_mode"),
         (BybitFuturesSLTPTradingEnvConfig, "margin_mode"),
         (OKXFuturesSLTPTradingEnvConfig, "margin_mode"),
     ]
 ])
 def test_the_venue_specific_margin_surface_is_untouched(config_cls, margin_field):
-    """Named per venue, not `margin_type XOR margin_mode`.
+    """Named per venue, not `margin_mode XOR margin_mode`.
 
-    The XOR form passed when binance's `margin_type` was renamed to `margin_mode` -- the
+    The XOR form passed when binance's `margin_mode` was renamed to `margin_mode` -- the
     exact unification it existed to prevent, since renaming changes a venue's public API
     and is #289's call. Symmetric assertions cannot catch a swap.
     """

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -3157,22 +3157,38 @@ def test_hoisting_a_default_did_not_change_it(config_cls):
     assert {f: getattr(config, f) for f in SHARED_DEFAULTS} == SHARED_DEFAULTS
 
 
-@pytest.mark.parametrize("config_cls,margin_field", [
-    pytest.param(c, m, id=c.__name__) for c, m in [
-        (BinanceFuturesSLTPTradingEnvConfig, "margin_mode"),
-        (BitgetFuturesSLTPTradingEnvConfig, "margin_mode"),
-        (BybitFuturesSLTPTradingEnvConfig, "margin_mode"),
-        (OKXFuturesSLTPTradingEnvConfig, "margin_mode"),
-    ]
-])
-def test_the_venue_specific_margin_surface_is_untouched(config_cls, margin_field):
-    """Named per venue, not `margin_mode XOR margin_mode`.
+def _margin_bearing_configs():
+    """Both variants per venue. The SLTP-only list let a base config drift unseen."""
+    import importlib
+    out = []
+    for venue, base, sltp in (
+        ("binance", "BinanceFuturesTradingEnvConfig", "BinanceFuturesSLTPTradingEnvConfig"),
+        ("bitget", "BitgetFuturesTradingEnvConfig", "BitgetFuturesSLTPTradingEnvConfig"),
+        ("bybit", "BybitFuturesTradingEnvConfig", "BybitFuturesSLTPTradingEnvConfig"),
+        ("okx", "OKXFuturesTradingEnvConfig", "OKXFuturesSLTPTradingEnvConfig"),
+    ):
+        out.append(getattr(importlib.import_module(f"torchtrade.envs.live.{venue}.env"), base))
+        out.append(getattr(importlib.import_module(f"torchtrade.envs.live.{venue}.env_sltp"), sltp))
+    return out
 
-    The XOR form passed when binance's `margin_mode` was renamed to `margin_mode` -- the
-    exact unification it existed to prevent, since renaming changes a venue's public API
-    and is #289's call. Symmetric assertions cannot catch a swap.
+
+@pytest.mark.parametrize("config_cls", _margin_bearing_configs(), ids=lambda c: c.__name__)
+def test_every_venue_spells_the_margin_field_the_same_way(config_cls):
+    """#289's call was made: one spelling, `margin_mode`, on all four venues.
+
+    This used to assert each venue's OWN name, because binance said `margin_type` and the
+    other three `margin_mode` -- one concept exchange-agnostic config code could not set.
+    It guarded against an accidental unification while a deliberate one was still open.
+
+    Named per venue rather than `margin_type XOR margin_mode`: the XOR form passes the
+    very swap it names as the risk, which is how the original divergence survived.
     """
-    assert margin_field in {f.name for f in dataclasses.fields(config_cls)}
+    names = {f.name for f in dataclasses.fields(config_cls)}
+    assert "margin_mode" in names
+    assert "margin_type" not in names, (
+        f"{config_cls.__name__} reintroduced margin_type; the VALUES stay venue-specific "
+        f"(okx 'cross' vs bitget/bybit 'crossed'), the field name does not"
+    )
 
 
 SIZING_CONFIGS = SLTP_CONFIGS + [

--- a/torchtrade/__init__.py
+++ b/torchtrade/__init__.py
@@ -11,5 +11,5 @@ from torchtrade.envs.offline import (
     SequentialTradingEnvSLTPConfig,
     OneStepTradingEnv,
     OneStepTradingEnvConfig,
-    MarginType,
+    MarginMode,
 )

--- a/torchtrade/envs/__init__.py
+++ b/torchtrade/envs/__init__.py
@@ -47,6 +47,4 @@ from torchtrade.envs.live.bybit import (
     BybitFuturesTradingEnvConfig,
     BybitFuturesSLTPTorchTradingEnv,
     BybitFuturesSLTPTradingEnvConfig,
-    MarginMode,
-    PositionMode,
 )

--- a/torchtrade/envs/__init__.py
+++ b/torchtrade/envs/__init__.py
@@ -24,7 +24,7 @@ from torchtrade.envs.offline import (
     SequentialTradingEnvSLTPConfig,
     OneStepTradingEnv,
     OneStepTradingEnvConfig,
-    MarginType,
+    MarginMode,
 )
 
 # Offline infrastructure

--- a/torchtrade/envs/core/common.py
+++ b/torchtrade/envs/core/common.py
@@ -40,6 +40,25 @@ def validate_position_sizing(
             raise ValueError(f"quantity_per_trade must be positive, got {quantity_per_trade}")
 
 
+def validate_offline_margin_mode(margin_mode) -> None:
+    """CROSSED is not implemented offline, so refuse it instead of silently isolating.
+
+    Offline liquidation always uses isolated_liquidation_price, so a CROSSED config
+    produced isolated math while the user believed otherwise (#289). The scalar env
+    raised; the vectorized one accepted it silently, which is the parity gap in
+    miniature -- one guard, two configs now.
+    """
+    from torchtrade.envs.core.common_types import MarginMode
+
+    if margin_mode is not MarginMode.ISOLATED:
+        raise ValueError(
+            f"margin_mode={margin_mode} is not implemented for the offline "
+            f"environments: liquidation always uses isolated_liquidation_price, so "
+            f"CROSSED silently produced isolated liquidation math (#289). Nothing "
+            f"reads this field. Use ISOLATED, or the live envs, which honour it."
+        )
+
+
 def validate_sltp_levels(
     stoploss_levels: Sequence[float], takeprofit_levels: Sequence[float]
 ) -> None:

--- a/torchtrade/envs/core/common.py
+++ b/torchtrade/envs/core/common.py
@@ -2,6 +2,8 @@
 
 from typing import Literal, Sequence
 
+from torchtrade.envs.core.common_types import MarginMode
+
 
 # Type alias for trade mode with autocomplete and validation
 # Use string literals "fractional", "notional", or "quantity" throughout the codebase
@@ -44,12 +46,8 @@ def validate_offline_margin_mode(margin_mode) -> None:
     """CROSSED is not implemented offline, so refuse it instead of silently isolating.
 
     Offline liquidation always uses isolated_liquidation_price, so a CROSSED config
-    produced isolated math while the user believed otherwise (#289). The scalar env
-    raised; the vectorized one accepted it silently, which is the parity gap in
-    miniature -- one guard, two configs now.
+    produced isolated math while the user believed otherwise (#289).
     """
-    from torchtrade.envs.core.common_types import MarginMode
-
     if margin_mode is not MarginMode.ISOLATED:
         raise ValueError(
             f"margin_mode={margin_mode} is not implemented for the offline "

--- a/torchtrade/envs/core/common_types.py
+++ b/torchtrade/envs/core/common_types.py
@@ -5,7 +5,7 @@ from enum import Enum
 from typing import Optional
 
 
-class MarginType(Enum):
+class MarginMode(Enum):
     """Margin type for futures trading.
 
     - ISOLATED: Margin is isolated to individual positions

--- a/torchtrade/envs/core/common_types.py
+++ b/torchtrade/envs/core/common_types.py
@@ -6,7 +6,7 @@ from typing import Optional
 
 
 class MarginMode(Enum):
-    """Margin type for futures trading.
+    """Margin mode for futures trading.
 
     - ISOLATED: Margin is isolated to individual positions
     - CROSSED: Margin is shared across all positions

--- a/torchtrade/envs/live/README.md
+++ b/torchtrade/envs/live/README.md
@@ -131,6 +131,37 @@ while True:
 
 The non-SLTP live environments share these base parameters:
 
+## Margin enums: import them venue-qualified (#289)
+
+Four venues define a `MarginMode` enum with the **same name and different values**, and
+those values are API wire strings:
+
+| venue | ISOLATED | CROSSED |
+|---|---|---|
+| binance (`core.common_types`) | `ISOLATED` | `CROSSED` |
+| bitget, bybit | `isolated` | `crossed` |
+| okx | `isolated` | `cross` (member is `CROSS`) |
+
+So an unqualified import at a namespace serving all four sends the wrong case to
+whichever venue it did not come from. Import from the venue, or from core for binance
+and the offline envs:
+
+```python
+from torchtrade.envs import MarginMode                       # core: binance + offline
+from torchtrade.envs.live.bitget.order_executor import MarginMode as BitgetMarginMode
+from torchtrade.envs.live import BybitMarginMode, OKXMarginMode
+```
+
+**Migrating from before #289.** `MarginType` was renamed to `MarginMode`, so binance's
+config field is `margin_mode` and matches the other three. Two package-level names
+changed with it, and both are silent rather than an ImportError, so they are worth
+checking by hand:
+
+- `torchtrade.envs.MarginMode` now resolves to **core's** enum (uppercase). It previously
+  resolved to bybit's (lowercase).
+- `torchtrade.envs.live.MarginMode` no longer exists. Use `BybitMarginMode`, which is what
+  it meant, or the venue module. okx was already aliased this way.
+
 ```python
 # There is no shared LiveEnvConfig -- each exchange ships its own dataclass. What they
 # have in common:

--- a/torchtrade/envs/live/README.md
+++ b/torchtrade/envs/live/README.md
@@ -89,7 +89,7 @@ while True:
 ### Binance Futures Trading
 
 ```python
-from torchtrade.envs.core.common_types import MarginType
+from torchtrade.envs.core.common_types import MarginMode
 
 import os
 from torchtrade.envs.live.binance.env import BinanceFuturesTorchTradingEnv, BinanceFuturesTradingEnvConfig
@@ -101,7 +101,7 @@ config = BinanceFuturesTradingEnvConfig(
     execute_on="1Min",
     demo=True,  # Use testnet for testing
     leverage=10.0,
-    margin_type=MarginType.ISOLATED,
+    margin_mode=MarginMode.ISOLATED,
 )
 
 env = BinanceFuturesTorchTradingEnv(
@@ -139,7 +139,7 @@ The non-SLTP live environments share these base parameters:
 #   action_levels, done_on_bankruptcy, bankrupt_threshold, seed,
 #   include_base_features
 #
-# Futures configs add: leverage, margin_type/margin_mode, demo,
+# Futures configs add: leverage, margin_mode/margin_mode, demo,
 #   observation_failure_policy; close_position_on_init/_on_reset are on the
 #   futures envs and alpaca, but not polymarket
 # Alpaca adds: paper, trade_mode; it also has close_position_on_init/_on_reset
@@ -163,11 +163,11 @@ trade_mode: str = "notional"                # "notional" | "quantity" here.
 
 **Binance:**
 ```python
-from torchtrade.envs.core.common_types import MarginType
+from torchtrade.envs.core.common_types import MarginMode
 
 demo: bool = True                           # Testnet or mainnet
 leverage: int = 1                           # the leverage APPLIED, not a cap
-margin_type: MarginType = MarginType.ISOLATED   # ISOLATED or CROSSED (the enum)
+margin_mode: MarginMode = MarginMode.ISOLATED   # ISOLATED or CROSSED (the enum)
 ```
 
 **Bitget:**

--- a/torchtrade/envs/live/README.md
+++ b/torchtrade/envs/live/README.md
@@ -139,7 +139,7 @@ The non-SLTP live environments share these base parameters:
 #   action_levels, done_on_bankruptcy, bankrupt_threshold, seed,
 #   include_base_features
 #
-# Futures configs add: leverage, margin_mode/margin_mode, demo,
+# Futures configs add: leverage, margin_mode, demo,
 #   observation_failure_policy; close_position_on_init/_on_reset are on the
 #   futures envs and alpaca, but not polymarket
 # Alpaca adds: paper, trade_mode; it also has close_position_on_init/_on_reset

--- a/torchtrade/envs/live/__init__.py
+++ b/torchtrade/envs/live/__init__.py
@@ -17,7 +17,6 @@ from torchtrade.envs.live.binance import (
     BinanceFuturesTorchTradingEnv,
     BinanceFuturesTradingEnvConfig,
     TradeMode,
-    MarginMode,
 )
 
 # Bitget
@@ -75,7 +74,6 @@ __all__ = [
     "BinanceFuturesTorchTradingEnv",
     "BinanceFuturesTradingEnvConfig",
     "TradeMode",
-    "MarginMode",
     # Bitget
     "BitgetObservationClass",
     "BitgetFuturesOrderClass",

--- a/torchtrade/envs/live/__init__.py
+++ b/torchtrade/envs/live/__init__.py
@@ -35,11 +35,14 @@ from torchtrade.envs.live.bybit import (
     BybitFuturesTradingEnvConfig,
     BybitFuturesSLTPTorchTradingEnv,
     BybitFuturesSLTPTradingEnvConfig,
-    MarginMode,
-    PositionMode,
+    MarginMode as BybitMarginMode,
+    PositionMode as BybitPositionMode,
 )
 
-# OKX (use qualified imports to avoid shadowing Bybit's MarginMode/PositionMode)
+# Every venue's margin enum is qualified here. They share a NAME and not their VALUES --
+# core/binance `ISOLATED`, bitget and bybit `isolated`, okx `cross` where the others say
+# `crossed` -- and those are API wire strings, so an unqualified one silently sends the
+# wrong case to whichever venue it did not come from (#289).
 from torchtrade.envs.live.okx import (
     OKXObservationClass,
     OKXFuturesOrderClass,
@@ -86,8 +89,8 @@ __all__ = [
     "BybitFuturesTradingEnvConfig",
     "BybitFuturesSLTPTorchTradingEnv",
     "BybitFuturesSLTPTradingEnvConfig",
-    "MarginMode",
-    "PositionMode",
+    "BybitMarginMode",
+    "BybitPositionMode",
     # OKX
     "OKXObservationClass",
     "OKXFuturesOrderClass",

--- a/torchtrade/envs/live/__init__.py
+++ b/torchtrade/envs/live/__init__.py
@@ -17,7 +17,7 @@ from torchtrade.envs.live.binance import (
     BinanceFuturesTorchTradingEnv,
     BinanceFuturesTradingEnvConfig,
     TradeMode,
-    MarginType,
+    MarginMode,
 )
 
 # Bitget
@@ -75,7 +75,7 @@ __all__ = [
     "BinanceFuturesTorchTradingEnv",
     "BinanceFuturesTradingEnvConfig",
     "TradeMode",
-    "MarginType",
+    "MarginMode",
     # Bitget
     "BitgetObservationClass",
     "BitgetFuturesOrderClass",

--- a/torchtrade/envs/live/binance/README.md
+++ b/torchtrade/envs/live/binance/README.md
@@ -16,7 +16,7 @@ Live trading integration with Binance for crypto futures markets (USDT-margined)
 ```python
 import os
 
-from torchtrade.envs.core.common_types import MarginType
+from torchtrade.envs.core.common_types import MarginMode
 from torchtrade.envs.live.binance.env import BinanceFuturesTorchTradingEnv, BinanceFuturesTradingEnvConfig
 
 config = BinanceFuturesTradingEnvConfig(
@@ -26,7 +26,7 @@ config = BinanceFuturesTradingEnvConfig(
     execute_on="1Min",
     demo=True,  # Use testnet first!
     leverage=10.0,
-    margin_type=MarginType.ISOLATED,
+    margin_mode=MarginMode.ISOLATED,
 )
 
 env = BinanceFuturesTorchTradingEnv(
@@ -47,11 +47,11 @@ obs = env.reset()
 ## Configuration
 
 ```python
-from torchtrade.envs.core.common_types import MarginType
+from torchtrade.envs.core.common_types import MarginMode
 from torchtrade.envs.core.live import ObservationFailurePolicy
 from torchtrade.envs.live.binance import BinanceFuturesTradingEnvConfig
 
-from torchtrade.envs.core.common_types import MarginType
+from torchtrade.envs.core.common_types import MarginMode
 from torchtrade.envs.core.live import ObservationFailurePolicy
 
 # Every field of BinanceFuturesTradingEnvConfig, with its real default.
@@ -62,7 +62,7 @@ config = BinanceFuturesTradingEnvConfig(
     window_sizes=10,
     execute_on='1Hour',
     leverage=1,
-    margin_type=MarginType.ISOLATED,
+    margin_mode=MarginMode.ISOLATED,
     action_levels=None,
     done_on_bankruptcy=True,
     bankrupt_threshold=0.1,
@@ -106,10 +106,10 @@ config = BinanceFuturesTradingEnvConfig(
 
 ```python
 from torchtrade.envs.live.binance import BinanceFuturesTradingEnvConfig
-from torchtrade.envs.core.common_types import MarginType
+from torchtrade.envs.core.common_types import MarginMode
 
 config = BinanceFuturesTradingEnvConfig(
-    margin_type=MarginType.ISOLATED,
+    margin_mode=MarginMode.ISOLATED,
     leverage=10.0,
 )
 ```
@@ -121,10 +121,10 @@ config = BinanceFuturesTradingEnvConfig(
 
 ```python
 from torchtrade.envs.live.binance import BinanceFuturesTradingEnvConfig
-from torchtrade.envs.core.common_types import MarginType
+from torchtrade.envs.core.common_types import MarginMode
 
 config = BinanceFuturesTradingEnvConfig(
-    margin_type=MarginType.CROSSED,
+    margin_mode=MarginMode.CROSSED,
     leverage=20.0,
 )
 ```
@@ -202,7 +202,7 @@ evaluating a policy that carries positions across funding timestamps.
 ## Example: Basic Futures Trading
 
 ```python
-from torchtrade.envs.core.common_types import MarginType
+from torchtrade.envs.core.common_types import MarginMode
 
 import os
 import torch
@@ -216,7 +216,7 @@ config = BinanceFuturesTradingEnvConfig(
     execute_on="1Min",
     demo=True,
     leverage=5.0,
-    margin_type=MarginType.ISOLATED,
+    margin_mode=MarginMode.ISOLATED,
 )
 
 env = BinanceFuturesTorchTradingEnv(

--- a/torchtrade/envs/live/binance/__init__.py
+++ b/torchtrade/envs/live/binance/__init__.py
@@ -4,7 +4,7 @@ from torchtrade.envs.live.binance.observation import BinanceObservationClass
 from torchtrade.envs.live.binance.order_executor import (
     BinanceFuturesOrderClass,
     TradeMode,
-    MarginType,
+    MarginMode,
     OrderStatus,
     PositionStatus,
 )
@@ -21,7 +21,7 @@ __all__ = [
     "BinanceObservationClass",
     "BinanceFuturesOrderClass",
     "TradeMode",
-    "MarginType",
+    "MarginMode",
     "OrderStatus",
     "PositionStatus",
     "BinanceFuturesTorchTradingEnv",

--- a/torchtrade/envs/live/binance/base.py
+++ b/torchtrade/envs/live/binance/base.py
@@ -132,5 +132,5 @@ class BinanceBaseTorchTradingEnv(TorchTradeFuturesLiveEnv):
             api_secret=api_secret,
             demo=self.config.demo,
             leverage=self.config.leverage,
-            margin_type=self.config.margin_type,
+            margin_mode=self.config.margin_mode,
         )

--- a/torchtrade/envs/live/binance/env.py
+++ b/torchtrade/envs/live/binance/env.py
@@ -17,7 +17,7 @@ from torchtrade.envs.live.binance.observation import BinanceObservationClass
 from torchtrade.envs.live.binance.order_executor import (
     TAKER_FEE,
     BinanceFuturesOrderClass,
-    MarginType,
+    MarginMode,
 )
 from torchtrade.envs.live.binance.base import BinanceBaseTorchTradingEnv
 from torchtrade.envs.utils.fractional_sizing import (
@@ -41,7 +41,7 @@ class BinanceFuturesTradingEnvConfig:
 
     # Trading parameters
     leverage: int = 1  # Leverage (1-125)
-    margin_type: MarginType = MarginType.ISOLATED
+    margin_mode: MarginMode = MarginMode.ISOLATED
 
     # Action space configuration (fractional mode only)
     action_levels: List[float] = None  # Custom action levels, or None for defaults

--- a/torchtrade/envs/live/binance/env_sltp.py
+++ b/torchtrade/envs/live/binance/env_sltp.py
@@ -18,7 +18,7 @@ from torchrl.data import Categorical
 from torchtrade.envs.live.binance.observation import BinanceObservationClass
 from torchtrade.envs.live.binance.order_executor import (
     BinanceFuturesOrderClass,
-    MarginType,
+    MarginMode,
 )
 from torchtrade.envs.live.binance.utils import normalize_binance_timeframe_config
 from torchtrade.envs.live.binance.base import BinanceBaseTorchTradingEnv
@@ -36,7 +36,7 @@ class BinanceFuturesSLTPTradingEnvConfig(BaseFuturesSLTPConfig):
     """
 
     # Trading parameters
-    margin_type: MarginType = MarginType.ISOLATED
+    margin_mode: MarginMode = MarginMode.ISOLATED
 
     _normalize_timeframes = staticmethod(normalize_binance_timeframe_config)
 

--- a/torchtrade/envs/live/binance/observation.py
+++ b/torchtrade/envs/live/binance/observation.py
@@ -50,9 +50,6 @@ class BinanceObservationClass(BaseFuturesObservationClass):
     def _convert_timeframe(self, timeframe: TimeFrame) -> str:
         return timeframe_to_binance(timeframe)
 
-    def _get_default_lookback(self) -> int:
-        return 500  # binance's kline default page size (its max is 1000)
-
     def _get_timestamp_column(self) -> str:
         return "open_time"
 

--- a/torchtrade/envs/live/binance/order_executor.py
+++ b/torchtrade/envs/live/binance/order_executor.py
@@ -15,7 +15,7 @@ import os
 from dotenv import load_dotenv
 
 from torchtrade.envs.core.common import TradeMode
-from torchtrade.envs.core.common_types import MarginType, OrderStatus
+from torchtrade.envs.core.common_types import MarginMode, OrderStatus
 from torchtrade.envs.core.state import POSITION_UNKNOWN
 from torchtrade.envs.utils.leverage import leverage_already_set, require_leverage_applied
 
@@ -64,7 +64,7 @@ class PositionStatus:
     mark_price: float
     leverage: float  # float, not int: int() truncated 1.5x to 1x, which then took
     # the no-liquidation branch and reported a levered position as safe (#277).
-    margin_type: str
+    margin_mode: str
     liquidation_price: float
 
 
@@ -92,7 +92,7 @@ class BinanceFuturesOrderClass(ExecutorHelpersMixin, TickSizeMixin):
         api_secret: str = "",
         demo: bool = True,
         leverage: int = 1,
-        margin_type: MarginType = MarginType.ISOLATED,
+        margin_mode: MarginMode = MarginMode.ISOLATED,
         client: Optional[object] = None,
     ):
         """
@@ -105,7 +105,7 @@ class BinanceFuturesOrderClass(ExecutorHelpersMixin, TickSizeMixin):
             api_secret: Binance API secret
             demo: Whether to use demo trading (default: True for safety)
             leverage: Leverage to use (1-125, default: 1)
-            margin_type: ISOLATED (margin per position, limits loss) or
+            margin_mode: ISOLATED (margin per position, limits loss) or
                         CROSSED (shared margin, higher liquidation risk)
             client: Optional pre-configured Client for dependency injection
         """
@@ -120,7 +120,7 @@ class BinanceFuturesOrderClass(ExecutorHelpersMixin, TickSizeMixin):
         self.trade_mode = trade_mode
         self.demo = demo
         self.leverage = leverage
-        self.margin_type = margin_type
+        self.margin_mode = margin_mode
         self.last_order_id = None
 
         self._tick_size: Optional[float] = None
@@ -169,7 +169,7 @@ class BinanceFuturesOrderClass(ExecutorHelpersMixin, TickSizeMixin):
         try:
             self.client.futures_change_margin_type(
                 symbol=self.symbol,
-                marginType=self.margin_type.value
+                marginType=self.margin_mode.value
             )
         except Exception as e:
             # May fail if already set to this margin type
@@ -437,7 +437,7 @@ class BinanceFuturesOrderClass(ExecutorHelpersMixin, TickSizeMixin):
                         leverage=float(
                             self.leverage if pos.get("leverage") in (None, "") else pos.get("leverage")
                         ),
-                        margin_type=pos.get("marginType", self.margin_type.value),
+                        margin_mode=pos.get("marginType", self.margin_mode.value),
                         liquidation_price=float(pos.get("liquidationPrice", 0)),
                     )
                     break

--- a/torchtrade/envs/live/bitget/observation.py
+++ b/torchtrade/envs/live/bitget/observation.py
@@ -148,68 +148,6 @@ class BitgetObservationClass(BaseFuturesObservationClass):
         """
         return timeframe_to_bitget(timeframe)
 
-    def _get_default_lookback(self) -> int:
-        """Get the default number of candles to fetch (Bitget limit)."""
-        return 200
-
     def _get_timestamp_column(self) -> str:
         """Get the name of the timestamp column."""
         return "timestamp"
-
-
-# Example usage:
-if __name__ == "__main__":
-
-    # Test with demo/testnet (no API keys needed for public data)
-    print("Testing BitgetObservationClass with CCXT...")
-
-    # Single timeframe example
-    print("\n1. Testing single timeframe...")
-    window_size = 10
-    observer = BitgetObservationClass(
-        symbol="BTC/USDT:USDT",  # CCXT perpetual swap format
-        time_frames=TimeFrame(1, TimeFrameUnit.Minute),
-        window_sizes=window_size,
-        demo=True
-    )
-    expected_keys = observer.get_keys()
-    print(f"   Expected keys: {expected_keys}")
-
-    try:
-        observations = observer.get_observations()
-        assert set(observations.keys()) == set(expected_keys), "Keys don't match expected keys"
-        assert observations[expected_keys[0]].shape == (window_size, 4), \
-            f"Expected shape ({window_size}, 4) for default features, got {observations[expected_keys[0]].shape}"
-        print("   ✓ Single timeframe test passed!")
-    except Exception as e:
-        print(f"   ✗ Single timeframe test failed: {e}")
-        import traceback
-        traceback.print_exc()
-
-    # Multiple timeframes example
-    print("\n2. Testing multiple timeframes...")
-    window_sizes = [10, 20]
-    observer = BitgetObservationClass(
-        symbol="BTC/USDT:USDT",  # CCXT perpetual swap format
-        time_frames=[
-            TimeFrame(1, TimeFrameUnit.Minute),
-            TimeFrame(5, TimeFrameUnit.Minute),
-        ],
-        window_sizes=window_sizes,
-        demo=True
-    )
-
-    expected_keys = observer.get_keys()
-    print(f"   Expected keys: {expected_keys}")
-
-    try:
-        observations = observer.get_observations()
-        assert set(observations.keys()) == set(expected_keys), "Keys don't match expected keys"
-        assert len(observations) == 2, "Expected exactly 2 observations"
-        print("   ✓ Multiple timeframes test passed!")
-    except Exception as e:
-        print(f"   ✗ Multiple timeframes test failed: {e}")
-        import traceback
-        traceback.print_exc()
-
-    print("\n✅ All tests completed!")

--- a/torchtrade/envs/live/bybit/observation.py
+++ b/torchtrade/envs/live/bybit/observation.py
@@ -118,10 +118,6 @@ class BybitObservationClass(BaseFuturesObservationClass):
         """
         return timeframe_to_bybit(timeframe)
 
-    def _get_default_lookback(self) -> int:
-        """Get the default number of candles to fetch (Bybit limit)."""
-        return 200
-
     def _get_timestamp_column(self) -> str:
         """Get the name of the timestamp column."""
         return "timestamp"

--- a/torchtrade/envs/live/okx/observation.py
+++ b/torchtrade/envs/live/okx/observation.py
@@ -118,10 +118,6 @@ class OKXObservationClass(BaseFuturesObservationClass):
         """
         return timeframe_to_okx(timeframe)
 
-    def _get_default_lookback(self) -> int:
-        """Get the default number of candles to fetch (OKX max per request is 300)."""
-        return 200
-
     def _get_timestamp_column(self) -> str:
         """Get the name of the timestamp column."""
         return "timestamp"

--- a/torchtrade/envs/live/shared/__init__.py
+++ b/torchtrade/envs/live/shared/__init__.py
@@ -1,6 +1,5 @@
 """Shared components for live trading environments."""
 
-from torchtrade.envs.live.shared.base_obs import BaseObservationClass
 from torchtrade.envs.live.shared.futures_base_obs import BaseFuturesObservationClass
 
-__all__ = ["BaseObservationClass", "BaseFuturesObservationClass"]
+__all__ = ["BaseFuturesObservationClass"]

--- a/torchtrade/envs/live/shared/__init__.py
+++ b/torchtrade/envs/live/shared/__init__.py
@@ -1,5 +1,6 @@
 """Shared components for live trading environments."""
 
+from torchtrade.envs.live.shared.base_obs import BaseObservationClass
 from torchtrade.envs.live.shared.futures_base_obs import BaseFuturesObservationClass
 
-__all__ = ["BaseFuturesObservationClass"]
+__all__ = ["BaseObservationClass", "BaseFuturesObservationClass"]

--- a/torchtrade/envs/live/shared/__init__.py
+++ b/torchtrade/envs/live/shared/__init__.py
@@ -1,5 +1,1 @@
 """Shared components for live trading environments."""
-
-from torchtrade.envs.live.shared.futures_base_obs import BaseFuturesObservationClass
-
-__all__ = ["BaseFuturesObservationClass"]

--- a/torchtrade/envs/live/shared/futures_base_obs.py
+++ b/torchtrade/envs/live/shared/futures_base_obs.py
@@ -63,16 +63,13 @@ class BaseFuturesObservationClass(BaseObservationClass):
             Provider-specific interval string (e.g., "1H" for Bitget, "1h" for Binance)
         """
         pass
-    @abstractmethod
-    def _get_default_lookback(self) -> int:
-        """Get the default number of candles to fetch."""
-        pass
+    def _fetch_single_timeframe(self, timeframe: TimeFrame, limit: int) -> pd.DataFrame:
+        """Fetch and preprocess data for a single timeframe.
 
-    def _fetch_single_timeframe(self, timeframe: TimeFrame, limit: int = None) -> pd.DataFrame:
-        """Fetch and preprocess data for a single timeframe."""
-        if limit is None:
-            limit = self._get_default_lookback()
-
+        `limit` is required here, unlike on the base: `get_observations` is the only
+        caller and always sizes it, and the fallback it used to have was a hook four
+        venues implemented and nothing ever reached (#288).
+        """
         # Convert TimeFrame to provider-specific interval format
         provider_interval = self._convert_timeframe(timeframe)
 

--- a/torchtrade/envs/live/shared/futures_live_base.py
+++ b/torchtrade/envs/live/shared/futures_live_base.py
@@ -37,14 +37,14 @@ from torchtrade.envs.utils.liquidation import (
 def _normalized_margin_mode(position_status):
     """Normalize concrete adapter labels to ``cross``/``isolated`` or unknown.
 
-    Binance exposes ``margin_type`` while the other adapters expose ``margin_mode``.
+    Binance exposes ``margin_mode`` while the other adapters expose ``margin_mode``.
     Unknown labels deliberately remain unknown: when the venue also omits a native
     liquidation price, guessing either route can report a dangerously safe distance.
     """
     margin_mode = getattr(
         position_status,
         "margin_mode",
-        getattr(position_status, "margin_type", None),
+        getattr(position_status, "margin_mode", None),
     )
     value = getattr(margin_mode, "value", margin_mode)
     value = str(value).lower()

--- a/torchtrade/envs/live/shared/futures_live_base.py
+++ b/torchtrade/envs/live/shared/futures_live_base.py
@@ -37,15 +37,12 @@ from torchtrade.envs.utils.liquidation import (
 def _normalized_margin_mode(position_status):
     """Normalize concrete adapter labels to ``cross``/``isolated`` or unknown.
 
-    Binance exposes ``margin_mode`` while the other adapters expose ``margin_mode``.
-    Unknown labels deliberately remain unknown: when the venue also omits a native
-    liquidation price, guessing either route can report a dangerously safe distance.
+    Every adapter exposes ``margin_mode`` since #289; the two-name fallback this used to
+    need died with the rename. Unknown labels deliberately remain unknown: when the venue
+    also omits a native liquidation price, guessing either route can report a dangerously
+    safe distance.
     """
-    margin_mode = getattr(
-        position_status,
-        "margin_mode",
-        getattr(position_status, "margin_mode", None),
-    )
+    margin_mode = getattr(position_status, "margin_mode", None)
     value = getattr(margin_mode, "value", margin_mode)
     value = str(value).lower()
     if value in {"0", "cross", "crossed"}:

--- a/torchtrade/envs/offline/__init__.py
+++ b/torchtrade/envs/offline/__init__.py
@@ -4,7 +4,7 @@
 from torchtrade.envs.offline.sequential import (
     SequentialTradingEnv,
     SequentialTradingEnvConfig,
-    MarginType,
+    MarginMode,
 )
 from torchtrade.envs.offline.sequential_sltp import (
     SequentialTradingEnvSLTP,
@@ -40,7 +40,7 @@ __all__ = [
     "VectorizedSequentialTradingEnvSLTP",
     "VectorizedSequentialTradingEnvSLTPConfig",
     # Types
-    "MarginType",
+    "MarginMode",
     # Infrastructure
     "MarketDataObservationSampler",
 ]

--- a/torchtrade/envs/offline/sequential.py
+++ b/torchtrade/envs/offline/sequential.py
@@ -42,6 +42,7 @@ from torchtrade.envs.utils.fractional_sizing import (
     POSITION_TOLERANCE_NOTIONAL,
 )
 from torchtrade.envs.core.common_types import MarginMode
+from torchtrade.envs.core.common import validate_offline_margin_mode
 from torchtrade.envs.utils.liquidation import (
     DEFAULT_MAINTENANCE_MARGIN_RATE,
     isolated_liquidation_price,
@@ -91,13 +92,7 @@ class SequentialTradingEnvConfig:
 
     def __post_init__(self):
         """Validate configuration and normalize timeframes."""
-        if self.margin_mode is not MarginMode.ISOLATED:
-            raise ValueError(
-                f"margin_mode={self.margin_mode} is not implemented for the offline "
-                f"environments: liquidation always uses isolated_liquidation_price, so "
-                f"CROSSED silently produced isolated liquidation math (#289). Nothing "
-                f"reads this field. Use ISOLATED, or the live envs, which honour it."
-            )
+        validate_offline_margin_mode(self.margin_mode)
         if self.include_base_features:
             raise ValueError(
                 "include_base_features=True is not implemented for the offline "
@@ -224,7 +219,6 @@ class SequentialTradingEnv(TorchTradeOfflineEnv):
         # Store configuration
         self.action_levels = config.action_levels
         self.leverage = config.leverage
-        self.margin_mode = config.margin_mode
         self.maintenance_margin_rate = config.maintenance_margin_rate
 
         # Define action spec

--- a/torchtrade/envs/offline/sequential.py
+++ b/torchtrade/envs/offline/sequential.py
@@ -41,7 +41,7 @@ from torchtrade.envs.utils.fractional_sizing import (
     POSITION_TOLERANCE_PCT,
     POSITION_TOLERANCE_NOTIONAL,
 )
-from torchtrade.envs.core.common_types import MarginType
+from torchtrade.envs.core.common_types import MarginMode
 from torchtrade.envs.utils.liquidation import (
     DEFAULT_MAINTENANCE_MARGIN_RATE,
     isolated_liquidation_price,
@@ -86,14 +86,14 @@ class SequentialTradingEnvConfig:
     # leverage > 1: Enables futures mode with liquidation mechanics
     # leverage == 1: Spot mode (no liquidation)
     leverage: int = 1
-    margin_type: MarginType = MarginType.ISOLATED
+    margin_mode: MarginMode = MarginMode.ISOLATED
     maintenance_margin_rate: float = DEFAULT_MAINTENANCE_MARGIN_RATE
 
     def __post_init__(self):
         """Validate configuration and normalize timeframes."""
-        if self.margin_type is not MarginType.ISOLATED:
+        if self.margin_mode is not MarginMode.ISOLATED:
             raise ValueError(
-                f"margin_type={self.margin_type} is not implemented for the offline "
+                f"margin_mode={self.margin_mode} is not implemented for the offline "
                 f"environments: liquidation always uses isolated_liquidation_price, so "
                 f"CROSSED silently produced isolated liquidation math (#289). Nothing "
                 f"reads this field. Use ISOLATED, or the live envs, which honour it."
@@ -224,7 +224,7 @@ class SequentialTradingEnv(TorchTradeOfflineEnv):
         # Store configuration
         self.action_levels = config.action_levels
         self.leverage = config.leverage
-        self.margin_type = config.margin_type
+        self.margin_mode = config.margin_mode
         self.maintenance_margin_rate = config.maintenance_margin_rate
 
         # Define action spec

--- a/torchtrade/envs/offline/vectorized_sequential.py
+++ b/torchtrade/envs/offline/vectorized_sequential.py
@@ -30,7 +30,7 @@ from torchtrade.envs.utils.fractional_sizing import (
 )
 
 from torchtrade.envs.core.default_rewards import batched_log_return_reward
-from torchtrade.envs.core.common_types import MarginType
+from torchtrade.envs.core.common_types import MarginMode
 from torchtrade.envs.utils.liquidation import DEFAULT_MAINTENANCE_MARGIN_RATE, require_fee_fits_maintenance
 
 # Money, prices and position sizes are tracked in float64 to match the scalar envs' Python
@@ -71,7 +71,7 @@ class VectorizedSequentialTradingEnvConfig:
 
     # Trading parameters
     leverage: int = 1
-    margin_type: MarginType = MarginType.ISOLATED
+    margin_mode: MarginMode = MarginMode.ISOLATED
     maintenance_margin_rate: float = DEFAULT_MAINTENANCE_MARGIN_RATE
 
     def __post_init__(self):

--- a/torchtrade/envs/offline/vectorized_sequential.py
+++ b/torchtrade/envs/offline/vectorized_sequential.py
@@ -31,6 +31,7 @@ from torchtrade.envs.utils.fractional_sizing import (
 
 from torchtrade.envs.core.default_rewards import batched_log_return_reward
 from torchtrade.envs.core.common_types import MarginMode
+from torchtrade.envs.core.common import validate_offline_margin_mode
 from torchtrade.envs.utils.liquidation import DEFAULT_MAINTENANCE_MARGIN_RATE, require_fee_fits_maintenance
 
 # Money, prices and position sizes are tracked in float64 to match the scalar envs' Python
@@ -81,6 +82,7 @@ class VectorizedSequentialTradingEnvConfig:
             )
         )
         validate_action_levels(self.action_levels)
+        validate_offline_margin_mode(self.margin_mode)
 
         if self.num_envs < 1:
             raise ValueError(f"num_envs must be >= 1, got {self.num_envs}")

--- a/torchtrade/envs/replay/order_executor.py
+++ b/torchtrade/envs/replay/order_executor.py
@@ -27,8 +27,7 @@ class PositionStatus:
     unrealized_pnl_pct: float
     mark_price: float
     leverage: int
-    margin_type: str    # Binance-compatible
-    margin_mode: str    # Bybit-compatible
+    margin_mode: str
     liquidation_price: float
 
 
@@ -331,7 +330,6 @@ class ReplayOrderExecutor:
                 unrealized_pnl_pct=unrealized_pnl_pct,
                 mark_price=self.current_price,
                 leverage=self.leverage,
-                margin_type="ISOLATED",
                 margin_mode="isolated",
                 liquidation_price=self.liquidation_price,
             )


### PR DESCRIPTION
Refs #288 (slice 2) and closes #289's naming bullet.

Three deletions and a rename, each measured before touching anything.

## `_get_default_lookback` was unreachable

An abstract hook implemented by **four** venues, called from exactly one place — the `if limit is None` fallback in the kline fetch. Planting `raise AssertionError` at that call site and running the full suite:

```
4004 passed, 16 skipped
```

Nothing takes the branch. `get_observations` always passes `limit=window_size + 50`, and the only argument-free call is alpaca's own override, which ignores it. Hook, branch and four implementations deleted; `limit` is now required on the futures fetch, which is what every caller already did.

## Two smaller ones

- **bitget's 56-line `__main__` block** — the twin of alpaca's, deleted in #404. Duplicated the test suite, needed live credentials to run.
- **`shared/__init__` now exports `BaseObservationClass`** — it became the venue-agnostic entry point in #404 and was reachable only by full path.

## One concept, two spellings (#289)

binance used `margin_type: MarginType`; bitget, bybit and okx used `margin_mode: MarginMode`. Same concept, so exchange-agnostic config code could not set it. Renamed binance's to match across 24 files.

`futures_change_margin_type` — the Binance **SDK's own** method — is deliberately untouched. The `\b` boundary handles that automatically because `_` is a word character, but it is the kind of thing worth checking rather than assuming.

**The rename surfaced something worse.** There are **six** `PositionStatus` dataclasses — one per venue plus replay — and replay's carried *both* `margin_type` and `margin_mode` as separate fields to satisfy both sets of readers. The collision is what turned it into a syntax error rather than a silent duplicate. One field now, and a guard fails if any venue reintroduces the other spelling on a config or a status.

**Values stay venue-specific, and must.** They are API strings: okx's is `cross` where bitget's and bybit's are `crossed`, and binance's is `CROSSED`. A single shared enum cannot carry all four — which is why this is a naming fix, not a consolidation. That distinction is why #289 deferred it here rather than attempting it inline.

## Left for slice 3

**Six `PositionStatus` copies** is the headline — larger than #288's original text describes, and now the main remaining duplication in the live stacks.

Full suite: **4005 passed, 16 skipped**. Net **+111/−156**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)