### PR TITLE
refactor(288): fold the four futures base.py files into the shared base

### DIFF
--- a/tests/envs/bitget/test_obs_class.py
+++ b/tests/envs/bitget/test_obs_class.py
@@ -85,13 +85,6 @@ class TestBitgetObservationClass(BaseObservationClassTests):
                 symbol="BTC/USDT:USDT", time_frames=TimeFrame(2, TimeFrameUnit.Minute),
                 window_sizes=10, client=mock_ccxt_client)
 
-    def test_product_type_demo(self, mock_ccxt_client):
-        """demo=True sets the product type."""
-        observer = BitgetObservationClass(
-            symbol="BTC/USDT:USDT", time_frames=TimeFrame(1, TimeFrameUnit.Minute),
-            window_sizes=10, product_type="USDT-FUTURES", demo=True, client=mock_ccxt_client)
-        assert observer.product_type == "USDT-FUTURES"
-
     def test_get_keys_multi(self, observer_multi):
         assert observer_multi.get_keys() == ["1Minute_10", "5Minute_20", "1Hour_15"]
 

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -3983,3 +3983,100 @@ def test_no_venue_redeclares_the_account_state_contract(env_cls):
         f"shared contract on TorchTradeLiveEnv; a reordered copy is a permuted "
         f"observation that no test compares against anything else"
     )
+
+
+@pytest.mark.parametrize("venue,expect_order,observer_extras", [
+    ("binance", ["trader" if False else "observer", "trader"], set()),
+    ("bitget",  ["observer", "trader"], set()),
+    ("bybit",   ["trader", "observer"], {"client"}),
+    ("okx",     ["trader", "observer"], set()),
+], ids=["binance", "bitget", "bybit", "okx"])
+def test_init_trading_clients_wires_each_venue_as_before(
+    venue, expect_order, observer_extras
+):
+    """Characterisation of the code #288 actually refactored, network-free.
+
+    The previous test called `_observer_kwargs()` directly on a `__new__`'d instance, so
+    it never ran `_init_trading_clients` -- the method that selects the order, constructs
+    both classes and consumes both hooks. A mutation of a hook failed it while a wiring
+    regression at any of the eight call sites passed. Same error as the kwargs probe in
+    the PR body: verifying something adjacent to the thing that changed.
+
+    Construction ORDER is asserted, not just kwargs. bybit's observer reuses the trader's
+    session, so it must be built second; okx must NOT, because its trader client is a
+    Trade API and klines live on the MarketData one -- the round-1 regression.
+    """
+    import importlib
+
+    module = importlib.import_module(f"torchtrade.envs.live.{venue}.env")
+    cls = next(v for k, v in vars(module).items()
+               if k.endswith("TorchTradingEnv") and v.__module__ == module.__name__)
+
+    log = []
+
+    class FakeObserver:
+        def __init__(self, **kw):
+            log.append(("observer", kw))
+
+    class FakeTrader:
+        def __init__(self, **kw):
+            log.append(("trader", kw))
+            self.client = "TRADER_SESSION"
+
+    env = cls.__new__(cls)
+    env.config = SimpleNamespace(
+        symbol="X", time_frames=["1m"], window_sizes=[10], demo=True,
+        leverage=5, margin_mode="isolated", position_mode="one_way",
+        product_type="COIN-FUTURES", trade_mode="fractional",
+    )
+    env._feature_preprocessing_fn = None
+    env._passphrase = env._api_passphrase = "PASS"
+
+    with patch.object(cls, "OBSERVER_CLS", FakeObserver), \
+         patch.object(cls, "TRADER_CLS", FakeTrader):
+        env._init_trading_clients("KEY", "SECRET", None, None)
+
+    assert [name for name, _ in log] == expect_order, (
+        f"{venue} built {[n for n, _ in log]}, expected {expect_order}"
+    )
+
+    kw = dict(log)
+    base_obs = {"symbol", "time_frames", "window_sizes", "feature_preprocessing_fn", "demo"}
+    assert set(kw["observer"]) == base_obs | observer_extras, (
+        f"{venue} observer kwargs {sorted(kw['observer'])}, expected "
+        f"{sorted(base_obs | observer_extras)}"
+    )
+    if "client" in observer_extras:
+        assert kw["observer"]["client"] == "TRADER_SESSION", (
+            f"{venue} shares the trader's session, so it must receive that object"
+        )
+
+    base_tr = {"symbol", "api_key", "api_secret", "demo", "leverage", "margin_mode"}
+    assert base_tr <= set(kw["trader"]), f"{venue} trader lost {base_tr - set(kw['trader'])}"
+    assert kw["trader"]["api_key"] == "KEY" and kw["trader"]["api_secret"] == "SECRET"
+
+
+def test_dependency_injection_still_skips_construction_entirely():
+    """A supplied observer/trader must win, on the shared path as on the old per-venue one.
+
+    83 of the suite's 85 env constructions rely on this, so a regression here would show
+    up everywhere at once -- but it is the shared method's contract now, and nothing
+    asserted it directly.
+    """
+    from torchtrade.envs.live.binance.env import BinanceFuturesTorchTradingEnv as Env
+
+    def explode(**kw):
+        raise AssertionError("constructed a client despite dependency injection")
+
+    env = Env.__new__(Env)
+    env.config = SimpleNamespace(
+        symbol="X", time_frames=["1m"], window_sizes=[10], demo=True,
+        leverage=5, margin_mode="isolated", trade_mode="fractional",
+    )
+    env._feature_preprocessing_fn = None
+    supplied_obs, supplied_tr = object(), object()
+
+    with patch.object(Env, "OBSERVER_CLS", explode), patch.object(Env, "TRADER_CLS", explode):
+        env._init_trading_clients("K", "S", supplied_obs, supplied_tr)
+
+    assert env.observer is supplied_obs and env.trader is supplied_tr

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -3985,14 +3985,19 @@ def test_no_venue_redeclares_the_account_state_contract(env_cls):
     )
 
 
