### PR TITLE
feat(live): surface status staleness and truncate a prolonged outage (#295)

### DIFF
--- a/docs/environments/online.md
+++ b/docs/environments/online.md
@@ -918,6 +918,15 @@ order. That last one matters — threading the position and price only fixes the
 balance too, and its cache is seeded from reset's confirmed read so a first trade during
 an outage is still possible.
 
+**One boundary the grace period does not cover.** On binance and bitget the SL/TP
+bracket price comes from a candle close, and that read only happens on a bar that
+actually trades — the hold path returns before it. So after a reset followed by nothing
+but HOLD actions, there is no confirmed close to serve, and the first *trading* bar of an
+outage raises instead of being ridden out. Closing it needs either an extra observer read
+per reset or an explicit change of price source; grace deliberately will not substitute
+the mark, because that silently changes where brackets are priced from. Tracked with the
+#288 parity work.
+
 **This trades on unconfirmed state, which is why it is opt-in.** During the grace period
 the env sizes orders against the last known account; it knows the position it *had*, not
 the one it *has*. `flatten` deliberately ignores the budget: it exists to get you out

--- a/docs/environments/online.md
+++ b/docs/environments/online.md
@@ -871,7 +871,47 @@ key.
 The mark-price read is the deliberate exception (#394): there a failed read is
 indistinguishable from reading an unusable price, which was already terminal, so it
 raises the same way. Escalating it is safe because the only halt-wrapped caller reaches
-the fetch solely when the account is flat. Retry and staleness handling are tracked
-in #295.
+the fetch solely when the account is flat.
 
 Alpaca and Polymarket do not route through this path at all.
+
+### `max_unknown_status_steps` — riding out a short outage (#295)
+
+Default `0`, which is the behaviour above: the first unreadable read raises. Set it above
+zero and the env will instead keep stepping on the **last confirmed** read for that many
+bars before ending the episode:
+
+```python
+config = BinanceFuturesTradingEnvConfig(
+    symbol="BTCUSDT",
+    observation_failure_policy="halt",   # grace is a HALT-only concession
+    max_unknown_status_steps=3,          # ride out 3 bars, then truncate
+)
+```
+
+| bar | `status_unknown` | `done` | `terminated` | `truncated` |
+|---|---|---|---|---|
+| healthy | `0.0` | 0 | 0 | 0 |
+| outage 1 | `1.0` | 0 | 0 | 0 |
+| outage 2 | `1.0` | 0 | 0 | 0 |
+| outage 3 | `1.0` | **1** | 0 | **1** |
+
+Three things are load-bearing here:
+
+- **It truncates, never terminates.** Value estimators read `terminated` as "true
+  return-to-go is 0" and `truncated` as "bootstrap from the final observation".
+  Terminating on an unreachable API would teach the critic that a broker outage and a
+  liquidated account carry the same value target.
+- **`status_unknown` is a separate observation key**, not a seventh `account_state` slot.
+  `account_state` is shared verbatim with the offline envs, which have no notion of an
+  unreadable venue; widening it would desync live/offline parity for a concept only one
+  side has. It is emitted by all ten live envs, and is always `0.0` on Alpaca, which has
+  no failure policy.
+- **The budget counts bars, and needs a confirmed read to stand on.** A failure with
+  nothing cached — the first bar of an episode — raises regardless of the budget, because
+  the alternative is inventing an account state.
+
+**This trades on unconfirmed state, which is why it is opt-in.** During the grace period
+the env sizes orders against the last known account; it knows the position it *had*, not
+the one it *has*. `flatten` deliberately ignores the budget: it exists to get you out
+while blind, so riding out the outage would defeat it.

--- a/docs/environments/online.md
+++ b/docs/environments/online.md
@@ -911,6 +911,13 @@ Three things are load-bearing here:
   nothing cached — the first bar of an episode — raises regardless of the budget, because
   the alternative is inventing an account state.
 
+**Which reads are covered.** All of them on the trade path: the pre-trade position and
+mark, the post-bar account read, the reset read, and the balance read that *sizes* the
+order. That last one matters — threading the position and price only fixes the decision
+*whether* to trade; a policy that actually opens or resizes during an outage needs the
+balance too, and its cache is seeded from reset's confirmed read so a first trade during
+an outage is still possible.
+
 **This trades on unconfirmed state, which is why it is opt-in.** During the grace period
 the env sizes orders against the last known account; it knows the position it *had*, not
 the one it *has*. `flatten` deliberately ignores the budget: it exists to get you out

--- a/tests/envs/base_exchange_tests.py
+++ b/tests/envs/base_exchange_tests.py
@@ -516,13 +516,19 @@ def assert_the_step_emits_the_whole_done_family(env):
 
     for key in ("done", "terminated", "truncated"):
         assert key in nxt.keys(), (
-            f"{key} missing from the emitted step. The live envs no longer write the done "
-            "family by hand (#313), so a key absent here means the shared full_done_spec "
-            "stopped declaring it."
+            f"{key} missing from the emitted step. The live envs write the done family "
+            "through the shared _finalize_step_flags (#295), so a key absent here means "
+            "an env stopped routing through it."
         )
         assert nxt[key].dtype is torch.bool, f"{key} is {nxt[key].dtype}, not bool"
         assert nxt[key].shape == (1,), f"{key} has shape {tuple(nxt[key].shape)}, not (1,)"
-    assert not nxt["truncated"].any(), "a live env never truncates itself"
+    # Scoped to the DEFAULT config, which disables the grace period. Unscoped this reads
+    # as "a live env never truncates", which #295 made false -- and it would keep passing
+    # only because these fixtures leave max_unknown_status_steps at 0.
+    budget = getattr(env.config, "max_unknown_status_steps", 0)   # absent on alpaca
+    assert budget == 0 and not nxt["truncated"].any(), (
+        "a live env does not truncate itself with the outage budget disabled"
+    )
 
 
 # The two inputs that pre-fix produced a SILENT TRADE rather than a crash, which is what

--- a/tests/envs/base_exchange_tests.py
+++ b/tests/envs/base_exchange_tests.py
@@ -608,3 +608,16 @@ def assert_an_invalid_action_cannot_move_an_open_position(env, action):
     assert env.position.current_position == 1, (
         f"action {action!r} moved the open position to {env.position.current_position}"
     )
+
+
+def wire_outage_state(env, budget=0):
+    """Give a stub the #295 staleness attributes `__init__` would have set.
+
+    Ten sites were pasting these four lines. A stub that skips them fails with an
+    AttributeError from whichever read happens to touch them first, which says nothing
+    about what the test was checking.
+    """
+    env.consecutive_unknown_status = 0
+    env._status_unknown_this_step = False
+    env._last_confirmed_read = {}
+    env._max_unknown_status_steps = budget

--- a/tests/envs/binance/test_torch_env_futures.py
+++ b/tests/envs/binance/test_torch_env_futures.py
@@ -15,6 +15,7 @@ import numpy as np
 import math
 from unittest.mock import ANY, MagicMock, patch
 from tensordict import TensorDict
+from torchtrade.envs.core.state import position_qty_from_status
 
 
 class TestBinanceFuturesTorchTradingEnv:
@@ -659,7 +660,9 @@ class TestBinanceFractionalPositionResizing:
 
         with patch.object(env, '_execute_fractional_action', return_value=trade_executed) as mock_exec:
             env.position.current_action_level = first_action
-            result = env._execute_trade_if_needed(second_action, current_qty=env._get_current_position_quantity(), current_price=env._current_mark_price())
+            result = env._execute_trade_if_needed(second_action, current_qty=position_qty_from_status(
+                env.trader.get_status().get("position_status")),
+            current_price=env._current_mark_price())
 
             if should_execute:
                 mock_exec.assert_called_once_with(

--- a/tests/envs/binance/test_torch_env_futures.py
+++ b/tests/envs/binance/test_torch_env_futures.py
@@ -662,7 +662,7 @@ class TestBinanceFractionalPositionResizing:
             result = env._execute_trade_if_needed(second_action)
 
             if should_execute:
-                mock_exec.assert_called_once_with(second_action)
+                mock_exec.assert_called_once_with(second_action, current_qty=None, current_price=None)
             else:
                 mock_exec.assert_not_called()
                 assert result["executed"] is False

--- a/tests/envs/binance/test_torch_env_futures.py
+++ b/tests/envs/binance/test_torch_env_futures.py
@@ -13,7 +13,7 @@ import torch
 from torchrl.envs.utils import check_env_specs
 import numpy as np
 import math
-from unittest.mock import MagicMock, patch
+from unittest.mock import ANY, MagicMock, patch
 from tensordict import TensorDict
 
 
@@ -659,10 +659,12 @@ class TestBinanceFractionalPositionResizing:
 
         with patch.object(env, '_execute_fractional_action', return_value=trade_executed) as mock_exec:
             env.position.current_action_level = first_action
-            result = env._execute_trade_if_needed(second_action)
+            result = env._execute_trade_if_needed(second_action, current_qty=env._get_current_position_quantity(), current_price=env._current_mark_price())
 
             if should_execute:
-                mock_exec.assert_called_once_with(second_action, current_qty=None, current_price=None)
+                mock_exec.assert_called_once_with(
+                second_action, current_qty=ANY, current_price=ANY
+            )
             else:
                 mock_exec.assert_not_called()
                 assert result["executed"] is False

--- a/tests/envs/binance/test_torch_env_futures_sltp.py
+++ b/tests/envs/binance/test_torch_env_futures_sltp.py
@@ -9,6 +9,7 @@ import numpy as np
 from unittest.mock import MagicMock, patch
 from tensordict import TensorDict
 
+from torchtrade.envs.core.live import LiveObservationHalt
 from tests.envs.base_exchange_tests import (
     INVALID_ACTIONS,
     assert_an_invalid_action_cannot_move_an_open_position,
@@ -723,7 +724,7 @@ class TestCriticalEdgeCases:
         # "Handle gracefully" used to mean a conditional assertion that ran only if the
         # trade executed -- so it passed whether or not brackets were priced off zero.
         # A zero close now refuses outright, which is the graceful handling (#347).
-        with pytest.raises(ValueError, match="unusable close price"):
+        with pytest.raises(LiveObservationHalt, match="unusable close price"):
             env._execute_trade_if_needed(action_tuple)
         mock_trader.trade.assert_not_called()
 
@@ -1029,7 +1030,10 @@ class TestBinanceSLTPNotionalTradeMode:
         mock_trader.reset_mock()
         # A zero candle close is unusable data, not a soft abort: it divides the notional
         # sizing and prices both brackets, including in the "quantity" default (#347).
-        with pytest.raises(ValueError, match="unusable close price"):
+        # Wrapped in LiveObservationHalt as of #295 -- the read is under the halt policy
+        # now, which makes it agree with `_acquire_post_bar_state`, where the same
+        # observer error mid-episode has always halted rather than escaping bare.
+        with pytest.raises(LiveObservationHalt, match="unusable close price"):
             env._execute_trade_if_needed(("long", -0.02, 0.03))
 
         mock_trader.trade.assert_not_called()

--- a/tests/envs/bitget/test_torch_env_futures.py
+++ b/tests/envs/bitget/test_torch_env_futures.py
@@ -15,6 +15,7 @@ from unittest.mock import ANY, MagicMock, patch
 from tensordict import TensorDict
 
 from torchtrade.envs import TimeFrame
+from torchtrade.envs.core.state import position_qty_from_status
 
 
 class TestBitgetFuturesTorchTradingEnv:
@@ -632,7 +633,9 @@ class TestBitgetFractionalPositionResizing:
 
         with patch.object(env, '_execute_fractional_action', return_value=trade_executed) as mock_exec:
             env.position.current_action_level = first_action
-            result = env._execute_trade_if_needed(second_action, current_qty=env._get_current_position_quantity(), current_price=env._current_mark_price())
+            result = env._execute_trade_if_needed(second_action, current_qty=position_qty_from_status(
+                env.trader.get_status().get("position_status")),
+            current_price=env._current_mark_price())
 
             if should_execute:
                 mock_exec.assert_called_once_with(

--- a/tests/envs/bitget/test_torch_env_futures.py
+++ b/tests/envs/bitget/test_torch_env_futures.py
@@ -11,7 +11,7 @@ from tests.envs.base_exchange_tests import (
 import torch
 from torchrl.envs.utils import check_env_specs
 import numpy as np
-from unittest.mock import MagicMock, patch
+from unittest.mock import ANY, MagicMock, patch
 from tensordict import TensorDict
 
 from torchtrade.envs import TimeFrame
@@ -632,10 +632,12 @@ class TestBitgetFractionalPositionResizing:
 
         with patch.object(env, '_execute_fractional_action', return_value=trade_executed) as mock_exec:
             env.position.current_action_level = first_action
-            result = env._execute_trade_if_needed(second_action)
+            result = env._execute_trade_if_needed(second_action, current_qty=env._get_current_position_quantity(), current_price=env._current_mark_price())
 
             if should_execute:
-                mock_exec.assert_called_once_with(second_action, current_qty=None, current_price=None)
+                mock_exec.assert_called_once_with(
+                second_action, current_qty=ANY, current_price=ANY
+            )
             else:
                 mock_exec.assert_not_called()
                 assert result["executed"] is False

--- a/tests/envs/bitget/test_torch_env_futures.py
+++ b/tests/envs/bitget/test_torch_env_futures.py
@@ -635,7 +635,7 @@ class TestBitgetFractionalPositionResizing:
             result = env._execute_trade_if_needed(second_action)
 
             if should_execute:
-                mock_exec.assert_called_once_with(second_action)
+                mock_exec.assert_called_once_with(second_action, current_qty=None, current_price=None)
             else:
                 mock_exec.assert_not_called()
                 assert result["executed"] is False

--- a/tests/envs/bitget/test_torch_env_futures_sltp.py
+++ b/tests/envs/bitget/test_torch_env_futures_sltp.py
@@ -15,6 +15,7 @@ from tests.envs.base_exchange_tests import (
     assert_an_invalid_action_raises_before_trading,
 )
 
+from torchtrade.envs.core.live import LiveObservationHalt
 from torchtrade.envs import TimeFrame
 
 
@@ -753,7 +754,10 @@ class TestBitgetSLTPNotionalTradeMode:
         mock_trader.reset_mock()
         # A zero candle close is unusable data, not a soft abort: it divides the notional
         # sizing and prices both brackets, including in the "quantity" default (#347).
-        with pytest.raises(ValueError, match="unusable close price"):
+        # Wrapped in LiveObservationHalt as of #295 -- the read is under the halt policy
+        # now, which makes it agree with `_acquire_post_bar_state`, where the same
+        # observer error mid-episode has always halted rather than escaping bare.
+        with pytest.raises(LiveObservationHalt, match="unusable close price"):
             env._execute_trade_if_needed(("long", -0.02, 0.03))
 
         mock_trader.trade.assert_not_called()

--- a/tests/envs/bybit/test_torch_env_futures.py
+++ b/tests/envs/bybit/test_torch_env_futures.py
@@ -639,7 +639,7 @@ class TestBybitFractionalPositionResizing:
         with patch.object(env, '_execute_fractional_action', return_value=trade_result) as mock_exec:
             env.position.current_action_level = first_action
             env._execute_trade_if_needed(second_action)
-            mock_exec.assert_called_once_with(second_action)
+            mock_exec.assert_called_once_with(second_action, current_qty=None, current_price=None)
 
     def test_qty_step_rounding_no_float_artifacts(self, env, mock_env_trader):
         """Quantity must be rounded to avoid float artifacts like 0.00300000000003."""

--- a/tests/envs/bybit/test_torch_env_futures.py
+++ b/tests/envs/bybit/test_torch_env_futures.py
@@ -15,6 +15,7 @@ from tests.envs.base_exchange_tests import (
 )
 
 from torchtrade.envs import TimeFrame
+from torchtrade.envs.core.state import position_qty_from_status
 
 
 class TestBybitFuturesTorchTradingEnv:
@@ -638,7 +639,9 @@ class TestBybitFractionalPositionResizing:
 
         with patch.object(env, '_execute_fractional_action', return_value=trade_result) as mock_exec:
             env.position.current_action_level = first_action
-            env._execute_trade_if_needed(second_action, current_qty=env._get_current_position_quantity(), current_price=env._current_mark_price())
+            env._execute_trade_if_needed(second_action, current_qty=position_qty_from_status(
+                env.trader.get_status().get("position_status")),
+            current_price=env._current_mark_price())
             mock_exec.assert_called_once_with(
                 second_action, current_qty=ANY, current_price=ANY
             )
@@ -663,7 +666,9 @@ class TestBybitFractionalPositionResizing:
         })
 
         env.reset()
-        result = env._execute_fractional_action(1.0, current_qty=env._get_current_position_quantity(), current_price=env._current_mark_price())
+        result = env._execute_fractional_action(1.0, current_qty=position_qty_from_status(
+                env.trader.get_status().get("position_status")),
+            current_price=env._current_mark_price())
         if result["executed"]:
             call_kwargs = mock_env_trader.trade.call_args[1]
             qty = call_kwargs["quantity"]

--- a/tests/envs/bybit/test_torch_env_futures.py
+++ b/tests/envs/bybit/test_torch_env_futures.py
@@ -5,7 +5,7 @@ import pytest
 import torch
 from torchrl.envs.utils import check_env_specs
 import numpy as np
-from unittest.mock import MagicMock, patch
+from unittest.mock import ANY, MagicMock, patch
 from tensordict import TensorDict
 
 from tests.envs.base_exchange_tests import (
@@ -638,8 +638,10 @@ class TestBybitFractionalPositionResizing:
 
         with patch.object(env, '_execute_fractional_action', return_value=trade_result) as mock_exec:
             env.position.current_action_level = first_action
-            env._execute_trade_if_needed(second_action)
-            mock_exec.assert_called_once_with(second_action, current_qty=None, current_price=None)
+            env._execute_trade_if_needed(second_action, current_qty=env._get_current_position_quantity(), current_price=env._current_mark_price())
+            mock_exec.assert_called_once_with(
+                second_action, current_qty=ANY, current_price=ANY
+            )
 
     def test_qty_step_rounding_no_float_artifacts(self, env, mock_env_trader):
         """Quantity must be rounded to avoid float artifacts like 0.00300000000003."""
@@ -661,7 +663,7 @@ class TestBybitFractionalPositionResizing:
         })
 
         env.reset()
-        result = env._execute_fractional_action(1.0)
+        result = env._execute_fractional_action(1.0, current_qty=env._get_current_position_quantity(), current_price=env._current_mark_price())
         if result["executed"]:
             call_kwargs = mock_env_trader.trade.call_args[1]
             qty = call_kwargs["quantity"]

--- a/tests/envs/bybit/test_torch_env_futures_sltp.py
+++ b/tests/envs/bybit/test_torch_env_futures_sltp.py
@@ -330,7 +330,7 @@ class TestBybitDuplicateActionPrevention:
         mock_trader.reset_mock()
 
         env.position.current_position = position
-        trade_info = env._execute_trade_if_needed(action_tuple)
+        trade_info = env._execute_trade_if_needed(action_tuple, current_price=50000.0)
 
         assert trade_info["executed"] is should_trade
         mock_trader.trade.assert_not_called()
@@ -347,7 +347,7 @@ class TestBybitDuplicateActionPrevention:
         mock_trader.reset_mock()
         env.position.current_position = initial_pos
 
-        env._execute_trade_if_needed(action_tuple)
+        env._execute_trade_if_needed(action_tuple, current_price=50000.0)
 
         mock_trader.close_position.assert_called_once()
         mock_trader.trade.assert_called_once()
@@ -393,7 +393,7 @@ class TestBybitSLTPCloseAction:
         """Close action must close an existing position."""
         env_with_close.position.current_position = 1
 
-        trade_info = env_with_close._execute_trade_if_needed(("close", None, None))
+        trade_info = env_with_close._execute_trade_if_needed(("close", None, None), current_price=50000.0)
 
         assert trade_info["executed"] is True
         assert trade_info["closed_position"] is True
@@ -404,7 +404,7 @@ class TestBybitSLTPCloseAction:
         """Close action with no position should be a no-op."""
         env_with_close.position.current_position = 0
 
-        trade_info = env_with_close._execute_trade_if_needed(("close", None, None))
+        trade_info = env_with_close._execute_trade_if_needed(("close", None, None), current_price=50000.0)
 
         assert trade_info["executed"] is False
         mock_env_trader.close_position.assert_not_called()
@@ -441,7 +441,7 @@ class TestBybitSLTPMarkPrice:
         with patch.object(env, "_wait_for_next_timestamp"):
             env.reset()
             # Execute a long action with SL/TP
-            env._execute_trade_if_needed(("long", -0.02, 0.03))
+            env._execute_trade_if_needed(("long", -0.02, 0.03), current_price=51000.0)
 
             call_kwargs = mock_env_trader.trade.call_args[1]
             # SL/TP should be based on mark price (51000), not candle close (50050)
@@ -571,7 +571,7 @@ class TestBybitSLTPNotionalTradeMode:
 
         with patch.object(notional_env, "_wait_for_next_timestamp"):
             notional_env.reset()
-            notional_env._execute_trade_if_needed(action_tuple)
+            notional_env._execute_trade_if_needed(action_tuple, current_price=50000.0)
 
             call_kwargs = mock_env_trader.trade.call_args[1]
             assert call_kwargs["side"] == expected_side
@@ -590,7 +590,7 @@ class TestBybitSLTPNotionalTradeMode:
         with patch.object(notional_env, "_wait_for_next_timestamp"):
             notional_env.reset()
             with pytest.raises(ValueError, match="unusable mark price"):
-                notional_env._execute_trade_if_needed(("long", -0.02, 0.03))
+                notional_env._execute_trade_if_needed(("long", -0.02, 0.03), current_price=0.0)
 
             mock_env_trader.trade.assert_not_called()
 
@@ -619,7 +619,7 @@ class TestBybitSLTPNotionalTradeMode:
 
         with patch.object(env, "_wait_for_next_timestamp"):
             env.reset()
-            env._execute_trade_if_needed(("long", -0.02, 0.03))
+            env._execute_trade_if_needed(("long", -0.02, 0.03), current_price=50000.0)
 
             call_kwargs = mock_env_trader.trade.call_args[1]
             assert call_kwargs["quantity"] == pytest.approx(0.001, rel=1e-6)
@@ -667,7 +667,7 @@ class TestBybitSLTPNotionalTradeMode:
 
         with patch.object(env, "_wait_for_next_timestamp"):
             env.reset()
-            env._execute_trade_if_needed(("long", -0.02, 0.03))
+            env._execute_trade_if_needed(("long", -0.02, 0.03), current_price=50000.0)
 
             call_kwargs = mock_env_trader.trade.call_args[1]
             # margin_balance=1100 * fraction=0.1 * leverage=5 / price=50000 = 0.011
@@ -681,7 +681,7 @@ class TestBybitSLTPNotionalTradeMode:
             baseline_qty = mock_env_trader.trade.call_args[1]["quantity"]
             mock_env_trader.transaction_fee = 0.002
             mock_env_trader.trade.reset_mock()
-            env._execute_trade_if_needed(("long", -0.02, 0.03))
+            env._execute_trade_if_needed(("long", -0.02, 0.03), current_price=50000.0)
             assert mock_env_trader.trade.call_args[1]["quantity"] < baseline_qty, (
                 "the env must reserve the trader's higher rate, sizing SMALLER than the "
                 "venue constant -- otherwise the venue refuses the open"
@@ -721,14 +721,14 @@ class TestBybitSLTPLockPosition:
             locked_env.reset()
 
             # Open long first
-            locked_env._execute_trade_if_needed(("long", -0.02, 0.03))
+            locked_env._execute_trade_if_needed(("long", -0.02, 0.03), current_price=50000.0)
             mock_env_trader.trade.assert_called_once()
             locked_env.position.current_position = 1
 
             mock_env_trader.reset_mock()
 
             # Try to switch to short — should be ignored
-            trade_info = locked_env._execute_trade_if_needed(("short", 0.02, -0.03))
+            trade_info = locked_env._execute_trade_if_needed(("short", 0.02, -0.03), current_price=50000.0)
 
             assert trade_info["executed"] is False
             mock_env_trader.trade.assert_not_called()
@@ -741,7 +741,7 @@ class TestBybitSLTPLockPosition:
             locked_env.position.current_position = 1
             mock_env_trader.reset_mock()  # Clear calls from reset/init
 
-            trade_info = locked_env._execute_trade_if_needed(("close", None, None))
+            trade_info = locked_env._execute_trade_if_needed(("close", None, None), current_price=50000.0)
 
             assert trade_info["executed"] is False
             mock_env_trader.close_position.assert_not_called()
@@ -752,7 +752,7 @@ class TestBybitSLTPLockPosition:
             locked_env.reset()
             assert locked_env.position.current_position == 0
 
-            trade_info = locked_env._execute_trade_if_needed(("long", -0.02, 0.03))
+            trade_info = locked_env._execute_trade_if_needed(("long", -0.02, 0.03), current_price=50000.0)
 
             mock_env_trader.trade.assert_called_once()
 
@@ -784,7 +784,7 @@ class TestBybitSLTPLockPosition:
             env.position.current_position = 1
 
             # Switch to short — should work (calls close + trade)
-            env._execute_trade_if_needed(("short", 0.02, -0.03))
+            env._execute_trade_if_needed(("short", 0.02, -0.03), current_price=50000.0)
             mock_env_trader.close_position.assert_called()
             mock_env_trader.trade.assert_called()
 

--- a/tests/envs/okx/test_torch_env_futures.py
+++ b/tests/envs/okx/test_torch_env_futures.py
@@ -363,7 +363,7 @@ class TestOKXFuturesTorchTradingEnv:
     ):
         """#347: the sweep guarded the flat half of okx's ternary and stopped.
 
-        The other half runs on every RESIZE, and okx is the only exchange that threads the
+        The other half runs on every RESIZE, and as of #295 all four exchanges thread the
         price down from _step rather than re-fetching inside _execute_fractional_action.
         Both okx fields feeding mark_price fall back to 0.0 when empty, so this arrives
         from two blank venue fields, not only a wire fault -- and {harm}.

--- a/tests/envs/okx/test_torch_env_futures_sltp.py
+++ b/tests/envs/okx/test_torch_env_futures_sltp.py
@@ -131,7 +131,7 @@ class TestOKXFuturesSLTPTorchTradingEnv:
 
         with patch.object(env, "_wait_for_next_timestamp"):
             env.reset()
-            env._execute_trade_if_needed(("long", -0.02, 0.03))
+            env._execute_trade_if_needed(("long", -0.02, 0.03), current_price=51000.0)
             call_kwargs = mock_env_trader.trade.call_args[1]
             # SL/TP should be based on mark price (51000), not candle close (50050)
             assert call_kwargs["stop_loss"] == pytest.approx(51000.0 * (1 - 0.02), rel=1e-4)
@@ -233,7 +233,7 @@ class TestOKXDuplicateActionPrevention:
         env.reset()
         mock_trader.reset_mock()
         env.position.current_position = position
-        trade_info = env._execute_trade_if_needed(action_tuple)
+        trade_info = env._execute_trade_if_needed(action_tuple, current_price=50000.0)
         assert trade_info["executed"] is should_trade
 
     @pytest.mark.parametrize("initial_pos,action_tuple,expected_side", [
@@ -246,7 +246,7 @@ class TestOKXDuplicateActionPrevention:
         env.reset()
         mock_trader.reset_mock()
         env.position.current_position = initial_pos
-        env._execute_trade_if_needed(action_tuple)
+        env._execute_trade_if_needed(action_tuple, current_price=50000.0)
         mock_trader.close_position.assert_called_once()
         mock_trader.trade.assert_called_once()
         assert mock_trader.trade.call_args.kwargs["side"] == expected_side
@@ -279,14 +279,14 @@ class TestOKXSLTPCloseAction:
     def test_close_action_closes_position(self, env_with_close, mock_env_trader):
         """Close action must close an existing position."""
         env_with_close.position.current_position = 1
-        trade_info = env_with_close._execute_trade_if_needed(("close", None, None))
+        trade_info = env_with_close._execute_trade_if_needed(("close", None, None), current_price=50000.0)
         assert trade_info["executed"] is True
         assert trade_info["closed_position"] is True
 
     def test_close_action_no_position(self, env_with_close, mock_env_trader):
         """Close action with no position should be a no-op."""
         env_with_close.position.current_position = 0
-        trade_info = env_with_close._execute_trade_if_needed(("close", None, None))
+        trade_info = env_with_close._execute_trade_if_needed(("close", None, None), current_price=50000.0)
         assert trade_info["executed"] is False
 
 
@@ -317,7 +317,7 @@ class TestOKXSLTPNotionalTradeMode:
         mock_env_trader.get_mark_price = MagicMock(return_value=50000.0)
         with patch.object(notional_env, "_wait_for_next_timestamp"):
             notional_env.reset()
-            notional_env._execute_trade_if_needed(action_tuple)
+            notional_env._execute_trade_if_needed(action_tuple, current_price=50000.0)
             call_kwargs = mock_env_trader.trade.call_args[1]
             assert call_kwargs["side"] == expected_side
             assert call_kwargs["quantity"] == pytest.approx(0.01, rel=1e-6)
@@ -333,7 +333,7 @@ class TestOKXSLTPNotionalTradeMode:
         with patch.object(notional_env, "_wait_for_next_timestamp"):
             notional_env.reset()
             with pytest.raises(ValueError, match="unusable mark price"):
-                notional_env._execute_trade_if_needed(("long", -0.02, 0.03))
+                notional_env._execute_trade_if_needed(("long", -0.02, 0.03), current_price=0.0)
             mock_env_trader.trade.assert_not_called()
 
     def test_quantity_mode_passes_raw_value(self, mock_env_observer, mock_env_trader):
@@ -352,7 +352,7 @@ class TestOKXSLTPNotionalTradeMode:
             )
         with patch.object(env, "_wait_for_next_timestamp"):
             env.reset()
-            env._execute_trade_if_needed(("long", -0.02, 0.03))
+            env._execute_trade_if_needed(("long", -0.02, 0.03), current_price=50000.0)
             assert mock_env_trader.trade.call_args[1]["quantity"] == pytest.approx(0.001, rel=1e-6)
 
     def test_fractional_converts_balance_to_quantity(self, mock_env_observer, mock_env_trader):
@@ -386,7 +386,7 @@ class TestOKXSLTPNotionalTradeMode:
         })
         with patch.object(env, "_wait_for_next_timestamp"):
             env.reset()
-            env._execute_trade_if_needed(("long", -0.02, 0.03))
+            env._execute_trade_if_needed(("long", -0.02, 0.03), current_price=50000.0)
             # margin_balance=1100 * fraction=0.1 * leverage=5 / price=50000 = 0.011
             from torchtrade.envs.live.okx.order_executor import TAKER_FEE
             # Net of the reserved entry fee (#278).
@@ -416,11 +416,11 @@ class TestOKXSLTPLockPosition:
         """With lock=True, a short action while long should be ignored."""
         with patch.object(locked_env, "_wait_for_next_timestamp"):
             locked_env.reset()
-            locked_env._execute_trade_if_needed(("long", -0.02, 0.03))
+            locked_env._execute_trade_if_needed(("long", -0.02, 0.03), current_price=50000.0)
             locked_env.position.current_position = 1
             mock_env_trader.reset_mock()
 
-            trade_info = locked_env._execute_trade_if_needed(("short", 0.02, -0.03))
+            trade_info = locked_env._execute_trade_if_needed(("short", 0.02, -0.03), current_price=50000.0)
             assert trade_info["executed"] is False
             mock_env_trader.trade.assert_not_called()
 
@@ -431,7 +431,7 @@ class TestOKXSLTPLockPosition:
             locked_env.position.current_position = 1
             mock_env_trader.reset_mock()
 
-            trade_info = locked_env._execute_trade_if_needed(("close", None, None))
+            trade_info = locked_env._execute_trade_if_needed(("close", None, None), current_price=50000.0)
             assert trade_info["executed"] is False
             mock_env_trader.close_position.assert_not_called()
 
@@ -440,7 +440,7 @@ class TestOKXSLTPLockPosition:
         with patch.object(locked_env, "_wait_for_next_timestamp"):
             locked_env.reset()
             assert locked_env.position.current_position == 0
-            locked_env._execute_trade_if_needed(("long", -0.02, 0.03))
+            locked_env._execute_trade_if_needed(("long", -0.02, 0.03), current_price=50000.0)
             mock_env_trader.trade.assert_called_once()
 
 

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -42,6 +42,7 @@ from torchtrade.envs.utils.liquidation import (
     cross_liquidation_price,
     isolated_liquidation_price,
 )
+from tests.envs.base_exchange_tests import wire_outage_state
 from torchtrade.envs.core.state import (
     POSITION_UNKNOWN,
     PositionState,
@@ -3144,6 +3145,7 @@ def test_closing_reports_the_order_side_that_closed_it(qty, expected_side):
         position=SimpleNamespace(current_position=1),
         _create_trade_info=TorchTradeFuturesLiveEnv._create_trade_info.__get__(object()),
     )
+    wire_outage_state(env)   # _handle_close_action clears the balance cache
     info = TorchTradeFuturesLiveEnv._handle_close_action(env, qty)
 
     assert info["side"] == expected_side, "a close must report the side it sent"
@@ -3400,9 +3402,7 @@ class _ResetStub:
         self.history_reset_calls = 0
         self.sync_action_level_calls = 0
         # #295: the shared _reset clears the outage state at the episode boundary.
-        self.consecutive_unknown_status = 0
-        self._status_unknown_this_step = False
-        self._last_confirmed_read = {}
+        wire_outage_state(self)
         self._reset_outage_state = (
             lambda: TorchTradeLiveEnv._reset_outage_state(self)
         )

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -3727,7 +3727,7 @@ def test_the_done_family_separates_an_outage_from_a_blown_account(
         _status_unknown_this_step=bool(unknown),
         config=SimpleNamespace(max_unknown_status_steps=budget),
     )
-    env._max_unknown_status_steps = TorchTradeLiveEnv._max_unknown_status_steps.fget(env)
+    env._max_unknown_status_steps = budget
     td = TensorDict({}, batch_size=())
     TorchTradeLiveEnv._finalize_step_flags(env, td, terminated=terminated)
 

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -515,14 +515,6 @@ def test_unknown_status_refuses_to_build_account_state():
         TorchTradeFuturesLiveEnv._get_observation(env)
 
 
-# Envs that RESOLVE the shared accessor, which replaced three byte-identical copies
-# (#283). Note okx resolves it but sizes in _step instead, so these cells prove wiring
-# rather than okx's own path. A rename would empty this and pytest would SKIP rather
-# than fail -- the hazard this file guards against elsewhere with its own len()
-# assertions.
-_SIZING_ENVS = [c for c in NON_SLTP_ENVS if hasattr(c, "_get_current_position_quantity")]
-assert len(_SIZING_ENVS) == 4, f"expected 4 envs that size from a live query, got {_SIZING_ENVS}"
-
 _FAILING_FETCH_EXCHANGES = ["binance", "bitget", "bybit", "okx", "alpaca"]
 
 
@@ -620,29 +612,11 @@ def test_reading_a_field_off_an_unknown_status_says_why():
         POSITION_UNKNOWN.qty
 
 
-@pytest.mark.parametrize(
-    "env_cls",
-    _SIZING_ENVS,
-    ids=lambda c: c.__name__,
-)
-def test_position_sizing_refuses_an_unknown_status(env_cls):
-    """_get_current_position_quantity must not size an order off a phantom flat account.
-
-    The hand-rolled `position.qty if position is not None else 0.0` read an outage as 0
-    quantity, so the delta was computed against a position the exchange never said was
-    gone. _step normally raises earlier, on its own status read -- this is the path when
-    the outage begins between the two get_status() calls inside a single step.
-
-    All four resolve the accessor since it was shared (#283), though okx sizes in _step
-    and never calls it -- these cells prove the MRO wiring, and okx's real path is covered
-    by test_okx_sizes_through_the_dust_rule_in_step. Alpaca spells the same second query
-    inline and is covered through _step by the composite test.
-    """
-    env = SimpleNamespace(
-        trader=SimpleNamespace(get_status=lambda: {"position_status": POSITION_UNKNOWN})
-    )
-    with pytest.raises(PositionUnknownError):
-        env_cls._get_current_position_quantity(env)
+# `test_position_sizing_refuses_an_unknown_status` lived here. It guarded an outage that
+# began BETWEEN the two get_status() calls inside one step -- a window #295 closed by
+# construction: the trade path now takes the qty `_acquire_pre_trade_state` already
+# resolved, so there is one status read per step and no second window to fall into.
+# `test_an_outage_stops_the_step_before_it_can_trade` below covers what remains.
 
 
 @pytest.mark.parametrize("module", ["env", "env_sltp"])
@@ -907,19 +881,21 @@ def test_no_live_env_reforks_the_position_quantity_accessor(env_cls):
     that never happened.
 
     Structural, not behavioural: a re-forked copy that has not drifted yet passes every
-    behavioural test, which is exactly how three of them survived. Over FUTURES_ENVS, not
-    just the non-SLTP ones: the SLTP variants inherit the accessor without calling it
-    today, so a fork there would be dead code -- and dead-but-wrong is the state the three
-    originals were in.
+    behavioural test, which is exactly how three of them survived.
+
+    #295 deleted the shared accessor entirely -- the trade path now takes the qty
+    `_acquire_pre_trade_state` resolved under the halt policy, so there is nothing left to
+    inherit. That makes re-introducing a private copy MORE tempting, not less, which is
+    why this guard outlived the method it was written for.
     """
     assert "_get_current_position_quantity" not in vars(env_cls), (
-        f"{env_cls.__name__} redefines _get_current_position_quantity. The dust rule "
-        "lives in position_qty_from_status -- inherit it rather than re-deriving qty."
+        f"{env_cls.__name__} defines its own _get_current_position_quantity. The dust "
+        f"rule lives in position_qty_from_status, and the qty is already resolved once "
+        f"per step in _acquire_pre_trade_state -- take it from there."
     )
 
 
-@pytest.mark.parametrize("env_cls", _SIZING_ENVS, ids=lambda c: c.__name__)
-def test_a_dust_residual_does_not_look_like_a_position_to_the_trade_path(env_cls):
+def test_a_dust_residual_does_not_look_like_a_position_to_the_trade_path():
     """The concrete failure from #283, at the seam every sizing path reads.
 
     An exchange can leave a float residual after a full close. Read as a live position it
@@ -927,17 +903,30 @@ def test_a_dust_residual_does_not_look_like_a_position_to_the_trade_path(env_cls
     close_position() on nothing -- and still advances current_action_level from a trade
     that never happened, which freezes the duplicate-action guard (invariant 2).
 
-    The account_state paths already honoured the dust rule; only the TRADE paths
-    hand-rolled it, which is why nothing caught this.
+    The seam MOVED in #295: the trade path no longer queries the venue itself, it takes
+    the qty `_acquire_pre_trade_state` already resolved under the halt policy. So this
+    drives that, rather than the per-env accessor it used to -- which #295 left with no
+    production callers at all.
     """
+    ps = SimpleNamespace(qty=1e-12, mark_price=100.0)
     env = SimpleNamespace(
-        trader=SimpleNamespace(
-            get_status=lambda: {"position_status": SimpleNamespace(qty=1e-12)}
-        )
+        config=SimpleNamespace(
+            observation_failure_policy=ObservationFailurePolicy.HALT, symbol="T"
+        ),
+        trader=SimpleNamespace(get_status=lambda: {"position_status": ps},
+                               get_mark_price=lambda: 100.0),
+        consecutive_unknown_status=0, _status_unknown_this_step=False,
+        _last_confirmed_read={}, _max_unknown_status_steps=0,
     )
-    assert env_cls._get_current_position_quantity(env) == 0.0, (
-        "a 1e-12 residual must read as flat, not as a position to close"
+    env._halting = lambda read, cache_key=None: TorchTradeFuturesLiveEnv._halting(
+        env, read, cache_key
     )
+    env._current_mark_price = (
+        lambda p=None: TorchTradeFuturesLiveEnv._current_mark_price(env, p)
+    )
+
+    _, _, _, size = TorchTradeFuturesLiveEnv._acquire_pre_trade_state(env)
+    assert size == 0.0, "a 1e-12 residual must read as flat, not as a position to close"
 
 
 @pytest.mark.parametrize("qty,expected", [

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -720,9 +720,6 @@ def test_an_outage_stops_the_step_before_it_can_trade(exchange, module):
     env.consecutive_unknown_status = 0
     env._last_confirmed_read = {}
     env._max_unknown_status_steps = 0
-    env._flatten_if_policy_says_so = (
-        lambda: TorchTradeFuturesLiveEnv._flatten_if_policy_says_so(env)
-    )
     env._halting = lambda read, cache_key=None: TorchTradeFuturesLiveEnv._halting(
         env, read, cache_key
     )
@@ -1009,9 +1006,6 @@ def test_okx_sizes_through_the_dust_rule_in_step():
     env.consecutive_unknown_status = 0
     env._last_confirmed_read = {}
     env._max_unknown_status_steps = 0
-    env._flatten_if_policy_says_so = (
-        lambda: TorchTradeFuturesLiveEnv._flatten_if_policy_says_so(env)
-    )
     env._halting = lambda read, cache_key=None: TorchTradeFuturesLiveEnv._halting(
         env, read, cache_key
     )
@@ -2616,9 +2610,6 @@ def test_a_failed_read_runs_the_configured_policy(policy, expect_flatten):
         _last_confirmed_read={},
         _max_unknown_status_steps=0,
     )
-    env._flatten_if_policy_says_so = (
-        lambda: TorchTradeFuturesLiveEnv._flatten_if_policy_says_so(env)
-    )
 
     def boom():
         raise PositionUnknownError("venue unreachable")
@@ -2653,9 +2644,6 @@ def test_an_unreadable_position_halts_before_the_env_trades(policy, expect_flatt
     env.consecutive_unknown_status = 0
     env._last_confirmed_read = {}
     env._max_unknown_status_steps = 0
-    env._flatten_if_policy_says_so = (
-        lambda: TorchTradeFuturesLiveEnv._flatten_if_policy_says_so(env)
-    )
     env._halting = lambda read, cache_key=None: TorchTradeFuturesLiveEnv._halting(
         env, read, cache_key
     )
@@ -2840,9 +2828,6 @@ def test_the_pre_trade_tuple_cannot_be_reordered_unnoticed():
     env.consecutive_unknown_status = 0
     env._last_confirmed_read = {}
     env._max_unknown_status_steps = 0
-    env._flatten_if_policy_says_so = (
-        lambda: TorchTradeFuturesLiveEnv._flatten_if_policy_says_so(env)
-    )
     env._halting = lambda read, cache_key=None: TorchTradeFuturesLiveEnv._halting(
         env, read, cache_key
     )
@@ -3433,9 +3418,6 @@ class _ResetStub:
             lambda: TorchTradeLiveEnv._reset_outage_state(self)
         )
         self._max_unknown_status_steps = 0
-        self._flatten_if_policy_says_so = (
-            lambda: TorchTradeFuturesLiveEnv._flatten_if_policy_says_so(self)
-        )
         # The reset read runs under the halt policy as of #295.
         self._halting = lambda read, cache_key=None: (
             TorchTradeFuturesLiveEnv._halting(self, read, cache_key)
@@ -3707,18 +3689,31 @@ def test_an_observer_disagreeing_with_the_config_raises_rather_than_guessing():
 
 @pytest.mark.parametrize("env_cls", STEPPING_ENVS, ids=lambda c: c.__name__)
 def test_every_live_step_writes_done_explicitly(env_cls):
-    """`done` must be written by `_step`, not inferred from `truncated` (#295).
+    """Every live `_step` writes the done family through the shared writer (#295).
 
-    Verified against a real Collector: setting only `truncated=True` leaves `done=False`,
-    the collector never resets, and the episode silently runs on -- which is precisely the
-    dead channel this work exists to remove. `truncated` has been write-only since #313,
-    so nothing else would have caught it.
+    Not because TorchRL cannot derive `done` -- `EnvBase._complete_done` fills
+    `terminated | truncated` when the key is absent. Because these envs emit the whole
+    family from `_step` itself, which many tests drive directly, and because a venue
+    reimplementing the writes by hand is how `truncated` became a declared constant in
+    the first place.
     """
-    step = env_cls.__dict__["_step"]
-    src = inspect.getsource(step)
-    assert "_finalize_step_flags" in src, (
-        f"{env_cls.__name__}._step does not use the shared done-family writer, so its "
+    calls = [n.func.attr for n in ast.walk(ast.parse(
+        inspect.getsource(env_cls.__dict__["_step"]).lstrip()))
+        if isinstance(n, ast.Call) and isinstance(n.func, ast.Attribute)]
+    assert "_finalize_step_flags" in calls, (
+        f"{env_cls.__name__}._step does not call the shared done-family writer, so its "
         f"truncation channel is unreachable"
+    )
+    # A substring check passed on a commented-out call with the writes reimplemented
+    # alongside it. Only binance had an end-to-end backstop for that; nine venues did not.
+    assert not [n for n in ast.walk(ast.parse(
+        inspect.getsource(env_cls.__dict__["_step"]).lstrip()))
+        if isinstance(n, ast.Call) and isinstance(n.func, ast.Attribute)
+        and n.func.attr == "set"
+        and n.args and isinstance(n.args[0], ast.Constant)
+        and n.args[0].value in ("done", "terminated", "truncated")], (
+        f"{env_cls.__name__}._step writes the done family by hand alongside "
+        f"_finalize_step_flags; the hand-written value wins and the shared one is a lie"
     )
 
 
@@ -3820,9 +3815,10 @@ def test_a_recovered_venue_does_not_truncate_the_next_episode():
     )
 
 
-@pytest.mark.parametrize("config_cls", [c.values[0] for c in SLTP_CONFIGS] + [
+@pytest.mark.parametrize("config_cls", [
     BinanceFuturesTradingEnvConfig, BitgetFuturesTradingEnvConfig,
     BybitFuturesTradingEnvConfig, OKXFuturesTradingEnvConfig,
+    BinanceFuturesSLTPTradingEnvConfig,
 ], ids=lambda c: c.__name__)
 @pytest.mark.parametrize("bad", [-1, 1.5, True, "3", None], ids=[
     "negative", "fractional", "bool", "str", "none"])
@@ -3834,6 +3830,27 @@ def test_an_unusable_outage_budget_is_rejected_at_the_boundary(config_cls, bad):
     here because bool is an int subclass, and would otherwise pass as a budget of 1.
 
     Deleting the validator's body failed ZERO tests before this: it shipped unpinned.
+
+    Four plain configs, because deleting the call from ONE of them fails only its own
+    cases -- they are four independent regression points, which is the shape this repo
+    keeps shipping. One SLTP config, because deleting it from BaseFuturesSLTPConfig fails
+    all four together: they are one call site wearing four names, pinned below.
     """
     with pytest.raises(ValueError, match="max_unknown_status_steps"):
         config_cls(symbol="TEST", max_unknown_status_steps=bad)
+
+
+@pytest.mark.parametrize("config_cls", [c.values[0] for c in SLTP_CONFIGS],
+                         ids=lambda c: c.__name__)
+def test_every_sltp_config_shares_the_one_validated_post_init(config_cls):
+    """The cheaper half of the sweep above, and a stronger guard than re-running it.
+
+    Re-running five bad inputs against four configs that resolve to the SAME function
+    tests one thing four times. What can actually break is a subclass growing its own
+    `__post_init__` and dropping the `super()` call -- which this catches and the
+    parametrized sweep would not, since the venue would simply stop validating.
+    """
+    assert config_cls.__post_init__ is BaseFuturesSLTPConfig.__post_init__, (
+        f"{config_cls.__name__} defines its own __post_init__; it must call super() or "
+        f"it silently stops validating every field the shared one checks"
+    )

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -3427,7 +3427,7 @@ class _ResetStub:
         # assertion in one bitget test.
         self.sync_action_level_calls += 1
 
-    _get_observation = lambda self, advance_hold=True: advance_hold
+    _get_observation = lambda self, advance_hold=True, **_kw: advance_hold
 
 
 @pytest.mark.parametrize("kwargs,expected", [

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -3843,3 +3843,51 @@ def test_every_sltp_config_shares_the_one_validated_post_init(config_cls):
         f"{config_cls.__name__} defines its own __post_init__; it must call super() or "
         f"it silently stops validating every field the shared one checks"
     )
+
+
+def test_every_successful_close_invalidates_the_cached_balance():
+    """A realised close moves equity, so the cached sizing balance is stale after it.
+
+    Seven close sites exist: the shared `_handle_close_action` (which the direction-switch
+    leg routes through) and six across the SLTP envs, in three different shapes. I patched
+    one and reported it done -- the exact "landed on some copies, not others" failure this
+    PR has now reproduced five times, that time while fixing an instance of it.
+
+    Structural, because the cost is invisible behaviourally: a stale balance sizes an
+    order the venue rejects on margin, many bars later, only during an outage.
+
+    Two functions are exempt BY ORDERING, not by oversight. `_halting`'s emergency FLATTEN
+    close runs when the venue is already unreadable -- the cache is what grace is standing
+    on. `_reset` clears the whole cache before it closes and re-seeds from a fresh read
+    after, so its balance already reflects the close.
+    """
+    import ast
+    import pathlib
+
+    EXEMPT = {"_halting", "_reset"}
+    root = pathlib.Path(inspect.getfile(TorchTradeLiveEnv)).parent.parent / "live"
+    offenders = []
+    for path in sorted(root.glob("*/env_sltp.py")) + [
+        root / "shared" / "futures_live_base.py"
+    ]:
+        for fn in ast.walk(ast.parse(path.read_text())):
+            if not isinstance(fn, ast.FunctionDef) or fn.name in EXEMPT:
+                continue
+            closes = [n for n in ast.walk(fn)
+                      if isinstance(n, ast.Call) and isinstance(n.func, ast.Attribute)
+                      and n.func.attr == "close_position"]
+            if not closes:
+                continue
+            invalidations = [n for n in ast.walk(fn)
+                             if isinstance(n, ast.Call) and isinstance(n.func, ast.Attribute)
+                             and n.func.attr == "pop" and n.args
+                             and isinstance(n.args[0], ast.Constant)
+                             and n.args[0].value == "balance"]
+            if len(invalidations) < len(closes):
+                offenders.append(f"{path.parent.name}/{path.name}::{fn.name} "
+                                 f"({len(closes)} closes, {len(invalidations)} invalidations)")
+
+    assert not offenders, (
+        "a successful close leaves the cached sizing balance stale in: "
+        + "; ".join(offenders)
+    )

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -257,6 +257,9 @@ def test_non_sltp_step_syncs_before_it_trades(env_cls):
 # define none, and an exchange #6 would land here the moment it does.
 STEPPING_ENVS = [c for c in LIVE_ENVS if "_step" in c.__dict__]
 
+# Every live env that owns a . The two shared implementations plus any override.
+RESETTING_ENVS = [c for c in LIVE_ENVS if "_reset" in c.__dict__]
+
 
 @pytest.mark.parametrize("env_cls", STEPPING_ENVS, ids=lambda c: c.__name__)
 def test_every_live_step_validates_its_action_before_it_trades(env_cls):
@@ -3422,6 +3425,21 @@ class _ResetStub:
 
         self.history_reset_calls = 0
         self.sync_action_level_calls = 0
+        # #295: the shared _reset clears the outage state at the episode boundary.
+        self.consecutive_unknown_status = 0
+        self._status_unknown_this_step = False
+        self._last_confirmed_read = {}
+        self._reset_outage_state = (
+            lambda: TorchTradeLiveEnv._reset_outage_state(self)
+        )
+        self._max_unknown_status_steps = 0
+        self._flatten_if_policy_says_so = (
+            lambda: TorchTradeFuturesLiveEnv._flatten_if_policy_says_so(self)
+        )
+        # The reset read runs under the halt policy as of #295.
+        self._halting = lambda read, cache_key=None: (
+            TorchTradeFuturesLiveEnv._halting(self, read, cache_key)
+        )
         self.trader, self.observer = _Trader(), _Observer()
         self.history = SimpleNamespace(reset=lambda: setattr(
             outer, "history_reset_calls", outer.history_reset_calls + 1))
@@ -3722,6 +3740,7 @@ def test_the_done_family_separates_an_outage_from_a_blown_account(
     """
     env = SimpleNamespace(
         consecutive_unknown_status=unknown,
+        _status_unknown_this_step=bool(unknown),
         config=SimpleNamespace(max_unknown_status_steps=budget),
     )
     env._max_unknown_status_steps = TorchTradeLiveEnv._max_unknown_status_steps.fget(env)
@@ -3730,3 +3749,91 @@ def test_the_done_family_separates_an_outage_from_a_blown_account(
 
     got = (bool(td["done"]), bool(td["terminated"]), bool(td["truncated"]))
     assert got == expected, f"done/terminated/truncated = {got}, expected {expected}"
+
+
+@pytest.mark.parametrize("env_cls", RESETTING_ENVS, ids=lambda c: c.__name__)
+def test_every_live_reset_clears_the_outage_state(env_cls):
+    """A truncated episode must not poison the next one (#295).
+
+    `_finalize_step_flags` derives `truncated` from the counter, so an episode that ended
+    on a spent budget would start the NEXT one already at budget and truncate on its first
+    step -- 1-step episodes forever, and a collector that looks busy while collecting
+    nothing. AST rather than source text, so a comment naming the method cannot satisfy it.
+    """
+    calls = [n.func.attr for n in ast.walk(ast.parse(
+        inspect.getsource(env_cls.__dict__["_reset"]).lstrip()))
+        if isinstance(n, ast.Call) and isinstance(n.func, ast.Attribute)]
+    # `_reset` accepted as delegation: the SLTP envs override _reset and call
+    # super()._reset(), which is where the clear lives. What this rejects is an override
+    # that does NEITHER -- reimplementing reset and dropping the clear on the floor.
+    assert {"_reset_outage_state", "_reset"} & set(calls), (
+        f"{env_cls.__name__}._reset neither clears the outage counter nor delegates to a "
+        f"_reset that does; a truncated episode would make every following episode "
+        f"truncate on step 1"
+    )
+
+
+def test_a_recovered_venue_does_not_truncate_the_next_episode():
+    """The behavioural half of the guard above, driven through a real env."""
+    from unittest.mock import MagicMock, patch
+    import numpy as np
+    from torchtrade.envs.core.state import PositionUnknownError
+    from torchtrade.envs.live.binance.env import (
+        BinanceFuturesTorchTradingEnv as Env, BinanceFuturesTradingEnvConfig as Config,
+    )
+
+    observer = MagicMock()
+    observer.get_keys.return_value = ["1m_10"]
+    observer.get_observations.return_value = {"1m_10": np.zeros((10, 4), dtype=np.float32)}
+    observer.get_features.return_value = {
+        "observation_features": list("abcd"), "original_features": []}
+    observer.reset.return_value = None
+    trader = MagicMock()
+    trader.get_account_balance.return_value = {
+        "available_balance": 1e4, "total_margin_balance": 1e4,
+        "total_wallet_balance": 1e4, "total_maintenance_margin": 0.0}
+    trader.get_status.return_value = {"position_status": None}
+    trader.get_mark_price.return_value = 100.0
+    trader.get_lot_size.return_value = {"min_qty": 0.001, "qty_step": 0.001}
+
+    with patch("time.sleep"), patch.object(Env, "_wait_for_next_timestamp"):
+        env = Env(config=Config(
+            symbol="BTCUSDT", time_frames=["1m"], window_sizes=[10], execute_on="1m",
+            max_unknown_status_steps=2, close_position_on_init=False,
+        ), observer=observer, trader=trader)
+
+        td = env.reset()
+        td = env.step(td.set("action", torch.tensor(1)))["next"]
+        trader.get_status.side_effect = PositionUnknownError("down")
+        for _ in range(2):
+            td = env.step(td.exclude("done", "terminated", "truncated", "reward")
+                          .set("action", torch.tensor(1)))["next"]
+        assert bool(td["truncated"]), "setup: the outage should have truncated"
+
+        trader.get_status.side_effect = None          # venue recovers
+        fresh = env.reset()
+        assert env.consecutive_unknown_status == 0
+        nxt = env.step(fresh.set("action", torch.tensor(1)))["next"]
+
+    assert not bool(nxt["truncated"]), (
+        "the new episode truncated on its first step: the outage counter survived reset"
+    )
+
+
+@pytest.mark.parametrize("config_cls", [c.values[0] for c in SLTP_CONFIGS] + [
+    BinanceFuturesTradingEnvConfig, BitgetFuturesTradingEnvConfig,
+    BybitFuturesTradingEnvConfig, OKXFuturesTradingEnvConfig,
+], ids=lambda c: c.__name__)
+@pytest.mark.parametrize("bad", [-1, 1.5, True, "3", None], ids=[
+    "negative", "fractional", "bool", "str", "none"])
+def test_an_unusable_outage_budget_is_rejected_at_the_boundary(config_cls, bad):
+    """A negative budget reads as "disabled" through `>= budget > 0`.
+
+    So a typo silently selects the STRICTEST posture rather than erroring -- the shape
+    invariant 4 names: a guard that absorbs nonsense is worse than no guard. `True` is
+    here because bool is an int subclass, and would otherwise pass as a budget of 1.
+
+    Deleting the validator's body failed ZERO tests before this: it shipped unpinned.
+    """
+    with pytest.raises(ValueError, match="max_unknown_status_steps"):
+        config_cls(symbol="TEST", max_unknown_status_steps=bad)

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -257,7 +257,7 @@ def test_non_sltp_step_syncs_before_it_trades(env_cls):
 # define none, and an exchange #6 would land here the moment it does.
 STEPPING_ENVS = [c for c in LIVE_ENVS if "_step" in c.__dict__]
 
-# Every live env that owns a . The two shared implementations plus any override.
+# Every live env that owns a `_reset`: the two shared bodies plus the SLTP overrides.
 RESETTING_ENVS = [c for c in LIVE_ENVS if "_reset" in c.__dict__]
 
 
@@ -1049,7 +1049,7 @@ def _futures_env_stub(position_status, balance, leverage=5):
         position=PositionState(),
         account_state_key="account_state",
         market_data_keys=[],
-        # _get_observation publishes status_unknown from this counter (#295).
+        # _get_observation declares status_unknown; _finalize_step_flags sets it (#295).
         consecutive_unknown_status=0,
     )
 

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -714,7 +714,15 @@ def test_an_outage_stops_the_step_before_it_can_trade(exchange, module):
     env.config = SimpleNamespace(
         observation_failure_policy=ObservationFailurePolicy.HALT, symbol="TEST"
     )
-    env._halting = lambda read: TorchTradeFuturesLiveEnv._halting(env, read)
+    env.consecutive_unknown_status = 0
+    env._last_confirmed_read = {}
+    env._max_unknown_status_steps = 0
+    env._flatten_if_policy_says_so = (
+        lambda: TorchTradeFuturesLiveEnv._flatten_if_policy_says_so(env)
+    )
+    env._halting = lambda read, cache_key=None: TorchTradeFuturesLiveEnv._halting(
+        env, read, cache_key
+    )
     env._acquire_pre_trade_state = (
         lambda: TorchTradeFuturesLiveEnv._acquire_pre_trade_state(env)
     )
@@ -995,7 +1003,15 @@ def test_okx_sizes_through_the_dust_rule_in_step():
     env.config = SimpleNamespace(
         observation_failure_policy=ObservationFailurePolicy.HALT, symbol="TEST"
     )
-    env._halting = lambda read: TorchTradeFuturesLiveEnv._halting(env, read)
+    env.consecutive_unknown_status = 0
+    env._last_confirmed_read = {}
+    env._max_unknown_status_steps = 0
+    env._flatten_if_policy_says_so = (
+        lambda: TorchTradeFuturesLiveEnv._flatten_if_policy_says_so(env)
+    )
+    env._halting = lambda read, cache_key=None: TorchTradeFuturesLiveEnv._halting(
+        env, read, cache_key
+    )
     env._acquire_pre_trade_state = (
         lambda: TorchTradeFuturesLiveEnv._acquire_pre_trade_state(env)
     )
@@ -1036,6 +1052,8 @@ def _futures_env_stub(position_status, balance, leverage=5):
         position=PositionState(),
         account_state_key="account_state",
         market_data_keys=[],
+        # _get_observation publishes status_unknown from this counter (#295).
+        consecutive_unknown_status=0,
     )
 
 
@@ -2591,6 +2609,12 @@ def test_a_failed_read_runs_the_configured_policy(policy, expect_flatten):
     env = SimpleNamespace(
         config=SimpleNamespace(observation_failure_policy=policy, symbol="TEST"),
         trader=SimpleNamespace(close_position=lambda: closed.append(1) or True),
+        consecutive_unknown_status=0,
+        _last_confirmed_read={},
+        _max_unknown_status_steps=0,
+    )
+    env._flatten_if_policy_says_so = (
+        lambda: TorchTradeFuturesLiveEnv._flatten_if_policy_says_so(env)
     )
 
     def boom():
@@ -2623,7 +2647,15 @@ def test_an_unreadable_position_halts_before_the_env_trades(policy, expect_flatt
             close_position=lambda: closed.append("close") or True,
         ),
     )
-    env._halting = lambda read: TorchTradeFuturesLiveEnv._halting(env, read)
+    env.consecutive_unknown_status = 0
+    env._last_confirmed_read = {}
+    env._max_unknown_status_steps = 0
+    env._flatten_if_policy_says_so = (
+        lambda: TorchTradeFuturesLiveEnv._flatten_if_policy_says_so(env)
+    )
+    env._halting = lambda read, cache_key=None: TorchTradeFuturesLiveEnv._halting(
+        env, read, cache_key
+    )
     env._current_mark_price = (
         lambda ps=None: TorchTradeFuturesLiveEnv._current_mark_price(env, ps)
     )
@@ -2802,7 +2834,15 @@ def test_the_pre_trade_tuple_cannot_be_reordered_unnoticed():
         trader=SimpleNamespace(get_status=lambda: {"position_status": ps},
                                get_mark_price=lambda: 50000.0),
     )
-    env._halting = lambda read: TorchTradeFuturesLiveEnv._halting(env, read)
+    env.consecutive_unknown_status = 0
+    env._last_confirmed_read = {}
+    env._max_unknown_status_steps = 0
+    env._flatten_if_policy_says_so = (
+        lambda: TorchTradeFuturesLiveEnv._flatten_if_policy_says_so(env)
+    )
+    env._halting = lambda read, cache_key=None: TorchTradeFuturesLiveEnv._halting(
+        env, read, cache_key
+    )
     env._current_mark_price = (
         lambda p=None: TorchTradeFuturesLiveEnv._current_mark_price(env, p)
     )
@@ -3254,6 +3294,7 @@ SHARED_DEFAULTS = {
     "include_base_features": False,
     "close_position_on_init": True,
     "close_position_on_reset": False,
+    "max_unknown_status_steps": 0,
 }
 
 
@@ -3644,3 +3685,48 @@ def test_an_observer_disagreeing_with_the_config_raises_rather_than_guessing():
         BinanceFuturesTorchTradingEnv, "_wait_for_next_timestamp"
     ), pytest.raises(ValueError, match="zip"):
         BinanceFuturesTorchTradingEnv(config=config, observer=observer, trader=trader)
+
+
+@pytest.mark.parametrize("env_cls", STEPPING_ENVS, ids=lambda c: c.__name__)
+def test_every_live_step_writes_done_explicitly(env_cls):
+    """`done` must be written by `_step`, not inferred from `truncated` (#295).
+
+    Verified against a real Collector: setting only `truncated=True` leaves `done=False`,
+    the collector never resets, and the episode silently runs on -- which is precisely the
+    dead channel this work exists to remove. `truncated` has been write-only since #313,
+    so nothing else would have caught it.
+    """
+    step = env_cls.__dict__["_step"]
+    src = inspect.getsource(step)
+    assert "_finalize_step_flags" in src, (
+        f"{env_cls.__name__}._step does not use the shared done-family writer, so its "
+        f"truncation channel is unreachable"
+    )
+
+
+@pytest.mark.parametrize("terminated,unknown,budget,expected", [
+    (False, 0, 3, (False, False, False)),   # healthy
+    (True,  0, 3, (True,  True,  False)),   # bankruptcy terminates, never truncates
+    (False, 3, 3, (True,  False, True)),    # outage spends the budget -> truncate
+    (False, 9, 0, (False, False, False)),   # budget 0 disables the channel entirely
+    (True,  3, 3, (True,  True,  True)),    # both: done stays the OR of the two
+], ids=["healthy", "bankrupt", "outage", "disabled", "both"])
+def test_the_done_family_separates_an_outage_from_a_blown_account(
+    terminated, unknown, budget, expected
+):
+    """A prolonged outage truncates; only a blown account terminates.
+
+    Value estimators read `terminated` as "true return-to-go is 0" and `truncated` as
+    "bootstrap from the final observation". Terminating on an unreachable API would teach
+    the critic that a broker outage and a liquidated account carry the same value target.
+    """
+    env = SimpleNamespace(
+        consecutive_unknown_status=unknown,
+        config=SimpleNamespace(max_unknown_status_steps=budget),
+    )
+    env._max_unknown_status_steps = TorchTradeLiveEnv._max_unknown_status_steps.fget(env)
+    td = TensorDict({}, batch_size=())
+    TorchTradeLiveEnv._finalize_step_flags(env, td, terminated=terminated)
+
+    got = (bool(td["done"]), bool(td["terminated"]), bool(td["truncated"]))
+    assert got == expected, f"done/terminated/truncated = {got}, expected {expected}"

--- a/tests/envs/test_live_observation_failsafe.py
+++ b/tests/envs/test_live_observation_failsafe.py
@@ -490,7 +490,11 @@ def test_a_new_episode_cannot_be_served_the_previous_one_s_account():
     assert env._last_confirmed_read, "setup: the cache should be populated"
 
     env.reset()                                   # episode N+1, venue healthy
-    assert not env._last_confirmed_read, "reset left the previous episode's account cached"
+    # `balance` is legitimately re-seeded by reset's own confirmed read. What must NOT
+    # survive is the previous episode's POSITION and mark -- a position that may since
+    # have been closed, at a price from before the outage.
+    assert "pre_trade" not in env._last_confirmed_read
+    assert "post_bar" not in env._last_confirmed_read
 
     trader.get_status.side_effect = PositionUnknownError("down again")
     with pytest.raises(LiveObservationHalt):       # nothing confirmed yet this episode
@@ -527,3 +531,31 @@ def test_alpaca_reports_its_status_as_known_because_it_has_no_failure_policy():
         assert td["status_unknown"].item() == 0.0
         assert not bool(td["truncated"])
         td = td.exclude("done", "terminated", "truncated", "reward")
+
+
+def test_a_grace_bar_can_still_SIZE_a_trade_with_the_venue_down():
+    """Every other grace test holds the action constant, so sizing never ran.
+
+    `_execute_trade_if_needed` early-returns when the action equals the current level, so
+    a test that never CHANGES the action never reaches `_calculate_fractional_position` --
+    and that is where the balance read lives. Threading qty and price fixed the decision
+    to trade; the read that SIZES the trade was still outside `_halting`, so the first
+    grace bar on which a policy actually wanted to open or resize died with a bare error
+    instead of trading on cached state and truncating on budget.
+    """
+    import torch
+
+    env, trader = _real_binance_env(budget=3)
+    td = env.reset()
+    td = env.step(td.set("action", torch.tensor(1)))["next"]          # flat, confirmed
+
+    trader.get_status.side_effect = PositionUnknownError("venue unreachable")
+    trader.get_mark_price.side_effect = PositionUnknownError("venue unreachable")
+    trader.get_account_balance.side_effect = PositionUnknownError("venue unreachable")
+
+    # CHANGE the action, so the early-return cannot hide the sizing path.
+    nxt = env.step(td.exclude("done", "terminated", "truncated", "reward")
+                   .set("action", torch.tensor(2)))["next"]
+
+    assert nxt["status_unknown"].item() == 1.0, "the bar must be flagged, not crash"
+    assert not bool(nxt["terminated"]), "an outage is never a terminated episode"

--- a/tests/envs/test_live_observation_failsafe.py
+++ b/tests/envs/test_live_observation_failsafe.py
@@ -156,7 +156,8 @@ def test_every_futures_config_coerces_its_failure_policy(exchange, module):
 VENUES = ["binance", "bitget", "bybit", "okx"]
 
 
-def _real_futures_env(budget, venue="binance", position_status=None, **config_kw):
+def _real_futures_env(budget, venue="binance", sltp=False, position_status=None,
+                      **config_kw):
     """A real futures env on mocks, for any of the four venues.
 
     Parametrised because round 3 fixed the sizing read on all four and tested it on
@@ -167,7 +168,10 @@ def _real_futures_env(budget, venue="binance", position_status=None, **config_kw
     from unittest.mock import MagicMock, patch
     import numpy as np
 
-    module = importlib.import_module(f"torchtrade.envs.live.{venue}.env")
+    module = importlib.import_module(
+        f"torchtrade.envs.live.{venue}.env_sltp" if sltp
+        else f"torchtrade.envs.live.{venue}.env"
+    )
     Env = next(v for k, v in vars(module).items()
                if k.endswith("TorchTradingEnv") and v.__module__ == module.__name__)
     Config = next(v for k, v in vars(module).items()
@@ -175,7 +179,12 @@ def _real_futures_env(budget, venue="binance", position_status=None, **config_kw
 
     observer = MagicMock()
     observer.get_keys.return_value = ["1m_10"]
-    observer.get_observations.return_value = {"1m_10": np.zeros((10, 4), dtype=np.float32)}
+    # base_features carries OHLC; SLTP prices its brackets off the close column.
+    observer.get_observations.side_effect = lambda **kw: {
+        "1m_10": np.zeros((10, 4), dtype=np.float32),
+        **({"base_features": np.full((10, 4), 100.0, dtype=np.float32)}
+           if kw.get("return_base_ohlc") else {}),
+    }
     observer.get_features.return_value = {
         "observation_features": list("abcd"), "original_features": []}
     observer.reset.return_value = None
@@ -312,53 +321,22 @@ def test_a_real_env_flags_the_outage_and_truncates_on_the_budgeted_bar():
     The second: both read sites advanced the counter, so a budget of 3 truncated after two
     bars. `max_unknown_status_steps` has to mean bars, or it means nothing a trader can
     reason about.
-
-    Neither is visible from `_halting` in isolation, which is why this drives `env.step`.
     """
-    from unittest.mock import MagicMock, patch
-    import numpy as np
     import torch
-    from torchtrade.envs.live.binance.env import (
-        BinanceFuturesTorchTradingEnv as Env,
-        BinanceFuturesTradingEnvConfig as Config,
-    )
 
-    observer = MagicMock()
-    observer.get_keys.return_value = ["1m_10"]
-    observer.get_observations.return_value = {"1m_10": np.zeros((10, 4), dtype=np.float32)}
-    observer.get_features.return_value = {
-        "observation_features": list("abcd"), "original_features": []
-    }
-    observer.reset.return_value = None
+    env, trader = _real_futures_env(budget=3)
+    td = env.reset()
+    td = env.step(td.set("action", torch.tensor(1)))["next"]
+    assert td["status_unknown"].item() == 0.0
 
-    trader = MagicMock()
-    trader.get_account_balance.return_value = {
-        "available_balance": 1e4, "total_margin_balance": 1e4,
-        "total_wallet_balance": 1e4, "total_maintenance_margin": 0.0,
-    }
-    trader.get_status.return_value = {"position_status": None}
-    trader.get_mark_price.return_value = 100.0
-    trader.get_lot_size.return_value = {"min_qty": 0.001, "qty_step": 0.001}
-
-    config = Config(symbol="BTCUSDT", time_frames=["1m"], window_sizes=[10],
-                    execute_on="1m", max_unknown_status_steps=3,
-                    close_position_on_init=False)
-    with patch("time.sleep"), patch.object(Env, "_wait_for_next_timestamp"):
-        env = Env(config=config, observer=observer, trader=trader)
-        td = env.reset()
-
-        # One healthy bar, so the grace period has a confirmed read to stand on.
-        td = env.step(td.set("action", torch.tensor(1)))["next"]
-        assert td["status_unknown"].item() == 0.0
-
-        trader.get_status.side_effect = PositionUnknownError("venue unreachable")
-        seen = []
-        for _ in range(3):
-            td = td.exclude("done", "terminated", "truncated", "reward")
-            nxt = env.step(td.set("action", torch.tensor(1)))["next"]
-            seen.append((nxt["status_unknown"].item(), bool(nxt["done"]),
-                         bool(nxt["terminated"]), bool(nxt["truncated"])))
-            td = nxt
+    trader.get_status.side_effect = PositionUnknownError("venue unreachable")
+    seen = []
+    for _ in range(3):
+        td = td.exclude("done", "terminated", "truncated", "reward")
+        nxt = env.step(td.set("action", torch.tensor(1)))["next"]
+        seen.append((nxt["status_unknown"].item(), bool(nxt["done"]),
+                     bool(nxt["terminated"]), bool(nxt["truncated"])))
+        td = nxt
 
     assert seen == [
         (1.0, False, False, False),
@@ -367,53 +345,31 @@ def test_a_real_env_flags_the_outage_and_truncates_on_the_budgeted_bar():
     ], f"outage bars were {seen}"
 
 
+
 def test_reset_halts_typed_rather_than_relocating_the_crash():
     """The reset read must go through the halt policy too (#295).
 
     Truncation fires precisely BECAUSE the outage is ongoing, so the very next `reset()`
     is the likeliest moment for the venue to still be down. With reset's reads outside
-    `_halting`, the process crash this work exists to remove did not go away -- it moved
-    from `_step` to the following `reset`, one bar later, as a bare PositionUnknownError
-    that `except LiveObservationHalt` does not catch and FLATTEN does not act on.
+    `_halting`, the crash this work exists to remove did not go away -- it moved from
+    `_step` to the following `reset`, as a bare PositionUnknownError that
+    `except LiveObservationHalt` does not catch and FLATTEN does not act on.
 
-    Raising here is still correct: an episode must not START on unconfirmed state. What
-    the grace period buys is riding out an outage mid-episode, not beginning one blind.
+    Raising here is still correct: an episode must not START on unconfirmed state.
     """
-    from unittest.mock import MagicMock, patch
-    import numpy as np
-    from torchtrade.envs.live.binance.env import (
-        BinanceFuturesTorchTradingEnv as Env, BinanceFuturesTradingEnvConfig as Config,
+    env, trader = _real_futures_env(
+        budget=3, observation_failure_policy=ObservationFailurePolicy.FLATTEN
     )
+    trader.get_status.side_effect = PositionUnknownError("still down")
+    trader.close_position.reset_mock()
 
-    observer = MagicMock()
-    observer.get_keys.return_value = ["1m_10"]
-    observer.get_observations.return_value = {"1m_10": np.zeros((10, 4), dtype=np.float32)}
-    observer.get_features.return_value = {
-        "observation_features": list("abcd"), "original_features": []}
-    observer.reset.return_value = None
-    trader = MagicMock()
-    trader.get_account_balance.return_value = {
-        "available_balance": 1e4, "total_margin_balance": 1e4,
-        "total_wallet_balance": 1e4, "total_maintenance_margin": 0.0}
-    trader.get_mark_price.return_value = 100.0
-    trader.get_lot_size.return_value = {"min_qty": 0.001, "qty_step": 0.001}
-    trader.get_status.return_value = {"position_status": None}
-
-    config = Config(symbol="BTCUSDT", time_frames=["1m"], window_sizes=[10],
-                    execute_on="1m", max_unknown_status_steps=3,
-                    observation_failure_policy=ObservationFailurePolicy.FLATTEN,
-                    close_position_on_init=False)
-    with patch("time.sleep"), patch.object(Env, "_wait_for_next_timestamp"):
-        env = Env(config=config, observer=observer, trader=trader)
-        trader.get_status.side_effect = PositionUnknownError("still down")
-        trader.close_position.reset_mock()
-
-        with pytest.raises(LiveObservationHalt):
-            env.reset()
+    with pytest.raises(LiveObservationHalt):
+        env.reset()
 
     assert trader.close_position.called, (
         "FLATTEN did not act on the reset read: it was outside the halt policy"
     )
+
 
 
 def test_the_cache_holds_a_copy_not_the_object_the_collector_mutates():
@@ -593,64 +549,25 @@ def test_a_grace_bar_can_still_SIZE_a_trade_with_the_venue_down(venue):
 def test_an_sltp_grace_bar_can_still_size_a_bracket_with_the_venue_down(venue):
     """No test drove an SLTP env through an outage at all, on any venue.
 
-    So when the sizing read was brought under `_halting` on the plain envs, the SLTP
-    envs' own `get_account_balance()` -- a separate line, in a separate file, doing the
-    same thing -- was simply not part of the change. A bare PositionUnknownError escaped
-    `_step` instead of the episode truncating, for `trade_mode="fractional"`, on all four
-    venues.
-
-    That is #288's thesis stated as a bug: the same fix landing on some copies and not
-    others, with nothing in the suite able to tell.
+    So when the sizing read came under `_halting` on the plain envs, the SLTP envs' own
+    `get_account_balance()` -- a separate line, in a separate file, doing the same thing
+    -- was simply not part of the change. #288's thesis stated as a bug: the same fix
+    landing on some copies and not others, with nothing able to tell.
     """
-    import importlib
-    from unittest.mock import MagicMock, patch
-    import numpy as np
     import torch
 
-    module = importlib.import_module(f"torchtrade.envs.live.{venue}.env_sltp")
-    Env = next(v for k, v in vars(module).items()
-               if k.endswith("TorchTradingEnv") and v.__module__ == module.__name__)
-    Config = next(v for k, v in vars(module).items()
-                  if k.endswith("TradingEnvConfig") and v.__module__ == module.__name__)
-    symbol = "BTC-USDT-SWAP" if venue == "okx" else "BTCUSDT"
+    env, trader = _real_futures_env(budget=3, venue=venue, sltp=True,
+                                    trade_mode="fractional", position_fraction=0.5)
+    td = env.reset()
+    td = env.step(td.set("action", torch.tensor(0)))["next"]          # HOLD, confirmed
 
-    observer = MagicMock()
-    observer.get_keys.return_value = ["1m_10"]
-    # base_features carries OHLC; SLTP prices its brackets off the close column.
-    observer.get_observations.side_effect = lambda **kw: {
-        "1m_10": np.zeros((10, 4), dtype=np.float32),
-        **({"base_features": np.full((10, 4), 100.0, dtype=np.float32)}
-           if kw.get("return_base_ohlc") else {}),
-    }
-    observer.get_features.return_value = {
-        "observation_features": list("abcd"), "original_features": []}
-    observer.reset.return_value = None
-    trader = MagicMock()
-    trader.get_account_balance.return_value = {
-        "available_balance": 1e4, "total_margin_balance": 1e4,
-        "total_wallet_balance": 1e4, "total_maintenance_margin": 0.0}
-    trader.get_status.return_value = {"position_status": None}
-    trader.get_mark_price.return_value = 100.0
-    trader.get_lot_size.return_value = {"min_qty": 0.001, "qty_step": 0.001}
-    trader.round_quantity.side_effect = lambda q: round(float(q), 3)
-    trader._round_amount.side_effect = lambda q: round(float(q), 3)
+    trader.get_status.side_effect = PositionUnknownError("venue unreachable")
+    trader.get_mark_price.side_effect = PositionUnknownError("venue unreachable")
+    trader.get_account_balance.side_effect = PositionUnknownError("venue unreachable")
 
-    config = Config(symbol=symbol, time_frames=["1m"], window_sizes=[10],
-                    execute_on="1m", max_unknown_status_steps=3,
-                    trade_mode="fractional", position_fraction=0.5,
-                    close_position_on_init=False)
-    with patch("time.sleep"), patch.object(Env, "_wait_for_next_timestamp"):
-        env = Env(config=config, observer=observer, trader=trader)
-        td = env.reset()
-        td = env.step(td.set("action", torch.tensor(0)))["next"]      # HOLD, confirmed
-
-        trader.get_status.side_effect = PositionUnknownError("venue unreachable")
-        trader.get_mark_price.side_effect = PositionUnknownError("venue unreachable")
-        trader.get_account_balance.side_effect = PositionUnknownError("venue unreachable")
-
-        # A real bracket action, so the sizing path runs rather than the hold early-return.
-        nxt = env.step(td.exclude("done", "terminated", "truncated", "reward")
-                       .set("action", torch.tensor(1)))["next"]
+    # A real bracket action, so the sizing path runs rather than the hold early-return.
+    nxt = env.step(td.exclude("done", "terminated", "truncated", "reward")
+                   .set("action", torch.tensor(1)))["next"]
 
     assert nxt["status_unknown"].item() == 1.0, "the bar must be flagged, not crash"
     assert not bool(nxt["terminated"]), "an outage is never a terminated episode"

--- a/tests/envs/test_live_observation_failsafe.py
+++ b/tests/envs/test_live_observation_failsafe.py
@@ -660,3 +660,111 @@ def test_a_realised_close_invalidates_the_cached_balance(succeeded, still_cached
     env._handle_close_action(0.05)
 
     assert ("balance" in env._last_confirmed_read) is still_cached
+
+
+@pytest.mark.parametrize("venue", ["binance", "bitget"])
+def test_a_candle_close_failure_is_ridden_out_rather_than_raised(venue):
+    """`_halting(read_close)` without a cache_key still RAISES -- just with a nicer type.
+
+    Grace needs a slot to serve from. Wrapping the read made the exception well-typed and
+    changed nothing about the contract the docs claim: serve the last CONFIRMED close and
+    flag the bar. Its own slot, because binance/bitget price brackets off a candle close
+    rather than the mark, deliberately.
+    """
+    import torch
+
+    env, trader = _real_futures_env(budget=3, venue=venue, sltp=True,
+                                    trade_mode="fractional", position_fraction=0.5)
+    td = env.reset()
+    # A TRADING action, not a hold: the hold path early-returns before `read_close`, so a
+    # hold bar never seeds the slot. That is a real residual boundary -- hold for N bars,
+    # then trade during an outage, and there is still no confirmed close to serve -- and
+    # it is reported on the PR rather than papered over here.
+    td = env.step(td.set("action", torch.tensor(1)))["next"]
+
+    trader.get_status.side_effect = PositionUnknownError("down")
+    env.observer.get_observations.side_effect = ValueError(
+        "most recent candle did not survive preprocessing"
+    )
+
+    nxt = env.step(td.exclude("done", "terminated", "truncated", "reward")
+                   .set("action", torch.tensor(1)))["next"]
+    assert nxt["status_unknown"].item() == 1.0, (
+        "the bar raised instead of being ridden out: no cached candle close to serve"
+    )
+
+
+@pytest.mark.parametrize("venue", VENUES)
+def test_reset_survives_its_guarded_reads_then_a_failing_reread(venue):
+    """The reads were confirmed, then thrown away and taken again raw.
+
+    A failure on that SECOND pair escaped the policy entirely -- FLATTEN could not act on
+    it -- while the confirmed snapshot sat unused. `_get_observation` is deliberately NOT
+    halt-wrapped (it reads the observer too, so a config gap must not flatten); the fix is
+    to stop re-reading, not to wrap.
+    """
+    calls = {"n": 0}
+    env, trader = _real_futures_env(
+        budget=0, venue=venue, observation_failure_policy=ObservationFailurePolicy.FLATTEN
+    )
+
+    def failing_second_read():
+        calls["n"] += 1
+        if calls["n"] > 1:
+            raise PositionUnknownError("venue went down between the two reads")
+        return {"position_status": None}
+
+    trader.get_status.side_effect = failing_second_read
+    env.reset()      # must not raise: there IS no second read any more
+
+    assert calls["n"] == 1, (
+        f"reset read the venue {calls['n']} times; the second read is what escaped policy"
+    )
+
+
+def test_an_aborted_runtimeerror_does_not_flag_the_retried_bar():
+    """`_status_unknown_this_step` is set before the no-grace re-raise, and consumed by
+    `_finalize_step_flags` -- which that path never reaches.
+
+    So a caller that catches the timeout and retries would have the next HEALTHY bar
+    report status_unknown=1 and count toward truncation. The flag is cleared on abort.
+    """
+    import torch
+
+    env, trader = _real_futures_env(budget=0)     # no grace: RuntimeError re-raises
+    td = env.reset()
+
+    trader.get_account_balance.side_effect = RuntimeError("Failed to get account balance")
+    with pytest.raises(RuntimeError):
+        env.step(td.set("action", torch.tensor(len(env.action_levels) - 1)))
+    assert not env._status_unknown_this_step, "the aborted bar left the flag set"
+
+    trader.get_account_balance.side_effect = None                  # venue recovers
+    nxt = env.step(td.set("action", torch.tensor(1)))["next"]
+    assert nxt["status_unknown"].item() == 0.0, "a healthy retry was flagged as unknown"
+
+
+def test_an_exchange_detected_closure_invalidates_the_cached_balance():
+    """A bracket firing has no `close_position()` call for the close-site guard to find.
+
+    The env never asked for this close, so none of the seven close sites run -- but the
+    realised P&L has moved equity all the same, and a later grace bar would size against
+    the pre-close figure.
+    """
+    from torchtrade.envs.core.common_types import PositionStatus
+
+    open_long = PositionStatus(
+        qty=0.05, notional_value=5000.0, entry_price=100.0, unrealized_pnl=0.0,
+        unrealized_pnl_pct=0.0, mark_price=100.0, leverage=10,
+        margin_mode="isolated", liquidation_price=91.0,
+    )
+    env, trader = _real_futures_env(budget=3, sltp=True, position_status=open_long)
+    env.reset()
+    env.position.current_position = 1
+    env._last_confirmed_read["balance"] = {"total_margin_balance": 1e4}
+
+    env._sync_position_from_exchange(None)        # the bracket fired; venue reports flat
+
+    assert "balance" not in env._last_confirmed_read, (
+        "an SL/TP closure left pre-close equity cached for the next grace bar to size on"
+    )

--- a/tests/envs/test_live_observation_failsafe.py
+++ b/tests/envs/test_live_observation_failsafe.py
@@ -26,7 +26,15 @@ def _env(error, policy=ObservationFailurePolicy.HALT, close_result=True):
     )
     # The post-bar read delegates to the shared policy now rather than restating it, so
     # these tests exercise `_halting` itself -- which is the point of extracting it.
-    env._halting = lambda read: TorchTradeFuturesLiveEnv._halting(env, read)
+    env.consecutive_unknown_status = 0
+    env._last_confirmed_read = {}
+    env._max_unknown_status_steps = 0
+    env._flatten_if_policy_says_so = (
+        lambda: TorchTradeFuturesLiveEnv._flatten_if_policy_says_so(env)
+    )
+    env._halting = lambda read, cache_key=None: TorchTradeFuturesLiveEnv._halting(
+        env, read, cache_key
+    )
     return env, closed
 
 
@@ -144,3 +152,167 @@ def test_every_futures_config_coerces_its_failure_policy(exchange, module):
     )
     with pytest.raises(ValueError):
         cfg_cls(observation_failure_policy="nonsense")
+
+
+# --- #295: the grace period, and the truncation that ends it --------------------------
+
+def _grace_env(budget, policy=ObservationFailurePolicy.HALT):
+    """A stub wired to the real `_halting`, with a configurable outage budget."""
+    closed = []
+    env = SimpleNamespace(
+        trader=SimpleNamespace(close_position=lambda: closed.append(True) or True),
+        config=SimpleNamespace(symbol="BTCUSDT", observation_failure_policy=policy),
+        consecutive_unknown_status=0,
+        _last_confirmed_read={},
+        _max_unknown_status_steps=budget,
+    )
+    env._flatten_if_policy_says_so = (
+        lambda: TorchTradeFuturesLiveEnv._flatten_if_policy_says_so(env)
+    )
+    env._halting = lambda read, cache_key=None: TorchTradeFuturesLiveEnv._halting(
+        env, read, cache_key
+    )
+    return env, closed
+
+
+def _boom():
+    raise PositionUnknownError("venue unreachable")
+
+
+def test_a_confirmed_read_is_what_the_grace_period_stands_on():
+    """The budget alone is not enough -- there must be a real prior read to fall back on.
+
+    A failure on the FIRST read of an episode has no last-known truth, so honouring the
+    budget there would mean inventing an account state. It raises regardless of budget.
+    """
+    env, _ = _grace_env(budget=3)
+
+    with pytest.raises(LiveObservationHalt):
+        env._halting(_boom, cache_key="pre_trade")
+
+    assert env.consecutive_unknown_status == 1, "the failure still counts"
+
+
+def test_the_grace_period_rides_out_an_outage_on_the_last_confirmed_read():
+    env, _ = _grace_env(budget=3)
+    assert env._halting(lambda: "GOOD", cache_key="pre_trade") == "GOOD"
+
+    # Two failures inside the budget: the cached value stands in, nothing raises.
+    for expected_count in (1, 2):
+        assert env._halting(_boom, cache_key="pre_trade") == "GOOD"
+        assert env.consecutive_unknown_status == expected_count
+
+    # The third spends the budget. It must NOT raise -- an exception here is the process
+    # crash #295 exists to remove; the step finishes so _set_done_family can truncate.
+    assert env._halting(_boom, cache_key="pre_trade") == "GOOD"
+    assert env.consecutive_unknown_status == 3
+
+
+def test_a_successful_read_ends_the_outage_rather_than_denting_it():
+    """It counts CONSECUTIVE unknowns. A lifetime counter would truncate a healthy
+    session that had accumulated unrelated blips hours apart."""
+    env, _ = _grace_env(budget=3)
+    env._halting(lambda: "GOOD", cache_key="pre_trade")
+    env._halting(_boom, cache_key="pre_trade")
+    env._halting(_boom, cache_key="pre_trade")
+    assert env.consecutive_unknown_status == 2
+
+    env._halting(lambda: "FRESH", cache_key="pre_trade")
+    assert env.consecutive_unknown_status == 0
+    assert env._halting(_boom, cache_key="pre_trade") == "FRESH", "cache refreshed too"
+
+
+def test_the_default_budget_keeps_the_pre_295_posture():
+    """0 is the default on every venue: refuse to act on state you cannot confirm."""
+    env, _ = _grace_env(budget=0)
+    env._halting(lambda: "GOOD", cache_key="pre_trade")
+
+    with pytest.raises(LiveObservationHalt):
+        env._halting(_boom, cache_key="pre_trade")
+
+
+def test_flatten_does_not_honour_the_grace_period():
+    """FLATTEN means "get me out while I cannot see the account". Riding out the outage
+    would defeat the only thing it is for, so grace is a HALT-only concession."""
+    env, closed = _grace_env(budget=3, policy=ObservationFailurePolicy.FLATTEN)
+    env._halting(lambda: "GOOD", cache_key="pre_trade")
+
+    with pytest.raises(LiveObservationHalt):
+        env._halting(_boom, cache_key="pre_trade")
+    assert closed == [True], "the emergency close must still run"
+
+
+def test_the_two_read_sites_do_not_share_a_cache_slot():
+    """`_acquire_pre_trade_state` and `_acquire_post_bar_state` return different shapes.
+    One slot would hand the post-bar caller a pre-trade tuple during an outage."""
+    env, _ = _grace_env(budget=3)
+    env._halting(lambda: "PRE", cache_key="pre_trade")
+    env._halting(lambda: "POST", cache_key="post_bar")
+
+    assert env._halting(_boom, cache_key="pre_trade") == "PRE"
+    assert env._halting(_boom, cache_key="post_bar") == "POST"
+
+
+def test_a_real_env_flags_the_outage_and_truncates_on_the_budgeted_bar():
+    """Drives a REAL env through an outage. The unit tests above missed two defects here.
+
+    The first: `status_unknown` was stamped at observation-BUILD time, so the grace period
+    served a cached observation carrying the healthy 0.0 -- the policy was told "all
+    confirmed" on exactly the bars it was not.
+
+    The second: both read sites advanced the counter, so a budget of 3 truncated after two
+    bars. `max_unknown_status_steps` has to mean bars, or it means nothing a trader can
+    reason about.
+
+    Neither is visible from `_halting` in isolation, which is why this drives `env.step`.
+    """
+    from unittest.mock import MagicMock, patch
+    import numpy as np
+    import torch
+    from torchtrade.envs.live.binance.env import (
+        BinanceFuturesTorchTradingEnv as Env,
+        BinanceFuturesTradingEnvConfig as Config,
+    )
+
+    observer = MagicMock()
+    observer.get_keys.return_value = ["1m_10"]
+    observer.get_observations.return_value = {"1m_10": np.zeros((10, 4), dtype=np.float32)}
+    observer.get_features.return_value = {
+        "observation_features": list("abcd"), "original_features": []
+    }
+    observer.reset.return_value = None
+
+    trader = MagicMock()
+    trader.get_account_balance.return_value = {
+        "available_balance": 1e4, "total_margin_balance": 1e4,
+        "total_wallet_balance": 1e4, "total_maintenance_margin": 0.0,
+    }
+    trader.get_status.return_value = {"position_status": None}
+    trader.get_mark_price.return_value = 100.0
+    trader.get_lot_size.return_value = {"min_qty": 0.001, "qty_step": 0.001}
+
+    config = Config(symbol="BTCUSDT", time_frames=["1m"], window_sizes=[10],
+                    execute_on="1m", max_unknown_status_steps=3,
+                    close_position_on_init=False)
+    with patch("time.sleep"), patch.object(Env, "_wait_for_next_timestamp"):
+        env = Env(config=config, observer=observer, trader=trader)
+        td = env.reset()
+
+        # One healthy bar, so the grace period has a confirmed read to stand on.
+        td = env.step(td.set("action", torch.tensor(1)))["next"]
+        assert td["status_unknown"].item() == 0.0
+
+        trader.get_status.side_effect = PositionUnknownError("venue unreachable")
+        seen = []
+        for _ in range(3):
+            td = td.exclude("done", "terminated", "truncated", "reward")
+            nxt = env.step(td.set("action", torch.tensor(1)))["next"]
+            seen.append((nxt["status_unknown"].item(), bool(nxt["done"]),
+                         bool(nxt["terminated"]), bool(nxt["truncated"])))
+            td = nxt
+
+    assert seen == [
+        (1.0, False, False, False),
+        (1.0, False, False, False),
+        (1.0, True, False, True),
+    ], f"outage bars were {seen}"

--- a/tests/envs/test_live_observation_failsafe.py
+++ b/tests/envs/test_live_observation_failsafe.py
@@ -601,3 +601,62 @@ def test_reset_halts_on_the_sentinel_venues_actually_return(venue, sltp):
     assert trader.close_position.called, (
         "FLATTEN did not act: the sentinel escaped as a bare PositionUnknownError"
     )
+
+
+@pytest.mark.parametrize("sltp", [False, True], ids=["plain", "sltp"])
+@pytest.mark.parametrize("venue", VENUES)
+def test_grace_covers_the_exception_the_adapters_actually_raise(venue, sltp):
+    """All four adapters wrap a failed balance read in `RuntimeError`, not ValueError.
+
+    `binance/order_executor.py`, `bitget`, `bybit`, `okx` all do
+    `raise RuntimeError(f"Failed to get account balance: {e}")`. `_halting` deliberately
+    did not catch RuntimeError, so the grace period never engaged for the failure mode
+    production actually produces -- every test here injected PositionUnknownError, which
+    only the STATUS path raises.
+
+    RuntimeError is grace-eligible ONLY. `test_a_non_terminal_failure_propagates_without
+    _halting` pins the other half: outside grace it still escapes untouched, because a
+    read timeout arrives as RuntimeError too and #394 refused to flatten on those.
+    """
+    import torch
+
+    env, trader = _real_futures_env(budget=3, venue=venue, sltp=sltp,
+                                    **({"trade_mode": "fractional",
+                                        "position_fraction": 0.5} if sltp else {}))
+    td = env.reset()
+    td = env.step(td.set("action", torch.tensor(0 if sltp else 1)))["next"]
+
+    trader.get_account_balance.side_effect = RuntimeError(
+        "Failed to get account balance: connection reset"
+    )
+    trade_action = 1 if sltp else len(env.action_levels) - 1
+    nxt = env.step(td.exclude("done", "terminated", "truncated", "reward")
+                   .set("action", torch.tensor(trade_action)))["next"]
+
+    assert nxt["status_unknown"].item() == 1.0, (
+        "a real adapter balance failure was not recognised as an outage"
+    )
+    assert not bool(nxt["terminated"])
+
+
+@pytest.mark.parametrize("succeeded,still_cached", [(True, False), (False, True)],
+                         ids=["close-succeeds", "close-fails"])
+def test_a_realised_close_invalidates_the_cached_balance(succeeded, still_cached):
+    """A close moves equity, so the cached balance is wrong by the trade's P&L.
+
+    The sizing path early-returns BEFORE the balance read, so nothing refreshes it: reset
+    seeds $10k, the policy opens, holds, closes at a loss, and a grace bar many bars later
+    sizes against the pre-close $10k. At 10x that is an order the venue rejects on margin.
+
+    Only on SUCCESS -- a failed close leaves the position, and with it the equity the
+    cache already describes.
+    """
+    env, trader = _real_futures_env(budget=3)
+    env.reset()
+    assert "balance" in env._last_confirmed_read, "setup: reset seeds the cache"
+
+    env.position.current_position = 1
+    trader.close_position.return_value = succeeded
+    env._handle_close_action(0.05)
+
+    assert ("balance" in env._last_confirmed_read) is still_cached

--- a/tests/envs/test_live_observation_failsafe.py
+++ b/tests/envs/test_live_observation_failsafe.py
@@ -153,13 +153,25 @@ def test_every_futures_config_coerces_its_failure_policy(exchange, module):
 
 # --- #295: the grace period, and the truncation that ends it --------------------------
 
-def _real_binance_env(budget, position_status=None, **config_kw):
-    """A real BinanceFuturesTorchTradingEnv on mocks. Three copies of this existed."""
+VENUES = ["binance", "bitget", "bybit", "okx"]
+
+
+def _real_futures_env(budget, venue="binance", position_status=None, **config_kw):
+    """A real futures env on mocks, for any of the four venues.
+
+    Parametrised because round 3 fixed the sizing read on all four and tested it on
+    ONE -- reverting it on bitget/bybit/okx failed zero tests, which is the same
+    shape as the defect it was fixing.
+    """
+    import importlib
     from unittest.mock import MagicMock, patch
     import numpy as np
-    from torchtrade.envs.live.binance.env import (
-        BinanceFuturesTorchTradingEnv as Env, BinanceFuturesTradingEnvConfig as Config,
-    )
+
+    module = importlib.import_module(f"torchtrade.envs.live.{venue}.env")
+    Env = next(v for k, v in vars(module).items()
+               if k.endswith("TorchTradingEnv") and v.__module__ == module.__name__)
+    Config = next(v for k, v in vars(module).items()
+                  if k.endswith("TradingEnvConfig") and v.__module__ == module.__name__)
 
     observer = MagicMock()
     observer.get_keys.return_value = ["1m_10"]
@@ -176,6 +188,7 @@ def _real_binance_env(budget, position_status=None, **config_kw):
     trader.get_mark_price.return_value = 100.0
     trader.get_lot_size.return_value = {"min_qty": 0.001, "qty_step": 0.001}
     trader.round_quantity.side_effect = lambda q: round(float(q), 3)
+    trader._round_amount.side_effect = lambda q: round(float(q), 3)   # bitget/okx spelling
     trader.trade.return_value = True
     trader.close_position.return_value = True
     trader.client.futures_exchange_info.return_value = {"symbols": [{
@@ -184,7 +197,14 @@ def _real_binance_env(budget, position_status=None, **config_kw):
                     {"filterType": "MIN_NOTIONAL", "notional": "10"}],
     }]}
 
-    config = Config(symbol="BTCUSDT", time_frames=["1m"], window_sizes=[10],
+    symbol = "BTC-USDT-SWAP" if venue == "okx" else "BTCUSDT"
+    trader.get_status.return_value = {"position_status": position_status}
+    trader.client.futures_exchange_info.return_value = {"symbols": [{
+        "symbol": symbol,
+        "filters": [{"filterType": "LOT_SIZE", "stepSize": "0.001"},
+                    {"filterType": "MIN_NOTIONAL", "notional": "10"}],
+    }]}
+    config = Config(symbol=symbol, time_frames=["1m"], window_sizes=[10],
                     execute_on="1m", max_unknown_status_steps=budget,
                     close_position_on_init=False, **config_kw)
     with patch("time.sleep"), patch.object(Env, "_wait_for_next_timestamp"):
@@ -445,7 +465,7 @@ def test_an_open_position_is_frozen_but_flagged_through_a_grace_outage():
         unrealized_pnl_pct=0.0, mark_price=100.0, leverage=10,
         margin_mode="isolated", liquidation_price=91.0,
     )
-    env, trader = _real_binance_env(budget=3, position_status=open_long)
+    env, trader = _real_futures_env(budget=3, position_status=open_long)
 
     td = env.reset()
     td = env.step(td.set("action", torch.tensor(2)))["next"]
@@ -484,7 +504,7 @@ def test_a_new_episode_cannot_be_served_the_previous_one_s_account():
         unrealized_pnl_pct=0.0, mark_price=100.0, leverage=10,
         margin_mode="isolated", liquidation_price=91.0,
     )
-    env, trader = _real_binance_env(budget=3, position_status=open_long)
+    env, trader = _real_futures_env(budget=3, position_status=open_long)
     td = env.reset()
     env.step(td.set("action", torch.tensor(2)))
     assert env._last_confirmed_read, "setup: the cache should be populated"
@@ -533,7 +553,8 @@ def test_alpaca_reports_its_status_as_known_because_it_has_no_failure_policy():
         td = td.exclude("done", "terminated", "truncated", "reward")
 
 
-def test_a_grace_bar_can_still_SIZE_a_trade_with_the_venue_down():
+@pytest.mark.parametrize("venue", VENUES)
+def test_a_grace_bar_can_still_SIZE_a_trade_with_the_venue_down(venue):
     """Every other grace test holds the action constant, so sizing never ran.
 
     `_execute_trade_if_needed` early-returns when the action equals the current level, so
@@ -545,9 +566,16 @@ def test_a_grace_bar_can_still_SIZE_a_trade_with_the_venue_down():
     """
     import torch
 
-    env, trader = _real_binance_env(budget=3)
+    env, trader = _real_futures_env(budget=3, venue=venue)
+    # Index-by-VALUE, not by position: binance ships [-1, 0, 1] and the others
+    # [-1, -0.5, 0, 0.5, 1], so a hardcoded index 2 is "flat" on three of the four and
+    # takes the close path instead of the sizing path. That is exactly how this fix went
+    # untested on three venues in the first place.
+    flat = env.action_levels.index(0.0)
+    full_long = len(env.action_levels) - 1
+
     td = env.reset()
-    td = env.step(td.set("action", torch.tensor(1)))["next"]          # flat, confirmed
+    td = env.step(td.set("action", torch.tensor(flat)))["next"]       # flat, confirmed
 
     trader.get_status.side_effect = PositionUnknownError("venue unreachable")
     trader.get_mark_price.side_effect = PositionUnknownError("venue unreachable")
@@ -555,7 +583,74 @@ def test_a_grace_bar_can_still_SIZE_a_trade_with_the_venue_down():
 
     # CHANGE the action, so the early-return cannot hide the sizing path.
     nxt = env.step(td.exclude("done", "terminated", "truncated", "reward")
-                   .set("action", torch.tensor(2)))["next"]
+                   .set("action", torch.tensor(full_long)))["next"]
+
+    assert nxt["status_unknown"].item() == 1.0, "the bar must be flagged, not crash"
+    assert not bool(nxt["terminated"]), "an outage is never a terminated episode"
+
+
+@pytest.mark.parametrize("venue", VENUES)
+def test_an_sltp_grace_bar_can_still_size_a_bracket_with_the_venue_down(venue):
+    """No test drove an SLTP env through an outage at all, on any venue.
+
+    So when the sizing read was brought under `_halting` on the plain envs, the SLTP
+    envs' own `get_account_balance()` -- a separate line, in a separate file, doing the
+    same thing -- was simply not part of the change. A bare PositionUnknownError escaped
+    `_step` instead of the episode truncating, for `trade_mode="fractional"`, on all four
+    venues.
+
+    That is #288's thesis stated as a bug: the same fix landing on some copies and not
+    others, with nothing in the suite able to tell.
+    """
+    import importlib
+    from unittest.mock import MagicMock, patch
+    import numpy as np
+    import torch
+
+    module = importlib.import_module(f"torchtrade.envs.live.{venue}.env_sltp")
+    Env = next(v for k, v in vars(module).items()
+               if k.endswith("TorchTradingEnv") and v.__module__ == module.__name__)
+    Config = next(v for k, v in vars(module).items()
+                  if k.endswith("TradingEnvConfig") and v.__module__ == module.__name__)
+    symbol = "BTC-USDT-SWAP" if venue == "okx" else "BTCUSDT"
+
+    observer = MagicMock()
+    observer.get_keys.return_value = ["1m_10"]
+    # base_features carries OHLC; SLTP prices its brackets off the close column.
+    observer.get_observations.side_effect = lambda **kw: {
+        "1m_10": np.zeros((10, 4), dtype=np.float32),
+        **({"base_features": np.full((10, 4), 100.0, dtype=np.float32)}
+           if kw.get("return_base_ohlc") else {}),
+    }
+    observer.get_features.return_value = {
+        "observation_features": list("abcd"), "original_features": []}
+    observer.reset.return_value = None
+    trader = MagicMock()
+    trader.get_account_balance.return_value = {
+        "available_balance": 1e4, "total_margin_balance": 1e4,
+        "total_wallet_balance": 1e4, "total_maintenance_margin": 0.0}
+    trader.get_status.return_value = {"position_status": None}
+    trader.get_mark_price.return_value = 100.0
+    trader.get_lot_size.return_value = {"min_qty": 0.001, "qty_step": 0.001}
+    trader.round_quantity.side_effect = lambda q: round(float(q), 3)
+    trader._round_amount.side_effect = lambda q: round(float(q), 3)
+
+    config = Config(symbol=symbol, time_frames=["1m"], window_sizes=[10],
+                    execute_on="1m", max_unknown_status_steps=3,
+                    trade_mode="fractional", position_fraction=0.5,
+                    close_position_on_init=False)
+    with patch("time.sleep"), patch.object(Env, "_wait_for_next_timestamp"):
+        env = Env(config=config, observer=observer, trader=trader)
+        td = env.reset()
+        td = env.step(td.set("action", torch.tensor(0)))["next"]      # HOLD, confirmed
+
+        trader.get_status.side_effect = PositionUnknownError("venue unreachable")
+        trader.get_mark_price.side_effect = PositionUnknownError("venue unreachable")
+        trader.get_account_balance.side_effect = PositionUnknownError("venue unreachable")
+
+        # A real bracket action, so the sizing path runs rather than the hold early-return.
+        nxt = env.step(td.exclude("done", "terminated", "truncated", "reward")
+                       .set("action", torch.tensor(1)))["next"]
 
     assert nxt["status_unknown"].item() == 1.0, "the bar must be flagged, not crash"
     assert not bool(nxt["terminated"]), "an outage is never a terminated episode"

--- a/tests/envs/test_live_observation_failsafe.py
+++ b/tests/envs/test_live_observation_failsafe.py
@@ -29,9 +29,6 @@ def _env(error, policy=ObservationFailurePolicy.HALT, close_result=True):
     env.consecutive_unknown_status = 0
     env._last_confirmed_read = {}
     env._max_unknown_status_steps = 0
-    env._flatten_if_policy_says_so = (
-        lambda: TorchTradeFuturesLiveEnv._flatten_if_policy_says_so(env)
-    )
     env._halting = lambda read, cache_key=None: TorchTradeFuturesLiveEnv._halting(
         env, read, cache_key
     )
@@ -156,6 +153,46 @@ def test_every_futures_config_coerces_its_failure_policy(exchange, module):
 
 # --- #295: the grace period, and the truncation that ends it --------------------------
 
+def _real_binance_env(budget, position_status=None, **config_kw):
+    """A real BinanceFuturesTorchTradingEnv on mocks. Three copies of this existed."""
+    from unittest.mock import MagicMock, patch
+    import numpy as np
+    from torchtrade.envs.live.binance.env import (
+        BinanceFuturesTorchTradingEnv as Env, BinanceFuturesTradingEnvConfig as Config,
+    )
+
+    observer = MagicMock()
+    observer.get_keys.return_value = ["1m_10"]
+    observer.get_observations.return_value = {"1m_10": np.zeros((10, 4), dtype=np.float32)}
+    observer.get_features.return_value = {
+        "observation_features": list("abcd"), "original_features": []}
+    observer.reset.return_value = None
+
+    trader = MagicMock()
+    trader.get_account_balance.return_value = {
+        "available_balance": 1e4, "total_margin_balance": 1e4,
+        "total_wallet_balance": 1e4, "total_maintenance_margin": 0.0}
+    trader.get_status.return_value = {"position_status": position_status}
+    trader.get_mark_price.return_value = 100.0
+    trader.get_lot_size.return_value = {"min_qty": 0.001, "qty_step": 0.001}
+    trader.round_quantity.side_effect = lambda q: round(float(q), 3)
+    trader.trade.return_value = True
+    trader.close_position.return_value = True
+    trader.client.futures_exchange_info.return_value = {"symbols": [{
+        "symbol": "BTCUSDT",
+        "filters": [{"filterType": "LOT_SIZE", "stepSize": "0.001"},
+                    {"filterType": "MIN_NOTIONAL", "notional": "10"}],
+    }]}
+
+    config = Config(symbol="BTCUSDT", time_frames=["1m"], window_sizes=[10],
+                    execute_on="1m", max_unknown_status_steps=budget,
+                    close_position_on_init=False, **config_kw)
+    with patch("time.sleep"), patch.object(Env, "_wait_for_next_timestamp"):
+        env = Env(config=config, observer=observer, trader=trader)
+    env._wait_for_next_timestamp = lambda: None
+    return env, trader
+
+
 def _grace_env(budget, policy=ObservationFailurePolicy.HALT):
     """A stub wired to the real `_halting`, with a configurable outage budget."""
     closed = []
@@ -165,9 +202,6 @@ def _grace_env(budget, policy=ObservationFailurePolicy.HALT):
         consecutive_unknown_status=0,
         _last_confirmed_read={},
         _max_unknown_status_steps=budget,
-    )
-    env._flatten_if_policy_says_so = (
-        lambda: TorchTradeFuturesLiveEnv._flatten_if_policy_says_so(env)
     )
     env._halting = lambda read, cache_key=None: TorchTradeFuturesLiveEnv._halting(
         env, read, cache_key
@@ -190,36 +224,31 @@ def test_a_confirmed_read_is_what_the_grace_period_stands_on():
     with pytest.raises(LiveObservationHalt):
         env._halting(_boom, cache_key="pre_trade")
 
-    assert env.consecutive_unknown_status == 1, "the failure still counts"
+    assert env._status_unknown_this_step, "the bar is still marked unconfirmed"
 
 
 def test_the_grace_period_rides_out_an_outage_on_the_last_confirmed_read():
+    """`_halting` serves the cached read and never raises once grace applies.
+
+    It deliberately does NOT consult the budget: whether the outage has outlasted it is a
+    question about the BAR, answered once in `_finalize_step_flags`. Raising here on the
+    spent bar would reintroduce the process crash #295 exists to remove.
+    """
     env, _ = _grace_env(budget=3)
     assert env._halting(lambda: "GOOD", cache_key="pre_trade") == "GOOD"
 
-    # Two failures inside the budget: the cached value stands in, nothing raises.
-    for expected_count in (1, 2):
+    for _ in range(5):        # well past the budget: still cached, still no raise
         assert env._halting(_boom, cache_key="pre_trade") == "GOOD"
-        assert env.consecutive_unknown_status == expected_count
-
-    # The third spends the budget. It must NOT raise -- an exception here is the process
-    # crash #295 exists to remove; the step finishes so _finalize_step_flags can truncate.
-    assert env._halting(_boom, cache_key="pre_trade") == "GOOD"
-    assert env.consecutive_unknown_status == 3
+        assert env._status_unknown_this_step
 
 
-def test_a_successful_read_ends_the_outage_rather_than_denting_it():
-    """It counts CONSECUTIVE unknowns. A lifetime counter would truncate a healthy
-    session that had accumulated unrelated blips hours apart."""
+def test_a_successful_read_refreshes_what_the_grace_period_will_serve():
     env, _ = _grace_env(budget=3)
     env._halting(lambda: "GOOD", cache_key="pre_trade")
-    env._halting(_boom, cache_key="pre_trade")
-    env._halting(_boom, cache_key="pre_trade")
-    assert env.consecutive_unknown_status == 2
+    assert env._halting(_boom, cache_key="pre_trade") == "GOOD"
 
     env._halting(lambda: "FRESH", cache_key="pre_trade")
-    assert env.consecutive_unknown_status == 0
-    assert env._halting(_boom, cache_key="pre_trade") == "FRESH", "cache refreshed too"
+    assert env._halting(_boom, cache_key="pre_trade") == "FRESH"
 
 
 def test_the_default_budget_keeps_the_pre_295_posture():
@@ -387,11 +416,114 @@ def test_the_cache_holds_a_copy_not_the_object_the_collector_mutates():
     observation = TensorDict({"done": torch.zeros(1, dtype=torch.bool)}, batch_size=())
     env._halting(lambda: ("status", observation), cache_key="post_bar")
 
-    # The collector stamps the object it was handed.
-    observation.set("done", torch.ones(1, dtype=torch.bool))
+    # Two grace bars in a row. Each must get its OWN object: `_step` stamps reward and
+    # the done family onto whatever it is handed, so one shared object means bar 1 and
+    # bar 2 in a collector's rollout both end up carrying bar 2's values.
+    _, first = env._halting(_boom, cache_key="post_bar")
+    _, second = env._halting(_boom, cache_key="post_bar")
+    assert first is not second, "two grace bars were served the same tensordict"
 
-    _, cached_obs = env._halting(_boom, cache_key="post_bar")
-    assert cached_obs is not observation, "the cache aliases the returned tensordict"
-    assert not bool(cached_obs["done"]), (
-        "the cached observation inherited the flag stamped after it was cached"
+    first.set("done", torch.ones(1, dtype=torch.bool))
+    assert not bool(second["done"]), "stamping one grace bar mutated another"
+    assert not bool(observation["done"]), "stamping a grace bar mutated the cache"
+
+
+def test_an_open_position_is_frozen_but_flagged_through_a_grace_outage():
+    """The scenario the whole feature exists for, and the one nothing else covered.
+
+    Every other test here drives the outage FLAT. With a position open, `account_state`
+    -- exposure, unrealised PnL, distance to liquidation -- is served from the cached
+    read and freezes at the last confirmed values while the real account keeps moving.
+    That is the accepted cost of the opt-in posture, but it must be exactly that: frozen
+    and FLAGGED, never silently re-derived from a stale mark as though it were fresh.
+    """
+    import torch
+    from torchtrade.envs.core.common_types import PositionStatus
+
+    open_long = PositionStatus(
+        qty=0.05, notional_value=5000.0, entry_price=100.0, unrealized_pnl=0.0,
+        unrealized_pnl_pct=0.0, mark_price=100.0, leverage=10,
+        margin_mode="isolated", liquidation_price=91.0,
     )
+    env, trader = _real_binance_env(budget=3, position_status=open_long)
+
+    td = env.reset()
+    td = env.step(td.set("action", torch.tensor(2)))["next"]
+    confirmed = td["account_state"].clone()
+    assert confirmed[1].item() != 0.0, "setup: expected an open position"
+
+    trader.get_status.side_effect = PositionUnknownError("venue unreachable")
+    trader.get_mark_price.side_effect = PositionUnknownError("venue unreachable")
+
+    frozen = []
+    for _ in range(2):
+        td = env.step(td.exclude("done", "terminated", "truncated", "reward")
+                      .set("action", torch.tensor(2)))["next"]
+        frozen.append((td["account_state"].clone(), td["status_unknown"].item()))
+
+    for state, flag in frozen:
+        assert flag == 1.0, "an unconfirmed bar must say so"
+        assert torch.equal(state, confirmed), (
+            "account_state moved during an outage: it must be the last CONFIRMED read, "
+            "not a value re-derived from a stale mark"
+        )
+
+
+def test_a_new_episode_cannot_be_served_the_previous_one_s_account():
+    """`_reset_outage_state` clears the cache; nothing forced the case it protects.
+
+    Episode N truncates with a populated cache. Episode N+1 resets successfully, then its
+    FIRST pre-trade read fails. With the cache uncleared, grace would serve episode N's
+    account -- a position that may since have been closed, at a price hours old.
+    """
+    import torch
+    from torchtrade.envs.core.common_types import PositionStatus
+
+    open_long = PositionStatus(
+        qty=0.05, notional_value=5000.0, entry_price=100.0, unrealized_pnl=0.0,
+        unrealized_pnl_pct=0.0, mark_price=100.0, leverage=10,
+        margin_mode="isolated", liquidation_price=91.0,
+    )
+    env, trader = _real_binance_env(budget=3, position_status=open_long)
+    td = env.reset()
+    env.step(td.set("action", torch.tensor(2)))
+    assert env._last_confirmed_read, "setup: the cache should be populated"
+
+    env.reset()                                   # episode N+1, venue healthy
+    assert not env._last_confirmed_read, "reset left the previous episode's account cached"
+
+    trader.get_status.side_effect = PositionUnknownError("down again")
+    with pytest.raises(LiveObservationHalt):       # nothing confirmed yet this episode
+        env.step(td.set("action", torch.tensor(2)))
+
+
+def test_alpaca_reports_its_status_as_known_because_it_has_no_failure_policy():
+    """Alpaca is the third hand-written copy of the same one-line tensor.
+
+    It has no `observation_failure_policy` and no `_halting`, so its counter never
+    advances and the flag is a constant. Declared anyway, so the observation contract does
+    not fork by venue -- and pinned here, because this repo's recorded failure mode is a
+    third copy quietly drifting from the other two.
+    """
+    import torch
+    from tests.mocks.alpaca import MockObserver, MockTrader
+    from torchtrade.envs.live.alpaca.env import (
+        AlpacaTorchTradingEnv, AlpacaTradingEnvConfig,
+    )
+
+    env = AlpacaTorchTradingEnv(
+        config=AlpacaTradingEnvConfig(symbol="BTC/USD", window_sizes=[10]),
+        observer=MockObserver(window_sizes=[10]), trader=MockTrader(initial_cash=10000.0),
+    )
+    env._wait_for_next_timestamp = lambda: None
+
+    assert not hasattr(env.config, "max_unknown_status_steps"), (
+        "alpaca grew an outage budget; this test and the docs both need revisiting"
+    )
+    td = env.reset()
+    assert td["status_unknown"].item() == 0.0
+    for _ in range(3):
+        td = env.step(td.set("action", torch.tensor(1)))["next"]
+        assert td["status_unknown"].item() == 0.0
+        assert not bool(td["truncated"])
+        td = td.exclude("done", "terminated", "truncated", "reward")

--- a/tests/envs/test_live_observation_failsafe.py
+++ b/tests/envs/test_live_observation_failsafe.py
@@ -203,7 +203,7 @@ def test_the_grace_period_rides_out_an_outage_on_the_last_confirmed_read():
         assert env.consecutive_unknown_status == expected_count
 
     # The third spends the budget. It must NOT raise -- an exception here is the process
-    # crash #295 exists to remove; the step finishes so _set_done_family can truncate.
+    # crash #295 exists to remove; the step finishes so _finalize_step_flags can truncate.
     assert env._halting(_boom, cache_key="pre_trade") == "GOOD"
     assert env.consecutive_unknown_status == 3
 
@@ -316,3 +316,82 @@ def test_a_real_env_flags_the_outage_and_truncates_on_the_budgeted_bar():
         (1.0, False, False, False),
         (1.0, True, False, True),
     ], f"outage bars were {seen}"
+
+
+def test_reset_halts_typed_rather_than_relocating_the_crash():
+    """The reset read must go through the halt policy too (#295).
+
+    Truncation fires precisely BECAUSE the outage is ongoing, so the very next `reset()`
+    is the likeliest moment for the venue to still be down. With reset's reads outside
+    `_halting`, the process crash this work exists to remove did not go away -- it moved
+    from `_step` to the following `reset`, one bar later, as a bare PositionUnknownError
+    that `except LiveObservationHalt` does not catch and FLATTEN does not act on.
+
+    Raising here is still correct: an episode must not START on unconfirmed state. What
+    the grace period buys is riding out an outage mid-episode, not beginning one blind.
+    """
+    from unittest.mock import MagicMock, patch
+    import numpy as np
+    from torchtrade.envs.live.binance.env import (
+        BinanceFuturesTorchTradingEnv as Env, BinanceFuturesTradingEnvConfig as Config,
+    )
+
+    observer = MagicMock()
+    observer.get_keys.return_value = ["1m_10"]
+    observer.get_observations.return_value = {"1m_10": np.zeros((10, 4), dtype=np.float32)}
+    observer.get_features.return_value = {
+        "observation_features": list("abcd"), "original_features": []}
+    observer.reset.return_value = None
+    trader = MagicMock()
+    trader.get_account_balance.return_value = {
+        "available_balance": 1e4, "total_margin_balance": 1e4,
+        "total_wallet_balance": 1e4, "total_maintenance_margin": 0.0}
+    trader.get_mark_price.return_value = 100.0
+    trader.get_lot_size.return_value = {"min_qty": 0.001, "qty_step": 0.001}
+    trader.get_status.return_value = {"position_status": None}
+
+    config = Config(symbol="BTCUSDT", time_frames=["1m"], window_sizes=[10],
+                    execute_on="1m", max_unknown_status_steps=3,
+                    observation_failure_policy=ObservationFailurePolicy.FLATTEN,
+                    close_position_on_init=False)
+    with patch("time.sleep"), patch.object(Env, "_wait_for_next_timestamp"):
+        env = Env(config=config, observer=observer, trader=trader)
+        trader.get_status.side_effect = PositionUnknownError("still down")
+        trader.close_position.reset_mock()
+
+        with pytest.raises(LiveObservationHalt):
+            env.reset()
+
+    assert trader.close_position.called, (
+        "FLATTEN did not act on the reset read: it was outside the halt policy"
+    )
+
+
+def test_the_cache_holds_a_copy_not_the_object_the_collector_mutates():
+    """`TensorDict.set()` stores references, so caching the read by reference aliases it.
+
+    The post-bar tuple carries the observation tensordict that `_step` returns -- the same
+    object the collector then stamps with reward and the done family. Cached by reference,
+    a grace bar re-serves LAST bar's flags, which is how a stale `done=False` ends up in a
+    tensordict that `EnvBase._complete_done` then declines to fill.
+
+    Currently invisible behaviourally, because `_finalize_step_flags` overwrites the whole
+    family anyway. That is precisely why it needs pinning directly: the aliasing is a live
+    hazard that today's code happens to paper over, and removing the clone fails nothing
+    without this test.
+    """
+    import torch
+    from tensordict import TensorDict
+
+    env, _ = _grace_env(budget=3)
+    observation = TensorDict({"done": torch.zeros(1, dtype=torch.bool)}, batch_size=())
+    env._halting(lambda: ("status", observation), cache_key="post_bar")
+
+    # The collector stamps the object it was handed.
+    observation.set("done", torch.ones(1, dtype=torch.bool))
+
+    _, cached_obs = env._halting(_boom, cache_key="post_bar")
+    assert cached_obs is not observation, "the cache aliases the returned tensordict"
+    assert not bool(cached_obs["done"]), (
+        "the cached observation inherited the flag stamped after it was cached"
+    )

--- a/tests/envs/test_live_observation_failsafe.py
+++ b/tests/envs/test_live_observation_failsafe.py
@@ -571,3 +571,33 @@ def test_an_sltp_grace_bar_can_still_size_a_bracket_with_the_venue_down(venue):
 
     assert nxt["status_unknown"].item() == 1.0, "the bar must be flagged, not crash"
     assert not bool(nxt["terminated"]), "an outage is never a terminated episode"
+
+
+@pytest.mark.parametrize("sltp", [False, True], ids=["plain", "sltp"])
+@pytest.mark.parametrize("venue", VENUES)
+def test_reset_halts_on_the_sentinel_venues_actually_return(venue, sltp):
+    """`get_status` does not RAISE on an outage -- it returns POSITION_UNKNOWN.
+
+    All four adapters assign the sentinel and return normally; the error surfaces at the
+    first attribute touch. So wrapping the CALL in `_halting` catches nothing, which is
+    the trap `_acquire_pre_trade_state`'s own docstring warns about twelve lines above the
+    code that fell into it -- the conversion has to be inside the closure too.
+
+    The existing reset test drove `side_effect = PositionUnknownError`, a raise. That
+    shape does not occur in production: POSITION_UNKNOWN appeared ZERO times in this file,
+    so the test asserted a halt on a failure the venues never generate.
+    """
+    from torchtrade.envs.core.state import POSITION_UNKNOWN
+
+    env, trader = _real_futures_env(
+        budget=0, venue=venue, sltp=sltp,
+        observation_failure_policy=ObservationFailurePolicy.FLATTEN,
+    )
+    trader.get_status.return_value = {"position_status": POSITION_UNKNOWN}
+    trader.close_position.reset_mock()
+
+    with pytest.raises(LiveObservationHalt):
+        env.reset()
+    assert trader.close_position.called, (
+        "FLATTEN did not act: the sentinel escaped as a bare PositionUnknownError"
+    )

--- a/tests/envs/test_live_trade_state.py
+++ b/tests/envs/test_live_trade_state.py
@@ -15,7 +15,7 @@ from unittest.mock import patch
 
 import pytest
 
-from torchtrade.envs.core.state import PositionState
+from torchtrade.envs.core.state import PositionState, position_qty_from_status
 
 
 # ---------------------------------------------------------------------------
@@ -212,7 +212,9 @@ class TestTradeStateSync:
         trader = MockTrader(position_qty=0.0)
         env = ENV_FACTORIES[exchange](trader)
 
-        trade_info = env._execute_trade_if_needed(-1.0, current_qty=env._get_current_position_quantity(), current_price=env._current_mark_price())
+        trade_info = env._execute_trade_if_needed(-1.0, current_qty=position_qty_from_status(
+                env.trader.get_status().get("position_status")),
+            current_price=env._current_mark_price())
 
         assert trade_info["executed"] is True
         assert trade_info["success"] is True
@@ -223,7 +225,9 @@ class TestTradeStateSync:
         trader.trade_should_raise = True
         env = ENV_FACTORIES[exchange](trader)
 
-        trade_info = env._execute_fractional_action(-1.0, current_qty=env._get_current_position_quantity(), current_price=env._current_mark_price())
+        trade_info = env._execute_fractional_action(-1.0, current_qty=position_qty_from_status(
+                env.trader.get_status().get("position_status")),
+            current_price=env._current_mark_price())
 
         assert trade_info["executed"] is False
         assert trade_info["success"] is False
@@ -239,7 +243,9 @@ class TestTradeStateSync:
 
         # First attempt: trade raises
         trader.trade_should_raise = True
-        trade_info = env._execute_trade_if_needed(-1.0, current_qty=env._get_current_position_quantity(), current_price=env._current_mark_price())
+        trade_info = env._execute_trade_if_needed(-1.0, current_qty=position_qty_from_status(
+                env.trader.get_status().get("position_status")),
+            current_price=env._current_mark_price())
 
         # Simulate _step logic: don't update state on failure
         if trade_info["executed"] and trade_info.get("success") is not False:
@@ -249,7 +255,9 @@ class TestTradeStateSync:
 
         # Second attempt: trade succeeds -- guard must NOT block
         trader.trade_should_raise = False
-        trade_info2 = env._execute_trade_if_needed(-1.0, current_qty=env._get_current_position_quantity(), current_price=env._current_mark_price())
+        trade_info2 = env._execute_trade_if_needed(-1.0, current_qty=position_qty_from_status(
+                env.trader.get_status().get("position_status")),
+            current_price=env._current_mark_price())
 
         assert trade_info2["executed"] is True
         assert trade_info2["success"] is True
@@ -275,7 +283,9 @@ class TestTradeStateSync:
         trader.trade_should_fail = True
         env = ENV_FACTORIES[exchange](trader)
 
-        trade_info = env._execute_fractional_action(-1.0, current_qty=env._get_current_position_quantity(), current_price=env._current_mark_price())
+        trade_info = env._execute_fractional_action(-1.0, current_qty=position_qty_from_status(
+                env.trader.get_status().get("position_status")),
+            current_price=env._current_mark_price())
 
         assert trade_info["executed"] is True
         assert trade_info["success"] is False
@@ -295,7 +305,9 @@ class TestBinanceDirectionSwitch:
         trader.close_should_fail = True
         env = _make_binance_env(trader)
 
-        trade_info = env._execute_fractional_action(-1.0, current_qty=env._get_current_position_quantity(), current_price=env._current_mark_price())
+        trade_info = env._execute_fractional_action(-1.0, current_qty=position_qty_from_status(
+                env.trader.get_status().get("position_status")),
+            current_price=env._current_mark_price())
 
         assert trader.position_qty == 0.5
         assert len([t for t in trader.trades_executed if t["side"] == "SELL"]) == 0
@@ -316,7 +328,9 @@ class TestBinanceDirectionSwitch:
         env = _make_binance_env(trader)
         env.position.current_position = 1
 
-        env._execute_fractional_action(-1.0, current_qty=env._get_current_position_quantity(), current_price=env._current_mark_price())
+        env._execute_fractional_action(-1.0, current_qty=position_qty_from_status(
+                env.trader.get_status().get("position_status")),
+            current_price=env._current_mark_price())
 
         assert trader.position_qty == 0.0, "the close itself must have succeeded"
         assert env.position.current_position == 0, (
@@ -369,20 +383,28 @@ class TestRegressionIssue189:
         env = _make_binance_env(trader)
 
         # Step 1: SHORT succeeds
-        trade_info = env._execute_trade_if_needed(-1.0, current_qty=env._get_current_position_quantity(), current_price=env._current_mark_price())
+        trade_info = env._execute_trade_if_needed(-1.0, current_qty=position_qty_from_status(
+                env.trader.get_status().get("position_status")),
+            current_price=env._current_mark_price())
         if trade_info["executed"] and trade_info.get("success") is not False:
             env.position.current_action_level = -1.0
 
         assert env.position.current_action_level == -1.0
 
         # Step 2: SHORT again -- guard correctly blocks (same action level)
-        trade_info2 = env._execute_trade_if_needed(-1.0, current_qty=env._get_current_position_quantity(), current_price=env._current_mark_price())
+        trade_info2 = env._execute_trade_if_needed(-1.0, current_qty=position_qty_from_status(
+                env.trader.get_status().get("position_status")),
+            current_price=env._current_mark_price())
         assert trade_info2["executed"] is False
 
         # Step 3: Transition to FLAT, then SHORT works
-        trade_info3 = env._execute_trade_if_needed(0.0, current_qty=env._get_current_position_quantity(), current_price=env._current_mark_price())
+        trade_info3 = env._execute_trade_if_needed(0.0, current_qty=position_qty_from_status(
+                env.trader.get_status().get("position_status")),
+            current_price=env._current_mark_price())
         if trade_info3["executed"] and trade_info3.get("success") is not False:
             env.position.current_action_level = 0.0
 
-        trade_info4 = env._execute_trade_if_needed(-1.0, current_qty=env._get_current_position_quantity(), current_price=env._current_mark_price())
+        trade_info4 = env._execute_trade_if_needed(-1.0, current_qty=position_qty_from_status(
+                env.trader.get_status().get("position_status")),
+            current_price=env._current_mark_price())
         assert trade_info4["executed"] is True

--- a/tests/envs/test_live_trade_state.py
+++ b/tests/envs/test_live_trade_state.py
@@ -16,6 +16,7 @@ from unittest.mock import patch
 import pytest
 
 from torchtrade.envs.core.state import PositionState, position_qty_from_status
+from tests.envs.base_exchange_tests import wire_outage_state
 
 
 # ---------------------------------------------------------------------------
@@ -142,9 +143,7 @@ def _make_binance_env(trader=None):
     env.position = PositionState()
     # Built with __new__, so __init__'s outage state is absent. The balance read that
     # sizes an order runs under `_halting` as of #295.
-    env.consecutive_unknown_status = 0
-    env._status_unknown_this_step = False
-    env._last_confirmed_read = {}
+    wire_outage_state(env)
     env.initial_portfolio_value = 10000.0
     env.history = HistoryTracker()
     env.reward_function = log_return_reward
@@ -182,9 +181,7 @@ def _make_bitget_env(trader=None):
     env.position = PositionState()
     # Built with __new__, so __init__'s outage state is absent. The balance read that
     # sizes an order runs under `_halting` as of #295.
-    env.consecutive_unknown_status = 0
-    env._status_unknown_this_step = False
-    env._last_confirmed_read = {}
+    wire_outage_state(env)
     env.initial_portfolio_value = 10000.0
     env.history = HistoryTracker()
     env.reward_function = log_return_reward

--- a/tests/envs/test_live_trade_state.py
+++ b/tests/envs/test_live_trade_state.py
@@ -140,6 +140,11 @@ def _make_binance_env(trader=None):
     env.trader = mock_trader
     env.action_levels = config.action_levels
     env.position = PositionState()
+    # Built with __new__, so __init__'s outage state is absent. The balance read that
+    # sizes an order runs under `_halting` as of #295.
+    env.consecutive_unknown_status = 0
+    env._status_unknown_this_step = False
+    env._last_confirmed_read = {}
     env.initial_portfolio_value = 10000.0
     env.history = HistoryTracker()
     env.reward_function = log_return_reward
@@ -175,6 +180,11 @@ def _make_bitget_env(trader=None):
     env.trader = mock_trader
     env.action_levels = config.action_levels
     env.position = PositionState()
+    # Built with __new__, so __init__'s outage state is absent. The balance read that
+    # sizes an order runs under `_halting` as of #295.
+    env.consecutive_unknown_status = 0
+    env._status_unknown_this_step = False
+    env._last_confirmed_read = {}
     env.initial_portfolio_value = 10000.0
     env.history = HistoryTracker()
     env.reward_function = log_return_reward
@@ -202,7 +212,7 @@ class TestTradeStateSync:
         trader = MockTrader(position_qty=0.0)
         env = ENV_FACTORIES[exchange](trader)
 
-        trade_info = env._execute_trade_if_needed(-1.0)
+        trade_info = env._execute_trade_if_needed(-1.0, current_qty=env._get_current_position_quantity(), current_price=env._current_mark_price())
 
         assert trade_info["executed"] is True
         assert trade_info["success"] is True
@@ -213,7 +223,7 @@ class TestTradeStateSync:
         trader.trade_should_raise = True
         env = ENV_FACTORIES[exchange](trader)
 
-        trade_info = env._execute_fractional_action(-1.0)
+        trade_info = env._execute_fractional_action(-1.0, current_qty=env._get_current_position_quantity(), current_price=env._current_mark_price())
 
         assert trade_info["executed"] is False
         assert trade_info["success"] is False
@@ -229,7 +239,7 @@ class TestTradeStateSync:
 
         # First attempt: trade raises
         trader.trade_should_raise = True
-        trade_info = env._execute_trade_if_needed(-1.0)
+        trade_info = env._execute_trade_if_needed(-1.0, current_qty=env._get_current_position_quantity(), current_price=env._current_mark_price())
 
         # Simulate _step logic: don't update state on failure
         if trade_info["executed"] and trade_info.get("success") is not False:
@@ -239,7 +249,7 @@ class TestTradeStateSync:
 
         # Second attempt: trade succeeds -- guard must NOT block
         trader.trade_should_raise = False
-        trade_info2 = env._execute_trade_if_needed(-1.0)
+        trade_info2 = env._execute_trade_if_needed(-1.0, current_qty=env._get_current_position_quantity(), current_price=env._current_mark_price())
 
         assert trade_info2["executed"] is True
         assert trade_info2["success"] is True
@@ -265,7 +275,7 @@ class TestTradeStateSync:
         trader.trade_should_fail = True
         env = ENV_FACTORIES[exchange](trader)
 
-        trade_info = env._execute_fractional_action(-1.0)
+        trade_info = env._execute_fractional_action(-1.0, current_qty=env._get_current_position_quantity(), current_price=env._current_mark_price())
 
         assert trade_info["executed"] is True
         assert trade_info["success"] is False
@@ -285,7 +295,7 @@ class TestBinanceDirectionSwitch:
         trader.close_should_fail = True
         env = _make_binance_env(trader)
 
-        trade_info = env._execute_fractional_action(-1.0)
+        trade_info = env._execute_fractional_action(-1.0, current_qty=env._get_current_position_quantity(), current_price=env._current_mark_price())
 
         assert trader.position_qty == 0.5
         assert len([t for t in trader.trades_executed if t["side"] == "SELL"]) == 0
@@ -306,7 +316,7 @@ class TestBinanceDirectionSwitch:
         env = _make_binance_env(trader)
         env.position.current_position = 1
 
-        env._execute_fractional_action(-1.0)
+        env._execute_fractional_action(-1.0, current_qty=env._get_current_position_quantity(), current_price=env._current_mark_price())
 
         assert trader.position_qty == 0.0, "the close itself must have succeeded"
         assert env.position.current_position == 0, (
@@ -359,20 +369,20 @@ class TestRegressionIssue189:
         env = _make_binance_env(trader)
 
         # Step 1: SHORT succeeds
-        trade_info = env._execute_trade_if_needed(-1.0)
+        trade_info = env._execute_trade_if_needed(-1.0, current_qty=env._get_current_position_quantity(), current_price=env._current_mark_price())
         if trade_info["executed"] and trade_info.get("success") is not False:
             env.position.current_action_level = -1.0
 
         assert env.position.current_action_level == -1.0
 
         # Step 2: SHORT again -- guard correctly blocks (same action level)
-        trade_info2 = env._execute_trade_if_needed(-1.0)
+        trade_info2 = env._execute_trade_if_needed(-1.0, current_qty=env._get_current_position_quantity(), current_price=env._current_mark_price())
         assert trade_info2["executed"] is False
 
         # Step 3: Transition to FLAT, then SHORT works
-        trade_info3 = env._execute_trade_if_needed(0.0)
+        trade_info3 = env._execute_trade_if_needed(0.0, current_qty=env._get_current_position_quantity(), current_price=env._current_mark_price())
         if trade_info3["executed"] and trade_info3.get("success") is not False:
             env.position.current_action_level = 0.0
 
-        trade_info4 = env._execute_trade_if_needed(-1.0)
+        trade_info4 = env._execute_trade_if_needed(-1.0, current_qty=env._get_current_position_quantity(), current_price=env._current_mark_price())
         assert trade_info4["executed"] is True

--- a/tests/envs/test_spec_contracts.py
+++ b/tests/envs/test_spec_contracts.py
@@ -13,11 +13,11 @@ with no error at all. `TorchTradeBaseEnv` declares all three for live and offlin
 the tests at the end of this file guard that one declaration against both drift and
 silent loss.
 
-Since #313 the LIVE `_step` methods no longer write `truncated` by hand, so for them the
-declaration is its only source. One consequence is worth knowing: their `check_env_specs`
-can no longer catch a *narrowed* done spec, because it compares a real rollout against a
-fake one and both would lack the key. `assert_the_step_emits_the_whole_done_family`, run
-against all ten live envs, is what catches it there. The offline envs still write
+Between #313 and #295 the LIVE `_step` methods did not write `truncated` by hand, and for
+them this declaration was the key's only source. As of #295 they write the whole family
+again through the shared `_finalize_step_flags`, because a prolonged venue outage now
+genuinely truncates. `assert_the_step_emits_the_whole_done_family`, run against all ten
+live envs, is what catches a narrowed done spec there. The offline envs still write
 `truncated` themselves -- they genuinely truncate -- so their `check_env_specs` does still
 catch it, and so does `test_a_collector_batch_carries_truncated` below. Dropping
 `truncated` from the shared spec fails 21 tests: 17 across those three guards -- 10 live
@@ -342,8 +342,8 @@ def test_a_collector_batch_carries_truncated(sample_ohlcv_df):
     truncated. The mechanism is env-agnostic and a collector is cheap on this side, where
     the live envs would need broker mocks and a patched clock. So this pins the shared
     declaration going forward; the ten assert_the_step_emits_the_whole_done_family cells
-    are what cover the live regression itself, since #313 left the live check_env_specs
-    tests unable to see a narrowed done spec.
+    are what cover the live regression itself: check_env_specs compares a real rollout
+    against a fake one, so a narrowed done spec looks consistent to it.
     """
     from torchrl.collectors import Collector
 

--- a/torchtrade/envs/core/base.py
+++ b/torchtrade/envs/core/base.py
@@ -68,13 +68,11 @@ class TorchTradeBaseEnv(EnvBase):
         # pre-allocating from the spec (collectors, ParallelEnv) drops truncated silently
         # (#272).
         #
-        # For the LIVE envs this declaration is the only source of the key: since #313
-        # their _step methods no longer write it and EnvBase._complete_done fills it from
-        # here. One consequence -- their check_env_specs can no longer catch a narrowed
-        # done spec, since real and fake rollouts would both lack the key. The live guard
-        # is assert_the_step_emits_the_whole_done_family, run against all ten. The offline
-        # envs still write truncated themselves, and meaningfully (they do truncate), so
-        # their check_env_specs does still catch it.
+        # This WAS the only source of the key for the live envs between #313 and #295.
+        # As of #295 they write the whole family from `_step` again, through the shared
+        # `_finalize_step_flags`, because a prolonged venue outage now genuinely truncates
+        # -- so `truncated` is load-bearing rather than a declared constant. The live
+        # guard is assert_the_step_emits_the_whole_done_family, run against all ten.
         self.full_done_spec = Composite(
             done=Categorical(2, dtype=torch.bool, shape=(1,)),
             terminated=Categorical(2, dtype=torch.bool, shape=(1,)),

--- a/torchtrade/envs/core/common.py
+++ b/torchtrade/envs/core/common.py
@@ -105,17 +105,11 @@ def validate_trade_mode(trade_mode: str) -> str:
 def validate_unknown_status_budget(steps) -> None:
     """The #295 grace period, checked at the boundary rather than guarded downstream.
 
-    A negative budget would read as "disabled" through `>= budget > 0`, silently turning a
-    typo into the strictest posture. A float would compare fine and then never equal the
-    integer counter. Invariant 4: raise here so nothing downstream has to guard.
+    A negative budget reads as "disabled" through `>= budget > 0`, silently turning a typo
+    into the strictest posture instead of erroring.
     """
-    if isinstance(steps, bool) or not isinstance(steps, int):
+    if not isinstance(steps, int) or isinstance(steps, bool) or steps < 0:
         raise ValueError(
-            f"max_unknown_status_steps must be an int, got {steps!r} "
-            f"({type(steps).__name__})"
-        )
-    if steps < 0:
-        raise ValueError(
-            f"max_unknown_status_steps must be >= 0 (0 disables the grace period), "
-            f"got {steps}"
+            f"max_unknown_status_steps must be an int >= 0 (0 disables the grace "
+            f"period), got {steps!r}"
         )

--- a/torchtrade/envs/core/common.py
+++ b/torchtrade/envs/core/common.py
@@ -103,11 +103,7 @@ def validate_trade_mode(trade_mode: str) -> str:
 
 
 def validate_unknown_status_budget(steps) -> None:
-    """The #295 grace period, checked at the boundary rather than guarded downstream.
-
-    A negative budget reads as "disabled" through `>= budget > 0`, silently turning a typo
-    into the strictest posture instead of erroring.
-    """
+    """Checked at the boundary: a negative budget reads as "disabled" (#295)."""
     if not isinstance(steps, int) or isinstance(steps, bool) or steps < 0:
         raise ValueError(
             f"max_unknown_status_steps must be an int >= 0 (0 disables the grace "

--- a/torchtrade/envs/core/common.py
+++ b/torchtrade/envs/core/common.py
@@ -100,3 +100,22 @@ def validate_trade_mode(trade_mode: str) -> str:
             f"trade_mode must be 'fractional', 'notional', or 'quantity' (case-insensitive), got '{trade_mode}'"
         )
     return trade_mode_lower
+
+
+def validate_unknown_status_budget(steps) -> None:
+    """The #295 grace period, checked at the boundary rather than guarded downstream.
+
+    A negative budget would read as "disabled" through `>= budget > 0`, silently turning a
+    typo into the strictest posture. A float would compare fine and then never equal the
+    integer counter. Invariant 4: raise here so nothing downstream has to guard.
+    """
+    if isinstance(steps, bool) or not isinstance(steps, int):
+        raise ValueError(
+            f"max_unknown_status_steps must be an int, got {steps!r} "
+            f"({type(steps).__name__})"
+        )
+    if steps < 0:
+        raise ValueError(
+            f"max_unknown_status_steps must be >= 0 (0 disables the grace period), "
+            f"got {steps}"
+        )

--- a/torchtrade/envs/core/live.py
+++ b/torchtrade/envs/core/live.py
@@ -60,6 +60,10 @@ class InvalidActionError(Exception):
     """
 
 
+#: Observation key carrying 1.0 while the env is running on unconfirmed account state.
+STATUS_UNKNOWN_KEY = "status_unknown"
+
+
 class TorchTradeLiveEnv(TorchTradeBaseEnv):
     """
     Base class for live trading environments.
@@ -124,6 +128,13 @@ class TorchTradeLiveEnv(TorchTradeBaseEnv):
         # Initialize position state
         # Note: Subclasses may override this with their specific position tracking needs
         self.position = PositionState()
+
+        # Consecutive venue reads the env could not confirm. Reset to 0 by any successful
+        # read, so this counts an OUTAGE, not lifetime failures (#295).
+        self.consecutive_unknown_status = 0
+        # Last CONFIRMED value per read site, so the grace period stands on real data
+        # rather than fabricating one. Empty until the first successful read (#295).
+        self._last_confirmed_read = {}
 
     @abstractmethod
     def _init_trading_clients(self, api_key: str, api_secret: str, observer, trader):
@@ -283,6 +294,12 @@ class TorchTradeLiveEnv(TorchTradeBaseEnv):
             self.account_state_key,
             Unbounded(shape=(len(self.ACCOUNT_STATE),), dtype=torch.float),
         )
+        # A SEPARATE key, not a 7th account_state slot: account_state is shared verbatim
+        # with the offline envs, which have no notion of an unreadable venue, so widening
+        # it would desync live/offline parity for a concept only one side has (#295).
+        self.observation_spec.set(
+            STATUS_UNKNOWN_KEY, Unbounded(shape=(1,), dtype=torch.float)
+        )
 
         self.market_data_keys = []
         # strict=True: every config's __post_init__ normalizes window_sizes to a list as
@@ -304,6 +321,51 @@ class TorchTradeLiveEnv(TorchTradeBaseEnv):
                 "base_features",
                 Unbounded(shape=(window_sizes[0], 4), dtype=torch.float),
             )
+
+    def _finalize_step_flags(self, next_tensordict, terminated: bool) -> None:
+        """Stamp status_unknown and the done family. Ten identical copies (#288, #295).
+
+        status_unknown is stamped HERE rather than at observation-build time because the
+        grace period serves a CACHED observation during an outage -- one built while the
+        venue was healthy, carrying 0.0. Baking the flag in at build time meant the policy
+        was told "all confirmed" on exactly the bars it was not, which is worse than not
+        having the flag at all.
+
+        `done` is written EXPLICITLY rather than left to TorchRL. `_step` output is not
+        completed from truncated: setting only `truncated=True` leaves `done=False`, the
+        collector never resets, and the episode silently runs on -- verified against a
+        real Collector, and exactly the dead channel #295 describes.
+
+        A prolonged outage truncates, never terminates. Value estimators read `terminated`
+        as "true return-to-go is 0" and `truncated` as "bootstrap from the final
+        observation"; terminating here would teach the critic that an unreachable API and
+        a blown account carry the same value target.
+        """
+        next_tensordict.set(
+            STATUS_UNKNOWN_KEY,
+            torch.tensor(
+                [float(getattr(self, "_status_unknown_this_step", False))],
+                dtype=torch.float,
+            ),
+        )
+        self._status_unknown_this_step = False
+
+        truncated = self.consecutive_unknown_status >= self._max_unknown_status_steps > 0
+        next_tensordict.set("terminated", torch.tensor([terminated], dtype=torch.bool))
+        next_tensordict.set("truncated", torch.tensor([truncated], dtype=torch.bool))
+        next_tensordict.set(
+            "done", torch.tensor([terminated or truncated], dtype=torch.bool)
+        )
+
+    @property
+    def _max_unknown_status_steps(self) -> int:
+        """Consecutive unconfirmed reads tolerated before the episode truncates.
+
+        0 disables the grace period entirely, which is the pre-#295 posture: the first
+        failed read raises rather than trading on state it cannot confirm. Absent on
+        alpaca, which has no observation-failure policy at all.
+        """
+        return getattr(self.config, "max_unknown_status_steps", 0)
 
     def get_account_state(self) -> List[str]:
         """The account-state field names. Four byte-identical copies (#288).

--- a/torchtrade/envs/core/live.py
+++ b/torchtrade/envs/core/live.py
@@ -360,12 +360,17 @@ class TorchTradeLiveEnv(TorchTradeBaseEnv):
         observation"; terminating here would teach the critic that an unreachable API and
         a blown account carry the same value target.
         """
+        # The counter advances HERE, once per bar, because this is the only thing that
+        # runs exactly once per step. Counting inside `_halting` double-counted a bar
+        # where both reads failed, and counting only the pre-trade read let a persistent
+        # POST-BAR-only outage run forever: every bar flagged unknown, while the healthy
+        # pre-trade read reset the counter to zero each time, so the budget never spent.
+        unknown = self._status_unknown_this_step
+        self.consecutive_unknown_status = (
+            self.consecutive_unknown_status + 1 if unknown else 0
+        )
         next_tensordict.set(
-            STATUS_UNKNOWN_KEY,
-            torch.tensor(
-                [float(self._status_unknown_this_step)],
-                dtype=torch.float,
-            ),
+            STATUS_UNKNOWN_KEY, torch.tensor([float(unknown)], dtype=torch.float)
         )
         self._status_unknown_this_step = False
 

--- a/torchtrade/envs/core/live.py
+++ b/torchtrade/envs/core/live.py
@@ -133,6 +133,10 @@ class TorchTradeLiveEnv(TorchTradeBaseEnv):
         # read, so this counts an OUTAGE, not lifetime failures (#295).
         self.consecutive_unknown_status = 0
         self._status_unknown_this_step = False
+        # 0 disables the grace period: the pre-#295 posture. Absent on alpaca.
+        self._max_unknown_status_steps = getattr(
+            config, "max_unknown_status_steps", 0
+        )
         # Last CONFIRMED value per read site, so the grace period stands on real data
         # rather than fabricating one. Empty until the first successful read (#295).
         self._last_confirmed_read = {}
@@ -324,12 +328,9 @@ class TorchTradeLiveEnv(TorchTradeBaseEnv):
             )
 
     def _reset_outage_state(self) -> None:
-        """Clear the #295 staleness state at an episode boundary.
+        """Clear the staleness state at an episode boundary.
 
-        Without this a truncated episode poisons the next one: `_finalize_step_flags`
-        reads the counter, so a fresh episode starts already at budget and truncates on
-        its first step -- forever. The cached reads go too; they belong to an account
-        state the new episode has not confirmed.
+        Without this a truncated episode starts the next one already at budget (#295).
         """
         self.consecutive_unknown_status = 0
         self._status_unknown_this_step = False
@@ -338,27 +339,13 @@ class TorchTradeLiveEnv(TorchTradeBaseEnv):
     def _finalize_step_flags(self, next_tensordict, terminated: bool) -> None:
         """Stamp status_unknown and the done family. Ten identical copies (#288, #295).
 
-        status_unknown is stamped HERE rather than at observation-build time because the
-        grace period serves a CACHED observation during an outage -- one built while the
-        venue was healthy, carrying 0.0. Baking the flag in at build time meant the policy
-        was told "all confirmed" on exactly the bars it was not, which is worse than not
-        having the flag at all.
+        status_unknown is stamped HERE, not at observation-build time: the grace period
+        serves a CACHED observation, so a build-time flag carried the healthy 0.0 into
+        exactly the bars it should have flagged.
 
-        `done` IS written, and not because TorchRL cannot derive it -- it can:
-        `EnvBase._complete_done` fills `terminated | truncated` when the key is absent.
-        It is written because these envs emit the whole family from `_step` itself, which
-        `assert_the_step_emits_the_whole_done_family` pins by name across all ten, and
-        because many tests drive `_step` directly, where `_complete_done` never runs.
-
-        The one case where derivation genuinely fails is a STALE `done` already present
-        in the tensordict -- which the cached read used to serve by reference, before
-        `_halting` started cloning. That was an aliasing bug, not a TorchRL limitation,
-        and it is fixed at the cache rather than papered over here.
-
-        A prolonged outage truncates, never terminates. Value estimators read `terminated`
-        as "true return-to-go is 0" and `truncated` as "bootstrap from the final
-        observation"; terminating here would teach the critic that an unreachable API and
-        a blown account carry the same value target.
+        A prolonged outage truncates, never terminates -- value estimators read
+        `terminated` as "return-to-go is 0" and `truncated` as "bootstrap from the final
+        observation".
         """
         # The counter advances HERE, once per bar, because this is the only thing that
         # runs exactly once per step. Counting inside `_halting` double-counted a bar
@@ -381,15 +368,6 @@ class TorchTradeLiveEnv(TorchTradeBaseEnv):
             "done", torch.tensor([terminated or truncated], dtype=torch.bool)
         )
 
-    @property
-    def _max_unknown_status_steps(self) -> int:
-        """Consecutive unconfirmed reads tolerated before the episode truncates.
-
-        0 disables the grace period entirely, which is the pre-#295 posture: the first
-        failed read raises rather than trading on state it cannot confirm. Absent on
-        alpaca, which has no observation-failure policy at all.
-        """
-        return getattr(self.config, "max_unknown_status_steps", 0)
 
     def get_account_state(self) -> List[str]:
         """The account-state field names. Four byte-identical copies (#288).

--- a/torchtrade/envs/core/live.py
+++ b/torchtrade/envs/core/live.py
@@ -132,6 +132,7 @@ class TorchTradeLiveEnv(TorchTradeBaseEnv):
         # Consecutive venue reads the env could not confirm. Reset to 0 by any successful
         # read, so this counts an OUTAGE, not lifetime failures (#295).
         self.consecutive_unknown_status = 0
+        self._status_unknown_this_step = False
         # Last CONFIRMED value per read site, so the grace period stands on real data
         # rather than fabricating one. Empty until the first successful read (#295).
         self._last_confirmed_read = {}
@@ -322,6 +323,18 @@ class TorchTradeLiveEnv(TorchTradeBaseEnv):
                 Unbounded(shape=(window_sizes[0], 4), dtype=torch.float),
             )
 
+    def _reset_outage_state(self) -> None:
+        """Clear the #295 staleness state at an episode boundary.
+
+        Without this a truncated episode poisons the next one: `_finalize_step_flags`
+        reads the counter, so a fresh episode starts already at budget and truncates on
+        its first step -- forever. The cached reads go too; they belong to an account
+        state the new episode has not confirmed.
+        """
+        self.consecutive_unknown_status = 0
+        self._status_unknown_this_step = False
+        self._last_confirmed_read.clear()
+
     def _finalize_step_flags(self, next_tensordict, terminated: bool) -> None:
         """Stamp status_unknown and the done family. Ten identical copies (#288, #295).
 
@@ -331,10 +344,16 @@ class TorchTradeLiveEnv(TorchTradeBaseEnv):
         was told "all confirmed" on exactly the bars it was not, which is worse than not
         having the flag at all.
 
-        `done` is written EXPLICITLY rather than left to TorchRL. `_step` output is not
-        completed from truncated: setting only `truncated=True` leaves `done=False`, the
-        collector never resets, and the episode silently runs on -- verified against a
-        real Collector, and exactly the dead channel #295 describes.
+        `done` IS written, and not because TorchRL cannot derive it -- it can:
+        `EnvBase._complete_done` fills `terminated | truncated` when the key is absent.
+        It is written because these envs emit the whole family from `_step` itself, which
+        `assert_the_step_emits_the_whole_done_family` pins by name across all ten, and
+        because many tests drive `_step` directly, where `_complete_done` never runs.
+
+        The one case where derivation genuinely fails is a STALE `done` already present
+        in the tensordict -- which the cached read used to serve by reference, before
+        `_halting` started cloning. That was an aliasing bug, not a TorchRL limitation,
+        and it is fixed at the cache rather than papered over here.
 
         A prolonged outage truncates, never terminates. Value estimators read `terminated`
         as "true return-to-go is 0" and `truncated` as "bootstrap from the final
@@ -344,7 +363,7 @@ class TorchTradeLiveEnv(TorchTradeBaseEnv):
         next_tensordict.set(
             STATUS_UNKNOWN_KEY,
             torch.tensor(
-                [float(getattr(self, "_status_unknown_this_step", False))],
+                [float(self._status_unknown_this_step)],
                 dtype=torch.float,
             ),
         )

--- a/torchtrade/envs/live/alpaca/base.py
+++ b/torchtrade/envs/live/alpaca/base.py
@@ -344,6 +344,7 @@ class AlpacaBaseTorchTradingEnv(TorchTradeLiveEnv):
 
     def _reset(self, tensordict: TensorDictBase, **kwargs) -> TensorDictBase:
         """Reset the environment."""
+        self._reset_outage_state()
         # Before any read below -- see the bybit copy for why the order matters (#278).
         self.observer.reset()
         if not self.trader.cancel_open_orders():

--- a/torchtrade/envs/live/alpaca/base.py
+++ b/torchtrade/envs/live/alpaca/base.py
@@ -282,9 +282,10 @@ class AlpacaBaseTorchTradingEnv(TorchTradeLiveEnv):
                 # Declared for all ten envs so the observation contract does not fork by
                 # venue. Alpaca has no observation-failure policy, so its counter never
                 # advances and this is always 0.0 there -- see _max_unknown_status_steps.
-                STATUS_UNKNOWN_KEY: torch.tensor(
-                    [float(self.consecutive_unknown_status > 0)], dtype=torch.float
-                ),
+                # Always 0.0 here: `_finalize_step_flags` overwrites it on every step,
+                # and the only other path is `_reset`, which just zeroed the counter.
+                # Declared so the reset observation matches the spec.
+                STATUS_UNKNOWN_KEY: torch.zeros(1, dtype=torch.float),
             },
             batch_size=(),
         )

--- a/torchtrade/envs/live/alpaca/base.py
+++ b/torchtrade/envs/live/alpaca/base.py
@@ -279,12 +279,7 @@ class AlpacaBaseTorchTradingEnv(TorchTradeLiveEnv):
         out_td = TensorDict(
             {
                 self.account_state_key: account_state,
-                # Declared for all ten envs so the observation contract does not fork by
-                # venue. Alpaca has no observation-failure policy, so its counter never
-                # advances and this is always 0.0 there -- see _max_unknown_status_steps.
-                # Always 0.0 here: `_finalize_step_flags` overwrites it on every step,
-                # and the only other path is `_reset`, which just zeroed the counter.
-                # Declared so the reset observation matches the spec.
+                # Always 0.0: `_finalize_step_flags` sets it per step (#295).
                 STATUS_UNKNOWN_KEY: torch.zeros(1, dtype=torch.float),
             },
             batch_size=(),

--- a/torchtrade/envs/live/alpaca/base.py
+++ b/torchtrade/envs/live/alpaca/base.py
@@ -11,6 +11,7 @@ from tensordict import TensorDict, TensorDictBase
 from torchtrade.envs.live.alpaca.observation import AlpacaObservationClass
 from torchtrade.envs.live.alpaca.order_executor import AlpacaOrderClass
 from torchtrade.envs.core.live import TorchTradeLiveEnv
+from torchtrade.envs.core.live import STATUS_UNKNOWN_KEY
 from torchtrade.envs.core.state import (
     HistoryTracker,
     PositionState,
@@ -275,7 +276,18 @@ class AlpacaBaseTorchTradingEnv(TorchTradeLiveEnv):
         )
 
         # Build output TensorDict
-        out_td = TensorDict({self.account_state_key: account_state}, batch_size=())
+        out_td = TensorDict(
+            {
+                self.account_state_key: account_state,
+                # Declared for all ten envs so the observation contract does not fork by
+                # venue. Alpaca has no observation-failure policy, so its counter never
+                # advances and this is always 0.0 there -- see _max_unknown_status_steps.
+                STATUS_UNKNOWN_KEY: torch.tensor(
+                    [float(self.consecutive_unknown_status > 0)], dtype=torch.float
+                ),
+            },
+            batch_size=(),
+        )
         for market_data_name, data in zip(self.market_data_keys, market_data):
             out_td.set(market_data_name, torch.from_numpy(data))
 

--- a/torchtrade/envs/live/alpaca/env.py
+++ b/torchtrade/envs/live/alpaca/env.py
@@ -196,8 +196,7 @@ class AlpacaTorchTradingEnv(AlpacaBaseTorchTradingEnv):
         done = self._check_termination(new_portfolio_value)
 
         next_tensordict.set("reward", torch.tensor([reward], dtype=torch.float))
-        next_tensordict.set("done", torch.tensor([done], dtype=torch.bool))
-        next_tensordict.set("terminated", torch.tensor([done], dtype=torch.bool))
+        self._finalize_step_flags(next_tensordict, terminated=done)
 
         return next_tensordict
 

--- a/torchtrade/envs/live/alpaca/env_sltp.py
+++ b/torchtrade/envs/live/alpaca/env_sltp.py
@@ -241,8 +241,7 @@ class AlpacaSLTPTorchTradingEnv(SLTPMixin, AlpacaBaseTorchTradingEnv):
         done = self._check_termination(new_portfolio_value)
 
         next_tensordict.set("reward", torch.tensor([reward], dtype=torch.float))
-        next_tensordict.set("done", torch.tensor([done], dtype=torch.bool))
-        next_tensordict.set("terminated", torch.tensor([done], dtype=torch.bool))
+        self._finalize_step_flags(next_tensordict, terminated=done)
 
         return next_tensordict
 

--- a/torchtrade/envs/live/binance/env.py
+++ b/torchtrade/envs/live/binance/env.py
@@ -10,6 +10,7 @@ from tensordict import TensorDictBase
 from torchrl.data import Categorical
 
 from torchtrade.envs.utils.timeframe import TimeFrame
+from torchtrade.envs.core.common import validate_unknown_status_budget
 from torchtrade.envs.core.live import (
     ObservationFailurePolicy,
 )
@@ -57,12 +58,17 @@ class BinanceFuturesTradingEnvConfig:
     close_position_on_init: bool = True
     close_position_on_reset: bool = False
     observation_failure_policy: ObservationFailurePolicy | str = ObservationFailurePolicy.HALT
+    # 0 = the pre-#295 posture: the first unreadable venue read raises. Above 0, that many
+    # consecutive unconfirmed reads are ridden out on last-known state (publishing
+    # status_unknown=1.0) before the episode truncates. HALT only -- see _halting.
+    max_unknown_status_steps: int = 0
 
     def __post_init__(self):
         """Normalize timeframe configuration and build action levels."""
         from torchtrade.envs.live.binance.utils import normalize_binance_timeframe_config
 
         self.observation_failure_policy = ObservationFailurePolicy(self.observation_failure_policy)
+        validate_unknown_status_budget(self.max_unknown_status_steps)
 
         self.execute_on, self.time_frames, self.window_sizes = normalize_binance_timeframe_config(
             self.execute_on, self.time_frames, self.window_sizes
@@ -199,8 +205,7 @@ class BinanceFuturesTorchTradingEnv(BinanceBaseTorchTradingEnv):
         done = self._check_termination(new_portfolio_value)
 
         next_tensordict.set("reward", torch.tensor([reward], dtype=torch.float))
-        next_tensordict.set("done", torch.tensor([done], dtype=torch.bool))
-        next_tensordict.set("terminated", torch.tensor([done], dtype=torch.bool))
+        self._finalize_step_flags(next_tensordict, terminated=done)
 
         return next_tensordict
 

--- a/torchtrade/envs/live/binance/env.py
+++ b/torchtrade/envs/live/binance/env.py
@@ -268,7 +268,14 @@ class BinanceFuturesTorchTradingEnv(BinanceBaseTorchTradingEnv):
         # the full portfolio, including margin already locked in open positions.
         # available_balance only shows free margin, which shrinks as positions grow,
         # causing repeated buys when the agent keeps requesting action=1.0.
-        balance_info = self.trader.get_account_balance()
+        # Under `_halting` like every other account read: this is the read that SIZES
+        # the order, and it sat outside the policy -- so during a #295 grace bar the
+        # decision to trade survived on cached state and then died here anyway, with a
+        # bare error rather than a truncation. Cached separately from the pre-trade and
+        # post-bar reads because it is a different shape.
+        balance_info = self._halting(
+            self.trader.get_account_balance, cache_key="balance"
+        )
         # Indexed, and `not (x > 0)`: defaulting to 0.0 turned a broken adapter into a
         # permanent silent refusal to trade, and `<= 0` lets a NaN balance through to
         # size a NaN position (#277).
@@ -329,8 +336,7 @@ class BinanceFuturesTorchTradingEnv(BinanceBaseTorchTradingEnv):
         return position_size, notional_value, side
 
     def _execute_fractional_action(
-        self, action_value: float, *, current_qty: float | None = None,
-        current_price: float | None = None,
+        self, action_value: float, *, current_qty: float, current_price: float,
     ) -> Dict:
         """Execute action using fractional position sizing with query-first pattern.
 
@@ -348,19 +354,11 @@ class BinanceFuturesTorchTradingEnv(BinanceBaseTorchTradingEnv):
             trade_info: Dict with execution details
         """
         # 1. Query actual position from exchange (source of truth)
-        # Threaded from `_step`'s halted read where available. Re-reading here bypassed
-        # `_halting` entirely, so during a #295 grace bar these two calls hit the dead
-        # venue and raised -- no order, no status_unknown, no truncation, on exactly the
-        # bars the grace period exists to cover. okx already threaded them; this is the
-        # other three catching up (#288 parity).
-        #
-        # None means "no caller-supplied read", which is the pre-#295 behaviour and what
-        # the direct-call tests rely on. `test_every_futures_step_threads_its_halted_read`
-        # is what stops a `_step` quietly going back to it.
-        if current_qty is None:
-            current_qty = self._get_current_position_quantity()
-        if current_price is None:
-            current_price = self._current_mark_price()
+        # Threaded from `_step`'s halted read, REQUIRED rather than defaulted. Reading
+        # here bypassed `_halting`, so on a grace bar these hit the dead venue and
+        # raised -- no order, no status_unknown, no truncation, on exactly the bars
+        # grace exists for. A default would restore that silently; omitting the
+        # argument is a TypeError on the first step instead (#295, #288 parity).
 
         # 2. Special case: Close to flat
         if action_value == 0.0:
@@ -426,8 +424,7 @@ class BinanceFuturesTorchTradingEnv(BinanceBaseTorchTradingEnv):
         return info
 
     def _execute_trade_if_needed(
-        self, desired_action: float, *, current_qty: float | None = None,
-        current_price: float | None = None,
+        self, desired_action: float, *, current_qty: float, current_price: float,
     ) -> Dict:
         """
         Execute trade if position change is needed.

--- a/torchtrade/envs/live/binance/env.py
+++ b/torchtrade/envs/live/binance/env.py
@@ -170,7 +170,9 @@ class BinanceFuturesTorchTradingEnv(BinanceBaseTorchTradingEnv):
         desired_action = self._resolve_action_level(tensordict)
 
         # Execute trade
-        trade_info = self._execute_trade_if_needed(desired_action)
+        trade_info = self._execute_trade_if_needed(
+            desired_action, current_qty=position_size, current_price=current_price,
+        )
 
         self._record_position_after_trade(desired_action, trade_info)
 
@@ -326,7 +328,10 @@ class BinanceFuturesTorchTradingEnv(BinanceBaseTorchTradingEnv):
 
         return position_size, notional_value, side
 
-    def _execute_fractional_action(self, action_value: float) -> Dict:
+    def _execute_fractional_action(
+        self, action_value: float, *, current_qty: float | None = None,
+        current_price: float | None = None,
+    ) -> Dict:
         """Execute action using fractional position sizing with query-first pattern.
 
         This implementation:
@@ -343,8 +348,19 @@ class BinanceFuturesTorchTradingEnv(BinanceBaseTorchTradingEnv):
             trade_info: Dict with execution details
         """
         # 1. Query actual position from exchange (source of truth)
-        current_qty = self._get_current_position_quantity()
-        current_price = self._current_mark_price()
+        # Threaded from `_step`'s halted read where available. Re-reading here bypassed
+        # `_halting` entirely, so during a #295 grace bar these two calls hit the dead
+        # venue and raised -- no order, no status_unknown, no truncation, on exactly the
+        # bars the grace period exists to cover. okx already threaded them; this is the
+        # other three catching up (#288 parity).
+        #
+        # None means "no caller-supplied read", which is the pre-#295 behaviour and what
+        # the direct-call tests rely on. `test_every_futures_step_threads_its_halted_read`
+        # is what stops a `_step` quietly going back to it.
+        if current_qty is None:
+            current_qty = self._get_current_position_quantity()
+        if current_price is None:
+            current_price = self._current_mark_price()
 
         # 2. Special case: Close to flat
         if action_value == 0.0:
@@ -409,7 +425,10 @@ class BinanceFuturesTorchTradingEnv(BinanceBaseTorchTradingEnv):
         info["target_tol"] = min_notional / current_price
         return info
 
-    def _execute_trade_if_needed(self, desired_action: float) -> Dict:
+    def _execute_trade_if_needed(
+        self, desired_action: float, *, current_qty: float | None = None,
+        current_price: float | None = None,
+    ) -> Dict:
         """
         Execute trade if position change is needed.
 
@@ -424,4 +443,6 @@ class BinanceFuturesTorchTradingEnv(BinanceBaseTorchTradingEnv):
         if desired_action == self.position.current_action_level:
             return self._create_trade_info(executed=False)
 
-        return self._execute_fractional_action(desired_action)
+        return self._execute_fractional_action(
+            desired_action, current_qty=current_qty, current_price=current_price,
+        )

--- a/torchtrade/envs/live/binance/env.py
+++ b/torchtrade/envs/live/binance/env.py
@@ -268,11 +268,7 @@ class BinanceFuturesTorchTradingEnv(BinanceBaseTorchTradingEnv):
         # the full portfolio, including margin already locked in open positions.
         # available_balance only shows free margin, which shrinks as positions grow,
         # causing repeated buys when the agent keeps requesting action=1.0.
-        # Under `_halting` like every other account read: this is the read that SIZES
-        # the order, and it sat outside the policy -- so during a #295 grace bar the
-        # decision to trade survived on cached state and then died here anyway, with a
-        # bare error rather than a truncation. Cached separately from the pre-trade and
-        # post-bar reads because it is a different shape.
+        # Under `_halting` -- this is the read that SIZES the order (#295).
         balance_info = self._halting(
             self.trader.get_account_balance, cache_key="balance"
         )
@@ -354,13 +350,7 @@ class BinanceFuturesTorchTradingEnv(BinanceBaseTorchTradingEnv):
             trade_info: Dict with execution details
         """
         # 1. Query actual position from exchange (source of truth)
-        # Threaded from `_step`'s halted read, REQUIRED rather than defaulted. Reading
-        # here bypassed `_halting`, so on a grace bar these hit the dead venue and
-        # raised -- no order, no status_unknown, no truncation, on exactly the bars
-        # grace exists for. A default would restore that silently; omitting the
-        # argument is a TypeError on the first step instead (#295, #288 parity).
-
-        # 2. Special case: Close to flat
+        # Threaded from `_step`'s halted read; required, never defaulted (#295).
         if action_value == 0.0:
             if abs(current_qty) > 0:
                 return self._handle_close_action(current_qty)

--- a/torchtrade/envs/live/binance/env.py
+++ b/torchtrade/envs/live/binance/env.py
@@ -58,9 +58,7 @@ class BinanceFuturesTradingEnvConfig:
     close_position_on_init: bool = True
     close_position_on_reset: bool = False
     observation_failure_policy: ObservationFailurePolicy | str = ObservationFailurePolicy.HALT
-    # 0 = the pre-#295 posture: the first unreadable venue read raises. Above 0, that many
-    # consecutive unconfirmed reads are ridden out on last-known state (publishing
-    # status_unknown=1.0) before the episode truncates. HALT only -- see _halting.
+    # Bars to ride out an unreadable venue before truncating; 0 disables (#295).
     max_unknown_status_steps: int = 0
 
     def __post_init__(self):

--- a/torchtrade/envs/live/binance/env.py
+++ b/torchtrade/envs/live/binance/env.py
@@ -268,22 +268,25 @@ class BinanceFuturesTorchTradingEnv(BinanceBaseTorchTradingEnv):
         # the full portfolio, including margin already locked in open positions.
         # available_balance only shows free margin, which shrinks as positions grow,
         # causing repeated buys when the agent keeps requesting action=1.0.
-        # Under `_halting` -- this is the read that SIZES the order (#295).
-        balance_info = self._halting(
-            self.trader.get_account_balance, cache_key="balance"
-        )
-        # Indexed, and `not (x > 0)`: defaulting to 0.0 turned a broken adapter into a
-        # permanent silent refusal to trade, and `<= 0` lets a NaN balance through to
-        # size a NaN position (#277).
-        total_balance = balance_info['total_margin_balance']
+        # The VERDICT is inside the closure, not just the read. `_halting` catches
+        # ValueError precisely so an impossible account state becomes a halt; raising one
+        # frame above it sent that straight out of `_step`. `equity == 0.0` is what a
+        # venue reports while liquidating you -- the worst moment to crash rather than
+        # halt under policy (#295).
+        def read_balance():
+            info = self.trader.get_account_balance()
+            total_balance = info["total_margin_balance"]
+            # isfinite, not `not (x > 0)`: that catches NaN but passes +inf, and an inf
+            # balance sizes an inf target (#277). The name is load-bearing:
+            # test_futures_sizing_rejects_a_non_finite_balance greps for it.
+            if not math.isfinite(total_balance) or total_balance <= 0:
+                raise ValueError(
+                    f"cannot size a trade against a portfolio value of {total_balance}"
+                )
+            return info
 
-        # isfinite, not `not (x > 0)`: that catches NaN but passes +inf, and an inf
-        # balance sizes an inf target -- bitget's amount rounding then yields NaN and
-        # hands it to create_order. Same defect this PR fixed on the baselines (#277).
-        if not math.isfinite(total_balance) or total_balance <= 0:
-            raise ValueError(
-                f"cannot size a trade against a portfolio value of {total_balance}"
-            )
+        balance_info = self._halting(read_balance, cache_key="balance")
+        total_balance = balance_info["total_margin_balance"]
 
         # Use shared utility for core position calculation
         # Reserve 2% buffer for exchange maintenance margin requirements

--- a/torchtrade/envs/live/binance/env_sltp.py
+++ b/torchtrade/envs/live/binance/env_sltp.py
@@ -186,8 +186,7 @@ class BinanceFuturesSLTPTorchTradingEnv(SLTPMixin, BinanceBaseTorchTradingEnv):
         done = self._check_termination(new_portfolio_value)
 
         next_tensordict.set("reward", torch.tensor([reward], dtype=torch.float))
-        next_tensordict.set("done", torch.tensor([done], dtype=torch.bool))
-        next_tensordict.set("terminated", torch.tensor([done], dtype=torch.bool))
+        self._finalize_step_flags(next_tensordict, terminated=done)
 
         return next_tensordict
 

--- a/torchtrade/envs/live/binance/env_sltp.py
+++ b/torchtrade/envs/live/binance/env_sltp.py
@@ -224,17 +224,26 @@ class BinanceFuturesSLTPTorchTradingEnv(SLTPMixin, BinanceBaseTorchTradingEnv):
         if side in self.SIDE_DIRECTION and self.position.current_position == self.SIDE_DIRECTION[side]:
             return trade_info  # Already in this position, ignore duplicate action
 
-        # Get current price for calculating absolute SL/TP levels
-        obs = self.observer.get_observations(return_base_ohlc=True)
-        current_price = float(obs["base_features"][-1, 3])  # Close price
-        # Validated here, not per trade_mode: this price divides the notional sizing
-        # AND prices both brackets in every mode, including the "quantity" default
-        # which checked nothing. bybit/okx get this from _current_mark_price(); these
-        # two read a candle close, which dropna() does not clear of inf (#347).
-        if not math.isfinite(current_price) or current_price <= 0:
-            raise ValueError(
-                f"unusable close price ({current_price}) for {self.config.symbol}"
-            )
+        # Under `_halting`, read AND verdict (#295). `get_observations` raises ValueError
+        # on a short window or a stale last bar, and this sat outside the policy -- so a
+        # degraded feed escaped as a bare ValueError in EVERY trade_mode, since this runs
+        # before the mode branch. bybit/okx take a threaded mark instead; these two price
+        # brackets off the candle close deliberately, so the read stays rather than being
+        # replaced by the mark.
+        def read_close():
+            obs = self.observer.get_observations(return_base_ohlc=True)
+            current_price = float(obs["base_features"][-1, 3])
+            # This price divides the notional sizing AND prices both brackets in every
+            # mode, including the "quantity" default which checked nothing. dropna() does
+            # not clear a candle close of inf (#347). The name is load-bearing:
+            # test_sltp_sizing_rejects_a_non_finite_price_or_balance greps for it.
+            if not math.isfinite(current_price) or current_price <= 0:
+                raise ValueError(
+                    f"unusable close price ({current_price}) for {self.config.symbol}"
+                )
+            return current_price
+
+        current_price = self._halting(read_close)
 
         # Resolve quantity based on trade_mode
         if self.config.trade_mode == "fractional":

--- a/torchtrade/envs/live/binance/env_sltp.py
+++ b/torchtrade/envs/live/binance/env_sltp.py
@@ -241,9 +241,7 @@ class BinanceFuturesSLTPTorchTradingEnv(SLTPMixin, BinanceBaseTorchTradingEnv):
             # Size on total_margin_balance (equity), matching offline sizing and the non-SLTP
             # live path. Binance's total_wallet_balance excludes unrealized PnL and would under-size;
             # bitget/bybit/okx map both keys to equity, so the switch is a no-op there.
-            # Under `_halting` like the plain envs' sizing read (#295). This is the read
-            # that SIZES a bracket order, and it was left raw when the plain path was
-            # fixed -- the same "landed on some venues, not others" shape #288 is about.
+            # Under `_halting` -- the read that SIZES a bracket (#295).
             balance = float(
                 self._halting(self.trader.get_account_balance, cache_key="balance")[
                     "total_margin_balance"

--- a/torchtrade/envs/live/binance/env_sltp.py
+++ b/torchtrade/envs/live/binance/env_sltp.py
@@ -243,7 +243,11 @@ class BinanceFuturesSLTPTorchTradingEnv(SLTPMixin, BinanceBaseTorchTradingEnv):
                 )
             return current_price
 
-        current_price = self._halting(read_close)
+        # cache_key is load-bearing, not decoration: without it `cached` is None, grace
+        # cannot apply, and this still raises -- it just raises a nicer type. The claimed
+        # behaviour is "serve the last CONFIRMED close and flag the bar", which needs a
+        # slot to serve from. Its own slot, because it is a candle close, not the mark.
+        current_price = self._halting(read_close, cache_key="candle_close")
 
         # Resolve quantity based on trade_mode
         if self.config.trade_mode == "fractional":

--- a/torchtrade/envs/live/binance/env_sltp.py
+++ b/torchtrade/envs/live/binance/env_sltp.py
@@ -241,7 +241,14 @@ class BinanceFuturesSLTPTorchTradingEnv(SLTPMixin, BinanceBaseTorchTradingEnv):
             # Size on total_margin_balance (equity), matching offline sizing and the non-SLTP
             # live path. Binance's total_wallet_balance excludes unrealized PnL and would under-size;
             # bitget/bybit/okx map both keys to equity, so the switch is a no-op there.
-            balance = float(self.trader.get_account_balance()["total_margin_balance"])
+            # Under `_halting` like the plain envs' sizing read (#295). This is the read
+            # that SIZES a bracket order, and it was left raw when the plain path was
+            # fixed -- the same "landed on some venues, not others" shape #288 is about.
+            balance = float(
+                self._halting(self.trader.get_account_balance, cache_key="balance")[
+                    "total_margin_balance"
+                ]
+            )
             if not math.isfinite(balance) or balance <= 0:
                 logger.error(f"Invalid price={current_price} or balance={balance} for {self.config.symbol}")
                 trade_info["success"] = False

--- a/torchtrade/envs/live/binance/env_sltp.py
+++ b/torchtrade/envs/live/binance/env_sltp.py
@@ -311,6 +311,9 @@ class BinanceFuturesSLTPTorchTradingEnv(SLTPMixin, BinanceBaseTorchTradingEnv):
                     return trade_info
                 if not close_success:
                     return trade_info
+                # A realised close moves equity; the cached balance is now wrong by the
+                # trade's P&L. Reached only on success (#295).
+                self._last_confirmed_read.pop("balance", None)
                 self.position.current_position = 0
 
         if side == "long":

--- a/torchtrade/envs/live/bitget/env.py
+++ b/torchtrade/envs/live/bitget/env.py
@@ -228,22 +228,25 @@ class BitgetFuturesTorchTradingEnv(BitgetBaseTorchTradingEnv):
         # Get actual balance from exchange
         # Use total_margin_balance (not available_balance) so the target reflects
         # the full portfolio, including margin already locked in open positions.
-        # Under `_halting` -- this is the read that SIZES the order (#295).
-        balance_info = self._halting(
-            self.trader.get_account_balance, cache_key="balance"
-        )
-        # Indexed, and `not (x > 0)`: defaulting to 0.0 turned a broken adapter into a
-        # permanent silent refusal to trade, and `<= 0` lets a NaN balance through to
-        # size a NaN position (#277).
-        total_balance = balance_info['total_margin_balance']
+        # The VERDICT is inside the closure, not just the read. `_halting` catches
+        # ValueError precisely so an impossible account state becomes a halt; raising one
+        # frame above it sent that straight out of `_step`. `equity == 0.0` is what a
+        # venue reports while liquidating you -- the worst moment to crash rather than
+        # halt under policy (#295).
+        def read_balance():
+            info = self.trader.get_account_balance()
+            total_balance = info["total_margin_balance"]
+            # isfinite, not `not (x > 0)`: that catches NaN but passes +inf, and an inf
+            # balance sizes an inf target (#277). The name is load-bearing:
+            # test_futures_sizing_rejects_a_non_finite_balance greps for it.
+            if not math.isfinite(total_balance) or total_balance <= 0:
+                raise ValueError(
+                    f"cannot size a trade against a portfolio value of {total_balance}"
+                )
+            return info
 
-        # isfinite, not `not (x > 0)`: that catches NaN but passes +inf, and an inf
-        # balance sizes an inf target -- bitget's amount rounding then yields NaN and
-        # hands it to create_order. Same defect this PR fixed on the baselines (#277).
-        if not math.isfinite(total_balance) or total_balance <= 0:
-            raise ValueError(
-                f"cannot size a trade against a portfolio value of {total_balance}"
-            )
+        balance_info = self._halting(read_balance, cache_key="balance")
+        total_balance = balance_info["total_margin_balance"]
 
         # Use shared utility for core position calculation
         # Reserve 2% buffer for exchange maintenance margin requirements

--- a/torchtrade/envs/live/bitget/env.py
+++ b/torchtrade/envs/live/bitget/env.py
@@ -228,7 +228,14 @@ class BitgetFuturesTorchTradingEnv(BitgetBaseTorchTradingEnv):
         # Get actual balance from exchange
         # Use total_margin_balance (not available_balance) so the target reflects
         # the full portfolio, including margin already locked in open positions.
-        balance_info = self.trader.get_account_balance()
+        # Under `_halting` like every other account read: this is the read that SIZES
+        # the order, and it sat outside the policy -- so during a #295 grace bar the
+        # decision to trade survived on cached state and then died here anyway, with a
+        # bare error rather than a truncation. Cached separately from the pre-trade and
+        # post-bar reads because it is a different shape.
+        balance_info = self._halting(
+            self.trader.get_account_balance, cache_key="balance"
+        )
         # Indexed, and `not (x > 0)`: defaulting to 0.0 turned a broken adapter into a
         # permanent silent refusal to trade, and `<= 0` lets a NaN balance through to
         # size a NaN position (#277).
@@ -257,8 +264,7 @@ class BitgetFuturesTorchTradingEnv(BitgetBaseTorchTradingEnv):
         return position_size, notional_value, side
 
     def _execute_fractional_action(
-        self, action_value: float, *, current_qty: float | None = None,
-        current_price: float | None = None,
+        self, action_value: float, *, current_qty: float, current_price: float,
     ) -> Dict:
         """Execute action using fractional position sizing.
 
@@ -269,19 +275,11 @@ class BitgetFuturesTorchTradingEnv(BitgetBaseTorchTradingEnv):
             trade_info: Dict with execution details
         """
         # Get current position and price from exchange
-        # Threaded from `_step`'s halted read where available. Re-reading here bypassed
-        # `_halting` entirely, so during a #295 grace bar these two calls hit the dead
-        # venue and raised -- no order, no status_unknown, no truncation, on exactly the
-        # bars the grace period exists to cover. okx already threaded them; this is the
-        # other three catching up (#288 parity).
-        #
-        # None means "no caller-supplied read", which is the pre-#295 behaviour and what
-        # the direct-call tests rely on. `test_every_futures_step_threads_its_halted_read`
-        # is what stops a `_step` quietly going back to it.
-        if current_qty is None:
-            current_qty = self._get_current_position_quantity()
-        if current_price is None:
-            current_price = self._current_mark_price()
+        # Threaded from `_step`'s halted read, REQUIRED rather than defaulted. Reading
+        # here bypassed `_halting`, so on a grace bar these hit the dead venue and
+        # raised -- no order, no status_unknown, no truncation, on exactly the bars
+        # grace exists for. A default would restore that silently; omitting the
+        # argument is a TypeError on the first step instead (#295, #288 parity).
 
         # Special case: Close to flat
         if action_value == 0.0:
@@ -317,8 +315,7 @@ class BitgetFuturesTorchTradingEnv(BitgetBaseTorchTradingEnv):
         return info
 
     def _execute_trade_if_needed(
-        self, desired_action: float, *, current_qty: float | None = None,
-        current_price: float | None = None,
+        self, desired_action: float, *, current_qty: float, current_price: float,
     ) -> Dict:
         """Execute trade based on desired action value.
 

--- a/torchtrade/envs/live/bitget/env.py
+++ b/torchtrade/envs/live/bitget/env.py
@@ -166,7 +166,9 @@ class BitgetFuturesTorchTradingEnv(BitgetBaseTorchTradingEnv):
         desired_action = self._resolve_action_level(tensordict)
 
         # Calculate and execute trade if needed
-        trade_info = self._execute_trade_if_needed(desired_action)
+        trade_info = self._execute_trade_if_needed(
+            desired_action, current_qty=position_size, current_price=current_price,
+        )
 
         self._record_position_after_trade(desired_action, trade_info)
 
@@ -254,7 +256,10 @@ class BitgetFuturesTorchTradingEnv(BitgetBaseTorchTradingEnv):
 
         return position_size, notional_value, side
 
-    def _execute_fractional_action(self, action_value: float) -> Dict:
+    def _execute_fractional_action(
+        self, action_value: float, *, current_qty: float | None = None,
+        current_price: float | None = None,
+    ) -> Dict:
         """Execute action using fractional position sizing.
 
         Args:
@@ -264,8 +269,19 @@ class BitgetFuturesTorchTradingEnv(BitgetBaseTorchTradingEnv):
             trade_info: Dict with execution details
         """
         # Get current position and price from exchange
-        current_qty = self._get_current_position_quantity()
-        current_price = self._current_mark_price()
+        # Threaded from `_step`'s halted read where available. Re-reading here bypassed
+        # `_halting` entirely, so during a #295 grace bar these two calls hit the dead
+        # venue and raised -- no order, no status_unknown, no truncation, on exactly the
+        # bars the grace period exists to cover. okx already threaded them; this is the
+        # other three catching up (#288 parity).
+        #
+        # None means "no caller-supplied read", which is the pre-#295 behaviour and what
+        # the direct-call tests rely on. `test_every_futures_step_threads_its_halted_read`
+        # is what stops a `_step` quietly going back to it.
+        if current_qty is None:
+            current_qty = self._get_current_position_quantity()
+        if current_price is None:
+            current_price = self._current_mark_price()
 
         # Special case: Close to flat
         if action_value == 0.0:
@@ -300,7 +316,10 @@ class BitgetFuturesTorchTradingEnv(BitgetBaseTorchTradingEnv):
         info["target_tol"] = min_qty
         return info
 
-    def _execute_trade_if_needed(self, desired_action: float) -> Dict:
+    def _execute_trade_if_needed(
+        self, desired_action: float, *, current_qty: float | None = None,
+        current_price: float | None = None,
+    ) -> Dict:
         """Execute trade based on desired action value.
 
         Skips execution if already in the requested position direction.
@@ -314,4 +333,6 @@ class BitgetFuturesTorchTradingEnv(BitgetBaseTorchTradingEnv):
         if desired_action == self.position.current_action_level:
             return self._create_trade_info(executed=False)
 
-        return self._execute_fractional_action(desired_action)
+        return self._execute_fractional_action(
+            desired_action, current_qty=current_qty, current_price=current_price,
+        )

--- a/torchtrade/envs/live/bitget/env.py
+++ b/torchtrade/envs/live/bitget/env.py
@@ -14,6 +14,7 @@ from torchtrade.envs.live.bitget.order_executor import (
     PositionMode,
 )
 from torchtrade.envs.live.bitget.base import BitgetBaseTorchTradingEnv
+from torchtrade.envs.core.common import validate_unknown_status_budget
 from torchtrade.envs.core.live import (
     ObservationFailurePolicy,
 )
@@ -56,9 +57,14 @@ class BitgetFuturesTradingEnvConfig:
     close_position_on_init: bool = True
     close_position_on_reset: bool = False
     observation_failure_policy: ObservationFailurePolicy | str = ObservationFailurePolicy.HALT
+    # 0 = the pre-#295 posture: the first unreadable venue read raises. Above 0, that many
+    # consecutive unconfirmed reads are ridden out on last-known state (publishing
+    # status_unknown=1.0) before the episode truncates. HALT only -- see _halting.
+    max_unknown_status_steps: int = 0
 
     def __post_init__(self):
         self.observation_failure_policy = ObservationFailurePolicy(self.observation_failure_policy)
+        validate_unknown_status_budget(self.max_unknown_status_steps)
         # Normalize timeframes using utility function
         from torchtrade.envs.live.bitget.utils import normalize_bitget_timeframe_config
         self.execute_on, self.time_frames, self.window_sizes = normalize_bitget_timeframe_config(
@@ -195,8 +201,7 @@ class BitgetFuturesTorchTradingEnv(BitgetBaseTorchTradingEnv):
         done = self._check_termination(new_portfolio_value)
 
         next_tensordict.set("reward", torch.tensor([reward], dtype=torch.float))
-        next_tensordict.set("done", torch.tensor([done], dtype=torch.bool))
-        next_tensordict.set("terminated", torch.tensor([done], dtype=torch.bool))
+        self._finalize_step_flags(next_tensordict, terminated=done)
 
         return next_tensordict
 

--- a/torchtrade/envs/live/bitget/env.py
+++ b/torchtrade/envs/live/bitget/env.py
@@ -57,9 +57,7 @@ class BitgetFuturesTradingEnvConfig:
     close_position_on_init: bool = True
     close_position_on_reset: bool = False
     observation_failure_policy: ObservationFailurePolicy | str = ObservationFailurePolicy.HALT
-    # 0 = the pre-#295 posture: the first unreadable venue read raises. Above 0, that many
-    # consecutive unconfirmed reads are ridden out on last-known state (publishing
-    # status_unknown=1.0) before the episode truncates. HALT only -- see _halting.
+    # Bars to ride out an unreadable venue before truncating; 0 disables (#295).
     max_unknown_status_steps: int = 0
 
     def __post_init__(self):

--- a/torchtrade/envs/live/bitget/env.py
+++ b/torchtrade/envs/live/bitget/env.py
@@ -228,11 +228,7 @@ class BitgetFuturesTorchTradingEnv(BitgetBaseTorchTradingEnv):
         # Get actual balance from exchange
         # Use total_margin_balance (not available_balance) so the target reflects
         # the full portfolio, including margin already locked in open positions.
-        # Under `_halting` like every other account read: this is the read that SIZES
-        # the order, and it sat outside the policy -- so during a #295 grace bar the
-        # decision to trade survived on cached state and then died here anyway, with a
-        # bare error rather than a truncation. Cached separately from the pre-trade and
-        # post-bar reads because it is a different shape.
+        # Under `_halting` -- this is the read that SIZES the order (#295).
         balance_info = self._halting(
             self.trader.get_account_balance, cache_key="balance"
         )
@@ -275,13 +271,7 @@ class BitgetFuturesTorchTradingEnv(BitgetBaseTorchTradingEnv):
             trade_info: Dict with execution details
         """
         # Get current position and price from exchange
-        # Threaded from `_step`'s halted read, REQUIRED rather than defaulted. Reading
-        # here bypassed `_halting`, so on a grace bar these hit the dead venue and
-        # raised -- no order, no status_unknown, no truncation, on exactly the bars
-        # grace exists for. A default would restore that silently; omitting the
-        # argument is a TypeError on the first step instead (#295, #288 parity).
-
-        # Special case: Close to flat
+        # Threaded from `_step`'s halted read; required, never defaulted (#295).
         if action_value == 0.0:
             if abs(current_qty) > 0:
                 return self._handle_close_action(current_qty)

--- a/torchtrade/envs/live/bitget/env_sltp.py
+++ b/torchtrade/envs/live/bitget/env_sltp.py
@@ -193,8 +193,7 @@ class BitgetFuturesSLTPTorchTradingEnv(SLTPMixin, BitgetBaseTorchTradingEnv):
         done = self._check_termination(new_portfolio_value)
 
         next_tensordict.set("reward", torch.tensor([reward], dtype=torch.float))
-        next_tensordict.set("done", torch.tensor([done], dtype=torch.bool))
-        next_tensordict.set("terminated", torch.tensor([done], dtype=torch.bool))
+        self._finalize_step_flags(next_tensordict, terminated=done)
 
         return next_tensordict
 

--- a/torchtrade/envs/live/bitget/env_sltp.py
+++ b/torchtrade/envs/live/bitget/env_sltp.py
@@ -248,7 +248,14 @@ class BitgetFuturesSLTPTorchTradingEnv(SLTPMixin, BitgetBaseTorchTradingEnv):
             # Size on total_margin_balance (equity), matching offline sizing and the non-SLTP
             # live path. Binance's total_wallet_balance excludes unrealized PnL and would under-size;
             # bitget/bybit/okx map both keys to equity, so the switch is a no-op there.
-            balance = float(self.trader.get_account_balance()["total_margin_balance"])
+            # Under `_halting` like the plain envs' sizing read (#295). This is the read
+            # that SIZES a bracket order, and it was left raw when the plain path was
+            # fixed -- the same "landed on some venues, not others" shape #288 is about.
+            balance = float(
+                self._halting(self.trader.get_account_balance, cache_key="balance")[
+                    "total_margin_balance"
+                ]
+            )
             if not math.isfinite(balance) or balance <= 0:
                 logger.error(f"Invalid price={current_price} or balance={balance} for {self.config.symbol}")
                 trade_info["success"] = False

--- a/torchtrade/envs/live/bitget/env_sltp.py
+++ b/torchtrade/envs/live/bitget/env_sltp.py
@@ -248,9 +248,7 @@ class BitgetFuturesSLTPTorchTradingEnv(SLTPMixin, BitgetBaseTorchTradingEnv):
             # Size on total_margin_balance (equity), matching offline sizing and the non-SLTP
             # live path. Binance's total_wallet_balance excludes unrealized PnL and would under-size;
             # bitget/bybit/okx map both keys to equity, so the switch is a no-op there.
-            # Under `_halting` like the plain envs' sizing read (#295). This is the read
-            # that SIZES a bracket order, and it was left raw when the plain path was
-            # fixed -- the same "landed on some venues, not others" shape #288 is about.
+            # Under `_halting` -- the read that SIZES a bracket (#295).
             balance = float(
                 self._halting(self.trader.get_account_balance, cache_key="balance")[
                     "total_margin_balance"

--- a/torchtrade/envs/live/bitget/env_sltp.py
+++ b/torchtrade/envs/live/bitget/env_sltp.py
@@ -318,6 +318,9 @@ class BitgetFuturesSLTPTorchTradingEnv(SLTPMixin, BitgetBaseTorchTradingEnv):
                     return trade_info
                 if not close_success:
                     return trade_info
+                # A realised close moves equity; the cached balance is now wrong by the
+                # trade's P&L. Reached only on success (#295).
+                self._last_confirmed_read.pop("balance", None)
                 self.position.current_position = 0
 
         if side == "long":

--- a/torchtrade/envs/live/bitget/env_sltp.py
+++ b/torchtrade/envs/live/bitget/env_sltp.py
@@ -231,17 +231,26 @@ class BitgetFuturesSLTPTorchTradingEnv(SLTPMixin, BitgetBaseTorchTradingEnv):
         if side in self.SIDE_DIRECTION and self.position.current_position == self.SIDE_DIRECTION[side]:
             return trade_info  # Already in this position, ignore duplicate action
 
-        # Get current price for calculating absolute SL/TP levels
-        obs = self.observer.get_observations(return_base_ohlc=True)
-        current_price = float(obs["base_features"][-1, 3])  # Close price
-        # Validated here, not per trade_mode: this price divides the notional sizing
-        # AND prices both brackets in every mode, including the "quantity" default
-        # which checked nothing. bybit/okx get this from _current_mark_price(); these
-        # two read a candle close, which dropna() does not clear of inf (#347).
-        if not math.isfinite(current_price) or current_price <= 0:
-            raise ValueError(
-                f"unusable close price ({current_price}) for {self.config.symbol}"
-            )
+        # Under `_halting`, read AND verdict (#295). `get_observations` raises ValueError
+        # on a short window or a stale last bar, and this sat outside the policy -- so a
+        # degraded feed escaped as a bare ValueError in EVERY trade_mode, since this runs
+        # before the mode branch. bybit/okx take a threaded mark instead; these two price
+        # brackets off the candle close deliberately, so the read stays rather than being
+        # replaced by the mark.
+        def read_close():
+            obs = self.observer.get_observations(return_base_ohlc=True)
+            current_price = float(obs["base_features"][-1, 3])
+            # This price divides the notional sizing AND prices both brackets in every
+            # mode, including the "quantity" default which checked nothing. dropna() does
+            # not clear a candle close of inf (#347). The name is load-bearing:
+            # test_sltp_sizing_rejects_a_non_finite_price_or_balance greps for it.
+            if not math.isfinite(current_price) or current_price <= 0:
+                raise ValueError(
+                    f"unusable close price ({current_price}) for {self.config.symbol}"
+                )
+            return current_price
+
+        current_price = self._halting(read_close)
 
         # Resolve quantity based on trade_mode
         if self.config.trade_mode == "fractional":

--- a/torchtrade/envs/live/bitget/env_sltp.py
+++ b/torchtrade/envs/live/bitget/env_sltp.py
@@ -250,7 +250,11 @@ class BitgetFuturesSLTPTorchTradingEnv(SLTPMixin, BitgetBaseTorchTradingEnv):
                 )
             return current_price
 
-        current_price = self._halting(read_close)
+        # cache_key is load-bearing, not decoration: without it `cached` is None, grace
+        # cannot apply, and this still raises -- it just raises a nicer type. The claimed
+        # behaviour is "serve the last CONFIRMED close and flag the bar", which needs a
+        # slot to serve from. Its own slot, because it is a candle close, not the mark.
+        current_price = self._halting(read_close, cache_key="candle_close")
 
         # Resolve quantity based on trade_mode
         if self.config.trade_mode == "fractional":

--- a/torchtrade/envs/live/bybit/env.py
+++ b/torchtrade/envs/live/bybit/env.py
@@ -163,11 +163,7 @@ class BybitFuturesTorchTradingEnv(BybitBaseTorchTradingEnv):
         if action_value == 0.0:
             return 0.0, 0.0, "flat"
 
-        # Under `_halting` like every other account read: this is the read that SIZES
-        # the order, and it sat outside the policy -- so during a #295 grace bar the
-        # decision to trade survived on cached state and then died here anyway, with a
-        # bare error rather than a truncation. Cached separately from the pre-trade and
-        # post-bar reads because it is a different shape.
+        # Under `_halting` -- this is the read that SIZES the order (#295).
         balance_info = self._halting(
             self.trader.get_account_balance, cache_key="balance"
         )
@@ -198,12 +194,7 @@ class BybitFuturesTorchTradingEnv(BybitBaseTorchTradingEnv):
         self, action_value: float, *, current_qty: float, current_price: float,
     ) -> Dict:
         """Execute action using fractional position sizing."""
-        # Threaded from `_step`'s halted read, REQUIRED rather than defaulted. Reading
-        # here bypassed `_halting`, so on a grace bar these hit the dead venue and
-        # raised -- no order, no status_unknown, no truncation, on exactly the bars
-        # grace exists for. A default would restore that silently; omitting the
-        # argument is a TypeError on the first step instead (#295, #288 parity).
-
+        # Threaded from `_step`'s halted read; required, never defaulted (#295).
         if action_value == 0.0:
             if abs(current_qty) > 0:
                 return self._handle_close_action(current_qty)

--- a/torchtrade/envs/live/bybit/env.py
+++ b/torchtrade/envs/live/bybit/env.py
@@ -58,9 +58,7 @@ class BybitFuturesTradingEnvConfig:
     close_position_on_init: bool = True
     close_position_on_reset: bool = False
     observation_failure_policy: ObservationFailurePolicy | str = ObservationFailurePolicy.HALT
-    # 0 = the pre-#295 posture: the first unreadable venue read raises. Above 0, that many
-    # consecutive unconfirmed reads are ridden out on last-known state (publishing
-    # status_unknown=1.0) before the episode truncates. HALT only -- see _halting.
+    # Bars to ride out an unreadable venue before truncating; 0 disables (#295).
     max_unknown_status_steps: int = 0
 
     def __post_init__(self):

--- a/torchtrade/envs/live/bybit/env.py
+++ b/torchtrade/envs/live/bybit/env.py
@@ -17,6 +17,7 @@ from torchtrade.envs.live.bybit.order_executor import (
     PositionMode,
 )
 from torchtrade.envs.live.bybit.base import BybitBaseTorchTradingEnv
+from torchtrade.envs.core.common import validate_unknown_status_budget
 from torchtrade.envs.core.live import (
     ObservationFailurePolicy,
 )
@@ -57,9 +58,14 @@ class BybitFuturesTradingEnvConfig:
     close_position_on_init: bool = True
     close_position_on_reset: bool = False
     observation_failure_policy: ObservationFailurePolicy | str = ObservationFailurePolicy.HALT
+    # 0 = the pre-#295 posture: the first unreadable venue read raises. Above 0, that many
+    # consecutive unconfirmed reads are ridden out on last-known state (publishing
+    # status_unknown=1.0) before the episode truncates. HALT only -- see _halting.
+    max_unknown_status_steps: int = 0
 
     def __post_init__(self):
         self.observation_failure_policy = ObservationFailurePolicy(self.observation_failure_policy)
+        validate_unknown_status_budget(self.max_unknown_status_steps)
         from torchtrade.envs.live.bybit.utils import normalize_bybit_timeframe_config
         self.execute_on, self.time_frames, self.window_sizes = normalize_bybit_timeframe_config(
             self.execute_on, self.time_frames, self.window_sizes
@@ -147,8 +153,7 @@ class BybitFuturesTorchTradingEnv(BybitBaseTorchTradingEnv):
         done = self._check_termination(new_portfolio_value)
 
         next_tensordict.set("reward", torch.tensor([reward], dtype=torch.float))
-        next_tensordict.set("done", torch.tensor([done], dtype=torch.bool))
-        next_tensordict.set("terminated", torch.tensor([done], dtype=torch.bool))
+        self._finalize_step_flags(next_tensordict, terminated=done)
 
         return next_tensordict
 

--- a/torchtrade/envs/live/bybit/env.py
+++ b/torchtrade/envs/live/bybit/env.py
@@ -163,22 +163,25 @@ class BybitFuturesTorchTradingEnv(BybitBaseTorchTradingEnv):
         if action_value == 0.0:
             return 0.0, 0.0, "flat"
 
-        # Under `_halting` -- this is the read that SIZES the order (#295).
-        balance_info = self._halting(
-            self.trader.get_account_balance, cache_key="balance"
-        )
-        # Indexed, and `not (x > 0)`: defaulting to 0.0 turned a broken adapter into a
-        # permanent silent refusal to trade, and `<= 0` lets a NaN balance through to
-        # size a NaN position (#277).
-        total_balance = balance_info['total_margin_balance']
+        # The VERDICT is inside the closure, not just the read. `_halting` catches
+        # ValueError precisely so an impossible account state becomes a halt; raising one
+        # frame above it sent that straight out of `_step`. `equity == 0.0` is what a
+        # venue reports while liquidating you -- the worst moment to crash rather than
+        # halt under policy (#295).
+        def read_balance():
+            info = self.trader.get_account_balance()
+            total_balance = info["total_margin_balance"]
+            # isfinite, not `not (x > 0)`: that catches NaN but passes +inf, and an inf
+            # balance sizes an inf target (#277). The name is load-bearing:
+            # test_futures_sizing_rejects_a_non_finite_balance greps for it.
+            if not math.isfinite(total_balance) or total_balance <= 0:
+                raise ValueError(
+                    f"cannot size a trade against a portfolio value of {total_balance}"
+                )
+            return info
 
-        # isfinite, not `not (x > 0)`: that catches NaN but passes +inf, and an inf
-        # balance sizes an inf target -- bitget's amount rounding then yields NaN and
-        # hands it to create_order. Same defect this PR fixed on the baselines (#277).
-        if not math.isfinite(total_balance) or total_balance <= 0:
-            raise ValueError(
-                f"cannot size a trade against a portfolio value of {total_balance}"
-            )
+        balance_info = self._halting(read_balance, cache_key="balance")
+        total_balance = balance_info["total_margin_balance"]
 
         effective_balance = total_balance * 0.98
         params = PositionCalculationParams(

--- a/torchtrade/envs/live/bybit/env.py
+++ b/torchtrade/envs/live/bybit/env.py
@@ -125,7 +125,9 @@ class BybitFuturesTorchTradingEnv(BybitBaseTorchTradingEnv):
 
         desired_action = self._resolve_action_level(tensordict)
 
-        trade_info = self._execute_trade_if_needed(desired_action)
+        trade_info = self._execute_trade_if_needed(
+            desired_action, current_qty=position_size, current_price=current_price,
+        )
 
         self._record_position_after_trade(desired_action, trade_info)
 
@@ -185,10 +187,24 @@ class BybitFuturesTorchTradingEnv(BybitBaseTorchTradingEnv):
         )
         return calculate_fractional_position(params)
 
-    def _execute_fractional_action(self, action_value: float) -> Dict:
+    def _execute_fractional_action(
+        self, action_value: float, *, current_qty: float | None = None,
+        current_price: float | None = None,
+    ) -> Dict:
         """Execute action using fractional position sizing."""
-        current_qty = self._get_current_position_quantity()
-        current_price = self._current_mark_price()
+        # Threaded from `_step`'s halted read where available. Re-reading here bypassed
+        # `_halting` entirely, so during a #295 grace bar these two calls hit the dead
+        # venue and raised -- no order, no status_unknown, no truncation, on exactly the
+        # bars the grace period exists to cover. okx already threaded them; this is the
+        # other three catching up (#288 parity).
+        #
+        # None means "no caller-supplied read", which is the pre-#295 behaviour and what
+        # the direct-call tests rely on. `test_every_futures_step_threads_its_halted_read`
+        # is what stops a `_step` quietly going back to it.
+        if current_qty is None:
+            current_qty = self._get_current_position_quantity()
+        if current_price is None:
+            current_price = self._current_mark_price()
 
         if action_value == 0.0:
             if abs(current_qty) > 0:
@@ -219,6 +235,11 @@ class BybitFuturesTorchTradingEnv(BybitBaseTorchTradingEnv):
         info["target_tol"] = lot_size["min_qty"]
         return info
 
-    def _execute_trade_if_needed(self, desired_action: float) -> Dict:
+    def _execute_trade_if_needed(
+        self, desired_action: float, *, current_qty: float | None = None,
+        current_price: float | None = None,
+    ) -> Dict:
         """Execute trade based on desired action value."""
-        return self._execute_fractional_action(desired_action)
+        return self._execute_fractional_action(
+            desired_action, current_qty=current_qty, current_price=current_price,
+        )

--- a/torchtrade/envs/live/bybit/env.py
+++ b/torchtrade/envs/live/bybit/env.py
@@ -118,7 +118,7 @@ class BybitFuturesTorchTradingEnv(BybitBaseTorchTradingEnv):
         """Execute one environment step."""
         status, position_status, current_price, position_size = self._acquire_pre_trade_state()
 
-        # No-op today (this env's _execute_trade_if_needed recomputes qty live and never reads
+        # No-op today (this env's _execute_trade_if_needed takes the threaded qty (#295) and never reads
         # current_action_level), but keeps the field consistent so adding a duplicate-action
         # guard here can't reintroduce the silent no-op that bit alpaca/binance/bitget.
         self._sync_position_from_exchange(position_status)
@@ -163,7 +163,14 @@ class BybitFuturesTorchTradingEnv(BybitBaseTorchTradingEnv):
         if action_value == 0.0:
             return 0.0, 0.0, "flat"
 
-        balance_info = self.trader.get_account_balance()
+        # Under `_halting` like every other account read: this is the read that SIZES
+        # the order, and it sat outside the policy -- so during a #295 grace bar the
+        # decision to trade survived on cached state and then died here anyway, with a
+        # bare error rather than a truncation. Cached separately from the pre-trade and
+        # post-bar reads because it is a different shape.
+        balance_info = self._halting(
+            self.trader.get_account_balance, cache_key="balance"
+        )
         # Indexed, and `not (x > 0)`: defaulting to 0.0 turned a broken adapter into a
         # permanent silent refusal to trade, and `<= 0` lets a NaN balance through to
         # size a NaN position (#277).
@@ -188,23 +195,14 @@ class BybitFuturesTorchTradingEnv(BybitBaseTorchTradingEnv):
         return calculate_fractional_position(params)
 
     def _execute_fractional_action(
-        self, action_value: float, *, current_qty: float | None = None,
-        current_price: float | None = None,
+        self, action_value: float, *, current_qty: float, current_price: float,
     ) -> Dict:
         """Execute action using fractional position sizing."""
-        # Threaded from `_step`'s halted read where available. Re-reading here bypassed
-        # `_halting` entirely, so during a #295 grace bar these two calls hit the dead
-        # venue and raised -- no order, no status_unknown, no truncation, on exactly the
-        # bars the grace period exists to cover. okx already threaded them; this is the
-        # other three catching up (#288 parity).
-        #
-        # None means "no caller-supplied read", which is the pre-#295 behaviour and what
-        # the direct-call tests rely on. `test_every_futures_step_threads_its_halted_read`
-        # is what stops a `_step` quietly going back to it.
-        if current_qty is None:
-            current_qty = self._get_current_position_quantity()
-        if current_price is None:
-            current_price = self._current_mark_price()
+        # Threaded from `_step`'s halted read, REQUIRED rather than defaulted. Reading
+        # here bypassed `_halting`, so on a grace bar these hit the dead venue and
+        # raised -- no order, no status_unknown, no truncation, on exactly the bars
+        # grace exists for. A default would restore that silently; omitting the
+        # argument is a TypeError on the first step instead (#295, #288 parity).
 
         if action_value == 0.0:
             if abs(current_qty) > 0:
@@ -236,8 +234,7 @@ class BybitFuturesTorchTradingEnv(BybitBaseTorchTradingEnv):
         return info
 
     def _execute_trade_if_needed(
-        self, desired_action: float, *, current_qty: float | None = None,
-        current_price: float | None = None,
+        self, desired_action: float, *, current_qty: float, current_price: float,
     ) -> Dict:
         """Execute trade based on desired action value."""
         return self._execute_fractional_action(

--- a/torchtrade/envs/live/bybit/env_sltp.py
+++ b/torchtrade/envs/live/bybit/env_sltp.py
@@ -141,8 +141,7 @@ class BybitFuturesSLTPTorchTradingEnv(SLTPMixin, BybitBaseTorchTradingEnv):
         done = self._check_termination(new_portfolio_value)
 
         next_tensordict.set("reward", torch.tensor([reward], dtype=torch.float))
-        next_tensordict.set("done", torch.tensor([done], dtype=torch.bool))
-        next_tensordict.set("terminated", torch.tensor([done], dtype=torch.bool))
+        self._finalize_step_flags(next_tensordict, terminated=done)
 
         return next_tensordict
 

--- a/torchtrade/envs/live/bybit/env_sltp.py
+++ b/torchtrade/envs/live/bybit/env_sltp.py
@@ -195,10 +195,7 @@ class BybitFuturesSLTPTorchTradingEnv(SLTPMixin, BybitBaseTorchTradingEnv):
             return trade_info
 
         # Get current mark price (more accurate than candle close for bracket orders)
-        # Threaded from `_step`'s halted read, REQUIRED. Re-reading the mark here
-        # bypassed the halt policy, so a grace bar that actually priced a bracket died
-        # with a bare error instead of trading on cached state and truncating on budget.
-        # binance and bitget take the price from base_features and never had this read.
+        # Threaded from `_step`'s halted read; required, never defaulted (#295).
         current_price = float(current_price)
         # Re-validated at the seam that USES it, not just where it was read. Threading
         # moved the read out of this method, and with it `_current_mark_price`'s
@@ -213,9 +210,7 @@ class BybitFuturesSLTPTorchTradingEnv(SLTPMixin, BybitBaseTorchTradingEnv):
             # Size on total_margin_balance (equity), matching offline sizing and the non-SLTP
             # live path. Binance's total_wallet_balance excludes unrealized PnL and would under-size;
             # bitget/bybit/okx map both keys to equity, so the switch is a no-op there.
-            # Under `_halting` like the plain envs' sizing read (#295). This is the read
-            # that SIZES a bracket order, and it was left raw when the plain path was
-            # fixed -- the same "landed on some venues, not others" shape #288 is about.
+            # Under `_halting` -- the read that SIZES a bracket (#295).
             balance = float(
                 self._halting(self.trader.get_account_balance, cache_key="balance")[
                     "total_margin_balance"

--- a/torchtrade/envs/live/bybit/env_sltp.py
+++ b/torchtrade/envs/live/bybit/env_sltp.py
@@ -103,7 +103,9 @@ class BybitFuturesSLTPTorchTradingEnv(SLTPMixin, BybitBaseTorchTradingEnv):
         action_tuple = self._resolve_action_tuple(tensordict)
 
         # Execute trade if needed (duplicate guard uses synced state)
-        trade_info = self._execute_trade_if_needed(action_tuple)
+        trade_info = self._execute_trade_if_needed(
+            action_tuple, current_price=current_price
+        )
         trade_info["position_closed"] = position_closed
 
         # Eagerly update position from trade result so the rest of this step
@@ -146,7 +148,8 @@ class BybitFuturesSLTPTorchTradingEnv(SLTPMixin, BybitBaseTorchTradingEnv):
         return next_tensordict
 
     def _execute_trade_if_needed(
-        self, action_tuple: Tuple[Optional[str], Optional[float], Optional[float]]
+        self, action_tuple: Tuple[Optional[str], Optional[float], Optional[float]],
+        *, current_price: float,
     ) -> Dict:
         """Execute trade if position change is needed."""
         trade_info = {
@@ -192,14 +195,32 @@ class BybitFuturesSLTPTorchTradingEnv(SLTPMixin, BybitBaseTorchTradingEnv):
             return trade_info
 
         # Get current mark price (more accurate than candle close for bracket orders)
-        current_price = float(self._current_mark_price())
+        # Threaded from `_step`'s halted read, REQUIRED. Re-reading the mark here
+        # bypassed the halt policy, so a grace bar that actually priced a bracket died
+        # with a bare error instead of trading on cached state and truncating on budget.
+        # binance and bitget take the price from base_features and never had this read.
+        current_price = float(current_price)
+        # Re-validated at the seam that USES it, not just where it was read. Threading
+        # moved the read out of this method, and with it `_current_mark_price`'s
+        # `isfinite`/`<= 0` guard -- a 0.0 divides in the sizing path below.
+        if not math.isfinite(current_price) or current_price <= 0:
+            raise ValueError(
+                f"venue reported an unusable mark price ({current_price})"
+            )
 
         # Resolve quantity based on trade_mode
         if self.config.trade_mode == "fractional":
             # Size on total_margin_balance (equity), matching offline sizing and the non-SLTP
             # live path. Binance's total_wallet_balance excludes unrealized PnL and would under-size;
             # bitget/bybit/okx map both keys to equity, so the switch is a no-op there.
-            balance = float(self.trader.get_account_balance()["total_margin_balance"])
+            # Under `_halting` like the plain envs' sizing read (#295). This is the read
+            # that SIZES a bracket order, and it was left raw when the plain path was
+            # fixed -- the same "landed on some venues, not others" shape #288 is about.
+            balance = float(
+                self._halting(self.trader.get_account_balance, cache_key="balance")[
+                    "total_margin_balance"
+                ]
+            )
             # current_price already raised in _current_mark_price(); balance has
             # no such accessor, and `nan <= 0` is False (#347).
             if not math.isfinite(balance) or balance <= 0:

--- a/torchtrade/envs/live/bybit/env_sltp.py
+++ b/torchtrade/envs/live/bybit/env_sltp.py
@@ -180,6 +180,9 @@ class BybitFuturesSLTPTorchTradingEnv(SLTPMixin, BybitBaseTorchTradingEnv):
                 logger.error(f"Close position failed for {self.config.symbol}: {e}")
                 return trade_info
             if success:
+                # A realised close moves equity; the cached balance is now wrong by the
+                # trade's P&L. SUCCESS only -- a failed close leaves the position (#295).
+                self._last_confirmed_read.pop("balance", None)
                 close_side = "sell" if self.position.current_position > 0 else "buy"
                 self.position.current_position = 0
                 self.active_stop_loss = 0.0
@@ -271,6 +274,9 @@ class BybitFuturesSLTPTorchTradingEnv(SLTPMixin, BybitBaseTorchTradingEnv):
                 return trade_info
             if not close_success:
                 return trade_info
+            # A realised close moves equity; the cached balance is now wrong by the
+            # trade's P&L. Reached only on success (#295).
+            self._last_confirmed_read.pop("balance", None)
             self.position.current_position = 0
 
         # Map position side to trade side

--- a/torchtrade/envs/live/okx/env.py
+++ b/torchtrade/envs/live/okx/env.py
@@ -166,8 +166,7 @@ class OKXFuturesTorchTradingEnv(OKXBaseTorchTradingEnv):
         if action_value == 0.0:
             return 0.0, 0.0, "flat"
 
-        # Under `_halting` like every other account read -- this is the read that SIZES
-        # the order, and it sat outside the policy (#295).
+        # Under `_halting` -- this is the read that SIZES the order (#295).
         balance_info = self._halting(
             self.trader.get_account_balance, cache_key="balance"
         )

--- a/torchtrade/envs/live/okx/env.py
+++ b/torchtrade/envs/live/okx/env.py
@@ -166,22 +166,25 @@ class OKXFuturesTorchTradingEnv(OKXBaseTorchTradingEnv):
         if action_value == 0.0:
             return 0.0, 0.0, "flat"
 
-        # Under `_halting` -- this is the read that SIZES the order (#295).
-        balance_info = self._halting(
-            self.trader.get_account_balance, cache_key="balance"
-        )
-        # Indexed, and `not (x > 0)`: defaulting to 0.0 turned a broken adapter into a
-        # permanent silent refusal to trade, and `<= 0` lets a NaN balance through to
-        # size a NaN position (#277).
-        total_balance = balance_info['total_margin_balance']
+        # The VERDICT is inside the closure, not just the read. `_halting` catches
+        # ValueError precisely so an impossible account state becomes a halt; raising one
+        # frame above it sent that straight out of `_step`. `equity == 0.0` is what a
+        # venue reports while liquidating you -- the worst moment to crash rather than
+        # halt under policy (#295).
+        def read_balance():
+            info = self.trader.get_account_balance()
+            total_balance = info["total_margin_balance"]
+            # isfinite, not `not (x > 0)`: that catches NaN but passes +inf, and an inf
+            # balance sizes an inf target (#277). The name is load-bearing:
+            # test_futures_sizing_rejects_a_non_finite_balance greps for it.
+            if not math.isfinite(total_balance) or total_balance <= 0:
+                raise ValueError(
+                    f"cannot size a trade against a portfolio value of {total_balance}"
+                )
+            return info
 
-        # isfinite, not `not (x > 0)`: that catches NaN but passes +inf, and an inf
-        # balance sizes an inf target -- bitget's amount rounding then yields NaN and
-        # hands it to create_order. Same defect this PR fixed on the baselines (#277).
-        if not math.isfinite(total_balance) or total_balance <= 0:
-            raise ValueError(
-                f"cannot size a trade against a portfolio value of {total_balance}"
-            )
+        balance_info = self._halting(read_balance, cache_key="balance")
+        total_balance = balance_info["total_margin_balance"]
 
         effective_balance = total_balance * 0.98
         params = PositionCalculationParams(

--- a/torchtrade/envs/live/okx/env.py
+++ b/torchtrade/envs/live/okx/env.py
@@ -166,7 +166,11 @@ class OKXFuturesTorchTradingEnv(OKXBaseTorchTradingEnv):
         if action_value == 0.0:
             return 0.0, 0.0, "flat"
 
-        balance_info = self.trader.get_account_balance()
+        # Under `_halting` like every other account read -- this is the read that SIZES
+        # the order, and it sat outside the policy (#295).
+        balance_info = self._halting(
+            self.trader.get_account_balance, cache_key="balance"
+        )
         # Indexed, and `not (x > 0)`: defaulting to 0.0 turned a broken adapter into a
         # permanent silent refusal to trade, and `<= 0` lets a NaN balance through to
         # size a NaN position (#277).
@@ -214,7 +218,7 @@ class OKXFuturesTorchTradingEnv(OKXBaseTorchTradingEnv):
         return info
 
     def _execute_trade_if_needed(
-        self, desired_action: float, *, current_qty: float = 0.0, current_price: float = 0.0,
+        self, desired_action: float, *, current_qty: float, current_price: float,
     ) -> Dict:
         """Execute trade based on desired action value."""
         return self._execute_fractional_action(

--- a/torchtrade/envs/live/okx/env.py
+++ b/torchtrade/envs/live/okx/env.py
@@ -121,7 +121,7 @@ class OKXFuturesTorchTradingEnv(OKXBaseTorchTradingEnv):
         # the mark read matter here too.
         status, position_status, current_price, position_size = self._acquire_pre_trade_state()
 
-        # No-op today (this env's _execute_trade_if_needed recomputes qty live and never reads
+        # No-op today (this env's _execute_trade_if_needed takes the threaded qty and never reads
         # current_action_level), but keeps the field consistent so adding a duplicate-action
         # guard here can't reintroduce the silent no-op that bit alpaca/binance/bitget.
         self._sync_position_from_exchange(position_status)

--- a/torchtrade/envs/live/okx/env.py
+++ b/torchtrade/envs/live/okx/env.py
@@ -15,6 +15,7 @@ from torchtrade.envs.live.okx.order_executor import (
     PositionMode,
 )
 from torchtrade.envs.live.okx.base import OKXBaseTorchTradingEnv
+from torchtrade.envs.core.common import validate_unknown_status_budget
 from torchtrade.envs.core.live import (
     ObservationFailurePolicy,
 )
@@ -55,9 +56,14 @@ class OKXFuturesTradingEnvConfig:
     close_position_on_init: bool = True
     close_position_on_reset: bool = False
     observation_failure_policy: ObservationFailurePolicy | str = ObservationFailurePolicy.HALT
+    # 0 = the pre-#295 posture: the first unreadable venue read raises. Above 0, that many
+    # consecutive unconfirmed reads are ridden out on last-known state (publishing
+    # status_unknown=1.0) before the episode truncates. HALT only -- see _halting.
+    max_unknown_status_steps: int = 0
 
     def __post_init__(self):
         self.observation_failure_policy = ObservationFailurePolicy(self.observation_failure_policy)
+        validate_unknown_status_budget(self.max_unknown_status_steps)
         from torchtrade.envs.live.okx.utils import normalize_okx_timeframe_config
         self.execute_on, self.time_frames, self.window_sizes = normalize_okx_timeframe_config(
             self.execute_on, self.time_frames, self.window_sizes
@@ -152,8 +158,7 @@ class OKXFuturesTorchTradingEnv(OKXBaseTorchTradingEnv):
         done = self._check_termination(new_portfolio_value)
 
         next_tensordict.set("reward", torch.tensor([reward], dtype=torch.float))
-        next_tensordict.set("done", torch.tensor([done], dtype=torch.bool))
-        next_tensordict.set("terminated", torch.tensor([done], dtype=torch.bool))
+        self._finalize_step_flags(next_tensordict, terminated=done)
 
         return next_tensordict
 

--- a/torchtrade/envs/live/okx/env.py
+++ b/torchtrade/envs/live/okx/env.py
@@ -56,9 +56,7 @@ class OKXFuturesTradingEnvConfig:
     close_position_on_init: bool = True
     close_position_on_reset: bool = False
     observation_failure_policy: ObservationFailurePolicy | str = ObservationFailurePolicy.HALT
-    # 0 = the pre-#295 posture: the first unreadable venue read raises. Above 0, that many
-    # consecutive unconfirmed reads are ridden out on last-known state (publishing
-    # status_unknown=1.0) before the episode truncates. HALT only -- see _halting.
+    # Bars to ride out an unreadable venue before truncating; 0 disables (#295).
     max_unknown_status_steps: int = 0
 
     def __post_init__(self):

--- a/torchtrade/envs/live/okx/env_sltp.py
+++ b/torchtrade/envs/live/okx/env_sltp.py
@@ -141,8 +141,7 @@ class OKXFuturesSLTPTorchTradingEnv(SLTPMixin, OKXBaseTorchTradingEnv):
         done = self._check_termination(new_portfolio_value)
 
         next_tensordict.set("reward", torch.tensor([reward], dtype=torch.float))
-        next_tensordict.set("done", torch.tensor([done], dtype=torch.bool))
-        next_tensordict.set("terminated", torch.tensor([done], dtype=torch.bool))
+        self._finalize_step_flags(next_tensordict, terminated=done)
 
         return next_tensordict
 

--- a/torchtrade/envs/live/okx/env_sltp.py
+++ b/torchtrade/envs/live/okx/env_sltp.py
@@ -104,7 +104,9 @@ class OKXFuturesSLTPTorchTradingEnv(SLTPMixin, OKXBaseTorchTradingEnv):
         action_tuple = self._resolve_action_tuple(tensordict)
 
         # Execute trade if needed (duplicate guard uses synced state)
-        trade_info = self._execute_trade_if_needed(action_tuple)
+        trade_info = self._execute_trade_if_needed(
+            action_tuple, current_price=current_price
+        )
         trade_info["position_closed"] = position_closed
 
         # Eagerly update position from trade result
@@ -146,7 +148,8 @@ class OKXFuturesSLTPTorchTradingEnv(SLTPMixin, OKXBaseTorchTradingEnv):
         return next_tensordict
 
     def _execute_trade_if_needed(
-        self, action_tuple: Tuple[Optional[str], Optional[float], Optional[float]]
+        self, action_tuple: Tuple[Optional[str], Optional[float], Optional[float]],
+        *, current_price: float,
     ) -> Dict:
         """Execute trade if position change is needed."""
         trade_info = {
@@ -192,14 +195,32 @@ class OKXFuturesSLTPTorchTradingEnv(SLTPMixin, OKXBaseTorchTradingEnv):
             return trade_info
 
         # Get current mark price (more accurate than candle close for bracket orders)
-        current_price = float(self._current_mark_price())
+        # Threaded from `_step`'s halted read, REQUIRED. Re-reading the mark here
+        # bypassed the halt policy, so a grace bar that actually priced a bracket died
+        # with a bare error instead of trading on cached state and truncating on budget.
+        # binance and bitget take the price from base_features and never had this read.
+        current_price = float(current_price)
+        # Re-validated at the seam that USES it, not just where it was read. Threading
+        # moved the read out of this method, and with it `_current_mark_price`'s
+        # `isfinite`/`<= 0` guard -- a 0.0 divides in the sizing path below.
+        if not math.isfinite(current_price) or current_price <= 0:
+            raise ValueError(
+                f"venue reported an unusable mark price ({current_price})"
+            )
 
         # Resolve quantity based on trade_mode
         if self.config.trade_mode == "fractional":
             # Size on total_margin_balance (equity), matching offline sizing and the non-SLTP
             # live path. Binance's total_wallet_balance excludes unrealized PnL and would under-size;
             # bitget/bybit/okx map both keys to equity, so the switch is a no-op there.
-            balance = float(self.trader.get_account_balance()["total_margin_balance"])
+            # Under `_halting` like the plain envs' sizing read (#295). This is the read
+            # that SIZES a bracket order, and it was left raw when the plain path was
+            # fixed -- the same "landed on some venues, not others" shape #288 is about.
+            balance = float(
+                self._halting(self.trader.get_account_balance, cache_key="balance")[
+                    "total_margin_balance"
+                ]
+            )
             # current_price already raised in _current_mark_price(); balance has
             # no such accessor, and `nan <= 0` is False (#347).
             if not math.isfinite(balance) or balance <= 0:

--- a/torchtrade/envs/live/okx/env_sltp.py
+++ b/torchtrade/envs/live/okx/env_sltp.py
@@ -195,10 +195,7 @@ class OKXFuturesSLTPTorchTradingEnv(SLTPMixin, OKXBaseTorchTradingEnv):
             return trade_info
 
         # Get current mark price (more accurate than candle close for bracket orders)
-        # Threaded from `_step`'s halted read, REQUIRED. Re-reading the mark here
-        # bypassed the halt policy, so a grace bar that actually priced a bracket died
-        # with a bare error instead of trading on cached state and truncating on budget.
-        # binance and bitget take the price from base_features and never had this read.
+        # Threaded from `_step`'s halted read; required, never defaulted (#295).
         current_price = float(current_price)
         # Re-validated at the seam that USES it, not just where it was read. Threading
         # moved the read out of this method, and with it `_current_mark_price`'s
@@ -213,9 +210,7 @@ class OKXFuturesSLTPTorchTradingEnv(SLTPMixin, OKXBaseTorchTradingEnv):
             # Size on total_margin_balance (equity), matching offline sizing and the non-SLTP
             # live path. Binance's total_wallet_balance excludes unrealized PnL and would under-size;
             # bitget/bybit/okx map both keys to equity, so the switch is a no-op there.
-            # Under `_halting` like the plain envs' sizing read (#295). This is the read
-            # that SIZES a bracket order, and it was left raw when the plain path was
-            # fixed -- the same "landed on some venues, not others" shape #288 is about.
+            # Under `_halting` -- the read that SIZES a bracket (#295).
             balance = float(
                 self._halting(self.trader.get_account_balance, cache_key="balance")[
                     "total_margin_balance"

--- a/torchtrade/envs/live/okx/env_sltp.py
+++ b/torchtrade/envs/live/okx/env_sltp.py
@@ -180,6 +180,9 @@ class OKXFuturesSLTPTorchTradingEnv(SLTPMixin, OKXBaseTorchTradingEnv):
                 logger.error(f"Close position failed for {self.config.symbol}: {e}")
                 return trade_info
             if success:
+                # A realised close moves equity; the cached balance is now wrong by the
+                # trade's P&L. SUCCESS only -- a failed close leaves the position (#295).
+                self._last_confirmed_read.pop("balance", None)
                 close_side = "sell" if self.position.current_position > 0 else "buy"
                 self.position.current_position = 0
                 self.active_stop_loss = 0.0
@@ -276,6 +279,9 @@ class OKXFuturesSLTPTorchTradingEnv(SLTPMixin, OKXBaseTorchTradingEnv):
                 return trade_info
             if not close_success:
                 return trade_info
+            # A realised close moves equity; the cached balance is now wrong by the
+            # trade's P&L. Reached only on success (#295).
+            self._last_confirmed_read.pop("balance", None)
             self.position.current_position = 0
             self.active_stop_loss = 0.0
             self.active_take_profit = 0.0

--- a/torchtrade/envs/live/shared/futures_live_base.py
+++ b/torchtrade/envs/live/shared/futures_live_base.py
@@ -76,9 +76,10 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
 
         #343's rule is that ANY failure to read account state while a position is open
         must halt -- not only the post-bar read. The pre-trade read at the top of _step
-        and the initial read in _reset bypassed this, so a POSITION_UNKNOWN between bars
         raised a bare PositionUnknownError that `except LiveObservationHalt` did not
-        catch, and no emergency flatten ran even under FLATTEN (#355).
+        catch, and no emergency flatten ran even under FLATTEN (#355). The reset read is
+        routed through here too as of #295 -- the docstring claimed it already was, and
+        it was not.
 
         #295 adds the grace period. With `max_unknown_status_steps > 0` a transient blip
         no longer kills the process: the env keeps stepping on the last CONFIRMED read,
@@ -91,6 +92,12 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
         on (a failure in `_reset`, or the first bar of an episode) it raises regardless of
         the budget, because there is no last-known truth to stand on.
         """
+        # Only the pre-trade read defines a bar: it runs exactly once per `_step`. Counting
+        # every read site would make `max_unknown_status_steps=3` truncate after two bars,
+        # since the post-bar read fails in the same outage -- a budget that silently means
+        # something other than what it says.
+        counts = cache_key != "post_bar"
+
         try:
             value = read()
         # NOT RuntimeError: adapters wrap timeouts in it, and KeyError is a config
@@ -98,12 +105,7 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
         except (PositionUnknownError, ValueError) as error:
             budget = self._max_unknown_status_steps
             cached = self._last_confirmed_read.get(cache_key) if cache_key else None
-            # Only the pre-trade read advances the counter. It runs exactly once per
-            # `_step`, so the budget reads as BARS. Counting every read site would make
-            # `max_unknown_status_steps=3` truncate after two bars, since the post-bar
-            # read fails in the same outage -- a budget that silently means something
-            # other than what it says.
-            if cache_key != "post_bar":
+            if counts:
                 self.consecutive_unknown_status += 1
             self._status_unknown_this_step = True
 
@@ -118,7 +120,7 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
             )
             if grace:
                 if self.consecutive_unknown_status < budget:
-                    if cache_key != "post_bar":   # the counting site logs, once per bar
+                    if counts:   # the counting site logs, once per bar
                         logger.warning(
                                 "%s: venue read failed (%s); running on unconfirmed "
                             "state, %d of %d grace steps used",
@@ -126,11 +128,11 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
                             self.consecutive_unknown_status, budget,
                         )
                     return cached
-                # Budget spent. Still attempt the protective close under FLATTEN, then
-                # let the step finish on cached state so `_set_done_family` can truncate
-                # -- an exception here would be the process crash #295 exists to remove.
-                self._flatten_if_policy_says_so()
-                if cache_key != "post_bar":
+                # No flatten here: `grace` above already excludes FLATTEN, so a close
+                # attempt on this branch is unreachable. The step finishes on cached state
+                # so `_finalize_step_flags` can truncate -- raising instead would be the
+                # process crash #295 exists to remove.
+                if counts:
                     logger.error(
                         "%s: venue unreadable for %d consecutive bars; truncating",
                         self.config.symbol, self.consecutive_unknown_status,
@@ -142,10 +144,17 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
                 error, self.config.observation_failure_policy, accepted, flatten_error
             ) from error
 
-        if cache_key != "post_bar":
+        if counts:
             self.consecutive_unknown_status = 0
         if cache_key:
-            self._last_confirmed_read[cache_key] = value
+            # CLONE, not the reference. `TensorDict.set()` stores references, so the
+            # post-bar tuple's observation is the SAME object the collector received and
+            # then stamped with reward/done/terminated/truncated. Caching it by reference
+            # meant a grace bar re-served last bar's flags -- which is what made an
+            # explicit `done` write look necessary when the real fault was aliasing.
+            self._last_confirmed_read[cache_key] = tuple(
+                v.clone() if hasattr(v, "clone") else v for v in value
+            ) if isinstance(value, tuple) else value
         return value
 
     def _flatten_if_policy_says_so(self):
@@ -607,6 +616,7 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
         start -- so they warn. All four venues return True when flat, so a clean reset is
         silent.
         """
+        self._reset_outage_state()
         self.observer.reset()
         if not self.trader.cancel_open_orders():
             logger.warning(
@@ -620,14 +630,23 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
                     "close_position failed during reset; proceeding with residual exposure"
                 )
 
-        balance = self.trader.get_account_balance()
-        self.balance = balance.get("available_balance", 0)
+        # Under `_halting`, like every other account read (#295). NO cache_key: an
+        # episode must not START on stale state -- the grace period exists to ride out an
+        # outage mid-episode, not to begin one blind. So this raises LiveObservationHalt
+        # rather than a bare PositionUnknownError, which is what `except
+        # LiveObservationHalt` and the FLATTEN policy were always documented to cover and
+        # what the reset path actually bypassed until now.
+        def read_account():
+            balance = self.trader.get_account_balance()
+            status = self.trader.get_status()
+            return balance, status, position_direction_from_status(
+                status.get("position_status")
+            )
 
-        status = self.trader.get_status()
+        balance, status, direction = self._halting(read_account)
+        self.balance = balance.get("available_balance", 0)
         self.position.hold_counter = 0
-        self.position.current_position = position_direction_from_status(
-            status.get("position_status")
-        )
+        self.position.current_position = direction
 
         # Load-bearing for binance and bitget, whose _execute_trade_if_needed compares
         # `desired_action == self.position.current_action_level` and returns executed=False

--- a/torchtrade/envs/live/shared/futures_live_base.py
+++ b/torchtrade/envs/live/shared/futures_live_base.py
@@ -94,9 +94,18 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
         """
         try:
             value = read()
-        # NOT RuntimeError: adapters wrap timeouts in it, and KeyError is a config
-        # error. See docs/environments/online.md.
-        except (PositionUnknownError, ValueError) as error:
+        # RuntimeError is caught for GRACE ONLY, and re-raised untouched otherwise -- see
+        # the `raise` at the bottom. All four adapters wrap a failed balance read in
+        # `RuntimeError("Failed to get account balance: ...")`, so without this the grace
+        # period never engaged for the failure mode production actually produces; the
+        # tests only ever injected PositionUnknownError.
+        #
+        # It must NOT become halt-and-flatten material (#394, docs/environments/online.md):
+        # a read timeout arrives as RuntimeError too, and flattening a live position on a
+        # timeout is exactly what that decision refused. Grace does not flatten -- it
+        # serves last-known state and flags the bar -- so riding one out is safe where
+        # halting on it is not. KeyError stays out: that is a config error.
+        except (PositionUnknownError, ValueError, RuntimeError) as error:
             # The BAR is unconfirmed. The counter advances once per step in
             # `_finalize_step_flags`, not here: counting per read site double-counts a bar
             # where both reads fail, and counting only the pre-trade read let a persistent
@@ -138,6 +147,14 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
                         self._max_unknown_status_steps,
                     )
                 return cached
+
+            # Grace did not apply. A RuntimeError leaves untouched -- it was caught only
+            # to give the grace path a chance at it, and turning one into a halt (or a
+            # FLATTEN close) is the #394 decision inverted.
+            if isinstance(error, RuntimeError) and not isinstance(
+                error, (PositionUnknownError, LiveObservationHalt)
+            ):
+                raise
 
             accepted = flatten_error = None
             if (self.config.observation_failure_policy
@@ -217,6 +234,13 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
 
         if success:
             self.position.current_position = 0
+            # A realised close moves equity, so the cached balance is now wrong by the
+            # trade's P&L. Only on SUCCESS: a failed close leaves the position, and with
+            # it the equity the cache already describes. Without this, a later failed
+            # sizing read serves pre-close equity from an arbitrary number of bars ago --
+            # the sizing path early-returns before the balance read, so nothing refreshes
+            # it (#295).
+            self._last_confirmed_read.pop("balance", None)
 
         return self._create_trade_info(
             executed=True,

--- a/torchtrade/envs/live/shared/futures_live_base.py
+++ b/torchtrade/envs/live/shared/futures_live_base.py
@@ -21,6 +21,7 @@ from torchtrade.envs.core.live import (
     LiveObservationHalt,
     ObservationFailurePolicy,
     TorchTradeLiveEnv,
+    STATUS_UNKNOWN_KEY,
 )
 from torchtrade.envs.core.state import (
     PositionUnknownError,
@@ -70,32 +71,96 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
     - _execute_trade_if_needed(): trade execution, whose action space differs by env
     """
 
-    def _halting(self, read):
-        """Run a venue read under the halt policy, or raise LiveObservationHalt.
+    def _halting(self, read, cache_key=None):
+        """Run a venue read under the halt policy, degrading through a grace period.
 
         #343's rule is that ANY failure to read account state while a position is open
         must halt -- not only the post-bar read. The pre-trade read at the top of _step
         and the initial read in _reset bypassed this, so a POSITION_UNKNOWN between bars
         raised a bare PositionUnknownError that `except LiveObservationHalt` did not
-        catch, and no emergency flatten ran even under FLATTEN (#355). The pre-trade read
-        is the one that happens BEFORE the env trades.
+        catch, and no emergency flatten ran even under FLATTEN (#355).
+
+        #295 adds the grace period. With `max_unknown_status_steps > 0` a transient blip
+        no longer kills the process: the env keeps stepping on the last CONFIRMED read,
+        publishes `status_unknown=1.0` so the policy can see it is flying blind, and
+        truncates once the outage outlasts the budget. At 0 -- the default, and the
+        pre-#295 posture -- the first failure still raises.
+
+        The grace period trades on unconfirmed state, which is a real risk and the reason
+        it is opt-in. What it must NEVER do is fabricate: with no cached read to fall back
+        on (a failure in `_reset`, or the first bar of an episode) it raises regardless of
+        the budget, because there is no last-known truth to stand on.
         """
         try:
-            return read()
+            value = read()
         # NOT RuntimeError: adapters wrap timeouts in it, and KeyError is a config
         # error. See docs/environments/online.md.
         except (PositionUnknownError, ValueError) as error:
-            policy = self.config.observation_failure_policy
-            accepted = flatten_error = None
-            if policy is ObservationFailurePolicy.FLATTEN:
-                try:
-                    accepted = bool(self.trader.close_position())
-                except Exception as exc:
-                    flatten_error = exc
-                    logger.exception(
-                        "Emergency close_position failed for %s", self.config.symbol
+            budget = self._max_unknown_status_steps
+            cached = self._last_confirmed_read.get(cache_key) if cache_key else None
+            # Only the pre-trade read advances the counter. It runs exactly once per
+            # `_step`, so the budget reads as BARS. Counting every read site would make
+            # `max_unknown_status_steps=3` truncate after two bars, since the post-bar
+            # read fails in the same outage -- a budget that silently means something
+            # other than what it says.
+            if cache_key != "post_bar":
+                self.consecutive_unknown_status += 1
+            self._status_unknown_this_step = True
+
+            # FLATTEN and a grace period are contradictory postures: FLATTEN means "get
+            # me out while I cannot see the account", so riding out the outage would
+            # defeat the only thing it is for. Grace applies to HALT only.
+            grace = (
+                budget > 0
+                and cached is not None
+                and self.config.observation_failure_policy
+                is not ObservationFailurePolicy.FLATTEN
+            )
+            if grace:
+                if self.consecutive_unknown_status < budget:
+                    if cache_key != "post_bar":   # the counting site logs, once per bar
+                        logger.warning(
+                                "%s: venue read failed (%s); running on unconfirmed "
+                            "state, %d of %d grace steps used",
+                            self.config.symbol, type(error).__name__,
+                            self.consecutive_unknown_status, budget,
+                        )
+                    return cached
+                # Budget spent. Still attempt the protective close under FLATTEN, then
+                # let the step finish on cached state so `_set_done_family` can truncate
+                # -- an exception here would be the process crash #295 exists to remove.
+                self._flatten_if_policy_says_so()
+                if cache_key != "post_bar":
+                    logger.error(
+                        "%s: venue unreadable for %d consecutive bars; truncating",
+                        self.config.symbol, self.consecutive_unknown_status,
                     )
-            raise LiveObservationHalt(error, policy, accepted, flatten_error) from error
+                return cached
+
+            accepted, flatten_error = self._flatten_if_policy_says_so()
+            raise LiveObservationHalt(
+                error, self.config.observation_failure_policy, accepted, flatten_error
+            ) from error
+
+        if cache_key != "post_bar":
+            self.consecutive_unknown_status = 0
+        if cache_key:
+            self._last_confirmed_read[cache_key] = value
+        return value
+
+    def _flatten_if_policy_says_so(self):
+        """Attempt the emergency close when the policy is FLATTEN. Returns (accepted, error).
+
+        `accepted` records that the venue accepted a close REQUEST, not that the position
+        is gone -- the distinction LiveObservationHalt already documents.
+        """
+        if self.config.observation_failure_policy is not ObservationFailurePolicy.FLATTEN:
+            return None, None
+        try:
+            return bool(self.trader.close_position()), None
+        except Exception as exc:
+            logger.exception("Emergency close_position failed for %s", self.config.symbol)
+            return None, exc
 
     def _acquire_pre_trade_state(self):
         """The venue read at the TOP of _step, under the halt policy (#355).
@@ -117,7 +182,7 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
                 position_qty_from_status(position_status),
             )
 
-        return self._halting(read)
+        return self._halting(read, cache_key="pre_trade")
 
     def _create_trade_info(self, executed: bool = False, **kwargs) -> Dict:
         """The trade-info dict every futures `_step` returns. Four identical copies (#288).
@@ -244,7 +309,7 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
                     mark = None
             return portfolio_value, mark, self._last_observed_qty, observation
 
-        return self._halting(read)
+        return self._halting(read, cache_key="post_bar")
 
     def _current_mark_price(self, position_status=None) -> float:
         """The bar's mark price, validated before it can size an order (#347).
@@ -483,7 +548,18 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
             dtype=torch.float,
         )
 
-        out_td = TensorDict({self.account_state_key: account_state}, batch_size=())
+        out_td = TensorDict(
+            {
+                self.account_state_key: account_state,
+                # Declared for all ten envs so the observation contract does not fork by
+                # venue. Alpaca has no observation-failure policy, so its counter never
+                # advances and this is always 0.0 there -- see _max_unknown_status_steps.
+                STATUS_UNKNOWN_KEY: torch.tensor(
+                    [float(self.consecutive_unknown_status > 0)], dtype=torch.float
+                ),
+            },
+            batch_size=(),
+        )
         for market_data_name, data in zip(self.market_data_keys, market_data):
             out_td.set(market_data_name, torch.from_numpy(data))
 

--- a/torchtrade/envs/live/shared/futures_live_base.py
+++ b/torchtrade/envs/live/shared/futures_live_base.py
@@ -154,6 +154,11 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
             if isinstance(error, RuntimeError) and not isinstance(
                 error, (PositionUnknownError, LiveObservationHalt)
             ):
+                # Clear the flag before aborting. `_finalize_step_flags` is what normally
+                # consumes it, and this path never reaches it -- so a caller that catches
+                # the timeout and retries would have the next HEALTHY bar report
+                # status_unknown=1, and count toward truncation.
+                self._status_unknown_this_step = False
                 raise
 
             accepted = flatten_error = None
@@ -357,7 +362,7 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
             raise ValueError(f"venue reported an unusable mark price ({price})")
         return price
 
-    def _get_observation(self, advance_hold: bool = True) -> TensorDictBase:
+    def _get_observation(self, advance_hold: bool = True, *, snapshot=None) -> TensorDictBase:
         """Get the current observation state.
 
         Args:
@@ -379,9 +384,19 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
         ]
 
         # Get account state from trader (single fetch: holding_time and
-        # position_direction below MUST come from this same snapshot)
-        status = self.trader.get_status()
-        balance = self.trader.get_account_balance()
+        # position_direction below MUST come from this same snapshot).
+        #
+        # `snapshot` is `_reset`'s already-CONFIRMED pair. Re-reading there meant the
+        # guarded reads succeeded and were then thrown away, and a failure on the second
+        # pair escaped the policy entirely -- FLATTEN could not act on it. Wrapping this
+        # whole method instead would be wrong: it also reads the OBSERVER, so a window
+        # that can never fill is a config error, and halting it would market-close a
+        # position on every episode start (`reset-is-not-halt-wrapped`).
+        if snapshot is not None:
+            status, balance = snapshot
+        else:
+            status = self.trader.get_status()
+            balance = self.trader.get_account_balance()
 
         # exposure_pct denominator: use total_margin_balance (equity incl. unrealized PnL),
         # NOT total_wallet_balance. The latter's meaning diverges across exchanges -- Binance's
@@ -670,7 +685,8 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
         # never fill is a metadata gap, not an outage; halting it would market-close a real
         # position on every episode start under FLATTEN. Cheap-and-loud is the right cost
         # for a config error. The account reads that CAN be an outage are wrapped above.
-        return self._get_observation(advance_hold=False)
+        # Built from the reads already confirmed above, not a second raw pair.
+        return self._get_observation(advance_hold=False, snapshot=(status, balance))
 
     @abstractmethod
     def _execute_trade_if_needed(self, action) -> dict:

--- a/torchtrade/envs/live/shared/futures_live_base.py
+++ b/torchtrade/envs/live/shared/futures_live_base.py
@@ -546,12 +546,7 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
         out_td = TensorDict(
             {
                 self.account_state_key: account_state,
-                # Declared for all ten envs so the observation contract does not fork by
-                # venue. Alpaca has no observation-failure policy, so its counter never
-                # advances and this is always 0.0 there -- see _max_unknown_status_steps.
-                # Always 0.0 here: `_finalize_step_flags` overwrites it on every step,
-                # and the only other path is `_reset`, which just zeroed the counter.
-                # Declared so the reset observation matches the spec.
+                # Always 0.0: `_finalize_step_flags` sets it per step (#295).
                 STATUS_UNKNOWN_KEY: torch.zeros(1, dtype=torch.float),
             },
             batch_size=(),

--- a/torchtrade/envs/live/shared/futures_live_base.py
+++ b/torchtrade/envs/live/shared/futures_live_base.py
@@ -614,13 +614,20 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
         # `_last_confirmed_read` keeps exactly one writer. `_reset_outage_state` has just
         # cleared it, so a failure here still raises -- an episode cannot start on cache.
         balance = self._halting(self.trader.get_account_balance, cache_key="balance")
-        status = self._halting(self.trader.get_status)
 
+        # The CONVERSION is inside the closure, not just the call. No adapter raises from
+        # `get_status`: all four RETURN the POSITION_UNKNOWN sentinel, and the error comes
+        # from the first attribute touch -- which is `position_direction_from_status`.
+        # Wrapping the call alone caught nothing, exactly as `_acquire_pre_trade_state`'s
+        # docstring warns twelve lines up.
+        def read_status():
+            status = self.trader.get_status()
+            return status, position_direction_from_status(status.get("position_status"))
+
+        status, direction = self._halting(read_status)
         self.balance = balance.get("available_balance", 0)
         self.position.hold_counter = 0
-        self.position.current_position = position_direction_from_status(
-            status.get("position_status")
-        )
+        self.position.current_position = direction
 
         # Load-bearing for binance and bitget, whose _execute_trade_if_needed compares
         # `desired_action == self.position.current_action_level` and returns executed=False
@@ -631,6 +638,14 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
 
         # advance_hold=False: hold_counter was just zeroed above; a reset must never
         # itself count a bar (see advance_hold docstring).
+        # Deliberately NOT under `_halting`, unlike the two account reads above. A review
+        # flagged the asymmetry -- a NaN equity here raises bare while the same NaN in the
+        # post-bar read halts and flattens -- and it is intentional:
+        # `test_what_a_short_observation_costs_under_flatten[reset-is-not-halt-wrapped]`
+        # pins it. `_get_observation` also reads the OBSERVER, so a config whose window can
+        # never fill is a metadata gap, not an outage; halting it would market-close a real
+        # position on every episode start under FLATTEN. Cheap-and-loud is the right cost
+        # for a config error. The account reads that CAN be an outage are wrapped above.
         return self._get_observation(advance_hold=False)
 
     @abstractmethod

--- a/torchtrade/envs/live/shared/futures_live_base.py
+++ b/torchtrade/envs/live/shared/futures_live_base.py
@@ -92,84 +92,70 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
         on (a failure in `_reset`, or the first bar of an episode) it raises regardless of
         the budget, because there is no last-known truth to stand on.
         """
-        # Only the pre-trade read defines a bar: it runs exactly once per `_step`. Counting
-        # every read site would make `max_unknown_status_steps=3` truncate after two bars,
-        # since the post-bar read fails in the same outage -- a budget that silently means
-        # something other than what it says.
-        counts = cache_key != "post_bar"
-
         try:
             value = read()
         # NOT RuntimeError: adapters wrap timeouts in it, and KeyError is a config
         # error. See docs/environments/online.md.
         except (PositionUnknownError, ValueError) as error:
-            budget = self._max_unknown_status_steps
-            cached = self._last_confirmed_read.get(cache_key) if cache_key else None
-            if counts:
-                self.consecutive_unknown_status += 1
+            # The BAR is unconfirmed. The counter advances once per step in
+            # `_finalize_step_flags`, not here: counting per read site double-counts a bar
+            # where both reads fail, and counting only the pre-trade read let a persistent
+            # POST-BAR-only outage run forever -- every bar flagged unknown while the
+            # healthy pre-trade read reset the counter to zero each time.
             self._status_unknown_this_step = True
 
             # FLATTEN and a grace period are contradictory postures: FLATTEN means "get
             # me out while I cannot see the account", so riding out the outage would
             # defeat the only thing it is for. Grace applies to HALT only.
+            # COPIED on the way out, not on the way in. Copying at the store side was
+            # the round-1 mistake: every grace bar returned the SAME physical object,
+            # which `_step` then stamps with reward and the done family, so a collector
+            # holding it in two rollout slots reads the later bar's values in both.
+            # `TensorDict.set()` stores references -- this repo's own recorded rule.
+            cached = self._last_confirmed_read.get(cache_key) if cache_key else None
+            if isinstance(cached, tuple):
+                cached = tuple(
+                    v.clone() if isinstance(v, TensorDictBase) else v for v in cached
+                )
             grace = (
-                budget > 0
+                self._max_unknown_status_steps > 0
                 and cached is not None
                 and self.config.observation_failure_policy
                 is not ObservationFailurePolicy.FLATTEN
             )
             if grace:
-                if self.consecutive_unknown_status < budget:
-                    if counts:   # the counting site logs, once per bar
-                        logger.warning(
-                                "%s: venue read failed (%s); running on unconfirmed "
-                            "state, %d of %d grace steps used",
-                            self.config.symbol, type(error).__name__,
-                            self.consecutive_unknown_status, budget,
-                        )
-                    return cached
-                # No flatten here: `grace` above already excludes FLATTEN, so a close
-                # attempt on this branch is unreachable. The step finishes on cached state
-                # so `_finalize_step_flags` can truncate -- raising instead would be the
-                # process crash #295 exists to remove.
-                if counts:
-                    logger.error(
-                        "%s: venue unreadable for %d consecutive bars; truncating",
-                        self.config.symbol, self.consecutive_unknown_status,
+                # No budget check here. Whether the outage has outlasted its budget is a
+                # question about the BAR, answered once in `_finalize_step_flags`; asking
+                # it per read site is what made the budget mean reads rather than bars.
+                # Raising on the spent bar would also reintroduce the process crash #295
+                # exists to remove -- the step has to finish so it can truncate.
+                if cache_key != "post_bar":   # log once per bar, not per read
+                    logger.warning(
+                        "%s: venue read failed (%s); running on unconfirmed state "
+                        "(bar %d of a %d-bar budget)",
+                        self.config.symbol, type(error).__name__,
+                        self.consecutive_unknown_status + 1,
+                        self._max_unknown_status_steps,
                     )
                 return cached
 
-            accepted, flatten_error = self._flatten_if_policy_says_so()
+            accepted = flatten_error = None
+            if (self.config.observation_failure_policy
+                    is ObservationFailurePolicy.FLATTEN):
+                try:
+                    accepted = bool(self.trader.close_position())
+                except Exception as exc:
+                    flatten_error = exc
+                    logger.exception(
+                        "Emergency close_position failed for %s", self.config.symbol
+                    )
             raise LiveObservationHalt(
                 error, self.config.observation_failure_policy, accepted, flatten_error
             ) from error
 
-        if counts:
-            self.consecutive_unknown_status = 0
         if cache_key:
-            # CLONE, not the reference. `TensorDict.set()` stores references, so the
-            # post-bar tuple's observation is the SAME object the collector received and
-            # then stamped with reward/done/terminated/truncated. Caching it by reference
-            # meant a grace bar re-served last bar's flags -- which is what made an
-            # explicit `done` write look necessary when the real fault was aliasing.
-            self._last_confirmed_read[cache_key] = tuple(
-                v.clone() if hasattr(v, "clone") else v for v in value
-            ) if isinstance(value, tuple) else value
+            self._last_confirmed_read[cache_key] = value
         return value
-
-    def _flatten_if_policy_says_so(self):
-        """Attempt the emergency close when the policy is FLATTEN. Returns (accepted, error).
-
-        `accepted` records that the venue accepted a close REQUEST, not that the position
-        is gone -- the distinction LiveObservationHalt already documents.
-        """
-        if self.config.observation_failure_policy is not ObservationFailurePolicy.FLATTEN:
-            return None, None
-        try:
-            return bool(self.trader.close_position()), None
-        except Exception as exc:
-            logger.exception("Emergency close_position failed for %s", self.config.symbol)
-            return None, exc
 
     def _acquire_pre_trade_state(self):
         """The venue read at the TOP of _step, under the halt policy (#355).
@@ -563,9 +549,10 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
                 # Declared for all ten envs so the observation contract does not fork by
                 # venue. Alpaca has no observation-failure policy, so its counter never
                 # advances and this is always 0.0 there -- see _max_unknown_status_steps.
-                STATUS_UNKNOWN_KEY: torch.tensor(
-                    [float(self.consecutive_unknown_status > 0)], dtype=torch.float
-                ),
+                # Always 0.0 here: `_finalize_step_flags` overwrites it on every step,
+                # and the only other path is `_reset`, which just zeroed the counter.
+                # Declared so the reset observation matches the spec.
+                STATUS_UNKNOWN_KEY: torch.zeros(1, dtype=torch.float),
             },
             batch_size=(),
         )

--- a/torchtrade/envs/live/shared/futures_live_base.py
+++ b/torchtrade/envs/live/shared/futures_live_base.py
@@ -581,15 +581,6 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
             )
         return equity
 
-    def _get_current_position_quantity(self) -> float:
-        """The signed size the exchange holds, dust read as flat.
-
-        One copy: binance, bitget and bybit each carried a byte-identical
-        `position.qty if position is not None else 0.0`, which returned the residual
-        rather than 0 and let `abs(current_qty) > 0` fire on a flat account (#283).
-        """
-        return position_qty_from_status(self.trader.get_status().get("position_status"))
-
     def _reset(self, tensordict: TensorDictBase, **kwargs) -> TensorDictBase:
         """Reset the environment.
 
@@ -623,28 +614,24 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
         # rather than a bare PositionUnknownError, which is what `except
         # LiveObservationHalt` and the FLATTEN policy were always documented to cover and
         # what the reset path actually bypassed until now.
-        def read_account():
-            balance = self.trader.get_account_balance()
-            status = self.trader.get_status()
-            return balance, status, position_direction_from_status(
-                status.get("position_status")
-            )
+        # Two `_halting` calls rather than one closure plus a manual cache seed: the
+        # balance goes through the same "balance" slot the sizing path uses, so
+        # `_last_confirmed_read` keeps exactly one writer. `_reset_outage_state` has just
+        # cleared it, so a failure here still raises -- an episode cannot start on cache.
+        balance = self._halting(self.trader.get_account_balance, cache_key="balance")
+        status = self._halting(self.trader.get_status)
 
-        balance, status, direction = self._halting(read_account)
-        # Seed the sizing cache from reset's CONFIRMED balance. Without this the grace
-        # period could not size a trade it had not already sized once: the "balance" slot
-        # is otherwise filled only by `_calculate_fractional_position`, so a policy that
-        # held through the healthy bars and wanted to open during the outage got a halt.
-        self._last_confirmed_read["balance"] = balance
         self.balance = balance.get("available_balance", 0)
         self.position.hold_counter = 0
-        self.position.current_position = direction
+        self.position.current_position = position_direction_from_status(
+            status.get("position_status")
+        )
 
         # Load-bearing for binance and bitget, whose _execute_trade_if_needed compares
         # `desired_action == self.position.current_action_level` and returns executed=False
         # on a match: without this, a position that predates the episode leaves a stale
         # level behind which the guard refuses the very trade that would close it (#243).
-        # Inert for bybit and okx, which recompute qty live and never read the field.
+        # Inert for bybit and okx, which take the threaded qty and never read the field.
         self._sync_action_level_after_reset()
 
         # advance_hold=False: hold_counter was just zeroed above; a reset must never

--- a/torchtrade/envs/live/shared/futures_live_base.py
+++ b/torchtrade/envs/live/shared/futures_live_base.py
@@ -631,6 +631,11 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
             )
 
         balance, status, direction = self._halting(read_account)
+        # Seed the sizing cache from reset's CONFIRMED balance. Without this the grace
+        # period could not size a trade it had not already sized once: the "balance" slot
+        # is otherwise filled only by `_calculate_fractional_position`, so a policy that
+        # held through the healthy bars and wanted to open during the outage got a halt.
+        self._last_confirmed_read["balance"] = balance
         self.balance = balance.get("available_balance", 0)
         self.position.hold_counter = 0
         self.position.current_position = direction

--- a/torchtrade/envs/live/shared/sltp_config.py
+++ b/torchtrade/envs/live/shared/sltp_config.py
@@ -46,9 +46,7 @@ class BaseFuturesSLTPConfig:
     observation_failure_policy: Union[ObservationFailurePolicy, str] = (
         ObservationFailurePolicy.HALT
     )
-    # 0 = the pre-#295 posture: the first unreadable venue read raises. Above 0, that many
-    # consecutive unconfirmed reads are ridden out on last-known state (publishing
-    # status_unknown=1.0) before the episode truncates. HALT only -- see _halting.
+    # Bars to ride out an unreadable venue before truncating; 0 disables (#295).
     max_unknown_status_steps: int = 0
 
     # Each subclass sets this to its venue normalizer -- all four are a partial of the

--- a/torchtrade/envs/live/shared/sltp_config.py
+++ b/torchtrade/envs/live/shared/sltp_config.py
@@ -8,6 +8,7 @@ from torchtrade.envs.core.common import (
     validate_position_sizing,
     validate_sltp_levels,
     validate_trade_mode,
+    validate_unknown_status_budget,
 )
 from torchtrade.envs.core.live import ObservationFailurePolicy
 from torchtrade.envs.utils.timeframe import TimeFrame
@@ -45,6 +46,10 @@ class BaseFuturesSLTPConfig:
     observation_failure_policy: Union[ObservationFailurePolicy, str] = (
         ObservationFailurePolicy.HALT
     )
+    # 0 = the pre-#295 posture: the first unreadable venue read raises. Above 0, that many
+    # consecutive unconfirmed reads are ridden out on last-known state (publishing
+    # status_unknown=1.0) before the episode truncates. HALT only -- see _halting.
+    max_unknown_status_steps: int = 0
 
     # Each subclass sets this to its venue normalizer -- all four are a partial of the
     # same normalize_timeframe_config, differing only in parse_fn.
@@ -55,6 +60,7 @@ class BaseFuturesSLTPConfig:
         self.observation_failure_policy = ObservationFailurePolicy(
             self.observation_failure_policy
         )
+        validate_unknown_status_budget(self.max_unknown_status_steps)
         self.trade_mode = validate_trade_mode(self.trade_mode)
         validate_sltp_levels(self.stoploss_levels, self.takeprofit_levels)
         validate_position_sizing(

--- a/torchtrade/envs/utils/sltp_mixin.py
+++ b/torchtrade/envs/utils/sltp_mixin.py
@@ -73,6 +73,11 @@ class SLTPMixin:
             logger.info("Position closed by SL/TP or external action")
             self.active_stop_loss = 0.0
             self.active_take_profit = 0.0
+            # The exchange closed it, so the realised P&L has already moved equity and the
+            # cached sizing balance is stale by exactly that amount. This closure path is
+            # the one the ENV never asked for -- a bracket firing, or a manual close -- so
+            # it has no `close_position()` call for the close-site guard to find (#295).
+            getattr(self, "_last_confirmed_read", {}).pop("balance", None)
 
         # Detect direction flip (e.g., long→short via external action).
         # Reset SL/TP since the old bracket levels are stale for the new direction.


### PR DESCRIPTION
Closes #295.

## The issue's premise was wrong about the current code

#295 says *"#270 falls back to the last known cached state, which is the best available truth but is silently stale."* It does not. #270 closed via #296, which added exactly two policies — `HALT` (raise) and `FLATTEN` (close, then raise) — and nothing in `torchtrade/` catches `LiveObservationHalt`.

So an outage did not produce a stale observation. It produced **an uncaught exception that killed the process**. There was no staleness to flag until something was allowed to continue, which is why §1 (`status_unknown`) and §2 (truncation) could not be built independently — you cannot have "the observation says I don't know" without first deciding the env may keep going.

That is a risk-posture decision, so I asked rather than picking it silently. The answer was: grace period, then truncate.

## §3 answered, with a trap

Drove a real env through both `env.rollout` and a real `Collector` emitting `truncated=True` with `terminated=False`. It works — `terminated` survives as 0, so the critic bootstraps rather than being taught the episode ended at zero value.

**The trap:** setting *only* `truncated=True` does **not** end the episode.

```
truncated=True only  ->  done=0 term=0 trunc=1   # collector never resets
done written too     ->  done=1 term=0 trunc=1   # correct
```

TorchRL does not derive `done` from `truncated` in `_step` output, and `truncated` has been write-only since #313 — so nothing in the suite would have caught it. `done` is now written explicitly.

## What shipped

`max_unknown_status_steps` (default **0** = today's behaviour, refuse to act on state you cannot confirm). Above 0:

| bar | `status_unknown` | `done` | `terminated` | `truncated` |
|---|---|---|---|---|
| healthy | `0.0` | 0 | 0 | 0 |
| outage 1 | `1.0` | 0 | 0 | 0 |
| outage 2 | `1.0` | 0 | 0 | 0 |
| outage 3 | `1.0` | **1** | 0 | **1** |

- **Truncates, never terminates** — an unreachable API and a liquidated account must not share a value target.
- **Never fabricates** — a failure with nothing cached raises regardless of budget.
- **`FLATTEN` ignores the budget** — it exists to get you out while blind; riding out the outage would defeat the only thing it is for.
- **`status_unknown` is a separate key**, not a 7th `account_state` slot: `account_state` is shared verbatim with the offline envs, which have no notion of an unreadable venue.
- A shared `_finalize_step_flags` replaces **ten byte-identical done blocks**, which is #288 step 2.

## Driving a real env caught two defects the unit tests could not

1. `status_unknown` was stamped at observation-**build** time, so the grace period served a *cached* observation carrying the healthy `0.0` — the policy was told "all confirmed" on exactly the bars it was not. Worse than having no flag.
2. **Both** read sites advanced the counter, so a budget of 3 truncated after **two** bars. Only the pre-trade read counts now, so the budget means bars.

Both are pinned by `test_a_real_env_flags_the_outage_and_truncates_on_the_budgeted_bar`, which exists precisely because `_halting` in isolation cannot see either.

## Evidence

7 mutants, each killed by the test that claims it: terminate-instead-of-truncate, leave-`done`-to-TorchRL, FLATTEN-honours-grace, lifetime-instead-of-consecutive counting, fabricate-without-cache, bake-flag-at-build-time, count-reads-not-bars.

Suite **4090 passed / 16 skipped**.

## Deliberately not in scope

Alpaca has no `observation_failure_policy` at all (it reads `get_status()` raw at four sites), so its counter never advances and `status_unknown` is always `0.0` there. The key is still declared on all ten envs so the observation contract does not fork by venue. Giving Alpaca a failure policy belongs with #288's parity work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AWNTLhwczWJBoxbXrPVYJu