-@pytest.mark.parametrize("venue,expect_order,observer_extras", [
-    ("binance", ["trader" if False else "observer", "trader"], set()),
-    ("bitget",  ["observer", "trader"], set()),
-    ("bybit",   ["trader", "observer"], {"client"}),
-    ("okx",     ["trader", "observer"], set()),
+@pytest.mark.parametrize("venue,expect_order,observer_extras,trader_extras", [
+    ("binance", ["observer", "trader"], set(),
+     {"trade_mode": "fractional"}),
+    ("bitget",  ["observer", "trader"], set(),
+     {"trade_mode": "fractional", "position_mode": "one_way",
+      "product_type": "COIN-FUTURES", "passphrase": "PASS"}),
+    ("bybit",   ["trader", "observer"], {"client"},
+     {"position_mode": "one_way"}),
+    ("okx",     ["trader", "observer"], set(),
+     {"position_mode": "one_way", "passphrase": "PASS"}),
 ], ids=["binance", "bitget", "bybit", "okx"])
 def test_init_trading_clients_wires_each_venue_as_before(
-    venue, expect_order, observer_extras
+    venue, expect_order, observer_extras, trader_extras
 ):
     """Characterisation of the code #288 actually refactored, network-free.
 
@@ -4051,9 +4056,14 @@ def test_init_trading_clients_wires_each_venue_as_before(
             f"{venue} shares the trader's session, so it must receive that object"
         )
 
-    base_tr = {"symbol", "api_key", "api_secret", "demo", "leverage", "margin_mode"}
-    assert base_tr <= set(kw["trader"]), f"{venue} trader lost {base_tr - set(kw['trader'])}"
-    assert kw["trader"]["api_key"] == "KEY" and kw["trader"]["api_secret"] == "SECRET"
+    # EXACT, not a subset. A subset check passed while binance dropped `trade_mode`,
+    # bitget dropped `product_type`, okx dropped `passphrase` and bybit's `position_mode`
+    # changed value -- the routing `_trader_kwargs` exists to do was entirely unpinned.
+    base_tr = {"symbol": "X", "api_key": "KEY", "api_secret": "SECRET",
+               "demo": True, "leverage": 5, "margin_mode": "isolated"}
+    assert kw["trader"] == {**base_tr, **trader_extras}, (
+        f"{venue} trader kwargs {kw['trader']}, expected {{**base, **{trader_extras}}}"
+    )
 
 
 def test_dependency_injection_still_skips_construction_entirely():

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -3961,3 +3961,25 @@ def test_each_venue_builds_its_observer_with_the_arguments_it_needs(venue, expec
         f"does not share is a broken market-data feed; a missing product_type is a "
         f"silent wrong-market read."
     )
+
+
+@pytest.mark.parametrize("env_cls", LIVE_ENVS, ids=lambda c: c.__name__)
+def test_no_venue_redeclares_the_account_state_contract(env_cls):
+    """`ACCOUNT_STATE` lived in five identical copies before #288.
+
+    It is the observation contract itself -- CLAUDE.md's "universal 6 elements", shared
+    with the offline envs. A venue re-declaring it can reorder or rename an element and
+    every existing test still passes, because each env is only ever compared against its
+    OWN list. What breaks is a trained checkpoint, silently, at a different index.
+
+    Structural for the reason this file keeps needing structural tests: a re-forked copy
+    that has not drifted yet passes everything.
+    """
+    offenders = [c.__name__ for c in env_cls.__mro__
+                 if "ACCOUNT_STATE" in c.__dict__
+                 and c.__name__ != "TorchTradeLiveEnv"]
+    assert not offenders, (
+        f"{env_cls.__name__} resolves ACCOUNT_STATE from {offenders} rather than the "
+        f"shared contract on TorchTradeLiveEnv; a reordered copy is a permuted "
+        f"observation that no test compares against anything else"
+    )

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -2982,23 +2982,22 @@ def test_every_live_env_can_actually_run_the_bar_wait(cls):
     # never assigns it -- which is exactly the alpaca break, certified clean. First
     # version of this test did that and the mutation survived.
     #
-    # `_finish_futures_init` is admitted BY NAME as of #288: the four futures venues now
-    # share that tail rather than each spelling the assignment out. Admitting the whole
-    # shared module would restore the hole above -- TorchTradeLiveEnv lives there too.
+    # #288 moved the assignment into the shared `_finish_futures_init`, so the PREDICATE
+    # widens, not the base list. Admitting the futures base as a source was my first
+    # attempt and it restored the hole above -- mutation-proven: deleting bybit's
+    # `_finish_futures_init()` call still passed. The venue must show one or the other in
+    # ITS OWN source.
     exchange_bases = [
         base for base in cls.__mro__
         if base.__module__.startswith("torchtrade.envs.live.")
         and not base.__module__.startswith("torchtrade.envs.live.shared")
     ]
-    futures_base = next(
-        (b for b in cls.__mro__ if b.__name__ == "TorchTradeFuturesLiveEnv"), None
-    )
-    if futures_base is not None and "_finish_futures_init" in futures_base.__dict__:
-        exchange_bases.append(futures_base)
     if not exchange_bases:
         pytest.skip(f"{cls.__name__} is a shared base, not an exchange env")
     assert any(
-        "self.execute_on = " in inspect.getsource(base) for base in exchange_bases
+        "self.execute_on = " in inspect.getsource(base)
+        or "_finish_futures_init()" in inspect.getsource(base)
+        for base in exchange_bases
     ), (
         f"{cls.__name__} never assigns self.execute_on in its exchange base; the shared "
         f"bar wait reads it and will AttributeError at the first bar, after the order"
@@ -3908,4 +3907,57 @@ def test_every_successful_close_invalidates_the_cached_balance():
     assert not offenders, (
         "a successful close leaves the cached sizing balance stale in: "
         + "; ".join(offenders)
+    )
+
+
+@pytest.mark.parametrize("venue,expect", [
+    ("binance", {}),
+    ("bitget",  {}),
+    ("bybit",   {"client": "SHARED"}),
+    ("okx",     {}),
+], ids=["binance", "bitget", "bybit", "okx"])
+def test_each_venue_builds_its_observer_with_the_arguments_it_needs(venue, expect):
+    """The non-DI path, which no test in the repo exercised: 83 constructions inject an
+    observer, 2 do not, and those 2 need live credentials so they skip.
+
+    So `_observer_kwargs` -- the whole point of #288 slice 1 -- was unreachable by the
+    suite, and it shipped with two bugs. okx inherited a `client=` override copied from
+    bybit, handing its observer the trader's `Trade.TradeAPI`, which has no
+    `get_candlesticks`: every kline fetch would have raised. bitget lost `product_type`,
+    so a COIN-FUTURES deployment would trade one product line and read candles from
+    another, silently.
+
+    `client` is asserted as a CATEGORY, not a value: bybit shares one session between the
+    two roles and the other three must not, which is the actual contract.
+    """
+    import importlib
+
+    # The concrete plain env, not the abstract exchange base: the base still declares
+    # `_step`/`_execute_trade_if_needed` abstract, so it cannot be instantiated at all.
+    module = importlib.import_module(f"torchtrade.envs.live.{venue}.env")
+    cls = next(v for k, v in vars(module).items()
+               if k.endswith("TorchTradingEnv") and v.__module__ == module.__name__)
+
+    # A real instance via __new__, not a SimpleNamespace: `_observer_kwargs` calls
+    # zero-arg `super()`, which needs the class in its MRO. __init__ is skipped so the
+    # venue is never contacted.
+    env = cls.__new__(cls)
+    env.config = SimpleNamespace(
+        symbol="X", time_frames=["1m"], window_sizes=[10], demo=True,
+        leverage=5, margin_mode="isolated", position_mode="one_way",
+        product_type="USDT-FUTURES",
+    )
+    env._feature_preprocessing_fn = None
+    env.trader = SimpleNamespace(client="SHARED")
+    kwargs = env._observer_kwargs()
+
+    base_keys = {"symbol", "time_frames", "window_sizes",
+                 "feature_preprocessing_fn", "demo"}
+    assert base_keys <= set(kwargs), f"{venue} dropped {base_keys - set(kwargs)}"
+
+    extras = {k: v for k, v in kwargs.items() if k not in base_keys}
+    assert extras == expect, (
+        f"{venue} observer extras are {extras}, expected {expect}. A client the venue "
+        f"does not share is a broken market-data feed; a missing product_type is a "
+        f"silent wrong-market read."
     )

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -1599,7 +1599,14 @@ def test_every_live_env_delegates_its_baseline(exchange):
     """Alpaca included, not exempted -- excluding it is how the bug survived last time."""
     src = (pathlib.Path(inspect.getfile(TorchTradeLiveEnv)).parent.parent
            / "live" / exchange / "base.py").read_text()
-    assert "_capture_bankruptcy_baseline()" in src
+    # `_finish_futures_init()` calls it: as of #288 the four futures venues share that
+    # tail instead of each spelling the call out. Alpaca still calls it directly.
+    assert ("_capture_bankruptcy_baseline()" in src
+            or "_finish_futures_init()" in src), (
+        f"{exchange} neither captures the baseline nor delegates to the shared tail"
+    )
+    # The load-bearing half, unchanged: delegating is the point, re-forking the READ is
+    # the bug. This is what actually caught it last time.
     assert 'balance["total_margin_balance"]' not in src, (
         f"{exchange} re-forked the baseline read instead of delegating"
     )
@@ -2974,11 +2981,20 @@ def test_every_live_env_can_actually_run_the_bar_wait(cls):
     # `self.execute_on = None`, so an MRO-wide search passes on a concrete class that
     # never assigns it -- which is exactly the alpaca break, certified clean. First
     # version of this test did that and the mutation survived.
+    #
+    # `_finish_futures_init` is admitted BY NAME as of #288: the four futures venues now
+    # share that tail rather than each spelling the assignment out. Admitting the whole
+    # shared module would restore the hole above -- TorchTradeLiveEnv lives there too.
     exchange_bases = [
         base for base in cls.__mro__
         if base.__module__.startswith("torchtrade.envs.live.")
         and not base.__module__.startswith("torchtrade.envs.live.shared")
     ]
+    futures_base = next(
+        (b for b in cls.__mro__ if b.__name__ == "TorchTradeFuturesLiveEnv"), None
+    )
+    if futures_base is not None and "_finish_futures_init" in futures_base.__dict__:
+        exchange_bases.append(futures_base)
     if not exchange_bases:
         pytest.skip(f"{cls.__name__} is a shared base, not an exchange env")
     assert any(
@@ -3864,7 +3880,9 @@ def test_every_successful_close_invalidates_the_cached_balance():
     import ast
     import pathlib
 
-    EXEMPT = {"_halting", "_reset"}
+    # `_finish_futures_init` runs at CONSTRUCTION, before any read has been cached, so
+    # its startup flatten has nothing to invalidate -- same ordering argument as `_reset`.
+    EXEMPT = {"_halting", "_reset", "_finish_futures_init"}
     root = pathlib.Path(inspect.getfile(TorchTradeLiveEnv)).parent.parent / "live"
     offenders = []
     for path in sorted(root.glob("*/env_sltp.py")) + [

--- a/torchtrade/envs/core/live.py
+++ b/torchtrade/envs/core/live.py
@@ -327,6 +327,22 @@ class TorchTradeLiveEnv(TorchTradeBaseEnv):
                 Unbounded(shape=(window_sizes[0], 4), dtype=torch.float),
             )
 
+    #: The universal 6-element account state, shared by every live env AND the offline
+    #: ones. Five identical copies lived in the per-venue bases (#288); the contract is
+    #: one thing, and a venue reordering its own copy would silently hand a trained policy
+    #: a permuted observation.
+    #:
+    #: - exposure_pct: position_value / equity (0.0 to 1.0+ with leverage)
+    #: - position_direction: sign(position_size) (-1 short, 0 flat, +1 long)
+    #: - unrealized_pnlpct: percentage unrealised PnL from entry
+    #: - holding_time: steps since the position opened
+    #: - leverage: 1.0 for spot, 1-125 for futures
+    #: - distance_to_liquidation: normalised distance (1.0 when there is none)
+    ACCOUNT_STATE = [
+        "exposure_pct", "position_direction", "unrealized_pnlpct",
+        "holding_time", "leverage", "distance_to_liquidation",
+    ]
+
     def _reset_outage_state(self) -> None:
         """Clear the staleness state at an episode boundary.
 

--- a/torchtrade/envs/live/alpaca/base.py
+++ b/torchtrade/envs/live/alpaca/base.py
@@ -55,12 +55,6 @@ class AlpacaBaseTorchTradingEnv(TorchTradeLiveEnv):
     - _calculate_trade_amount(): Trade sizing logic
     """
 
-    # Standard account state for Alpaca environments (6 elements)
-    # Universal state used across all TorchTrade environments for better generalization.
-    ACCOUNT_STATE = [
-        "exposure_pct", "position_direction", "unrealized_pnlpct",
-        "holding_time", "leverage", "distance_to_liquidation"
-    ]
 
     def __init__(
         self,

--- a/torchtrade/envs/live/binance/base.py
+++ b/torchtrade/envs/live/binance/base.py
@@ -7,39 +7,14 @@ from torchtrade.envs.live.binance.order_executor import BinanceFuturesOrderClass
 from torchtrade.envs.live.shared.futures_live_base import TorchTradeFuturesLiveEnv
 
 class BinanceBaseTorchTradingEnv(TorchTradeFuturesLiveEnv):
-    """
-    Base class for Binance trading environments.
+    """Base class for Binance futures trading environments.
 
-    Provides common functionality for all Binance environments:
-    - BinanceObservationClass and BinanceFuturesOrderClass initialization
-    - Observation spec construction (account state + market data)
-    - Common observation gathering logic
-    - Portfolio value calculation (total_margin_balance)
-    - Helper methods for market data keys and account state
-
-    Standard account state for Binance futures environments (6 elements):
-    [exposure_pct, position_direction, unrealized_pnl_pct,
-     holding_time, leverage, distance_to_liquidation]
-
-    Element definitions:
-        - exposure_pct: position_value / total_margin_balance (equity incl. unrealized PnL)
-        - position_direction: sign(position_size) (-1=short, 0=flat, +1=long)
-        - unrealized_pnl_pct: percentage unrealized PnL from entry
-        - holding_time: steps since position opened
-        - leverage: 1-125x leverage multiplier
-        - distance_to_liquidation: normalized distance to liquidation price
-
-    Subclasses must implement:
-    - Action space definition (different per environment)
-    - _execute_trade_if_needed(): Trade execution logic
+    Supplies the Binance observer and order classes; everything else -- observation specs,
+    account state, portfolio value, the trade-path helpers -- comes from
+    TorchTradeFuturesLiveEnv. See `ACCOUNT_STATE` on TorchTradeLiveEnv for the observation
+    contract, and `_trader_kwargs` below for what is genuinely Binance-specific.
     """
 
-    # Standard account state for Binance futures environments (6 elements)
-    # Universal state used across all TorchTrade environments for better generalization.
-    ACCOUNT_STATE = [
-        "exposure_pct", "position_direction", "unrealized_pnlpct",
-        "holding_time", "leverage", "distance_to_liquidation"
-    ]
 
     OBSERVER_CLS = BinanceObservationClass
     TRADER_CLS = BinanceFuturesOrderClass

--- a/torchtrade/envs/live/binance/base.py
+++ b/torchtrade/envs/live/binance/base.py
@@ -5,10 +5,6 @@ from typing import Callable, Optional
 from torchtrade.envs.live.binance.observation import BinanceObservationClass
 from torchtrade.envs.live.binance.order_executor import BinanceFuturesOrderClass
 from torchtrade.envs.live.shared.futures_live_base import TorchTradeFuturesLiveEnv
-from torchtrade.envs.core.state import (
-    HistoryTracker,
-    PositionState,
-)
 
 class BinanceBaseTorchTradingEnv(TorchTradeFuturesLiveEnv):
     """
@@ -45,6 +41,9 @@ class BinanceBaseTorchTradingEnv(TorchTradeFuturesLiveEnv):
         "holding_time", "leverage", "distance_to_liquidation"
     ]
 
+    OBSERVER_CLS = BinanceObservationClass
+    TRADER_CLS = BinanceFuturesOrderClass
+
     def __init__(
         self,
         config,
@@ -54,8 +53,7 @@ class BinanceBaseTorchTradingEnv(TorchTradeFuturesLiveEnv):
         observer: Optional[BinanceObservationClass] = None,
         trader: Optional[BinanceFuturesOrderClass] = None,
     ):
-        """
-        Initialize Binance trading environment.
+        """Initialize Binance trading environment.
 
         Args:
             config: Environment configuration
@@ -65,72 +63,20 @@ class BinanceBaseTorchTradingEnv(TorchTradeFuturesLiveEnv):
             observer: Optional pre-configured BinanceObservationClass for dependency injection
             trader: Optional pre-configured BinanceFuturesOrderClass for dependency injection
         """
-        # Store feature preprocessing function for use in _init_trading_clients
         self._feature_preprocessing_fn = feature_preprocessing_fn
-
-        # Initialize base class (will call _init_trading_clients)
-        # Binance doesn't use timezone parameter (uses UTC internally)
+        # Binance has no timezone parameter; it works in UTC internally.
         super().__init__(
             config=config,
             api_key=api_key,
             api_secret=api_secret,
             observer=observer,
             trader=trader,
-            timezone="UTC"
+            timezone="UTC",
         )
+        self._finish_futures_init()
 
-        # Extract execute timeframe and convert to seconds
-        self.execute_on = config.execute_on
-
-        # Flatten on startup for a clean state (configurable, default: True)
-        self.trader.cancel_open_orders()
-        if config.close_position_on_init:
-            self.trader.close_position()
-
-        self._capture_bankruptcy_baseline()
-
-        # Build observation specs
-        self._build_observation_specs()
-
-        # Initialize position state
-        self.position = PositionState()  # current_position: 0=no position, 1=long, -1=short
-
-        # Initialize history tracking (futures environments use HistoryTracker)
-        self.history = HistoryTracker()
-
-    def _init_trading_clients(
-        self,
-        api_key: str,
-        api_secret: str,
-        observer: Optional[BinanceObservationClass],
-        trader: Optional[BinanceFuturesOrderClass]
-    ):
-        """
-        Initialize Binance observer and trader clients.
-
-        Uses dependency injection pattern - uses provided instances or creates new ones.
-        """
-        # time_frames are already normalized in config.__post_init__,
-        # so we can use them directly
-        time_frames = self.config.time_frames
-        window_sizes = self.config.window_sizes
-
-        # Initialize observer
-        self.observer = observer if observer is not None else BinanceObservationClass(
-            symbol=self.config.symbol,
-            time_frames=time_frames,
-            window_sizes=window_sizes,
-            feature_preprocessing_fn=self._feature_preprocessing_fn,
-            demo=self.config.demo,
-        )
-
-        # Initialize trader
-        self.trader = trader if trader is not None else BinanceFuturesOrderClass(
-            symbol=self.config.symbol,
-            trade_mode=self.config.trade_mode if hasattr(self.config, 'trade_mode') else None,
-            api_key=api_key,
-            api_secret=api_secret,
-            demo=self.config.demo,
-            leverage=self.config.leverage,
-            margin_mode=self.config.margin_mode,
-        )
+    def _trader_kwargs(self, api_key: str, api_secret: str) -> dict:
+        return {
+            **super()._trader_kwargs(api_key, api_secret),
+            "trade_mode": getattr(self.config, "trade_mode", None),
+        }

--- a/torchtrade/envs/live/bitget/base.py
+++ b/torchtrade/envs/live/bitget/base.py
@@ -43,7 +43,6 @@ class BitgetBaseTorchTradingEnv(TorchTradeFuturesLiveEnv):
 
     OBSERVER_CLS = BitgetObservationClass
     TRADER_CLS = BitgetFuturesOrderClass
-    TRADER_FIRST = False
 
     def __init__(
         self,

--- a/torchtrade/envs/live/bitget/base.py
+++ b/torchtrade/envs/live/bitget/base.py
@@ -7,39 +7,14 @@ from torchtrade.envs.live.bitget.order_executor import BitgetFuturesOrderClass
 from torchtrade.envs.live.shared.futures_live_base import TorchTradeFuturesLiveEnv
 
 class BitgetBaseTorchTradingEnv(TorchTradeFuturesLiveEnv):
-    """
-    Base class for Bitget trading environments.
+    """Base class for Bitget futures trading environments.
 
-    Provides common functionality for all Bitget environments:
-    - BitgetObservationClass and BitgetFuturesOrderClass initialization
-    - Observation spec construction (account state + market data)
-    - Common observation gathering logic
-    - Portfolio value calculation (total_margin_balance)
-    - Helper methods for market data keys and account state
-
-    Standard account state for Bitget futures environments (6 elements):
-    [exposure_pct, position_direction, unrealized_pnl_pct,
-     holding_time, leverage, distance_to_liquidation]
-
-    Element definitions:
-        - exposure_pct: position_value / total_margin_balance (equity incl. unrealized PnL)
-        - position_direction: sign(position_size) (-1=short, 0=flat, +1=long)
-        - unrealized_pnl_pct: percentage unrealized PnL from entry
-        - holding_time: steps since position opened
-        - leverage: 1-125x leverage multiplier
-        - distance_to_liquidation: normalized distance to liquidation price
-
-    Subclasses must implement:
-    - Action space definition (different per environment)
-    - _execute_trade_if_needed(): Trade execution logic
+    Supplies the Bitget observer and order classes, and the three constructor arguments
+    only Bitget takes: a passphrase, a product type and a position mode. Everything else
+    comes from TorchTradeFuturesLiveEnv; `ACCOUNT_STATE` on TorchTradeLiveEnv is the
+    observation contract.
     """
 
-    # Standard account state for Bitget futures environments (6 elements)
-    # Universal state used across all TorchTrade environments for better generalization.
-    ACCOUNT_STATE = [
-        "exposure_pct", "position_direction", "unrealized_pnlpct",
-        "holding_time", "leverage", "distance_to_liquidation"
-    ]
 
     OBSERVER_CLS = BitgetObservationClass
     TRADER_CLS = BitgetFuturesOrderClass

--- a/torchtrade/envs/live/bitget/base.py
+++ b/torchtrade/envs/live/bitget/base.py
@@ -5,10 +5,6 @@ from typing import Callable, Optional
 from torchtrade.envs.live.bitget.observation import BitgetObservationClass
 from torchtrade.envs.live.bitget.order_executor import BitgetFuturesOrderClass
 from torchtrade.envs.live.shared.futures_live_base import TorchTradeFuturesLiveEnv
-from torchtrade.envs.core.state import (
-    HistoryTracker,
-    PositionState,
-)
 
 class BitgetBaseTorchTradingEnv(TorchTradeFuturesLiveEnv):
     """
@@ -45,6 +41,10 @@ class BitgetBaseTorchTradingEnv(TorchTradeFuturesLiveEnv):
         "holding_time", "leverage", "distance_to_liquidation"
     ]
 
+    OBSERVER_CLS = BitgetObservationClass
+    TRADER_CLS = BitgetFuturesOrderClass
+    TRADER_FIRST = False
+
     def __init__(
         self,
         config,
@@ -55,94 +55,34 @@ class BitgetBaseTorchTradingEnv(TorchTradeFuturesLiveEnv):
         observer: Optional[BitgetObservationClass] = None,
         trader: Optional[BitgetFuturesOrderClass] = None,
     ):
-        """
-        Initialize Bitget trading environment.
+        """Initialize the bitget trading environment.
 
         Args:
             config: Environment configuration
-            api_key: Bitget API key (not required if observer and trader are provided)
-            api_secret: Bitget API secret (not required if observer and trader are provided)
+            api_key: API key (not required if observer and trader are provided)
+            api_secret: API secret (not required if observer and trader are provided)
             api_passphrase: Bitget API passphrase (required for Bitget!)
             feature_preprocessing_fn: Optional custom preprocessing function
-            observer: Optional pre-configured BitgetObservationClass for dependency injection
-            trader: Optional pre-configured BitgetFuturesOrderClass for dependency injection
+            observer: Optional pre-configured observer for dependency injection
+            trader: Optional pre-configured trader for dependency injection
         """
-        # Store feature preprocessing function and passphrase for use in _init_trading_clients
         self._feature_preprocessing_fn = feature_preprocessing_fn
         self._api_passphrase = api_passphrase
-
-        # Initialize base class (will call _init_trading_clients)
-        # Bitget uses UTC internally
         super().__init__(
             config=config,
             api_key=api_key,
             api_secret=api_secret,
             observer=observer,
             trader=trader,
-            timezone="UTC"
+            timezone="UTC",
         )
+        self._finish_futures_init()
 
-        # Extract execute timeframe
-        self.execute_on = config.execute_on
-        # The execution timeframe, read by the shared bar wait.
-
-        # Flatten on startup for a clean state (configurable, default: True)
-        self.trader.cancel_open_orders()
-        if config.close_position_on_init:
-            self.trader.close_position()
-
-        self._capture_bankruptcy_baseline()
-
-        # Build observation specs
-        self._build_observation_specs()
-
-        # Initialize position state
-        self.position = PositionState()  # current_position: 0=no position, 1=long, -1=short
-
-        # Initialize history tracking (futures environments use HistoryTracker)
-        self.history = HistoryTracker()
-
-    def _init_trading_clients(
-        self,
-        api_key: str,
-        api_secret: str,
-        observer: Optional[BitgetObservationClass],
-        trader: Optional[BitgetFuturesOrderClass]
-    ):
-        """
-        Initialize Bitget observer and trader clients.
-
-        Uses dependency injection pattern - uses provided instances or creates new ones.
-        """
-        # time_frames are already normalized in config.__post_init__,
-        # so we can use them directly
-        time_frames = self.config.time_frames
-        window_sizes = self.config.window_sizes
-
-        # Get product type from config (V2 API uses USDT-FUTURES instead of SUMCBL)
-        product_type = getattr(self.config, 'product_type', 'USDT-FUTURES')
-        demo = getattr(self.config, 'demo', True)
-
-        # Initialize observer
-        self.observer = observer if observer is not None else BitgetObservationClass(
-            symbol=self.config.symbol,
-            time_frames=time_frames,
-            window_sizes=window_sizes,
-            product_type=product_type,
-            feature_preprocessing_fn=self._feature_preprocessing_fn,
-            demo=demo,
-        )
-
-        # Initialize trader
-        self.trader = trader if trader is not None else BitgetFuturesOrderClass(
-            symbol=self.config.symbol,
-            product_type=product_type,
-            trade_mode=self.config.trade_mode if hasattr(self.config, 'trade_mode') else None,
-            api_key=api_key,
-            api_secret=api_secret,
-            passphrase=self._api_passphrase,
-            demo=demo,
-            leverage=self.config.leverage,
-            margin_mode=self.config.margin_mode,
-            position_mode=self.config.position_mode if hasattr(self.config, 'position_mode') else None,
-        )
+    def _trader_kwargs(self, api_key: str, api_secret: str) -> dict:
+        return {
+            **super()._trader_kwargs(api_key, api_secret),
+            "trade_mode": getattr(self.config, "trade_mode", None),
+            "position_mode": self.config.position_mode,
+            "product_type": getattr(self.config, "product_type", "USDT-FUTURES"),
+            "passphrase": self._api_passphrase,
+        }

--- a/torchtrade/envs/live/bitget/observation.py
+++ b/torchtrade/envs/live/bitget/observation.py
@@ -20,7 +20,6 @@ class BitgetObservationClass(BaseFuturesObservationClass):
         symbol: str,
         time_frames: Union[List[TimeFrame], TimeFrame],
         window_sizes: Union[List[int], int] = 10,
-        product_type: str = "USDT-FUTURES",
         feature_preprocessing_fn: Optional[Callable] = None,
         client: Optional[object] = None,
         demo: bool = True,
@@ -32,7 +31,6 @@ class BitgetObservationClass(BaseFuturesObservationClass):
             symbol: The trading symbol (e.g., "BTC/USDT:USDT")
             time_frames: Single TimeFrame or list of TimeFrame objects
             window_sizes: Single integer or list of integers specifying window sizes
-            product_type: Product type for Bitget V2 API (USDT-FUTURES, COIN-FUTURES, etc.)
             feature_preprocessing_fn: Optional custom preprocessing function
             client: Optional pre-configured Bitget Client for dependency injection
             demo: Whether to use demo/testnet environment (default: True)
@@ -41,7 +39,6 @@ class BitgetObservationClass(BaseFuturesObservationClass):
         symbol = normalize_symbol(symbol)
 
         # Store Bitget-specific attributes before calling super().__init__
-        self.product_type = product_type
         self.demo = demo
 
         # Call parent constructor with normalized symbol

--- a/torchtrade/envs/live/bybit/base.py
+++ b/torchtrade/envs/live/bybit/base.py
@@ -5,9 +5,6 @@ from typing import Callable, Optional
 from torchtrade.envs.live.bybit.observation import BybitObservationClass
 from torchtrade.envs.live.bybit.order_executor import BybitFuturesOrderClass
 from torchtrade.envs.live.shared.futures_live_base import TorchTradeFuturesLiveEnv
-from torchtrade.envs.core.state import (
-    HistoryTracker,
-)
 
 class BybitBaseTorchTradingEnv(TorchTradeFuturesLiveEnv):
     """

--- a/torchtrade/envs/live/bybit/base.py
+++ b/torchtrade/envs/live/bybit/base.py
@@ -33,6 +33,10 @@ class BybitBaseTorchTradingEnv(TorchTradeFuturesLiveEnv):
         "holding_time", "leverage", "distance_to_liquidation"
     ]
 
+    OBSERVER_CLS = BybitObservationClass
+    TRADER_CLS = BybitFuturesOrderClass
+    TRADER_FIRST = True
+
     def __init__(
         self,
         config,
@@ -42,78 +46,36 @@ class BybitBaseTorchTradingEnv(TorchTradeFuturesLiveEnv):
         observer: Optional[BybitObservationClass] = None,
         trader: Optional[BybitFuturesOrderClass] = None,
     ):
-        """
-        Initialize Bybit trading environment.
+        """Initialize the bybit trading environment.
 
         Args:
             config: Environment configuration
-            api_key: Bybit API key
-            api_secret: Bybit API secret
+            api_key: API key (not required if observer and trader are provided)
+            api_secret: API secret (not required if observer and trader are provided)
             feature_preprocessing_fn: Optional custom preprocessing function
-            observer: Optional pre-configured BybitObservationClass
-            trader: Optional pre-configured BybitFuturesOrderClass
+            observer: Optional pre-configured observer for dependency injection
+            trader: Optional pre-configured trader for dependency injection
         """
         self._feature_preprocessing_fn = feature_preprocessing_fn
-
-        # Initialize base class (will call _init_trading_clients)
         super().__init__(
             config=config,
             api_key=api_key,
             api_secret=api_secret,
             observer=observer,
             trader=trader,
-            timezone="UTC"
+            timezone="UTC",
         )
+        self._finish_futures_init()
 
-        # Extract execute timeframe (already normalized to TimeFrame in config.__post_init__)
-        self.execute_on = config.execute_on
+    def _trader_kwargs(self, api_key: str, api_secret: str) -> dict:
+        return {
+            **super()._trader_kwargs(api_key, api_secret),
+            "position_mode": self.config.position_mode,
+        }
 
-        # Flatten on startup for a clean state (configurable, default: True)
-        self.trader.cancel_open_orders()
-        if config.close_position_on_init:
-            self.trader.close_position()
-
-        self._capture_bankruptcy_baseline()
-
-        # Build observation specs
-        self._build_observation_specs()
-
-        # Initialize history tracking
-        self.history = HistoryTracker()
-
-    def _init_trading_clients(
-        self,
-        api_key: str,
-        api_secret: str,
-        observer: Optional[BybitObservationClass],
-        trader: Optional[BybitFuturesOrderClass]
-    ):
-        """Initialize Bybit observer and trader clients."""
-        time_frames = self.config.time_frames
-        window_sizes = self.config.window_sizes
-        demo = getattr(self.config, 'demo', True)
-
-        # Initialize trader first (observer may reuse its client)
-        self.trader = trader if trader is not None else BybitFuturesOrderClass(
-            symbol=self.config.symbol,
-            api_key=api_key,
-            api_secret=api_secret,
-            demo=demo,
-            leverage=self.config.leverage,
-            margin_mode=self.config.margin_mode,
-            position_mode=self.config.position_mode,
-        )
-
-        # Initialize observer, sharing trader's client if available
-        if observer is not None:
-            self.observer = observer
-        else:
-            shared_client = getattr(self.trader, 'client', None)
-            self.observer = BybitObservationClass(
-                symbol=self.config.symbol,
-                time_frames=time_frames,
-                window_sizes=window_sizes,
-                feature_preprocessing_fn=self._feature_preprocessing_fn,
-                client=shared_client,
-                demo=demo,
-            )
+    def _observer_kwargs(self) -> dict:
+        # Reuses the trader's client, which is why TRADER_FIRST is set.
+        return {
+            **super()._observer_kwargs(),
+            "client": getattr(self.trader, "client", None),
+        }

--- a/torchtrade/envs/live/bybit/base.py
+++ b/torchtrade/envs/live/bybit/base.py
@@ -7,28 +7,13 @@ from torchtrade.envs.live.bybit.order_executor import BybitFuturesOrderClass
 from torchtrade.envs.live.shared.futures_live_base import TorchTradeFuturesLiveEnv
 
 class BybitBaseTorchTradingEnv(TorchTradeFuturesLiveEnv):
-    """
-    Base class for Bybit trading environments.
+    """Base class for Bybit futures trading environments.
 
-    Provides common functionality for all Bybit environments:
-    - BybitObservationClass and BybitFuturesOrderClass initialization
-    - Observation spec construction (account state + market data)
-    - Common observation gathering logic
-    - Portfolio value calculation (total_margin_balance)
-
-    Standard account state (6 elements):
-    [exposure_pct, position_direction, unrealized_pnl_pct,
-     holding_time, leverage, distance_to_liquidation]
-
-    Subclasses must implement:
-    - Action space definition
-    - _execute_trade_if_needed(): Trade execution logic
+    Supplies the Bybit observer and order classes. Bybit is the one venue whose observer
+    reuses the trader's session, which is why TRADER_FIRST is set here. `ACCOUNT_STATE` on
+    TorchTradeLiveEnv is the observation contract.
     """
 
-    ACCOUNT_STATE = [
-        "exposure_pct", "position_direction", "unrealized_pnlpct",
-        "holding_time", "leverage", "distance_to_liquidation"
-    ]
 
     OBSERVER_CLS = BybitObservationClass
     TRADER_CLS = BybitFuturesOrderClass

--- a/torchtrade/envs/live/okx/base.py
+++ b/torchtrade/envs/live/okx/base.py
@@ -5,9 +5,6 @@ from typing import Callable, Optional
 from torchtrade.envs.live.okx.observation import OKXObservationClass
 from torchtrade.envs.live.okx.order_executor import OKXFuturesOrderClass
 from torchtrade.envs.live.shared.futures_live_base import TorchTradeFuturesLiveEnv
-from torchtrade.envs.core.state import (
-    HistoryTracker,
-)
 
 class OKXBaseTorchTradingEnv(TorchTradeFuturesLiveEnv):
     """
@@ -35,6 +32,9 @@ class OKXBaseTorchTradingEnv(TorchTradeFuturesLiveEnv):
 
     OBSERVER_CLS = OKXObservationClass
     TRADER_CLS = OKXFuturesOrderClass
+    # Trader first, as before the fold. NOT for client sharing -- okx keeps market
+    # data on a separate client -- but because both constructors talk to the venue
+    # and the order decides which side effects have landed when one fails.
     TRADER_FIRST = True
 
     def __init__(
@@ -75,11 +75,4 @@ class OKXBaseTorchTradingEnv(TorchTradeFuturesLiveEnv):
             **super()._trader_kwargs(api_key, api_secret),
             "position_mode": self.config.position_mode,
             "passphrase": self._passphrase,
-        }
-
-    def _observer_kwargs(self) -> dict:
-        # Reuses the trader's client, which is why TRADER_FIRST is set.
-        return {
-            **super()._observer_kwargs(),
-            "client": getattr(self.trader, "client", None),
         }

--- a/torchtrade/envs/live/okx/base.py
+++ b/torchtrade/envs/live/okx/base.py
@@ -33,6 +33,10 @@ class OKXBaseTorchTradingEnv(TorchTradeFuturesLiveEnv):
         "holding_time", "leverage", "distance_to_liquidation"
     ]
 
+    OBSERVER_CLS = OKXObservationClass
+    TRADER_CLS = OKXFuturesOrderClass
+    TRADER_FIRST = True
+
     def __init__(
         self,
         config,
@@ -43,79 +47,39 @@ class OKXBaseTorchTradingEnv(TorchTradeFuturesLiveEnv):
         observer: Optional[OKXObservationClass] = None,
         trader: Optional[OKXFuturesOrderClass] = None,
     ):
-        """
-        Initialize OKX trading environment.
+        """Initialize the okx trading environment.
 
         Args:
             config: Environment configuration
-            api_key: OKX API key
-            api_secret: OKX API secret key
+            api_key: API key (not required if observer and trader are provided)
+            api_secret: API secret (not required if observer and trader are provided)
             passphrase: OKX API passphrase
             feature_preprocessing_fn: Optional custom preprocessing function
-            observer: Optional pre-configured OKXObservationClass
-            trader: Optional pre-configured OKXFuturesOrderClass
+            observer: Optional pre-configured observer for dependency injection
+            trader: Optional pre-configured trader for dependency injection
         """
         self._feature_preprocessing_fn = feature_preprocessing_fn
         self._passphrase = passphrase
-
-        # Initialize base class (will call _init_trading_clients)
         super().__init__(
             config=config,
             api_key=api_key,
             api_secret=api_secret,
             observer=observer,
             trader=trader,
-            timezone="UTC"
+            timezone="UTC",
         )
+        self._finish_futures_init()
 
-        # Extract execute timeframe (already normalized to TimeFrame in config.__post_init__)
-        self.execute_on = config.execute_on
+    def _trader_kwargs(self, api_key: str, api_secret: str) -> dict:
+        return {
+            **super()._trader_kwargs(api_key, api_secret),
+            "position_mode": self.config.position_mode,
+            "passphrase": self._passphrase,
+        }
 
-        # Flatten on startup for a clean state (configurable, default: True)
-        self.trader.cancel_open_orders()
-        if config.close_position_on_init:
-            self.trader.close_position()
-
-        self._capture_bankruptcy_baseline()
-
-        # Build observation specs
-        self._build_observation_specs()
-
-        # Initialize history tracking
-        self.history = HistoryTracker()
-
-    def _init_trading_clients(
-        self,
-        api_key: str,
-        api_secret: str,
-        observer: Optional[OKXObservationClass],
-        trader: Optional[OKXFuturesOrderClass]
-    ):
-        """Initialize OKX observer and trader clients."""
-        time_frames = self.config.time_frames
-        window_sizes = self.config.window_sizes
-        demo = getattr(self.config, 'demo', True)
-
-        # Initialize trader first (observer may reuse its client)
-        self.trader = trader if trader is not None else OKXFuturesOrderClass(
-            symbol=self.config.symbol,
-            api_key=api_key,
-            api_secret=api_secret,
-            passphrase=self._passphrase,
-            demo=demo,
-            leverage=self.config.leverage,
-            margin_mode=self.config.margin_mode,
-            position_mode=self.config.position_mode,
-        )
-
-        # Initialize observer
-        if observer is not None:
-            self.observer = observer
-        else:
-            self.observer = OKXObservationClass(
-                symbol=self.config.symbol,
-                time_frames=time_frames,
-                window_sizes=window_sizes,
-                feature_preprocessing_fn=self._feature_preprocessing_fn,
-                demo=demo,
-            )
+    def _observer_kwargs(self) -> dict:
+        # Reuses the trader's client, which is why TRADER_FIRST is set.
+        return {
+            **super()._observer_kwargs(),
+            "client": getattr(self.trader, "client", None),
+        }

--- a/torchtrade/envs/live/okx/base.py
+++ b/torchtrade/envs/live/okx/base.py
@@ -7,28 +7,14 @@ from torchtrade.envs.live.okx.order_executor import OKXFuturesOrderClass
 from torchtrade.envs.live.shared.futures_live_base import TorchTradeFuturesLiveEnv
 
 class OKXBaseTorchTradingEnv(TorchTradeFuturesLiveEnv):
-    """
-    Base class for OKX trading environments.
+    """Base class for OKX futures trading environments.
 
-    Provides common functionality for all OKX environments:
-    - OKXObservationClass and OKXFuturesOrderClass initialization
-    - Observation spec construction (account state + market data)
-    - Common observation gathering logic
-    - Portfolio value calculation
-
-    Standard account state (6 elements):
-    [exposure_pct, position_direction, unrealized_pnl_pct,
-     holding_time, leverage, distance_to_liquidation]
-
-    Subclasses must implement:
-    - Action space definition
-    - _execute_trade_if_needed(): Trade execution logic
+    Supplies the OKX observer and order classes plus the passphrase OKX requires. Its
+    observer deliberately builds its OWN client: the trader's is a Trade API and klines
+    live on the MarketData one. `ACCOUNT_STATE` on TorchTradeLiveEnv is the observation
+    contract.
     """
 
-    ACCOUNT_STATE = [
-        "exposure_pct", "position_direction", "unrealized_pnlpct",
-        "holding_time", "leverage", "distance_to_liquidation"
-    ]
 
     OBSERVER_CLS = OKXObservationClass
     TRADER_CLS = OKXFuturesOrderClass

--- a/torchtrade/envs/live/shared/futures_live_base.py
+++ b/torchtrade/envs/live/shared/futures_live_base.py
@@ -17,6 +17,7 @@ import math
 import torch
 from tensordict import TensorDict, TensorDictBase
 
+from torchtrade.envs.core.state import HistoryTracker
 from torchtrade.envs.core.live import (
     LiveObservationHalt,
     ObservationFailurePolicy,
@@ -28,6 +29,7 @@ from torchtrade.envs.core.state import (
     advance_hold_counter,
     position_direction_from_status,
     position_qty_from_status,
+    PositionState,
 )
 from torchtrade.envs.utils.liquidation import (
     isolated_liquidation_price,
@@ -70,6 +72,82 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
     - _init_trading_clients(): provider-specific client construction
     - _execute_trade_if_needed(): trade execution, whose action space differs by env
     """
+
+    #: The venue's observation and order classes. Set by each exchange's base (#288).
+    OBSERVER_CLS = None
+    TRADER_CLS = None
+
+    #: Build the trader before the observer. True where the observer reuses the trader's
+    #: client (bybit, okx). Preserved per venue rather than normalised: both constructors
+    #: talk to the exchange, so the order decides which side effects have already landed
+    #: when the other one fails.
+    TRADER_FIRST = False
+
+    def _observer_kwargs(self) -> dict:
+        """Arguments for `OBSERVER_CLS`. Override to ADD venue-specific ones."""
+        return dict(
+            symbol=self.config.symbol,
+            time_frames=self.config.time_frames,
+            window_sizes=self.config.window_sizes,
+            feature_preprocessing_fn=self._feature_preprocessing_fn,
+            demo=self.config.demo,
+        )
+
+    def _trader_kwargs(self, api_key: str, api_secret: str) -> dict:
+        """Arguments for `TRADER_CLS`. Override to ADD venue-specific ones.
+
+        This is where the credential shapes stopped being a problem. okx and bitget take a
+        `passphrase` and binance and bybit do not, which is why folding these four looked
+        like a choice between `**credentials` (untyped) and an optional argument two
+        venues ignore -- the dead-parameter defect #289 deleted. The passphrase never
+        reaches anything but the trader, so a hook here needs neither.
+        """
+        return dict(
+            symbol=self.config.symbol,
+            api_key=api_key,
+            api_secret=api_secret,
+            demo=self.config.demo,
+            leverage=self.config.leverage,
+            margin_mode=self.config.margin_mode,
+        )
+
+    def _init_trading_clients(self, api_key, api_secret, observer, trader):
+        """Four near-identical copies, folded (#288).
+
+        Dependency injection: a supplied instance wins, otherwise build from the class
+        attributes.
+        """
+        def make_trader():
+            self.trader = trader if trader is not None else self.TRADER_CLS(
+                **self._trader_kwargs(api_key, api_secret)
+            )
+
+        def make_observer():
+            self.observer = observer if observer is not None else self.OBSERVER_CLS(
+                **self._observer_kwargs()
+            )
+
+        for build in ((make_trader, make_observer) if self.TRADER_FIRST
+                      else (make_observer, make_trader)):
+            build()
+
+    def _finish_futures_init(self) -> None:
+        """The tail every futures env ran verbatim after `super().__init__` (#288).
+
+        Ordering is load-bearing and was identical in all four: flatten before the
+        baseline, so the baseline is the balance the episode actually starts from.
+        """
+        self.execute_on = self.config.execute_on
+
+        self.trader.cancel_open_orders()
+        if self.config.close_position_on_init:
+            self.trader.close_position()
+
+        self._capture_bankruptcy_baseline()
+        self._build_observation_specs()
+
+        self.position = PositionState()
+        self.history = HistoryTracker()
 
     def _halting(self, read, cache_key=None):
         """Run a venue read under the halt policy, degrading through a grace period.

--- a/torchtrade/envs/live/shared/futures_live_base.py
+++ b/torchtrade/envs/live/shared/futures_live_base.py
@@ -77,10 +77,10 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
     OBSERVER_CLS = None
     TRADER_CLS = None
 
-    #: Build the trader before the observer. True where the observer reuses the trader's
-    #: client (bybit, okx). Preserved per venue rather than normalised: both constructors
-    #: talk to the exchange, so the order decides which side effects have already landed
-    #: when the other one fails.
+    #: Build the trader before the observer. bybit shares the trader's pybit session with
+    #: its observer; okx keeps its pre-fold order for the reason below. Preserved per venue
+    #: rather than normalised: every trader __init__ WRITES leverage and margin mode to the
+    #: venue, so this decides whether that write lands before an observer failure.
     TRADER_FIRST = False
 
     def _observer_kwargs(self) -> dict:
@@ -96,11 +96,6 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
     def _trader_kwargs(self, api_key: str, api_secret: str) -> dict:
         """Arguments for `TRADER_CLS`. Override to ADD venue-specific ones.
 
-        This is where the credential shapes stopped being a problem. okx and bitget take a
-        `passphrase` and binance and bybit do not, which is why folding these four looked
-        like a choice between `**credentials` (untyped) and an optional argument two
-        venues ignore -- the dead-parameter defect #289 deleted. The passphrase never
-        reaches anything but the trader, so a hook here needs neither.
         """
         return dict(
             symbol=self.config.symbol,
@@ -127,9 +122,12 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
                 **self._observer_kwargs()
             )
 
-        for build in ((make_trader, make_observer) if self.TRADER_FIRST
-                      else (make_observer, make_trader)):
-            build()
+        if self.TRADER_FIRST:
+            make_trader()
+            make_observer()
+        else:
+            make_observer()
+            make_trader()
 
     def _finish_futures_init(self) -> None:
         """The tail every futures env ran verbatim after `super().__init__` (#288).
@@ -146,7 +144,8 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
         self._capture_bankruptcy_baseline()
         self._build_observation_specs()
 
-        self.position = PositionState()
+        # `self.position` is already built in TorchTradeLiveEnv.__init__, which runs
+        # before this tail. binance and bitget rebuilt it; bybit and okx never did.
         self.history = HistoryTracker()
 
     def _halting(self, read, cache_key=None):


### PR DESCRIPTION
Slice 1 of #288. **Net −109 lines** (four `base.py`: 524 → 246), suite 4184 green.

`base.py` was **66–96% identical** after exchange-name substitution, in two tight clusters:

| | binance | bitget | bybit |
|---|---|---|---|
| **bitget** | 90% | | |
| **bybit** | 71% | 67% | |
| **okx** | 70% | 66% | **94%** |

524 lines across four files → 336, plus ~90 shared. Each venue's base is now its two class attributes, a typed `__init__` that forwards, and a `_trader_kwargs` override naming only what is genuinely venue-specific.

## The credential shape was never the blocker I recorded

I had this issue marked stuck on exactly one thing: okx and bitget take a `passphrase` and binance and bybit don't, so folding looked like a choice between `**credentials` (losing the typed signature) and an optional argument two venues ignore — the dead-parameter defect #289 deleted.

**The passphrase never reaches anything except the trader.** A `_trader_kwargs()` hook needs neither horn. And once it existed it absorbed `trade_mode`, `position_mode` and `product_type` as well — which vary across *different, overlapping* venue sets, a problem I hadn't counted when I called it blocked.

```python
def _trader_kwargs(self, api_key, api_secret):
    return {**super()._trader_kwargs(api_key, api_secret),
            "position_mode": self.config.position_mode,
            "passphrase": self._passphrase}
```

## What I deliberately did not normalise

**`TRADER_FIRST`.** bybit and okx build the trader first so the observer can reuse its client; binance and bitget build the observer first. Both constructors talk to the exchange, so that order decides which side effects have already landed when the other one fails. Preserving it costs one class attribute; normalising it would be a real behaviour change smuggled into a refactor.

## Verification

**A correction: the "IDENTICAL constructor kwargs" proof originally claimed here was invalid.** The probe patched one class at a time, so on the `TRADER_FIRST` venues the real trader constructor ran first, hit the network and threw — the observer was never reached. It recorded `"observer": "ERR ValueError"` on both sides, and I diffed two identical *error strings*.

It hid a live-money regression: okx's observer was handed the trader's `Trade.TradeAPI`, which has no `get_candlesticks`. Fixed, and the real verification is now a test rather than a script — `test_init_trading_clients_wires_each_venue_as_before` runs the refactored method with recording fakes, network-free, asserting construction order and complete kwargs per venue.

Measured against three wiring regressions, old approach vs new:

| mutation | new | old |
|---|---|---|
| ignore `TRADER_FIRST` | 2 failed | **0 failed** |
| observer built from trader kwargs | 4 failed | **0 failed** |
| dependency injection ignored | 1 failed | **0 failed** |

## Three structural guards fired — updated, not weakened

- **`execute_on`** — now admits `_finish_futures_init` **by name**. Admitting the whole shared module would restore the MRO hole the guard exists to close (`TorchTradeLiveEnv` lives there too, and initialises `execute_on = None`).
- **bankruptcy baseline** — accepts delegation to the shared tail; its load-bearing half (a re-forked balance *read*) is untouched.
- **close-site invalidation** — exempts `_finish_futures_init`: its startup flatten runs at construction, before any read is cached, so there is nothing to invalidate. Same ordering argument as `_reset`.

## Scope

Deliberately slice 1 only, per @CharlieHelps on #409: *"prioritize #288 immediately after this; expanding this already-large safety change into the full refactor would make the invariants harder, not easier, to review."*

Remaining: `env_sltp.py` incl. the 70-line config dataclass ×4 (~900), `env.py` trade-path helpers (~500), the verbatim executor helpers, and routing more per-venue tests through `base_exchange_tests`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AWNTLhwczWJBoxbXrPVYJu
