### PR TITLE
refactor(288): fold the four plain _step copies, and fix a fallback that never ran

### DIFF
--- a/tests/envs/base_exchange_tests.py
+++ b/tests/envs/base_exchange_tests.py
@@ -631,7 +631,9 @@ def _sole(module, suffix):
     """
     found = [
         v for k, v in vars(module).items()
-        if k.endswith(suffix) and getattr(v, "__module__", None) == module.__name__
+        if isinstance(v, type)          # `__module__` resolves through the class, so a
+        and k.endswith(suffix)          # module-level INSTANCE would otherwise qualify
+        and getattr(v, "__module__", None) == module.__name__
     ]
     assert len(found) == 1, (
         f"{module.__name__} defines {len(found)} classes ending in {suffix!r} "

--- a/tests/envs/base_exchange_tests.py
+++ b/tests/envs/base_exchange_tests.py
@@ -621,3 +621,20 @@ def wire_outage_state(env, budget=0):
     env._status_unknown_this_step = False
     env._last_confirmed_read = {}
     env._max_unknown_status_steps = budget
+
+def _sole(module, suffix):
+    """The ONE class in `module` whose name ends in `suffix`.
+
+    Not `next(...)`, which returns the first match in DEFINITION order: a decoy declared
+    above the real class silently becomes the subject, and a guard then passes green on a
+    class nobody meant to check.
+    """
+    found = [
+        v for k, v in vars(module).items()
+        if k.endswith(suffix) and getattr(v, "__module__", None) == module.__name__
+    ]
+    assert len(found) == 1, (
+        f"{module.__name__} defines {len(found)} classes ending in {suffix!r} "
+        f"({[c.__name__ for c in found]}); the guard would have silently picked the first"
+    )
+    return found[0]

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -79,6 +79,45 @@ FUTURES_ENVS = [
     if issubclass(c, TorchTradeFuturesLiveEnv) and c is not TorchTradeFuturesLiveEnv
 ]
 
+# Split by module, and resolved from the registry rather than by scanning a module
+# namespace for a name ending in "TorchTradingEnv": `next(...)` returns the FIRST match in
+# definition order, so a second class defined above the real one silently becomes the
+# subject. Not hypothetical -- with a decoy that INHERITS the shared `_step` (and so
+# satisfies an identity check vacuously), the guard below passed green while the real
+# class's `_step` was re-forked to raise.
+PLAIN_FUTURES_ENVS = [c for c in FUTURES_ENVS if c.__module__.endswith(".env")]
+SLTP_FUTURES_ENVS = [c for c in FUTURES_ENVS if c.__module__.endswith(".env_sltp")]
+assert len(PLAIN_FUTURES_ENVS) == len(SLTP_FUTURES_ENVS) == 4, (
+    "a list that SHRINKS is the hazard, not one that empties: pyproject's "
+    "empty_parameter_set_mark already turns an empty list into a collection error, but "
+    "4 -> 3 is silent, and that is the shape #411's loss actually took"
+)
+
+
+def _sole(module, suffix, **require):
+    """The ONE class in `module` whose name ends in `suffix`.
+
+    Not `next(...)`: that returns the first match in DEFINITION order, so a second class
+    declared above the real one silently becomes the subject. Verified by mutation -- a
+    decoy that inherits the shared `_step` (and so satisfies an identity check vacuously)
+    let a re-forked `_step` on the real class pass green, in the very guard written to
+    catch it. Asserting the count converts that into a failure that names both classes.
+
+    `require` takes predicates applied to each candidate, for the call sites that need a
+    concrete or a dataclass one.
+    """
+    found = [
+        v for k, v in vars(module).items()
+        if k.endswith(suffix)
+        and getattr(v, "__module__", None) == module.__name__
+        and all(pred(v) for pred in require.values())
+    ]
+    assert len(found) == 1, (
+        f"{module.__name__} defines {len(found)} classes ending in {suffix!r} "
+        f"({[c.__name__ for c in found]}); the guard would have silently picked the first"
+    )
+    return found[0]
+
 
 @pytest.mark.parametrize("done_on_bankruptcy,portfolio_value,expected", [
     (True, 50.0, True),    # below 10% of the 1000 initial -> bankrupt
@@ -161,13 +200,24 @@ def test_discovery_covers_every_live_exchange():
     """
     exchanges = {cls.__module__.split(".")[-2] for cls in LIVE_ENVS} - {"shared"}
     assert exchanges == {"alpaca", "binance", "bitget", "bybit", "okx"}
-    # NON_SLTP_ENVS drives the call-site guard below, and an empty parametrize SKIPS rather
-    # than fails -- a module rename would silently retire that guard.
+    # NON_SLTP_ENVS drives the call-site guard below. An EMPTY list is already a collection
+    # error (pyproject's empty_parameter_set_mark); a list that merely shrinks is not, and
+    # that is the failure this pins.
     assert len(NON_SLTP_ENVS) == 5
+    # FUTURES_ENVS drives the observation re-fork guard and is NOT covered by the exchange
+    # set above: a venue that stops inheriting TorchTradeFuturesLiveEnv keeps its exchange
+    # name here and silently drops its cases from that guard.
+    assert len(FUTURES_ENVS) == 12 and len(LIVE_ENVS) == 16
 
 
 @pytest.mark.parametrize("method", [
     "_check_termination", "_sync_action_level_after_reset", "_build_observation_specs",
+    # Everything the shared `_step` calls. Guarding `_step` itself is not enough: a venue
+    # that re-forks one of ITS callees still passes the `_step` identity check while the
+    # "a shared fix lands once" guarantee is already gone. Verified -- a byte-identical
+    # copy of a callee on one venue failed zero of 1076 tests.
+    "_record_position_after_trade", "_resolve_action_level",
+    "_wait_for_next_timestamp", "_finalize_step_flags",
 ])
 @pytest.mark.parametrize("env_cls", LIVE_ENVS, ids=lambda c: c.__name__)
 def test_no_live_env_overrides_shared_method(env_cls, method):
@@ -194,6 +244,10 @@ def test_no_live_env_overrides_shared_method(env_cls, method):
         # what converts a failed fetch into a type `_halting` catches.
         "_current_mark_price",
         "_halting",
+        # The shared `_step`'s two state reads. Both apply the halt policy (#295); a venue
+        # copy of either is where that policy stops being one policy.
+        "_acquire_pre_trade_state",
+        "_acquire_post_bar_state",
     ],
 )
 @pytest.mark.parametrize("env_cls", FUTURES_ENVS, ids=lambda c: c.__name__)
@@ -2432,8 +2486,7 @@ def test_the_size_an_env_reports_actually_reaches_the_position(exchange):
     import importlib
 
     mod = importlib.import_module(f"torchtrade.envs.live.{exchange}.env")
-    cls = next(v for k, v in vars(mod).items()
-               if k.endswith("TorchTradingEnv") and v.__module__ == mod.__name__)
+    cls = _sole(mod, "TorchTradingEnv")
     call = next(
         (n for n in ast.walk(ast.parse(inspect.getsource(cls._step).lstrip()))
          if isinstance(n, ast.Call) and isinstance(n.func, ast.Attribute)
@@ -2478,9 +2531,8 @@ def test_a_real_step_lands_both_size_values_on_the_position(exchange, min_qty):
 
     module = importlib.import_module(f"torchtrade.envs.live.{exchange}.env")
     # not abstract, and defined here: `vars` also carries the imported base class
-    env_cls = next(v for k, v in vars(module).items()
-                   if k.endswith("TorchTradingEnv") and isinstance(v, type)
-                   and not getattr(v, "__abstractmethods__", None)
+    env_cls = _sole(module, "TorchTradingEnv",
+                    concrete=lambda v: not getattr(v, "__abstractmethods__", None)
                    and v.__module__ == module.__name__)
 
     trader = MagicMock()
@@ -2527,9 +2579,8 @@ def _build_env_with(env_cls, module, trader):
     # __module__, not just the name: `vars` also carries any config imported into the
     # module. Both env_sltp modules import their shared base, and without this filter
     # `next` returns THAT -- a test that silently stops testing the venue (#288).
-    config_cls = next(v for k, v in vars(module).items()
-                      if k.endswith("Config") and hasattr(v, "__dataclass_fields__")
-                      and v.__module__ == module.__name__)
+    config_cls = _sole(module, "Config",
+                       dataclass=lambda v: hasattr(v, "__dataclass_fields__"))
     try:
         config = config_cls(symbol="BTCUSDT", demo=True, time_frames=["1m"],
                             window_sizes=[10], execute_on="1m", leverage=5)
@@ -2637,8 +2688,7 @@ def test_the_pre_trade_read_halts_like_the_post_bar_one(exchange, module):
     import importlib
 
     mod = importlib.import_module(f"torchtrade.envs.live.{exchange}.{module}")
-    cls = next(v for k, v in vars(mod).items()
-               if k.endswith("TorchTradingEnv") and v.__module__ == mod.__name__)
+    cls = _sole(mod, "TorchTradingEnv")
 
     # AST call POSITIONS, not a substring. A substring passed on a commented-out call and
     # on the real call moved AFTER the dispatch -- so it proved neither that the read
@@ -4001,8 +4051,7 @@ def test_each_venue_builds_its_observer_with_the_arguments_it_needs(venue, expec
     # The concrete plain env, not the abstract exchange base: the base still declares
     # `_step`/`_execute_trade_if_needed` abstract, so it cannot be instantiated at all.
     module = importlib.import_module(f"torchtrade.envs.live.{venue}.env")
-    cls = next(v for k, v in vars(module).items()
-               if k.endswith("TorchTradingEnv") and v.__module__ == module.__name__)
+    cls = _sole(module, "TorchTradingEnv")
 
     # A real instance via __new__, not a SimpleNamespace: `_observer_kwargs` calls
     # zero-arg `super()`, which needs the class in its MRO. __init__ is skipped so the
@@ -4080,8 +4129,7 @@ def test_init_trading_clients_wires_each_venue_as_before(
     import importlib
 
     module = importlib.import_module(f"torchtrade.envs.live.{venue}.env")
-    cls = next(v for k, v in vars(module).items()
-               if k.endswith("TorchTradingEnv") and v.__module__ == module.__name__)
+    cls = _sole(module, "TorchTradingEnv")
 
     log = []
 
@@ -4194,26 +4242,30 @@ def test_the_shared_sltp_step_keeps_its_two_unpinned_contracts(venue):
 # the mixin's (no futures pre-trade acquisition, no mark). It overrides `_step` on purpose
 # and inherits `_reset`, which IS identical. Deleting alpaca's `_step` as "redundant"
 # would hand a spot env the futures step.
-@pytest.mark.parametrize("venue", ["binance", "bitget", "bybit", "okx"])
-def test_no_sltp_env_reforks_the_shared_step(venue):
-    """#288 folded four SLTP `_step`/`_reset` copies into SLTPMixin. Nothing noticed when
-    one of them did not fold.
+@pytest.mark.parametrize("method", ["_step", "_reset"])
+@pytest.mark.parametrize("cls,owner", [
+    *((c, TorchTradeFuturesLiveEnv) for c in PLAIN_FUTURES_ENVS),
+    *((c, SLTPMixin) for c in SLTP_FUTURES_ENVS),
+], ids=[c.__name__ for c in PLAIN_FUTURES_ENVS + SLTP_FUTURES_ENVS])
+def test_no_futures_env_reforks_a_shared_step_or_reset(cls, owner, method):
+    """#288 folded eight `_step`/`_reset` copies onto two owners. Nothing noticed when one
+    of them did not fold.
 
-    I reverted bybit's file mid-way through mutation testing and it kept its own copies.
-    The suite stayed green -- of course it did: the copy still worked. An incomplete fold
-    is invisible behaviourally, and stays invisible right up until someone fixes a bug in
-    the shared copy and bybit does not get it. That is #288's entire thesis.
+    Reverting bybit's file mid-way through mutation testing left it with private copies and
+    the suite stayed green -- of course it did, the copy still worked. An incomplete fold is
+    invisible behaviourally, right up until a fix lands on the shared copy and bybit does
+    not get it.
+
+    Identity against the owner, not `"_step" not in vars(cls)`. The two are equivalent
+    today only because SLTPMixin sits directly after the class in the MRO -- I checked,
+    there is nothing between them. Insert one intermediate base and absence-from-the-
+    subclass starts passing on a copy that really does shadow the owner; identity does not
+    care where in the MRO the copy is planted.
     """
-    import importlib
-
-    mod = importlib.import_module(f"torchtrade.envs.live.{venue}.env_sltp")
-    cls = next(v for k, v in vars(mod).items()
-               if k.endswith("TorchTradingEnv") and v.__module__ == mod.__name__)
-
-    reforked = [name for name in ("_step", "_reset") if name in vars(cls)]
-    assert not reforked, (
-        f"{cls.__name__} defines its own {reforked}; SLTPMixin owns them, and a private "
-        f"copy is where a shared fix silently fails to land"
+    assert getattr(cls, method) is getattr(owner, method), (
+        f"{cls.__name__}.{method} resolves to {getattr(cls, method).__qualname__} rather "
+        f"than {owner.__name__}.{method}; a private copy is where a shared fix silently "
+        f"fails to land"
     )
 
 
@@ -4277,26 +4329,86 @@ def test_the_history_row_records_the_side_actually_traded(side_idx, expected):
     )
 
 
-@pytest.mark.parametrize("venue", ["binance", "bitget", "bybit", "okx"])
-@pytest.mark.parametrize("level_idx,expected_sign", [(-1, 1.0), (0, -1.0)],
+# The venue names behind the registry, so a fifth exchange joins these tests on its own.
+PLAIN_VENUES = [c.__module__.split(".")[-2] for c in PLAIN_FUTURES_ENVS]
+
+
+@pytest.mark.parametrize("venue", PLAIN_VENUES)
+def test_the_plain_history_row_is_the_one_the_reward_function_scores(venue):
+    """Four mutations in the shared plain `_step` that failed ZERO tests.
+
+    The reward overwrite, the post-bar price, and the post-trade qty are all read back out
+    of `history` -- by the reward function on the next step, and by every analysis of the
+    episode after it. Each was silently droppable:
+
+      reward -> 0.0                       the placeholder `record_step` writes
+      drop `history.rewards[-1] = reward`  same, one line later
+      price=current_price                  the PRE-trade bar; `_acquire_post_bar_state`
+                                           spends 20 lines arguing this exact point (#278)
+      position=position_size               the PRE-trade qty, so an opening row reads flat
+
+    The SLTP fold pinned the reward one for its four venues and the plain fold shipped
+    without it -- the same "landed on some copies, not others" this issue exists to end.
+
+    Pre-trade and post-bar are given DIFFERENT prices (100 -> 120) on purpose: with one
+    price the two `price=` spellings are indistinguishable, which is why this went unseen.
+    """
+    from tests.envs.test_live_observation_failsafe import _real_futures_env
+    from torchtrade.envs.core.common_types import PositionStatus
+
+    env, trader = _real_futures_env(budget=0, venue=venue)
+    env.reward_function = lambda history: 4.25   # unmistakable, not a placeholder
+
+    opened = PositionStatus(
+        qty=0.05, notional_value=6000.0, entry_price=100.0, unrealized_pnl=0.0,
+        unrealized_pnl_pct=0.0, mark_price=120.0, leverage=10,
+        margin_mode="isolated", liquidation_price=91.0,
+    )
+    bar = {"done": False}
+
+    trader.get_status.side_effect = lambda: {
+        "position_status": opened if bar["done"] else None
+    }
+    trader.get_mark_price.side_effect = lambda: 120.0 if bar["done"] else 100.0
+
+    real_wait = env._wait_for_next_timestamp
+    env._wait_for_next_timestamp = lambda: (bar.__setitem__("done", True), real_wait())[1]
+
+    td = env.reset()
+    out = env.step(td.set("action", torch.tensor(len(env.action_levels) - 1)))["next"]
+
+    assert out["reward"].item() == pytest.approx(4.25), (
+        f"{venue}: the step returned the placeholder reward, not reward_function's"
+    )
+    assert env.history.rewards[-1] == pytest.approx(4.25), (
+        f"{venue}: history kept `record_step`'s 0.0 placeholder; the reward function reads "
+        f"this row on the NEXT step"
+    )
+    assert env.history.base_prices[-1] == pytest.approx(120.0), (
+        f"{venue}: the row carries the pre-trade price 100.0, so price[t] would pair with "
+        f"portfolio_value[t] from a different bar (#278)"
+    )
+    assert env.history.positions[-1] == pytest.approx(0.05), (
+        f"{venue}: the opening row records the pre-trade qty, so it reads flat"
+    )
+
+
+@pytest.mark.parametrize("venue", PLAIN_VENUES)
+@pytest.mark.parametrize("want,expected_sign", [(1, 1.0), (-1, -1.0)],
                          ids=["full-long", "full-short"])
 def test_the_plain_history_row_records_the_action_actually_traded(
-    venue, level_idx, expected_sign
+    venue, want, expected_sign
 ):
     """`action` in the history row is what the reward function scores.
 
-    Flipping its sign in the shared plain `_step` fails ZERO tests. I pinned exactly this
-    on the SLTP path an hour ago and left the plain one -- the same "some copies, not
-    others" this issue is about, in the guard against it.
-
-    Indexed by VALUE: binance ships [-1, 0, 1] and the others [-1, -0.5, 0, 0.5, 1], so a
-    hardcoded index means different things per venue.
+    Flipping its sign in the shared plain `_step` fails ZERO tests.
     """
-    import torch
     from tests.envs.test_live_observation_failsafe import _real_futures_env
 
-    env, trader = _real_futures_env(budget=0, venue=venue)
-    action = len(env.action_levels) - 1 if level_idx == -1 else 0
+    env, _ = _real_futures_env(budget=0, venue=venue)
+    # By VALUE: binance ships [-1, 0, 1] and the others [-1, -0.5, 0, 0.5, 1], so a
+    # hardcoded index means a different position size per venue.
+    action = env.action_levels.index(want)
     td = env.reset()
     env.step(td.set("action", torch.tensor(action)))
 
@@ -4307,23 +4419,17 @@ def test_the_plain_history_row_records_the_action_actually_traded(
     )
 
 
-@pytest.mark.parametrize("shared_step,module", [
-    ("TorchTradeFuturesLiveEnv", "env"), ("SLTPMixin", "env_sltp"),
-], ids=["plain", "sltp"])
-def test_a_flat_bar_falls_back_to_the_pre_trade_price(shared_step, module):
+@pytest.mark.parametrize("sltp", [False, True], ids=["plain", "sltp"])
+def test_a_flat_bar_falls_back_to_the_pre_trade_price(sltp):
     """`new_price = new_price if new_price is not None else current_price`.
 
     `_acquire_post_bar_state` returns None for the mark when the account is flat -- there
     is no position to read one from. Dropping the fallback feeds None into
     `history.record_step(price=...)`, and every downstream reader of that row gets it.
-
-    Failed zero tests on BOTH shared steps: the comment explaining why the fallback exists
-    has been carried through four copies and two folds without anything asserting it.
     """
-    import torch
     from tests.envs.test_live_observation_failsafe import _real_futures_env
 
-    env, trader = _real_futures_env(budget=0, venue="binance", sltp=(module == "env_sltp"))
+    env, trader = _real_futures_env(budget=0, venue="binance", sltp=sltp)
     td = env.reset()
 
     # The mark goes unavailable only for the POST-bar read: the pre-trade read must
@@ -4347,38 +4453,9 @@ def test_a_flat_bar_falls_back_to_the_pre_trade_price(shared_step, module):
     env._wait_for_next_timestamp = wait
     env.step(td.set("action", torch.tensor(0)))
 
-    # The VALUE, not just the type. `isinstance(..., (int, float))` passed on a fallback
-    # changed to `else 0.0` -- wrong but numeric -- while the docstring claimed the test
-    # verified "the pre-trade price". 100.0 is what the mock's get_mark_price returned on
-    # the pre-trade read, so it is the only correct answer here.
+    # 100.0 is what get_mark_price returned on the PRE-trade read. Asserting the value
+    # rather than the type: `isinstance(..., (int, float))` passes on an `else 0.0`.
     assert env.history.base_prices[-1] == pytest.approx(100.0), (
         f"a flat bar recorded {env.history.base_prices[-1]!r} rather than the pre-trade "
         f"price of 100.0"
-    )
-
-
-@pytest.mark.parametrize("venue", ["binance", "bitget", "bybit", "okx"])
-def test_no_plain_futures_env_reforks_the_shared_step(venue):
-    """The PLAIN `_step` must resolve to TorchTradeFuturesLiveEnv, not a venue copy.
-
-    I wrote `test_no_sltp_env_reforks_the_shared_step` for the SLTP fold and shipped the
-    plain fold without the equivalent -- the fifth time in this issue that a fix landed on
-    some copies and not others, this time in the guard against exactly that.
-
-    Mutation-proven necessary: appending a BYTE-IDENTICAL copy of the shared `_step` to
-    bitget/env.py passed all 819 tests in this file. An incomplete fold is invisible
-    behaviourally, because a copy that has not drifted yet works perfectly -- right up
-    until a shared fix fails to land on the venue holding one.
-
-    Not folded into `test_no_futures_env_reforks_the_shared_observation`: its FUTURES_ENVS
-    list includes the SLTP envs, which resolve `_step` to SLTPMixin by design.
-    """
-    import importlib
-
-    mod = importlib.import_module(f"torchtrade.envs.live.{venue}.env")
-    cls = next(v for k, v in vars(mod).items()
-               if k.endswith("TorchTradingEnv") and v.__module__ == mod.__name__)
-    assert cls._step is TorchTradeFuturesLiveEnv._step, (
-        f"{cls.__name__} re-forks _step instead of resolving the shared one; a private "
-        f"copy is where a shared fix silently fails to land"
     )

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -650,7 +650,7 @@ def test_reading_a_field_off_an_unknown_status_says_why():
 # `test_position_sizing_refuses_an_unknown_status` lived here. It guarded an outage that
 # began BETWEEN the two get_status() calls inside one step -- a window #295 closed by
 # construction: the trade path now takes the qty `_acquire_pre_trade_state` already
-# resolved, so there is one status read per step and no second window to fall into.
+# resolved, so there is one PRE-TRADE status read and no second window to fall into.
 # `test_an_outage_stops_the_step_before_it_can_trade` below covers what remains.
 
 
@@ -4188,6 +4188,70 @@ _SHARED_METHOD_OWNERSHIP = [
         "_reset_sltp_state",
     )),
 ]
+# By NAME, not by count. Dropping `_reset` from the matrix above passed 936 tests: the
+# registry-length pins guard the ENV axis, and nothing guarded the METHOD axis. This also
+# says out loud what is meant to be shared, so adding a genuinely shared method is a
+# deliberate edit here rather than an arithmetic fix.
+assert {(owner.__name__, method) for _, owner, method in _SHARED_METHOD_OWNERSHIP} == {
+    ("TorchTradeLiveEnv", "_record_and_score"),
+    ("TorchTradeFuturesLiveEnv", "_step"),
+    ("TorchTradeFuturesLiveEnv", "_reset"),
+    ("SLTPMixin", "_step"),
+    ("SLTPMixin", "_reset"),
+    ("SLTPMixin", "_resolve_action_tuple"),
+    ("SLTPMixin", "_record_sltp_position"),
+    ("SLTPMixin", "_reset_sltp_state"),
+}
+
+
+# binance and bitget take the mixin's `_dispatch_sltp_trade`; bybit and okx override it to
+# thread the price (#295). That split is intended, so the hook is out of the uniform table
+# above -- but "intended for two venues" is not "unguarded for the other two": a later
+# private override in binance or bitget would otherwise evade every guard in this file.
+_DISPATCH_INHERITORS = [c for c in SLTP_FUTURES_ENVS
+                        if c.__module__.split(".")[-2] in ("binance", "bitget")]
+_DISPATCH_OVERRIDERS = [c for c in SLTP_FUTURES_ENVS
+                        if c.__module__.split(".")[-2] in ("bybit", "okx")]
+assert len(_DISPATCH_INHERITORS) == len(_DISPATCH_OVERRIDERS) == 2
+
+
+@pytest.mark.parametrize("cls", _DISPATCH_INHERITORS, ids=lambda c: c.__name__)
+def test_the_dispatch_hook_is_inherited_where_it_is_not_deliberately_overridden(cls):
+    """The venue-variation hook is still owned, for the venues that do not vary.
+
+    bybit and okx override `_dispatch_sltp_trade` to pass the threaded price rather than
+    let the executor re-read it (#295). binance and bitget price their brackets off a
+    candle close and take the mixin's default -- so for them a private copy is a re-fork
+    like any other, and nothing said so.
+    """
+    assert cls._dispatch_sltp_trade is SLTPMixin._dispatch_sltp_trade, (
+        f"{cls.__name__} defines its own _dispatch_sltp_trade. Only bybit and okx have a "
+        f"reason to (the #295 threaded price); if this venue now needs one too, move it "
+        f"into _DISPATCH_OVERRIDERS deliberately rather than letting the hook drift"
+    )
+
+
+@pytest.mark.parametrize("cls", _DISPATCH_OVERRIDERS, ids=lambda c: c.__name__)
+def test_the_dispatch_overriders_thread_the_price_they_were_given(cls):
+    """And the two that DO override must consume the threaded price, not re-read it.
+
+    Excluding them from the ownership table costs the identity check; this replaces it
+    with what identity was standing in for.
+    """
+    call = next(
+        (n for n in ast.walk(ast.parse(
+            inspect.getsource(cls._dispatch_sltp_trade).lstrip()))
+         if isinstance(n, ast.Call) and isinstance(n.func, ast.Attribute)
+         and n.func.attr == "_execute_trade_if_needed"),
+        None,
+    )
+    assert call is not None, f"{cls.__name__}'s override never dispatches the trade"
+    assert any(kw.arg == "current_price" and isinstance(kw.value, ast.Name)
+               for kw in call.keywords), (
+        f"{cls.__name__} overrides _dispatch_sltp_trade but does not forward the threaded "
+        f"current_price -- the only reason the override exists (#295); re-reading it "
+        f"inside the trade path bypasses the halt policy"
+    )
 
 
 @pytest.mark.parametrize("cls,owner,method", _SHARED_METHOD_OWNERSHIP,
@@ -4322,7 +4386,12 @@ def test_a_reset_clears_the_bracket_on_the_shared_sltp_owner():
 
 
 def test_the_trade_takes_the_qty_and_price_the_pre_trade_read_acquired():
-    """#295: the trade uses the qty and price the pre-trade read acquired, not its own.
+    """#295: the shared `_step` FORWARDS the qty and price its pre-trade read acquired.
+
+    Scope, stated because the stub sets it: `_execute_trade_if_needed` is replaced here,
+    so this pins the shared CALLER -- what it threads, and that it does not read again.
+    It does not prove a venue's executor then uses those values rather than re-reading;
+    that is the venues' own contract, covered behaviourally by the SLTP grace-bar tests.
 
     `_execute_trade_if_needed` is NOT shared, so this contract belongs where the shared
     `_step` is owned rather than in one venue's file.

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -79,38 +79,24 @@ FUTURES_ENVS = [
     if issubclass(c, TorchTradeFuturesLiveEnv) and c is not TorchTradeFuturesLiveEnv
 ]
 
-# Split by module, and resolved from the registry rather than by scanning a module
-# namespace for a name ending in "TorchTradingEnv": `next(...)` returns the FIRST match in
-# definition order, so a second class defined above the real one silently becomes the
-# subject. Not hypothetical -- with a decoy that INHERITS the shared `_step` (and so
-# satisfies an identity check vacuously), the guard below passed green while the real
-# class's `_step` was re-forked to raise.
+# Split by module. Preferred over scanning a module namespace -- see `_sole` below.
 PLAIN_FUTURES_ENVS = [c for c in FUTURES_ENVS if c.__module__.endswith(".env")]
 SLTP_FUTURES_ENVS = [c for c in FUTURES_ENVS if c.__module__.endswith(".env_sltp")]
-assert len(PLAIN_FUTURES_ENVS) == len(SLTP_FUTURES_ENVS) == 4, (
-    "a list that SHRINKS is the hazard, not one that empties: pyproject's "
-    "empty_parameter_set_mark already turns an empty list into a collection error, but "
-    "4 -> 3 is silent, and that is the shape #411's loss actually took"
-)
+# 4 -> 3 is the hazard: an EMPTY list is already a collection error (pyproject sets
+# empty_parameter_set_mark), but a list that merely shrinks is silent.
+assert len(PLAIN_FUTURES_ENVS) == len(SLTP_FUTURES_ENVS) == 4
 
 
-def _sole(module, suffix, **require):
+def _sole(module, suffix):
     """The ONE class in `module` whose name ends in `suffix`.
 
-    Not `next(...)`: that returns the first match in DEFINITION order, so a second class
-    declared above the real one silently becomes the subject. Verified by mutation -- a
-    decoy that inherits the shared `_step` (and so satisfies an identity check vacuously)
-    let a re-forked `_step` on the real class pass green, in the very guard written to
-    catch it. Asserting the count converts that into a failure that names both classes.
-
-    `require` takes predicates applied to each candidate, for the call sites that need a
-    concrete or a dataclass one.
+    Not `next(...)`, which returns the first match in DEFINITION order: a decoy declared
+    above the real class silently becomes the subject, and a guard then passes green on a
+    class nobody meant to check.
     """
     found = [
         v for k, v in vars(module).items()
-        if k.endswith(suffix)
-        and getattr(v, "__module__", None) == module.__name__
-        and all(pred(v) for pred in require.values())
+        if k.endswith(suffix) and getattr(v, "__module__", None) == module.__name__
     ]
     assert len(found) == 1, (
         f"{module.__name__} defines {len(found)} classes ending in {suffix!r} "
@@ -200,14 +186,9 @@ def test_discovery_covers_every_live_exchange():
     """
     exchanges = {cls.__module__.split(".")[-2] for cls in LIVE_ENVS} - {"shared"}
     assert exchanges == {"alpaca", "binance", "bitget", "bybit", "okx"}
-    # NON_SLTP_ENVS drives the call-site guard below. An EMPTY list is already a collection
-    # error (pyproject's empty_parameter_set_mark); a list that merely shrinks is not, and
-    # that is the failure this pins.
+    # These drive the guards below; a list that shrinks rather than empties is silent.
     assert len(NON_SLTP_ENVS) == 5
-    # FUTURES_ENVS drives the observation re-fork guard and is NOT covered by the exchange
-    # set above: a venue that stops inheriting TorchTradeFuturesLiveEnv keeps its exchange
-    # name here and silently drops its cases from that guard.
-    assert len(FUTURES_ENVS) == 12 and len(LIVE_ENVS) == 16
+    assert len(FUTURES_ENVS) == 12
 
 
 @pytest.mark.parametrize("method", [
@@ -712,11 +693,7 @@ def test_an_outage_stops_the_step_before_it_can_trade(exchange, module):
     # and a discovery predicate keyed on where the method LIVES silently stops finding
     # its subject the moment that changes -- pytest then reports a StopIteration rather
     # than a missing guard.
-    env_cls = next(
-        c for c in vars(env_mod).values()
-        if isinstance(c, type) and c.__module__ == env_mod.__name__
-        and c.__name__.endswith("TorchTradingEnv")
-    )
+    env_cls = _sole(env_mod, "TorchTradingEnv")
 
     orders = []
     unexpected = None
@@ -2424,11 +2401,7 @@ def test_every_live_config_validates_its_action_levels(exchange):
     import importlib
 
     module = importlib.import_module(f"torchtrade.envs.live.{exchange}.env")
-    config_cls = next(
-        v for k, v in vars(module).items()
-        if k.endswith("Config") and hasattr(v, "__dataclass_fields__")
-        and v.__module__ == module.__name__
-    )
+    config_cls = _sole(module, "Config")
     with pytest.raises(ValueError):
         config_cls(symbol="BTC/USD", action_levels=[0.0, float("nan"), 1.0])
 
@@ -2530,10 +2503,7 @@ def test_a_real_step_lands_both_size_values_on_the_position(exchange, min_qty):
     import importlib
 
     module = importlib.import_module(f"torchtrade.envs.live.{exchange}.env")
-    # not abstract, and defined here: `vars` also carries the imported base class
-    env_cls = _sole(module, "TorchTradingEnv",
-                    concrete=lambda v: not getattr(v, "__abstractmethods__", None)
-                   and v.__module__ == module.__name__)
+    env_cls = _sole(module, "TorchTradingEnv")
 
     trader = MagicMock()
     trader.get_status = MagicMock(return_value={"position_status": None})
@@ -2579,8 +2549,7 @@ def _build_env_with(env_cls, module, trader):
     # __module__, not just the name: `vars` also carries any config imported into the
     # module. Both env_sltp modules import their shared base, and without this filter
     # `next` returns THAT -- a test that silently stops testing the venue (#288).
-    config_cls = _sole(module, "Config",
-                       dataclass=lambda v: hasattr(v, "__dataclass_fields__"))
+    config_cls = _sole(module, "Config")
     try:
         config = config_cls(symbol="BTCUSDT", demo=True, time_frames=["1m"],
                             window_sizes=[10], execute_on="1m", leverage=5)
@@ -4206,37 +4175,6 @@ def test_dependency_injection_still_skips_construction_entirely():
     assert env.observer is supplied_obs and env.trader is supplied_tr
 
 
-@pytest.mark.parametrize("venue", ["binance", "bitget", "bybit", "okx"])
-def test_the_shared_sltp_step_keeps_its_two_unpinned_contracts(venue):
-    """#288 folded four SLTP `_step` copies into one. Three of its behaviours had NO test.
-
-    Found by mutating the freshly-shared method: zeroing the reward, dropping
-    `position_closed`, and removing `_reset_sltp_state()` each failed ZERO tests. Those
-    gaps predate the fold, but one copy means one break now reaches all four venues at
-    once -- which is the argument for folding and equally the argument for pinning it.
-
-    - reward must come from `reward_function`, not a placeholder. `record_step` writes 0.0
-      first because the function reads the history it is about to be scored on; the
-      overwrite on the next line is the whole point and nothing checked it happened.
-    """
-    import torch
-    from tests.envs.test_live_observation_failsafe import _real_futures_env
-
-    env, trader = _real_futures_env(budget=0, venue=venue, sltp=True)
-    env.reward_function = lambda history: 4.25          # unmistakable, not a placeholder
-
-    td = env.reset()
-    env.active_stop_loss, env.active_take_profit = 111.0, 222.0
-    out = env.step(td.set("action", torch.tensor(0)))["next"]
-
-    assert out["reward"].item() == pytest.approx(4.25), (
-        "the reward is the placeholder `record_step` writes, not the reward function's"
-    )
-    assert env.history.rewards[-1] == pytest.approx(4.25), (
-        "history kept the 0.0 placeholder, so the next step scores against a lie"
-    )
-
-
 # alpaca is absent DELIBERATELY, and that is worth stating rather than leaving to be
 # inferred from an omission: it is a SPOT env whose SLTP `_step` is only 35% identical to
 # the mixin's (no futures pre-trade acquisition, no mark). It overrides `_step` on purpose
@@ -4333,31 +4271,42 @@ def test_the_history_row_records_the_side_actually_traded(side_idx, expected):
 PLAIN_VENUES = [c.__module__.split(".")[-2] for c in PLAIN_FUTURES_ENVS]
 
 
-@pytest.mark.parametrize("venue", PLAIN_VENUES)
-def test_the_plain_history_row_is_the_one_the_reward_function_scores(venue):
-    """Four mutations in the shared plain `_step` that failed ZERO tests.
+@pytest.mark.parametrize("sltp", [False, True], ids=["plain", "sltp"])
+def test_the_history_row_is_the_one_the_reward_function_scores(sltp):
+    """Five contracts of the shared `_step` that failed ZERO tests between them.
 
-    The reward overwrite, the post-bar price, and the post-trade qty are all read back out
-    of `history` -- by the reward function on the next step, and by every analysis of the
-    episode after it. Each was silently droppable:
+    Everything here is read back out of `history` -- by the reward function on the next
+    step, and by every analysis of the episode after it:
 
-      reward -> 0.0                       the placeholder `record_step` writes
-      drop `history.rewards[-1] = reward`  same, one line later
-      price=current_price                  the PRE-trade bar; `_acquire_post_bar_state`
-                                           spends 20 lines arguing this exact point (#278)
-      position=position_size               the PRE-trade qty, so an opening row reads flat
+      reward -> 0.0                      the placeholder `record_step` writes
+      drop `history.rewards[-1] = ...`   same, one line later
+      reward computed BEFORE record_step it then scores a one-bar-stale history: the
+                                         reward at t belongs to the action at t-1 (#278)
+      price=current_price                the PRE-trade bar, against a post-bar PV
+      position=position_size             the PRE-trade qty, so an opening row reads flat
 
-    The SLTP fold pinned the reward one for its four venues and the plain fold shipped
-    without it -- the same "landed on some copies, not others" this issue exists to end.
+    Parametrised on plain vs SLTP, NOT on venue. `TorchTradeFuturesLiveEnv._step` and
+    `SLTPMixin._step` hold SEPARATE copies of the record-then-overwrite tail, so each
+    needs its own pin; the four venues within each share one function object, and
+    mutating it fails all four identically. Which venue resolves to which owner is the
+    re-fork guard's job, not this one's.
 
-    Pre-trade and post-bar are given DIFFERENT prices (100 -> 120) on purpose: with one
-    price the two `price=` spellings are indistinguishable, which is why this went unseen.
+    ONE step, not two. `reward_function` counts the history, so a reward computed before
+    `record_step` scores 0 rows instead of 1 -- indistinguishable from the placeholder by
+    VALUE, but both are caught, which is what the assertion is for. A second step would
+    make them distinguishable and silently kill the price and qty assertions instead: the
+    pre/post asymmetry below is armed once, so by step two both reads return the post-bar
+    values and `price=current_price` becomes identical to `price=new_price`. I wrote the
+    two-step version first and the two mutations survived it.
+
+    NOT covered here, and still unpinned: alpaca keeps its own two copies of this tail
+    (`live/alpaca/env.py`, `live/alpaca/env_sltp.py`) -- outside this fold.
     """
     from tests.envs.test_live_observation_failsafe import _real_futures_env
     from torchtrade.envs.core.common_types import PositionStatus
 
-    env, trader = _real_futures_env(budget=0, venue=venue)
-    env.reward_function = lambda history: 4.25   # unmistakable, not a placeholder
+    env, trader = _real_futures_env(budget=0, venue="binance", sltp=sltp)
+    env.reward_function = lambda history: float(len(history.actions))
 
     opened = PositionStatus(
         qty=0.05, notional_value=6000.0, entry_price=100.0, unrealized_pnl=0.0,
@@ -4365,7 +4314,6 @@ def test_the_plain_history_row_is_the_one_the_reward_function_scores(venue):
         margin_mode="isolated", liquidation_price=91.0,
     )
     bar = {"done": False}
-
     trader.get_status.side_effect = lambda: {
         "position_status": opened if bar["done"] else None
     }
@@ -4375,37 +4323,40 @@ def test_the_plain_history_row_is_the_one_the_reward_function_scores(venue):
     env._wait_for_next_timestamp = lambda: (bar.__setitem__("done", True), real_wait())[1]
 
     td = env.reset()
-    out = env.step(td.set("action", torch.tensor(len(env.action_levels) - 1)))["next"]
+    if sltp:
+        env.active_stop_loss, env.active_take_profit = 111.0, 222.0
+    action = 0 if sltp else len(env.action_levels) - 1
+    out = env.step(td.set("action", torch.tensor(action)))["next"]
 
-    assert out["reward"].item() == pytest.approx(4.25), (
-        f"{venue}: the step returned the placeholder reward, not reward_function's"
+    rows = len(env.history.actions)
+    assert out["reward"].item() == pytest.approx(float(rows)), (
+        f"the step returned {out['reward'].item()}, not reward_function's score of the "
+        f"{rows} row(s) that existed when it was called; 0.0 is either the placeholder "
+        f"or a reward computed before `record_step` wrote its row"
     )
-    assert env.history.rewards[-1] == pytest.approx(4.25), (
-        f"{venue}: history kept `record_step`'s 0.0 placeholder; the reward function reads "
-        f"this row on the NEXT step"
+    assert env.history.rewards[-1] == pytest.approx(float(rows)), (
+        "history kept `record_step`'s 0.0 placeholder; the reward function reads this "
+        "row on the NEXT step"
     )
     assert env.history.base_prices[-1] == pytest.approx(120.0), (
-        f"{venue}: the row carries the pre-trade price 100.0, so price[t] would pair with "
-        f"portfolio_value[t] from a different bar (#278)"
+        "the row carries the pre-trade price 100.0, so price[t] would pair with "
+        "portfolio_value[t] from a different bar (#278)"
     )
     assert env.history.positions[-1] == pytest.approx(0.05), (
-        f"{venue}: the opening row records the pre-trade qty, so it reads flat"
+        "the opening row records the pre-trade qty, so it reads flat"
     )
 
 
-@pytest.mark.parametrize("venue", PLAIN_VENUES)
 @pytest.mark.parametrize("want,expected_sign", [(1, 1.0), (-1, -1.0)],
                          ids=["full-long", "full-short"])
-def test_the_plain_history_row_records_the_action_actually_traded(
-    venue, want, expected_sign
-):
+def test_the_plain_history_row_records_the_action_actually_traded(want, expected_sign):
     """`action` in the history row is what the reward function scores.
 
     Flipping its sign in the shared plain `_step` fails ZERO tests.
     """
     from tests.envs.test_live_observation_failsafe import _real_futures_env
 
-    env, _ = _real_futures_env(budget=0, venue=venue)
+    env, _ = _real_futures_env(budget=0, venue="binance")
     # By VALUE: binance ships [-1, 0, 1] and the others [-1, -0.5, 0, 0.5, 1], so a
     # hardcoded index means a different position size per venue.
     action = env.action_levels.index(want)
@@ -4414,7 +4365,7 @@ def test_the_plain_history_row_records_the_action_actually_traded(
 
     recorded = env.history.actions[-1]
     assert recorded * expected_sign > 0, (
-        f"{venue}: a {'long' if expected_sign > 0 else 'short'} action recorded "
+        f"a {'long' if expected_sign > 0 else 'short'} action recorded "
         f"{recorded} in the history row the reward function reads"
     )
 

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -42,10 +42,9 @@ from torchtrade.envs.utils.liquidation import (
     cross_liquidation_price,
     isolated_liquidation_price,
 )
-from tests.envs.base_exchange_tests import wire_outage_state
+from tests.envs.base_exchange_tests import _sole, wire_outage_state
 from tests.envs.test_live_observation_failsafe import _real_futures_env
 from torchtrade.envs.core.common_types import PositionStatus
-from tests.envs.base_exchange_tests import _sole
 from torchtrade.envs.core.state import (
     POSITION_UNKNOWN,
     PositionState,
@@ -82,14 +81,11 @@ FUTURES_ENVS = [
     if issubclass(c, TorchTradeFuturesLiveEnv) and c is not TorchTradeFuturesLiveEnv
 ]
 
-# Split by module.
 PLAIN_FUTURES_ENVS = [c for c in FUTURES_ENVS if c.__module__.endswith(".env")]
 SLTP_FUTURES_ENVS = [c for c in FUTURES_ENVS if c.__module__.endswith(".env_sltp")]
 # 4 -> 3 is the hazard: an EMPTY list is already a collection error (pyproject sets
 # empty_parameter_set_mark), but a list that merely shrinks is silent.
 assert len(PLAIN_FUTURES_ENVS) == len(SLTP_FUTURES_ENVS) == 4
-
-
 
 
 @pytest.mark.parametrize("done_on_bankruptcy,portfolio_value,expected", [
@@ -173,9 +169,8 @@ def test_discovery_covers_every_live_exchange():
     """
     exchanges = {cls.__module__.split(".")[-2] for cls in LIVE_ENVS} - {"shared"}
     assert exchanges == {"alpaca", "binance", "bitget", "bybit", "okx"}
-    # These drive the guards below; a list that shrinks rather than empties is silent.
     assert len(NON_SLTP_ENVS) == 5
-    assert len(FUTURES_ENVS) == 12
+    assert len(FUTURES_ENVS) == 12          # 4 venues x (base, env, env_sltp)
 
 
 @pytest.mark.parametrize("method", [
@@ -183,7 +178,6 @@ def test_discovery_covers_every_live_exchange():
     # Everything the shared `_step` calls. Guarding `_step` itself is not enough: a venue
     # that re-forks one of ITS callees still passes the `_step` identity check while the
     # "a shared fix lands once" guarantee is already gone. Verified -- a byte-identical
-    # copy of a callee on one venue failed zero of 1076 tests.
     "_record_position_after_trade", "_resolve_action_level",
     "_wait_for_next_timestamp", "_finalize_step_flags",
 ])
@@ -678,8 +672,6 @@ def test_an_outage_stops_the_step_before_it_can_trade(exchange, module):
     env_mod = importlib.import_module(f"torchtrade.envs.live.{exchange}.{module}")
     # By NAME, not by `"_step" in vars(c)`: #288 moved the SLTP `_step` onto the mixin,
     # and a discovery predicate keyed on where the method LIVES silently stops finding
-    # its subject the moment that changes -- pytest then reports a StopIteration rather
-    # than a missing guard.
     env_cls = _sole(env_mod, "TorchTradingEnv")
 
     orders = []
@@ -2533,9 +2525,6 @@ def _build_env_with(env_cls, module, trader):
         "observation_features": ["a", "b", "c", "d"], "original_features": []})
     observer.intervals, observer.window_sizes = ["1m"], [10]
 
-    # __module__, not just the name: `vars` also carries any config imported into the
-    # module. Both env_sltp modules import their shared base, and without this filter
-    # `next` returns THAT -- a test that silently stops testing the venue (#288).
     config_cls = _sole(module, "Config")
     try:
         config = config_cls(symbol="BTCUSDT", demo=True, time_frames=["1m"],
@@ -4167,14 +4156,12 @@ def test_dependency_injection_still_skips_construction_entirely():
 # the mixin's (no futures pre-trade acquisition, no mark). It overrides `_step` on purpose
 # and inherits `_reset`, which IS identical. Deleting alpaca's `_step` as "redundant"
 # would hand a spot env the futures step.
-# Per OWNER, because the two own different method sets. The SLTP callees were unguarded:
-# a byte-identical copy of `_record_sltp_position` on one venue passed the whole suite.
+# Per OWNER, because the two own different method sets.
 #
 # `_dispatch_sltp_trade` is deliberately ABSENT. It is the venue-variation hook -- its own
 # docstring calls it "the ONE thing `_step` varies by venue" -- and bybit and okx really do
 # override it, to thread the price rather than re-read it (#295). Guarding it would demand
-# a fold of the one method that exists not to be folded. Adding it here failed exactly
-# those two venues, which is how I found out.
+# a fold of the one method that exists not to be folded.
 _SHARED_METHOD_OWNERSHIP = [
     *((c, TorchTradeFuturesLiveEnv, m)
       for c in PLAIN_FUTURES_ENVS for m in ("_step", "_reset")),
@@ -4183,16 +4170,12 @@ _SHARED_METHOD_OWNERSHIP = [
         "_reset_sltp_state",
     )),
 ]
-assert len(_SHARED_METHOD_OWNERSHIP) == 4 * 2 + 4 * 5
 
 
 @pytest.mark.parametrize("cls,owner,method", _SHARED_METHOD_OWNERSHIP,
                          ids=[f"{c.__name__}-{m}" for c, _, m in _SHARED_METHOD_OWNERSHIP])
 def test_no_futures_env_reforks_a_shared_step_or_reset(cls, owner, method):
-    """#288 folded eight `_step`/`_reset` copies onto two owners. Nothing noticed when one
-    of them did not fold.
-
-    An incomplete fold is invisible behaviourally, right up until a fix lands on the
+    """An incomplete fold is invisible behaviourally, right up until a fix lands on the
     shared copy and one venue does not get it.
 
     Identity against the owner, not `"_step" not in vars(cls)`: those are equivalent only
@@ -4266,40 +4249,71 @@ def test_the_history_row_records_the_side_actually_traded(side_idx, expected):
 
 
 def test_the_trade_takes_the_qty_and_price_the_pre_trade_read_acquired():
-    """#295: one status read per step, threaded into the trade -- not re-read.
+    """#295: the trade uses the qty and price the pre-trade read acquired, not its own.
 
-    Zeroing `current_qty` survives BOTH contract files. Across the whole suite it dies to
-    exactly one test, in bitget's venue file, incidentally. That is the wrong home for it:
-    `_execute_trade_if_needed` is NOT shared, so the "command flat, close a position the
-    env did not open" path runs through venue-specific code on all four venues and is
-    exercised on one. The contract belongs where the shared `_step` is owned.
+    `_execute_trade_if_needed` is NOT shared, so this contract belongs where the shared
+    `_step` is owned rather than in one venue's file.
 
-    Re-reading instead of threading is what let an outage open a window between the two
-    reads, which is the whole of #295; a zeroed qty makes the executor believe it is flat
-    and re-open a position it already holds.
+    The venue reports something DIFFERENT after the first read. That is the whole design:
+    with the fixture's constant mocks a re-read returns the identical value, so the first
+    version of this test passed under the very mutation it names -- swapping the threaded
+    price for `self._current_mark_price()` changed nothing observable. Constants cannot
+    distinguish "read once and thread it" from "read again"; only a changing venue can.
+
+    The read COUNT is pinned too, and it is the stricter half: two status reads per step,
+    the pre-trade one and the post-bar one. A third is a re-read, which is the window an
+    outage slips through even when the values happen to agree.
     """
-    open_long = PositionStatus(
+    held = PositionStatus(
         qty=0.05, notional_value=6000.0, entry_price=100.0, unrealized_pnl=0.0,
         unrealized_pnl_pct=0.0, mark_price=100.0, leverage=10,
         margin_mode="isolated", liquidation_price=91.0,
     )
-    env, trader = _real_futures_env(budget=0, venue="binance", position_status=open_long)
+    moved = PositionStatus(
+        qty=0.99, notional_value=99000.0, entry_price=100.0, unrealized_pnl=0.0,
+        unrealized_pnl_pct=0.0, mark_price=999.0, leverage=10,
+        margin_mode="isolated", liquidation_price=91.0,
+    )
+    env, trader = _real_futures_env(budget=0, venue="binance", position_status=held)
+
+    reads = {"status": 0, "mark": 0}
+
+    def status():
+        reads["status"] += 1
+        return {"position_status": held if reads["status"] == 1 else moved}
+
+    def mark():
+        reads["mark"] += 1
+        return 100.0 if reads["mark"] == 1 else 999.0
+
+    trader.get_status.side_effect = status
+    trader.get_mark_price.side_effect = mark
 
     seen = {}
-    env._execute_trade_if_needed = lambda action, **kw: (
-        seen.update(kw), {"executed": False}
-    )[1]
+
+    def spy(action, **kw):
+        seen.update(kw)
+        return {"executed": False}          # a real return: five sites in binance alone
+
+    env._execute_trade_if_needed = spy
 
     td = env.reset()
+    reads["status"] = reads["mark"] = 0     # count the STEP's reads, not reset's
     env.step(td.set("action", torch.tensor(0)))
 
+    assert seen, "setup: the trade was never dispatched, so nothing was threaded to it"
     assert seen.get("current_qty") == pytest.approx(0.05), (
-        f"the trade was handed current_qty={seen.get('current_qty')!r} rather than the "
-        f"0.05 the pre-trade read acquired; 0.0 reads as flat and re-opens the position"
+        f"the trade was handed current_qty={seen.get('current_qty')!r}; 0.99 means it "
+        f"re-read the venue instead of taking what the pre-trade read acquired (#295), "
+        f"and 0.0 means it was dropped"
     )
     assert seen.get("current_price") == pytest.approx(100.0), (
-        f"the trade was handed current_price={seen.get('current_price')!r} rather than "
-        f"the price the pre-trade read acquired under the halt policy (#295)"
+        f"the trade was handed current_price={seen.get('current_price')!r}; 999.0 means "
+        f"it re-read the mark rather than taking the threaded one (#295)"
+    )
+    assert reads["status"] == 2, (
+        f"{reads['status']} status reads in one step, not 2 (pre-trade and post-bar); an "
+        f"extra read is the outage window #295 closed by threading"
     )
 
 
@@ -4335,7 +4349,12 @@ def test_the_history_row_is_the_one_the_reward_function_scores(sltp):
     trader.get_mark_price.side_effect = lambda: 120.0 if bar["done"] else 100.0
 
     real_wait = env._wait_for_next_timestamp
-    env._wait_for_next_timestamp = lambda: (bar.__setitem__("done", True), real_wait())[1]
+
+    def wait():
+        bar["done"] = True
+        return real_wait()
+
+    env._wait_for_next_timestamp = wait
 
     td = env.reset()
     if sltp:
@@ -4343,13 +4362,14 @@ def test_the_history_row_is_the_one_the_reward_function_scores(sltp):
     action = 0 if sltp else len(env.action_levels) - 1
     out = env.step(td.set("action", torch.tensor(action)))["next"]
 
-    rows = len(env.history.actions)
-    assert out["reward"].item() == pytest.approx(float(rows)), (
-        f"the step returned {out['reward'].item()}, not reward_function's score of the "
-        f"{rows} row(s) that existed when it was called; 0.0 is either the placeholder "
-        f"or a reward computed before `record_step` wrote its row"
+    # The literal 1, not `len(history.actions)` re-read here: a count taken after the step
+    # moves with the bug, so a doubled `record_step` would score 2 against 2 rows and pass.
+    assert out["reward"].item() == pytest.approx(1.0), (
+        f"the step returned {out['reward'].item()}, not reward_function's score of the 1 "
+        f"row that existed when it was called; 0.0 is either the placeholder or a reward "
+        f"computed before `record_step` wrote its row"
     )
-    assert env.history.rewards[-1] == pytest.approx(float(rows)), (
+    assert env.history.rewards[-1] == pytest.approx(1.0), (
         "history kept `record_step`'s 0.0 placeholder; the reward function reads this "
         "row on the NEXT step"
     )
@@ -4363,16 +4383,15 @@ def test_the_history_row_is_the_one_the_reward_function_scores(sltp):
 
 
 # binance ships [-1, 0, 1]; the other three ship [-1, -0.5, 0, 0.5, 1]. The venue axis is
-# NOT theatre here, though it is on every other test in this file: venues differ in DATA,
+# NOT theatre here, unlike elsewhere in this file: venues differ in DATA,
 # not only in code, and on binance a mutation flattening the level to its sign is a no-op.
-# It survived until this case existed.
+#
 @pytest.mark.parametrize("venue,want", [
     ("binance", 1), ("binance", -1), ("bitget", 0.5), ("bitget", -0.5),
 ], ids=["full-long", "full-short", "half-long", "half-short"])
 def test_the_plain_history_row_records_the_action_actually_traded(venue, want):
-    """`action` in the history row is what the reward function scores.
-
-    Flipping its sign in the shared plain `_step` fails ZERO tests.
+    """`action` in the history row is what the reward function scores -- the LEVEL, not
+    its sign.
     """
     env, _ = _real_futures_env(budget=0, venue=venue)
     # Index by value, not position: the action_levels lists differ in length.
@@ -4384,10 +4403,6 @@ def test_the_plain_history_row_records_the_action_actually_traded(venue, want):
     assert recorded == pytest.approx(float(want)), (
         f"the row recorded {recorded} rather than the action level {float(want)} actually "
         f"traded; a sign-only check passes on a halved or a flattened level"
-    )
-    assert recorded * want > 0, (
-        f"a {'long' if want > 0 else 'short'} action recorded {recorded} in the history "
-        f"row the reward function reads"
     )
 
 
@@ -4407,8 +4422,7 @@ def test_a_flat_bar_falls_back_to_the_pre_trade_price(sltp):
     The `setup:` assertion is not ceremony. The scenario is armed by a one-shot flag
     flipped inside `_wait_for_next_timestamp`; delete that call from the shared `_step`
     and the flag never flips, the post-bar mark never fails, the fallback never runs --
-    and without this assertion the test still passed. A test whose subject can vanish
-    while it stays green has to check that its own scenario happened.
+    and without this assertion the test still passed.
     """
     env, trader = _real_futures_env(budget=0, venue="binance", sltp=sltp)
     td = env.reset()

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -2424,8 +2424,6 @@ def test_the_size_an_env_reports_actually_reaches_the_position(exchange):
     every COMPLETE fill would have read as a partial one. Exactly the defect the previous
     round fixed, one layer up.
     """
-    src = (pathlib.Path(inspect.getfile(TorchTradeLiveEnv)).parent.parent
-           / "live" / exchange / "env.py").read_text()   # noqa: F841 -- see below
 
     # AST over the RESOLVED `_step`, not the venue file: #288 moved the plain `_step` onto
     # TorchTradeFuturesLiveEnv, so a file scan reads a module that no longer contains the
@@ -4349,7 +4347,38 @@ def test_a_flat_bar_falls_back_to_the_pre_trade_price(shared_step, module):
     env._wait_for_next_timestamp = wait
     env.step(td.set("action", torch.tensor(0)))
 
-    assert env.history.base_prices[-1] is not None, "a flat bar recorded a None price"
-    assert isinstance(env.history.base_prices[-1], (int, float)), (
-        f"a flat bar recorded {env.history.base_prices[-1]!r} rather than the pre-trade price"
+    # The VALUE, not just the type. `isinstance(..., (int, float))` passed on a fallback
+    # changed to `else 0.0` -- wrong but numeric -- while the docstring claimed the test
+    # verified "the pre-trade price". 100.0 is what the mock's get_mark_price returned on
+    # the pre-trade read, so it is the only correct answer here.
+    assert env.history.base_prices[-1] == pytest.approx(100.0), (
+        f"a flat bar recorded {env.history.base_prices[-1]!r} rather than the pre-trade "
+        f"price of 100.0"
+    )
+
+
+@pytest.mark.parametrize("venue", ["binance", "bitget", "bybit", "okx"])
+def test_no_plain_futures_env_reforks_the_shared_step(venue):
+    """The PLAIN `_step` must resolve to TorchTradeFuturesLiveEnv, not a venue copy.
+
+    I wrote `test_no_sltp_env_reforks_the_shared_step` for the SLTP fold and shipped the
+    plain fold without the equivalent -- the fifth time in this issue that a fix landed on
+    some copies and not others, this time in the guard against exactly that.
+
+    Mutation-proven necessary: appending a BYTE-IDENTICAL copy of the shared `_step` to
+    bitget/env.py passed all 819 tests in this file. An incomplete fold is invisible
+    behaviourally, because a copy that has not drifted yet works perfectly -- right up
+    until a shared fix fails to land on the venue holding one.
+
+    Not folded into `test_no_futures_env_reforks_the_shared_observation`: its FUTURES_ENVS
+    list includes the SLTP envs, which resolve `_step` to SLTPMixin by design.
+    """
+    import importlib
+
+    mod = importlib.import_module(f"torchtrade.envs.live.{venue}.env")
+    cls = next(v for k, v in vars(mod).items()
+               if k.endswith("TorchTradingEnv") and v.__module__ == mod.__name__)
+    assert cls._step is TorchTradeFuturesLiveEnv._step, (
+        f"{cls.__name__} re-forks _step instead of resolving the shared one; a private "
+        f"copy is where a shared fix silently fails to land"
     )

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -2425,11 +2425,28 @@ def test_the_size_an_env_reports_actually_reaches_the_position(exchange):
     round fixed, one layer up.
     """
     src = (pathlib.Path(inspect.getfile(TorchTradeLiveEnv)).parent.parent
-           / "live" / exchange / "env.py").read_text()
+           / "live" / exchange / "env.py").read_text()   # noqa: F841 -- see below
 
-    assert "_record_position_after_trade(desired_action, trade_info)" in src, (
-        f"{exchange} does not hand the whole trade_info to the recorder, so a size value "
-        f"it computes can be silently dropped on the way"
+    # AST over the RESOLVED `_step`, not the venue file: #288 moved the plain `_step` onto
+    # TorchTradeFuturesLiveEnv, so a file scan reads a module that no longer contains the
+    # call. And a substring cannot tell `trade_info` from `trade_info["qty"]` -- which is
+    # exactly the half-passing this guard exists to reject.
+    import importlib
+
+    mod = importlib.import_module(f"torchtrade.envs.live.{exchange}.env")
+    cls = next(v for k, v in vars(mod).items()
+               if k.endswith("TorchTradingEnv") and v.__module__ == mod.__name__)
+    call = next(
+        (n for n in ast.walk(ast.parse(inspect.getsource(cls._step).lstrip()))
+         if isinstance(n, ast.Call) and isinstance(n.func, ast.Attribute)
+         and n.func.attr == "_record_position_after_trade"),
+        None,
+    )
+    assert call is not None, f"{exchange}'s _step never records the position it traded"
+    passed = [a.id for a in call.args if isinstance(a, ast.Name)]
+    assert "trade_info" in passed, (
+        f"{exchange} hands the recorder {ast.unparse(call)} rather than the whole "
+        f"trade_info, so a size value it computes can be silently dropped on the way"
     )
 
 
@@ -4259,4 +4276,80 @@ def test_the_history_row_records_the_side_actually_traded(side_idx, expected):
     assert env.history.actions[-1] == pytest.approx(expected), (
         f"a {want or 'hold'} bracket recorded {env.history.actions[-1]} in the history "
         f"row the reward function reads, expected {expected}"
+    )
+
+
+@pytest.mark.parametrize("venue", ["binance", "bitget", "bybit", "okx"])
+@pytest.mark.parametrize("level_idx,expected_sign", [(-1, 1.0), (0, -1.0)],
+                         ids=["full-long", "full-short"])
+def test_the_plain_history_row_records_the_action_actually_traded(
+    venue, level_idx, expected_sign
+):
+    """`action` in the history row is what the reward function scores.
+
+    Flipping its sign in the shared plain `_step` fails ZERO tests. I pinned exactly this
+    on the SLTP path an hour ago and left the plain one -- the same "some copies, not
+    others" this issue is about, in the guard against it.
+
+    Indexed by VALUE: binance ships [-1, 0, 1] and the others [-1, -0.5, 0, 0.5, 1], so a
+    hardcoded index means different things per venue.
+    """
+    import torch
+    from tests.envs.test_live_observation_failsafe import _real_futures_env
+
+    env, trader = _real_futures_env(budget=0, venue=venue)
+    action = len(env.action_levels) - 1 if level_idx == -1 else 0
+    td = env.reset()
+    env.step(td.set("action", torch.tensor(action)))
+
+    recorded = env.history.actions[-1]
+    assert recorded * expected_sign > 0, (
+        f"{venue}: a {'long' if expected_sign > 0 else 'short'} action recorded "
+        f"{recorded} in the history row the reward function reads"
+    )
+
+
+@pytest.mark.parametrize("shared_step,module", [
+    ("TorchTradeFuturesLiveEnv", "env"), ("SLTPMixin", "env_sltp"),
+], ids=["plain", "sltp"])
+def test_a_flat_bar_falls_back_to_the_pre_trade_price(shared_step, module):
+    """`new_price = new_price if new_price is not None else current_price`.
+
+    `_acquire_post_bar_state` returns None for the mark when the account is flat -- there
+    is no position to read one from. Dropping the fallback feeds None into
+    `history.record_step(price=...)`, and every downstream reader of that row gets it.
+
+    Failed zero tests on BOTH shared steps: the comment explaining why the fallback exists
+    has been carried through four copies and two folds without anything asserting it.
+    """
+    import torch
+    from tests.envs.test_live_observation_failsafe import _real_futures_env
+
+    env, trader = _real_futures_env(budget=0, venue="binance", sltp=(module == "env_sltp"))
+    td = env.reset()
+
+    # The mark goes unavailable only for the POST-bar read: the pre-trade read must
+    # succeed, or the step halts before it ever reaches the fallback. That asymmetry is
+    # the whole scenario -- a flat account has no position mark to read, and the post-bar
+    # fetch is deliberately allowed to fail rather than halt an episode over a label.
+    state = {"traded": False}
+
+    def mark():
+        if state["traded"]:
+            raise RuntimeError("post-bar mark unavailable")
+        return 100.0
+
+    real_wait = env._wait_for_next_timestamp
+
+    def wait():
+        state["traded"] = True
+        return real_wait()
+
+    trader.get_mark_price.side_effect = mark
+    env._wait_for_next_timestamp = wait
+    env.step(td.set("action", torch.tensor(0)))
+
+    assert env.history.base_prices[-1] is not None, "a flat bar recorded a None price"
+    assert isinstance(env.history.base_prices[-1], (int, float)), (
+        f"a flat bar recorded {env.history.base_prices[-1]!r} rather than the pre-trade price"
     )

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -4248,6 +4248,61 @@ def test_the_history_row_records_the_side_actually_traded(side_idx, expected):
     )
 
 
+@pytest.mark.parametrize("trade_info,expect_recorded", [
+    ({"executed": True, "success": True}, True),
+    ({"executed": True, "success": False}, False),   # the venue REFUSED the bracket
+    ({"executed": False}, False),                    # nothing was sent
+], ids=["accepted", "refused", "not-sent"])
+def test_a_refused_sltp_bracket_does_not_write_a_phantom_position(trade_info,
+                                                                  expect_recorded):
+    """`executed and success is not False` gates the SLTP position write.
+
+    Replacing that condition with `if True:` survives the whole suite: a bracket the venue
+    REFUSED then writes `position.current_position`, so the cache reads long while the
+    account is flat. That is invariant 2 inverted -- the cache overriding exchange truth --
+    and the next bar's duplicate-action guard trusts it.
+
+    The plain owner's identical guard in `_record_position_after_trade` is covered; this
+    one was not. Same rule, two owners, one pinned -- which is #288's thesis about what
+    duplication costs, in the gate rather than in the code.
+    """
+    env, trader = _real_futures_env(budget=0, venue="binance", sltp=True)
+    env._dispatch_sltp_trade = lambda action_tuple, current_price: trade_info
+
+    td = env.reset()
+    assert env.position.current_position == 0, "setup: expected to start flat"
+    env.active_stop_loss, env.active_take_profit = 111.0, 222.0
+    env.step(td.set("action", torch.tensor(1)))     # a bracket action, not the hold
+
+    recorded = env.position.current_position != 0
+    assert recorded is expect_recorded, (
+        f"trade_info={trade_info} left current_position="
+        f"{env.position.current_position}; a refused or unsent bracket must leave the "
+        f"cache flat, or the next bar's duplicate-action guard trusts a position that "
+        f"does not exist"
+    )
+
+
+def test_a_reset_clears_the_bracket_on_the_shared_sltp_owner():
+    """`_reset_sltp_state` is pinned for alpaca only, and alpaca does not share this copy.
+
+    alpaca is spot: it is deliberately absent from SLTP_FUTURES_ENVS, so the identity
+    guard does not reach it. Neuter the mixin copy the four FUTURES venues actually use
+    and the suite stays green -- stale SL/TP levels then survive into the next episode,
+    where they arm brackets the agent never chose.
+    """
+    env, _ = _real_futures_env(budget=0, venue="binance", sltp=True)
+    env.reset()
+    env.active_stop_loss, env.active_take_profit = 111.0, 222.0
+
+    env.reset()
+
+    assert (env.active_stop_loss, env.active_take_profit) == (0.0, 0.0), (
+        f"reset left SL/TP at ({env.active_stop_loss}, {env.active_take_profit}); a live "
+        f"bracket carried into the next episode arms on a position it never opened"
+    )
+
+
 def test_the_trade_takes_the_qty_and_price_the_pre_trade_read_acquired():
     """#295: the trade uses the qty and price the pre-trade read acquired, not its own.
 
@@ -4264,9 +4319,14 @@ def test_the_trade_takes_the_qty_and_price_the_pre_trade_read_acquired():
     the pre-trade one and the post-bar one. A third is a re-read, which is the window an
     outage slips through even when the values happen to agree.
     """
+    # mark 137.0 against entry 100.0 and a fetched mark of 100.0: with an open position
+    # the threaded price comes from `position_status.mark_price`, so any of the three
+    # plausible re-reads -- `_current_mark_price()` with no status, `get_mark_price()`,
+    # `entry_price` -- lands on 100.0 and is distinguishable. They were not when every
+    # number in the fixture was 100.0.
     held = PositionStatus(
         qty=0.05, notional_value=6000.0, entry_price=100.0, unrealized_pnl=0.0,
-        unrealized_pnl_pct=0.0, mark_price=100.0, leverage=10,
+        unrealized_pnl_pct=0.0, mark_price=137.0, leverage=10,
         margin_mode="isolated", liquidation_price=91.0,
     )
     moved = PositionStatus(
@@ -4307,9 +4367,15 @@ def test_the_trade_takes_the_qty_and_price_the_pre_trade_read_acquired():
         f"re-read the venue instead of taking what the pre-trade read acquired (#295), "
         f"and 0.0 means it was dropped"
     )
-    assert seen.get("current_price") == pytest.approx(100.0), (
-        f"the trade was handed current_price={seen.get('current_price')!r}; 999.0 means "
-        f"it re-read the mark rather than taking the threaded one (#295)"
+    assert seen.get("current_price") == pytest.approx(137.0), (
+        f"the trade was handed current_price={seen.get('current_price')!r}; 100.0 means "
+        f"it re-read the mark or fell back to entry_price rather than taking the threaded "
+        f"one (#295)"
+    )
+    assert reads["mark"] == 0, (
+        f"{reads['mark']} mark fetches in a step that holds a position; the mark comes "
+        f"off the status snapshot already read, and a fetch is a second round-trip that "
+        f"can halt the episode"
     )
     assert reads["status"] == 2, (
         f"{reads['status']} status reads in one step, not 2 (pre-trade and post-bar); an "

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -43,6 +43,9 @@ from torchtrade.envs.utils.liquidation import (
     isolated_liquidation_price,
 )
 from tests.envs.base_exchange_tests import wire_outage_state
+from tests.envs.test_live_observation_failsafe import _real_futures_env
+from torchtrade.envs.core.common_types import PositionStatus
+from tests.envs.base_exchange_tests import _sole
 from torchtrade.envs.core.state import (
     POSITION_UNKNOWN,
     PositionState,
@@ -79,7 +82,7 @@ FUTURES_ENVS = [
     if issubclass(c, TorchTradeFuturesLiveEnv) and c is not TorchTradeFuturesLiveEnv
 ]
 
-# Split by module. Preferred over scanning a module namespace -- see `_sole` below.
+# Split by module.
 PLAIN_FUTURES_ENVS = [c for c in FUTURES_ENVS if c.__module__.endswith(".env")]
 SLTP_FUTURES_ENVS = [c for c in FUTURES_ENVS if c.__module__.endswith(".env_sltp")]
 # 4 -> 3 is the hazard: an EMPTY list is already a collection error (pyproject sets
@@ -87,22 +90,6 @@ SLTP_FUTURES_ENVS = [c for c in FUTURES_ENVS if c.__module__.endswith(".env_sltp
 assert len(PLAIN_FUTURES_ENVS) == len(SLTP_FUTURES_ENVS) == 4
 
 
-def _sole(module, suffix):
-    """The ONE class in `module` whose name ends in `suffix`.
-
-    Not `next(...)`, which returns the first match in DEFINITION order: a decoy declared
-    above the real class silently becomes the subject, and a guard then passes green on a
-    class nobody meant to check.
-    """
-    found = [
-        v for k, v in vars(module).items()
-        if k.endswith(suffix) and getattr(v, "__module__", None) == module.__name__
-    ]
-    assert len(found) == 1, (
-        f"{module.__name__} defines {len(found)} classes ending in {suffix!r} "
-        f"({[c.__name__ for c in found]}); the guard would have silently picked the first"
-    )
-    return found[0]
 
 
 @pytest.mark.parametrize("done_on_bankruptcy,portfolio_value,expected", [
@@ -4180,25 +4167,38 @@ def test_dependency_injection_still_skips_construction_entirely():
 # the mixin's (no futures pre-trade acquisition, no mark). It overrides `_step` on purpose
 # and inherits `_reset`, which IS identical. Deleting alpaca's `_step` as "redundant"
 # would hand a spot env the futures step.
-@pytest.mark.parametrize("method", ["_step", "_reset"])
-@pytest.mark.parametrize("cls,owner", [
-    *((c, TorchTradeFuturesLiveEnv) for c in PLAIN_FUTURES_ENVS),
-    *((c, SLTPMixin) for c in SLTP_FUTURES_ENVS),
-], ids=[c.__name__ for c in PLAIN_FUTURES_ENVS + SLTP_FUTURES_ENVS])
+# Per OWNER, because the two own different method sets. The SLTP callees were unguarded:
+# a byte-identical copy of `_record_sltp_position` on one venue passed the whole suite.
+#
+# `_dispatch_sltp_trade` is deliberately ABSENT. It is the venue-variation hook -- its own
+# docstring calls it "the ONE thing `_step` varies by venue" -- and bybit and okx really do
+# override it, to thread the price rather than re-read it (#295). Guarding it would demand
+# a fold of the one method that exists not to be folded. Adding it here failed exactly
+# those two venues, which is how I found out.
+_SHARED_METHOD_OWNERSHIP = [
+    *((c, TorchTradeFuturesLiveEnv, m)
+      for c in PLAIN_FUTURES_ENVS for m in ("_step", "_reset")),
+    *((c, SLTPMixin, m) for c in SLTP_FUTURES_ENVS for m in (
+        "_step", "_reset", "_resolve_action_tuple", "_record_sltp_position",
+        "_reset_sltp_state",
+    )),
+]
+assert len(_SHARED_METHOD_OWNERSHIP) == 4 * 2 + 4 * 5
+
+
+@pytest.mark.parametrize("cls,owner,method", _SHARED_METHOD_OWNERSHIP,
+                         ids=[f"{c.__name__}-{m}" for c, _, m in _SHARED_METHOD_OWNERSHIP])
 def test_no_futures_env_reforks_a_shared_step_or_reset(cls, owner, method):
     """#288 folded eight `_step`/`_reset` copies onto two owners. Nothing noticed when one
     of them did not fold.
 
-    Reverting bybit's file mid-way through mutation testing left it with private copies and
-    the suite stayed green -- of course it did, the copy still worked. An incomplete fold is
-    invisible behaviourally, right up until a fix lands on the shared copy and bybit does
-    not get it.
+    An incomplete fold is invisible behaviourally, right up until a fix lands on the
+    shared copy and one venue does not get it.
 
-    Identity against the owner, not `"_step" not in vars(cls)`. The two are equivalent
-    today only because SLTPMixin sits directly after the class in the MRO -- I checked,
-    there is nothing between them. Insert one intermediate base and absence-from-the-
-    subclass starts passing on a copy that really does shadow the owner; identity does not
-    care where in the MRO the copy is planted.
+    Identity against the owner, not `"_step" not in vars(cls)`: those are equivalent only
+    while SLTPMixin sits directly after the class in the MRO. Insert one intermediate base
+    and absence-from-the-subclass starts passing on a copy that really does shadow the
+    owner; identity does not care where the copy is planted.
     """
     assert getattr(cls, method) is getattr(owner, method), (
         f"{cls.__name__}.{method} resolves to {getattr(cls, method).__qualname__} rather "
@@ -4251,8 +4251,6 @@ def test_the_history_row_records_the_side_actually_traded(side_idx, expected):
     action is.
     """
     import torch
-    from tests.envs.test_live_observation_failsafe import _real_futures_env
-
     env, trader = _real_futures_env(budget=0, venue="binance", sltp=True)
     td = env.reset()
 
@@ -4267,43 +4265,60 @@ def test_the_history_row_records_the_side_actually_traded(side_idx, expected):
     )
 
 
-# The venue names behind the registry, so a fifth exchange joins these tests on its own.
-PLAIN_VENUES = [c.__module__.split(".")[-2] for c in PLAIN_FUTURES_ENVS]
+def test_the_trade_takes_the_qty_and_price_the_pre_trade_read_acquired():
+    """#295: one status read per step, threaded into the trade -- not re-read.
+
+    Zeroing `current_qty` survives BOTH contract files. Across the whole suite it dies to
+    exactly one test, in bitget's venue file, incidentally. That is the wrong home for it:
+    `_execute_trade_if_needed` is NOT shared, so the "command flat, close a position the
+    env did not open" path runs through venue-specific code on all four venues and is
+    exercised on one. The contract belongs where the shared `_step` is owned.
+
+    Re-reading instead of threading is what let an outage open a window between the two
+    reads, which is the whole of #295; a zeroed qty makes the executor believe it is flat
+    and re-open a position it already holds.
+    """
+    open_long = PositionStatus(
+        qty=0.05, notional_value=6000.0, entry_price=100.0, unrealized_pnl=0.0,
+        unrealized_pnl_pct=0.0, mark_price=100.0, leverage=10,
+        margin_mode="isolated", liquidation_price=91.0,
+    )
+    env, trader = _real_futures_env(budget=0, venue="binance", position_status=open_long)
+
+    seen = {}
+    env._execute_trade_if_needed = lambda action, **kw: (
+        seen.update(kw), {"executed": False}
+    )[1]
+
+    td = env.reset()
+    env.step(td.set("action", torch.tensor(0)))
+
+    assert seen.get("current_qty") == pytest.approx(0.05), (
+        f"the trade was handed current_qty={seen.get('current_qty')!r} rather than the "
+        f"0.05 the pre-trade read acquired; 0.0 reads as flat and re-opens the position"
+    )
+    assert seen.get("current_price") == pytest.approx(100.0), (
+        f"the trade was handed current_price={seen.get('current_price')!r} rather than "
+        f"the price the pre-trade read acquired under the halt policy (#295)"
+    )
 
 
 @pytest.mark.parametrize("sltp", [False, True], ids=["plain", "sltp"])
 def test_the_history_row_is_the_one_the_reward_function_scores(sltp):
-    """Five contracts of the shared `_step` that failed ZERO tests between them.
+    """The history row the reward function scores. Each assertion below kills a mutation
+    of the shared `_step` that failed zero tests.
 
-    Everything here is read back out of `history` -- by the reward function on the next
-    step, and by every analysis of the episode after it:
+    Parametrised on plain vs SLTP, NOT on venue: the two owners hold SEPARATE copies of
+    the record-then-overwrite tail, while the four venues within each share one function
+    object and die to the same mutation identically.
 
-      reward -> 0.0                      the placeholder `record_step` writes
-      drop `history.rewards[-1] = ...`   same, one line later
-      reward computed BEFORE record_step it then scores a one-bar-stale history: the
-                                         reward at t belongs to the action at t-1 (#278)
-      price=current_price                the PRE-trade bar, against a post-bar PV
-      position=position_size             the PRE-trade qty, so an opening row reads flat
+    ONE step, not two: the pre/post price asymmetry below is armed once, so by step two
+    both reads return the post-bar value and the price and qty assertions stop
+    discriminating.
 
-    Parametrised on plain vs SLTP, NOT on venue. `TorchTradeFuturesLiveEnv._step` and
-    `SLTPMixin._step` hold SEPARATE copies of the record-then-overwrite tail, so each
-    needs its own pin; the four venues within each share one function object, and
-    mutating it fails all four identically. Which venue resolves to which owner is the
-    re-fork guard's job, not this one's.
-
-    ONE step, not two. `reward_function` counts the history, so a reward computed before
-    `record_step` scores 0 rows instead of 1 -- indistinguishable from the placeholder by
-    VALUE, but both are caught, which is what the assertion is for. A second step would
-    make them distinguishable and silently kill the price and qty assertions instead: the
-    pre/post asymmetry below is armed once, so by step two both reads return the post-bar
-    values and `price=current_price` becomes identical to `price=new_price`. I wrote the
-    two-step version first and the two mutations survived it.
-
-    NOT covered here, and still unpinned: alpaca keeps its own two copies of this tail
+    Not covered here: alpaca keeps its own two copies of this tail
     (`live/alpaca/env.py`, `live/alpaca/env_sltp.py`) -- outside this fold.
     """
-    from tests.envs.test_live_observation_failsafe import _real_futures_env
-    from torchtrade.envs.core.common_types import PositionStatus
 
     env, trader = _real_futures_env(budget=0, venue="binance", sltp=sltp)
     env.reward_function = lambda history: float(len(history.actions))
@@ -4343,56 +4358,70 @@ def test_the_history_row_is_the_one_the_reward_function_scores(sltp):
         "portfolio_value[t] from a different bar (#278)"
     )
     assert env.history.positions[-1] == pytest.approx(0.05), (
-        "the opening row records the pre-trade qty, so it reads flat"
+        "the row records the pre-trade qty, so a position held across the bar reads flat"
     )
 
 
-@pytest.mark.parametrize("want,expected_sign", [(1, 1.0), (-1, -1.0)],
-                         ids=["full-long", "full-short"])
-def test_the_plain_history_row_records_the_action_actually_traded(want, expected_sign):
+# binance ships [-1, 0, 1]; the other three ship [-1, -0.5, 0, 0.5, 1]. The venue axis is
+# NOT theatre here, though it is on every other test in this file: venues differ in DATA,
+# not only in code, and on binance a mutation flattening the level to its sign is a no-op.
+# It survived until this case existed.
+@pytest.mark.parametrize("venue,want", [
+    ("binance", 1), ("binance", -1), ("bitget", 0.5), ("bitget", -0.5),
+], ids=["full-long", "full-short", "half-long", "half-short"])
+def test_the_plain_history_row_records_the_action_actually_traded(venue, want):
     """`action` in the history row is what the reward function scores.
 
     Flipping its sign in the shared plain `_step` fails ZERO tests.
     """
-    from tests.envs.test_live_observation_failsafe import _real_futures_env
-
-    env, _ = _real_futures_env(budget=0, venue="binance")
-    # By VALUE: binance ships [-1, 0, 1] and the others [-1, -0.5, 0, 0.5, 1], so a
-    # hardcoded index means a different position size per venue.
+    env, _ = _real_futures_env(budget=0, venue=venue)
+    # Index by value, not position: the action_levels lists differ in length.
     action = env.action_levels.index(want)
     td = env.reset()
     env.step(td.set("action", torch.tensor(action)))
 
     recorded = env.history.actions[-1]
-    assert recorded * expected_sign > 0, (
-        f"a {'long' if expected_sign > 0 else 'short'} action recorded "
-        f"{recorded} in the history row the reward function reads"
+    assert recorded == pytest.approx(float(want)), (
+        f"the row recorded {recorded} rather than the action level {float(want)} actually "
+        f"traded; a sign-only check passes on a halved or a flattened level"
+    )
+    assert recorded * want > 0, (
+        f"a {'long' if want > 0 else 'short'} action recorded {recorded} in the history "
+        f"row the reward function reads"
     )
 
 
 @pytest.mark.parametrize("sltp", [False, True], ids=["plain", "sltp"])
 def test_a_flat_bar_falls_back_to_the_pre_trade_price(sltp):
-    """`new_price = new_price if new_price is not None else current_price`.
+    """A flat bar has no post-bar mark; the row must carry the pre-trade price.
 
     `_acquire_post_bar_state` returns None for the mark when the account is flat -- there
     is no position to read one from. Dropping the fallback feeds None into
     `history.record_step(price=...)`, and every downstream reader of that row gets it.
-    """
-    from tests.envs.test_live_observation_failsafe import _real_futures_env
 
+    137.0, not the fixture's 100.0: `_real_futures_env` also fills `base_features` with
+    100.0, so asserting 100.0 could not tell the pre-trade MARK from the observer's close
+    -- and the close is the plausible wrong implementation, since the SLTP path prices its
+    brackets off exactly that.
+
+    The `setup:` assertion is not ceremony. The scenario is armed by a one-shot flag
+    flipped inside `_wait_for_next_timestamp`; delete that call from the shared `_step`
+    and the flag never flips, the post-bar mark never fails, the fallback never runs --
+    and without this assertion the test still passed. A test whose subject can vanish
+    while it stays green has to check that its own scenario happened.
+    """
     env, trader = _real_futures_env(budget=0, venue="binance", sltp=sltp)
     td = env.reset()
 
-    # The mark goes unavailable only for the POST-bar read: the pre-trade read must
-    # succeed, or the step halts before it ever reaches the fallback. That asymmetry is
-    # the whole scenario -- a flat account has no position mark to read, and the post-bar
-    # fetch is deliberately allowed to fail rather than halt an episode over a label.
-    state = {"traded": False}
+    # The mark fails only for the POST-bar read: the pre-trade read must succeed, or the
+    # step halts before it ever reaches the fallback.
+    state = {"traded": False, "post_bar_failed": False}
 
     def mark():
         if state["traded"]:
+            state["post_bar_failed"] = True
             raise RuntimeError("post-bar mark unavailable")
-        return 100.0
+        return 137.0
 
     real_wait = env._wait_for_next_timestamp
 
@@ -4404,9 +4433,12 @@ def test_a_flat_bar_falls_back_to_the_pre_trade_price(sltp):
     env._wait_for_next_timestamp = wait
     env.step(td.set("action", torch.tensor(0)))
 
-    # 100.0 is what get_mark_price returned on the PRE-trade read. Asserting the value
-    # rather than the type: `isinstance(..., (int, float))` passes on an `else 0.0`.
-    assert env.history.base_prices[-1] == pytest.approx(100.0), (
+    assert state["post_bar_failed"], (
+        "setup: the post-bar mark fetch never failed, so the fallback under test never "
+        "ran -- this test would pass on any implementation"
+    )
+    # The value, not the type: `isinstance(..., (int, float))` passes on an `else 0.0`.
+    assert env.history.base_prices[-1] == pytest.approx(137.0), (
         f"a flat bar recorded {env.history.base_prices[-1]!r} rather than the pre-trade "
-        f"price of 100.0"
+        f"mark of 137.0 (100.0 would mean it took the observer's close instead)"
     )

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -3762,21 +3762,36 @@ def test_every_live_step_writes_done_explicitly(env_cls):
     reimplementing the writes by hand is how `truncated` became a declared constant in
     the first place.
     """
-    calls = [n.func.attr for n in ast.walk(ast.parse(
-        inspect.getsource(env_cls._step).lstrip()))
-        if isinstance(n, ast.Call) and isinstance(n.func, ast.Attribute)]
-    assert "_finalize_step_flags" in calls, (
-        f"{env_cls.__name__}._step does not call the shared done-family writer, so its "
-        f"truncation channel is unreachable"
+    def _attr_calls(func):
+        return [n.func.attr for n in ast.walk(ast.parse(inspect.getsource(func).lstrip()))
+                if isinstance(n, ast.Call) and isinstance(n.func, ast.Attribute)]
+
+    # One hop is allowed, and only one: #288 moved the record-then-score tail onto
+    # `_record_and_score`, so `_step` now reaches the writer through it. The delegate is
+    # pinned below, so "delegates" cannot become "delegates to something that stopped
+    # writing the family".
+    step_calls = _attr_calls(env_cls._step)
+    assert ("_finalize_step_flags" in step_calls
+            or "_record_and_score" in step_calls), (
+        f"{env_cls.__name__}._step neither calls the shared done-family writer nor the "
+        f"tail that does, so its truncation channel is unreachable"
+    )
+    assert "_finalize_step_flags" in _attr_calls(env_cls._record_and_score), (
+        f"{env_cls.__name__}._record_and_score stopped calling the done-family writer; "
+        f"every `_step` that delegates to it silently lost its truncation channel"
     )
     # A substring check passed on a commented-out call with the writes reimplemented
     # alongside it. Only binance had an end-to-end backstop for that; nine venues did not.
-    assert not [n for n in ast.walk(ast.parse(
-        inspect.getsource(env_cls._step).lstrip()))
+    # Both bodies, since the writes could be hand-rolled in either.
+    hand_written = [
+        n for func in (env_cls._step, env_cls._record_and_score)
+        for n in ast.walk(ast.parse(inspect.getsource(func).lstrip()))
         if isinstance(n, ast.Call) and isinstance(n.func, ast.Attribute)
         and n.func.attr == "set"
         and n.args and isinstance(n.args[0], ast.Constant)
-        and n.args[0].value in ("done", "terminated", "truncated")], (
+        and n.args[0].value in ("done", "terminated", "truncated")
+    ]
+    assert not hand_written, (
         f"{env_cls.__name__}._step writes the done family by hand alongside "
         f"_finalize_step_flags; the hand-written value wins and the shared one is a lie"
     )
@@ -4163,6 +4178,9 @@ def test_dependency_injection_still_skips_construction_entirely():
 # override it, to thread the price rather than re-read it (#295). Guarding it would demand
 # a fold of the one method that exists not to be folded.
 _SHARED_METHOD_OWNERSHIP = [
+    # `_record_and_score` is owned by TorchTradeLiveEnv and reached by all TEN stepping
+    # envs, alpaca included -- the only tail in this file that alpaca shares (#288).
+    *((c, TorchTradeLiveEnv, "_record_and_score") for c in STEPPING_ENVS),
     *((c, TorchTradeFuturesLiveEnv, m)
       for c in PLAIN_FUTURES_ENVS for m in ("_step", "_reset")),
     *((c, SLTPMixin, m) for c in SLTP_FUTURES_ENVS for m in (
@@ -4388,16 +4406,16 @@ def test_the_history_row_is_the_one_the_reward_function_scores(sltp):
     """The history row the reward function scores. Each assertion below kills a mutation
     of the shared `_step` that failed zero tests.
 
-    Parametrised on plain vs SLTP, NOT on venue: the two owners hold SEPARATE copies of
-    the record-then-overwrite tail, while the four venues within each share one function
-    object and die to the same mutation identically.
+    Parametrised on plain vs SLTP, NOT on venue. Since #288 folded the tail itself onto
+    `TorchTradeLiveEnv._record_and_score` there is ONE copy for all ten live envs, so the
+    reward contracts die here once; what still differs per owner is what each `_step`
+    THREADS into it -- the price, the qty, and how the action level is derived. That is
+    what these two cases pin. Which venue resolves to which owner is the re-fork guard's
+    job, and alpaca is covered by that guard rather than by a case here.
 
     ONE step, not two: the pre/post price asymmetry below is armed once, so by step two
     both reads return the post-bar value and the price and qty assertions stop
     discriminating.
-
-    Not covered here: alpaca keeps its own two copies of this tail
-    (`live/alpaca/env.py`, `live/alpaca/env_sltp.py`) -- outside this fold.
     """
 
     env, trader = _real_futures_env(budget=0, venue="binance", sltp=sltp)

--- a/tests/envs/test_live_observation_failsafe.py
+++ b/tests/envs/test_live_observation_failsafe.py
@@ -1,6 +1,7 @@
 """#343: a live env that cannot read its own account state must halt, not improvise."""
 
 import pytest
+from tests.envs.base_exchange_tests import _sole
 from types import SimpleNamespace
 
 from torchtrade.envs.core.live import (
@@ -114,8 +115,6 @@ def test_every_futures_step_reads_state_through_the_halting_helper(exchange, mod
     import importlib
     import inspect
 
-    from tests.envs.test_live_env_base import _sole
-
     mod = importlib.import_module(f"torchtrade.envs.live.{exchange}.{module}")
     source = inspect.getsource(_sole(mod, "TorchTradingEnv")._step)
 
@@ -133,8 +132,6 @@ def test_every_futures_config_coerces_its_failure_policy(exchange, module):
     exercising the subclass coercion it exists to pin (#288 review).
     """
     import importlib
-
-    from tests.envs.test_live_env_base import _sole
 
     mod = importlib.import_module(f"torchtrade.envs.live.{exchange}.{module}")
     cfg_cls = _sole(mod, "Config")
@@ -168,8 +165,6 @@ def _real_futures_env(budget, venue="binance", sltp=False, position_status=None,
         f"torchtrade.envs.live.{venue}.env_sltp" if sltp
         else f"torchtrade.envs.live.{venue}.env"
     )
-    from tests.envs.test_live_env_base import _sole
-
     Env = _sole(module, "TorchTradingEnv")
     Config = _sole(module, "TradingEnvConfig")
 

--- a/tests/envs/test_live_observation_failsafe.py
+++ b/tests/envs/test_live_observation_failsafe.py
@@ -172,10 +172,10 @@ def _real_futures_env(budget, venue="binance", sltp=False, position_status=None,
         f"torchtrade.envs.live.{venue}.env_sltp" if sltp
         else f"torchtrade.envs.live.{venue}.env"
     )
-    Env = next(v for k, v in vars(module).items()
-               if k.endswith("TorchTradingEnv") and v.__module__ == module.__name__)
-    Config = next(v for k, v in vars(module).items()
-                  if k.endswith("TradingEnvConfig") and v.__module__ == module.__name__)
+    from tests.envs.test_live_env_base import _sole
+
+    Env = _sole(module, "TorchTradingEnv")
+    Config = _sole(module, "TradingEnvConfig")
 
     observer = MagicMock()
     observer.get_keys.return_value = ["1m_10"]

--- a/tests/envs/test_live_observation_failsafe.py
+++ b/tests/envs/test_live_observation_failsafe.py
@@ -532,6 +532,13 @@ def test_a_grace_bar_can_still_SIZE_a_trade_with_the_venue_down(venue):
     nxt = env.step(td.exclude("done", "terminated", "truncated", "reward")
                    .set("action", torch.tensor(full_long)))["next"]
 
+    # `status_unknown` alone is over-determined: the failing `get_status` raises it
+    # whether or not the sizing path is ever reached. Neutering the trade dispatch left
+    # this test green. The point of the test is that the trade STILL HAPPENS.
+    assert trader.trade.called, (
+        "the grace bar never reached the trade: this test passes on an env that gives up "
+        "on the outage, which is the opposite of what it is named for"
+    )
     assert nxt["status_unknown"].item() == 1.0, "the bar must be flagged, not crash"
     assert not bool(nxt["terminated"]), "an outage is never a terminated episode"
 
@@ -560,6 +567,13 @@ def test_an_sltp_grace_bar_can_still_size_a_bracket_with_the_venue_down(venue):
     nxt = env.step(td.exclude("done", "terminated", "truncated", "reward")
                    .set("action", torch.tensor(1)))["next"]
 
+    # `status_unknown` alone is over-determined: the failing `get_status` raises it
+    # whether or not the sizing path is ever reached. Neutering the trade dispatch left
+    # this test green. The point of the test is that the trade STILL HAPPENS.
+    assert trader.trade.called, (
+        "the grace bar never reached the trade: this test passes on an env that gives up "
+        "on the outage, which is the opposite of what it is named for"
+    )
     assert nxt["status_unknown"].item() == 1.0, "the bar must be flagged, not crash"
     assert not bool(nxt["terminated"]), "an outage is never a terminated episode"
 

--- a/tests/envs/test_live_observation_failsafe.py
+++ b/tests/envs/test_live_observation_failsafe.py
@@ -114,11 +114,10 @@ def test_every_futures_step_reads_state_through_the_halting_helper(exchange, mod
     import importlib
     import inspect
 
-    ns = importlib.import_module(f"torchtrade.envs.live.{exchange}.{module}").__dict__
-    env_cls = next(v for k, v in ns.items()
-                   if inspect.isclass(v) and k.endswith("TorchTradingEnv")
-                   and v.__module__.endswith(module))
-    source = inspect.getsource(env_cls._step)
+    from tests.envs.test_live_env_base import _sole
+
+    mod = importlib.import_module(f"torchtrade.envs.live.{exchange}.{module}")
+    source = inspect.getsource(_sole(mod, "TorchTradingEnv")._step)
 
     assert "_acquire_post_bar_state()" in source, f"{exchange}/{module} bypasses the halt"
     assert "self._get_observation()" not in source, f"{exchange}/{module} reads directly"
@@ -129,19 +128,16 @@ def test_every_futures_step_reads_state_through_the_halting_helper(exchange, mod
 def test_every_futures_config_coerces_its_failure_policy(exchange, module):
     """A bad policy string must be rejected at the boundary, not in production.
 
-    The `__module__` filter matches the env_cls discovery above and is load-bearing: the
-    SLTP configs now import their shared base into the module namespace, and without it
-    `next()` returns that base for all four venues -- so this test silently stopped
+    `_sole`'s `__module__` filter is load-bearing here: the SLTP configs import their
+    shared base into the module namespace, and without it this test silently stopped
     exercising the subclass coercion it exists to pin (#288 review).
     """
     import importlib
-    import inspect
 
-    ns = importlib.import_module(f"torchtrade.envs.live.{exchange}.{module}").__dict__
-    cfg_cls = next(v for k, v in ns.items()
-                   if inspect.isclass(v) and k.endswith("Config")
-                   and hasattr(v, "observation_failure_policy")
-                   and v.__module__.endswith(module))
+    from tests.envs.test_live_env_base import _sole
+
+    mod = importlib.import_module(f"torchtrade.envs.live.{exchange}.{module}")
+    cfg_cls = _sole(mod, "Config")
 
     assert cfg_cls().observation_failure_policy is ObservationFailurePolicy.HALT
     assert cfg_cls(observation_failure_policy="flatten").observation_failure_policy is (

--- a/torchtrade/envs/core/live.py
+++ b/torchtrade/envs/core/live.py
@@ -352,6 +352,34 @@ class TorchTradeLiveEnv(TorchTradeBaseEnv):
         self._status_unknown_this_step = False
         self._last_confirmed_read.clear()
 
+    def _record_and_score(self, next_tensordict, *, price, action, portfolio_value,
+                          position):
+        """The tail every live `_step` ran verbatim -- four copies, alpaca included (#288).
+
+        Ordering is the contract. `record_step` writes a 0.0 placeholder FIRST because
+        `reward_function` scores the history it is about to be added to; the overwrite on
+        the next line is what makes the row true. Scoring before recording makes the reward
+        at t belong to the action at t-1, which is the #278 shape and the reason this is
+        one method rather than four.
+
+        Returns `next_tensordict` so a `_step` ends `return self._record_and_score(...)`.
+        """
+        self.history.record_step(
+            price=price,
+            action=action,
+            reward=0.0,
+            portfolio_value=portfolio_value,
+            position=position,
+        )
+        reward = float(self.reward_function(self.history))
+        self.history.rewards[-1] = reward
+
+        next_tensordict.set("reward", torch.tensor([reward], dtype=torch.float))
+        self._finalize_step_flags(
+            next_tensordict, terminated=self._check_termination(portfolio_value)
+        )
+        return next_tensordict
+
     def _finalize_step_flags(self, next_tensordict, terminated: bool) -> None:
         """Stamp status_unknown and the done family. Ten identical copies (#288, #295).
 

--- a/torchtrade/envs/live/alpaca/env.py
+++ b/torchtrade/envs/live/alpaca/env.py
@@ -177,28 +177,10 @@ class AlpacaTorchTradingEnv(AlpacaBaseTorchTradingEnv):
             )
             new_price = current_price
 
-        # Record step history FIRST (reward function needs updated history!)
-        self.history.record_step(
-            price=new_price,
-            action=desired_action,
-            reward=0.0,  # Placeholder, will be set after reward calculation
-            portfolio_value=new_portfolio_value,
-            position=new_qty,
+        return self._record_and_score(
+            next_tensordict, price=new_price, action=desired_action,
+            portfolio_value=new_portfolio_value, position=new_qty,
         )
-
-        # Calculate reward using UPDATED history tracker
-        reward = float(self.reward_function(self.history))
-
-        # Update the reward in history
-        self.history.rewards[-1] = reward
-
-        # Check termination
-        done = self._check_termination(new_portfolio_value)
-
-        next_tensordict.set("reward", torch.tensor([reward], dtype=torch.float))
-        self._finalize_step_flags(next_tensordict, terminated=done)
-
-        return next_tensordict
 
 
     def _execute_trade_if_needed(self, desired_action: float) -> Dict:

--- a/torchtrade/envs/live/alpaca/env_sltp.py
+++ b/torchtrade/envs/live/alpaca/env_sltp.py
@@ -214,28 +214,10 @@ class AlpacaSLTPTorchTradingEnv(SLTPMixin, AlpacaBaseTorchTradingEnv):
         # Convert action_tuple to numeric action for history
         action_value = 1.0 if action_tuple != (None, None) else 0.0
 
-        # Record step history FIRST (reward function needs updated history!)
-        self.history.record_step(
-            price=new_price,
-            action=action_value,
-            reward=0.0,  # Placeholder, will be set after reward calculation
-            portfolio_value=new_portfolio_value,
-            position=new_qty,
+        return self._record_and_score(
+            next_tensordict, price=new_price, action=action_value,
+            portfolio_value=new_portfolio_value, position=new_qty,
         )
-
-        # Calculate reward using UPDATED history tracker
-        reward = float(self.reward_function(self.history))
-
-        # Update the reward in history
-        self.history.rewards[-1] = reward
-
-        # Check termination
-        done = self._check_termination(new_portfolio_value)
-
-        next_tensordict.set("reward", torch.tensor([reward], dtype=torch.float))
-        self._finalize_step_flags(next_tensordict, terminated=done)
-
-        return next_tensordict
 
     def _execute_trade_if_needed(self, action_tuple: Tuple[Optional[float], Optional[float]]) -> Dict:
         """Execute trade if position change is needed.

--- a/torchtrade/envs/live/binance/env.py
+++ b/torchtrade/envs/live/binance/env.py
@@ -3,10 +3,8 @@ from dataclasses import dataclass
 from typing import Dict, List, Optional, Union, Callable
 import logging
 
-import torch
 
 logger = logging.getLogger(__name__)
-from tensordict import TensorDictBase
 from torchrl.data import Categorical
 
 from torchtrade.envs.utils.timeframe import TimeFrame
@@ -157,7 +155,6 @@ class BinanceFuturesTorchTradingEnv(BinanceBaseTorchTradingEnv):
         # Define action space (environment-specific)
         self.action_levels = config.action_levels
         self.action_spec = Categorical(len(self.action_levels))
-
 
 
     def _get_symbol_info(self) -> Dict:

--- a/torchtrade/envs/live/binance/env.py
+++ b/torchtrade/envs/live/binance/env.py
@@ -158,56 +158,6 @@ class BinanceFuturesTorchTradingEnv(BinanceBaseTorchTradingEnv):
         self.action_levels = config.action_levels
         self.action_spec = Categorical(len(self.action_levels))
 
-    def _step(self, tensordict: TensorDictBase) -> TensorDictBase:
-        """Execute one environment step."""
-
-        # Get current price and position from trader status (avoids redundant observation call)
-        status, position_status, current_price, position_size = self._acquire_pre_trade_state()
-
-        self._sync_position_from_exchange(position_status)
-
-        # Get desired action
-        desired_action = self._resolve_action_level(tensordict)
-
-        # Execute trade
-        trade_info = self._execute_trade_if_needed(
-            desired_action, current_qty=position_size, current_price=current_price,
-        )
-
-        self._record_position_after_trade(desired_action, trade_info)
-
-        # Wait for next time step
-        self._wait_for_next_timestamp()
-
-        # Get updated state
-        new_portfolio_value, new_price, new_qty, next_tensordict = self._acquire_post_bar_state()
-        # None when the account is flat: there is no position mark to read, and
-        # fetching one would add a round-trip that can halt the episode. The
-        # pre-trade price is the honest fallback -- flat rows carry no PnL anyway.
-        new_price = new_price if new_price is not None else current_price
-
-        # Record step history FIRST (reward function needs updated history!)
-        self.history.record_step(
-            price=new_price,
-            action=desired_action,
-            reward=0.0,  # Placeholder, will be set after reward calculation
-            portfolio_value=new_portfolio_value,
-            position=new_qty
-        )
-
-        # Calculate reward using UPDATED history tracker
-        reward = float(self.reward_function(self.history))
-
-        # Update the reward in history
-        self.history.rewards[-1] = reward
-
-        # Check termination
-        done = self._check_termination(new_portfolio_value)
-
-        next_tensordict.set("reward", torch.tensor([reward], dtype=torch.float))
-        self._finalize_step_flags(next_tensordict, terminated=done)
-
-        return next_tensordict
 
 
     def _get_symbol_info(self) -> Dict:

--- a/torchtrade/envs/live/bitget/env.py
+++ b/torchtrade/envs/live/bitget/env.py
@@ -154,56 +154,6 @@ class BitgetFuturesTorchTradingEnv(BitgetBaseTorchTradingEnv):
         self.action_levels = config.action_levels
         self.action_spec = Categorical(len(self.action_levels))
 
-    def _step(self, tensordict: TensorDictBase) -> TensorDictBase:
-        """Execute one environment step."""
-
-        # Get current price and position from trader status (avoids redundant observation call)
-        status, position_status, current_price, position_size = self._acquire_pre_trade_state()
-
-        self._sync_position_from_exchange(position_status)
-
-        # Get desired action level
-        desired_action = self._resolve_action_level(tensordict)
-
-        # Calculate and execute trade if needed
-        trade_info = self._execute_trade_if_needed(
-            desired_action, current_qty=position_size, current_price=current_price,
-        )
-
-        self._record_position_after_trade(desired_action, trade_info)
-
-        # Wait for next time step
-        self._wait_for_next_timestamp()
-
-        # Get updated state
-        new_portfolio_value, new_price, new_qty, next_tensordict = self._acquire_post_bar_state()
-        # None when the account is flat: there is no position mark to read, and
-        # fetching one would add a round-trip that can halt the episode. The
-        # pre-trade price is the honest fallback -- flat rows carry no PnL anyway.
-        new_price = new_price if new_price is not None else current_price
-
-        # Record step history FIRST (reward function needs updated history!)
-        self.history.record_step(
-            price=new_price,
-            action=desired_action,
-            reward=0.0,  # Placeholder, will be set after reward calculation
-            portfolio_value=new_portfolio_value,
-            position=new_qty
-        )
-
-        # Calculate reward using UPDATED history tracker
-        reward = float(self.reward_function(self.history))
-
-        # Update the reward in history
-        self.history.rewards[-1] = reward
-
-        # Check termination
-        done = self._check_termination(new_portfolio_value)
-
-        next_tensordict.set("reward", torch.tensor([reward], dtype=torch.float))
-        self._finalize_step_flags(next_tensordict, terminated=done)
-
-        return next_tensordict
 
 
     def _calculate_fractional_position(self, action_value: float, current_price: float) -> tuple[float, float, str]:

--- a/torchtrade/envs/live/bitget/env.py
+++ b/torchtrade/envs/live/bitget/env.py
@@ -2,8 +2,6 @@ import math
 from dataclasses import dataclass
 from typing import List, Optional, Union, Callable, Dict
 
-import torch
-from tensordict import TensorDictBase
 from torchrl.data import Categorical
 
 from torchtrade.envs.live.bitget.observation import BitgetObservationClass
@@ -23,7 +21,6 @@ from torchtrade.envs.utils.fractional_sizing import (
     calculate_fractional_position,
     PositionCalculationParams,
 )
-
 
 
 @dataclass
@@ -153,7 +150,6 @@ class BitgetFuturesTorchTradingEnv(BitgetBaseTorchTradingEnv):
         # Define action space (environment-specific)
         self.action_levels = config.action_levels
         self.action_spec = Categorical(len(self.action_levels))
-
 
 
     def _calculate_fractional_position(self, action_value: float, current_price: float) -> tuple[float, float, str]:

--- a/torchtrade/envs/live/bybit/env.py
+++ b/torchtrade/envs/live/bybit/env.py
@@ -5,8 +5,6 @@ from torchtrade.envs.utils.precision import decimals_for_step
 from dataclasses import dataclass
 from typing import List, Optional, Union, Callable, Dict
 
-import torch
-from tensordict import TensorDictBase
 from torchrl.data import Categorical
 
 from torchtrade.envs.live.bybit.observation import BybitObservationClass
@@ -113,7 +111,6 @@ class BybitFuturesTorchTradingEnv(BybitBaseTorchTradingEnv):
 
         self.action_levels = config.action_levels
         self.action_spec = Categorical(len(self.action_levels))
-
 
 
     def _calculate_fractional_position(self, action_value: float, current_price: float) -> tuple[float, float, str]:

--- a/torchtrade/envs/live/bybit/env.py
+++ b/torchtrade/envs/live/bybit/env.py
@@ -114,48 +114,6 @@ class BybitFuturesTorchTradingEnv(BybitBaseTorchTradingEnv):
         self.action_levels = config.action_levels
         self.action_spec = Categorical(len(self.action_levels))
 
-    def _step(self, tensordict: TensorDictBase) -> TensorDictBase:
-        """Execute one environment step."""
-        status, position_status, current_price, position_size = self._acquire_pre_trade_state()
-
-        # No-op today (this env's _execute_trade_if_needed takes the threaded qty (#295) and never reads
-        # current_action_level), but keeps the field consistent so adding a duplicate-action
-        # guard here can't reintroduce the silent no-op that bit alpaca/binance/bitget.
-        self._sync_position_from_exchange(position_status)
-
-        desired_action = self._resolve_action_level(tensordict)
-
-        trade_info = self._execute_trade_if_needed(
-            desired_action, current_qty=position_size, current_price=current_price,
-        )
-
-        self._record_position_after_trade(desired_action, trade_info)
-
-        self._wait_for_next_timestamp()
-
-        new_portfolio_value, new_price, new_qty, next_tensordict = self._acquire_post_bar_state()
-        # None when the account is flat: there is no position mark to read, and
-        # fetching one would add a round-trip that can halt the episode. The
-        # pre-trade price is the honest fallback -- flat rows carry no PnL anyway.
-        new_price = new_price if new_price is not None else current_price
-
-        self.history.record_step(
-            price=new_price,
-            action=desired_action,
-            reward=0.0,
-            portfolio_value=new_portfolio_value,
-            position=new_qty
-        )
-
-        reward = float(self.reward_function(self.history))
-        self.history.rewards[-1] = reward
-
-        done = self._check_termination(new_portfolio_value)
-
-        next_tensordict.set("reward", torch.tensor([reward], dtype=torch.float))
-        self._finalize_step_flags(next_tensordict, terminated=done)
-
-        return next_tensordict
 
 
     def _calculate_fractional_position(self, action_value: float, current_price: float) -> tuple[float, float, str]:

--- a/torchtrade/envs/live/okx/env.py
+++ b/torchtrade/envs/live/okx/env.py
@@ -113,52 +113,6 @@ class OKXFuturesTorchTradingEnv(OKXBaseTorchTradingEnv):
         self.action_levels = config.action_levels
         self.action_spec = Categorical(len(self.action_levels))
 
-    def _step(self, tensordict: TensorDictBase) -> TensorDictBase:
-        """Execute one environment step."""
-        # Sized through the canonical rule, not the raw venue qty: a dust residual read as
-        # a live position makes abs(current_qty) > 0 true on a flat account (#283). okx
-        # alone threads the price into sizing rather than re-fetching, so both halves of
-        # the mark read matter here too.
-        status, position_status, current_price, position_size = self._acquire_pre_trade_state()
-
-        # No-op today (this env's _execute_trade_if_needed takes the threaded qty and never reads
-        # current_action_level), but keeps the field consistent so adding a duplicate-action
-        # guard here can't reintroduce the silent no-op that bit alpaca/binance/bitget.
-        self._sync_position_from_exchange(position_status)
-
-        desired_action = self._resolve_action_level(tensordict)
-
-        trade_info = self._execute_trade_if_needed(
-            desired_action, current_qty=position_size, current_price=current_price,
-        )
-
-        self._record_position_after_trade(desired_action, trade_info)
-
-        self._wait_for_next_timestamp()
-
-        new_portfolio_value, new_price, new_qty, next_tensordict = self._acquire_post_bar_state()
-        # None when the account is flat: there is no position mark to read, and
-        # fetching one would add a round-trip that can halt the episode. The
-        # pre-trade price is the honest fallback -- flat rows carry no PnL anyway.
-        new_price = new_price if new_price is not None else current_price
-
-        self.history.record_step(
-            price=new_price,
-            action=desired_action,
-            reward=0.0,
-            portfolio_value=new_portfolio_value,
-            position=new_qty
-        )
-
-        reward = float(self.reward_function(self.history))
-        self.history.rewards[-1] = reward
-
-        done = self._check_termination(new_portfolio_value)
-
-        next_tensordict.set("reward", torch.tensor([reward], dtype=torch.float))
-        self._finalize_step_flags(next_tensordict, terminated=done)
-
-        return next_tensordict
 
 
     def _calculate_fractional_position(self, action_value: float, current_price: float) -> tuple[float, float, str]:

--- a/torchtrade/envs/live/okx/env.py
+++ b/torchtrade/envs/live/okx/env.py
@@ -3,8 +3,6 @@ import math
 from dataclasses import dataclass
 from typing import List, Optional, Union, Callable, Dict
 
-import torch
-from tensordict import TensorDictBase
 from torchrl.data import Categorical
 
 from torchtrade.envs.live.okx.observation import OKXObservationClass
@@ -112,7 +110,6 @@ class OKXFuturesTorchTradingEnv(OKXBaseTorchTradingEnv):
 
         self.action_levels = config.action_levels
         self.action_spec = Categorical(len(self.action_levels))
-
 
 
     def _calculate_fractional_position(self, action_value: float, current_price: float) -> tuple[float, float, str]:

--- a/torchtrade/envs/live/shared/futures_live_base.py
+++ b/torchtrade/envs/live/shared/futures_live_base.py
@@ -133,13 +133,11 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
         """One step for the four PLAIN futures envs (#288).
 
         The SLTP envs override this via SLTPMixin, which precedes this class in their MRO;
-        alpaca does not inherit this class. Ordering is load-bearing, and each constraint
-        is stated where it binds rather than listed here.
+        alpaca does not inherit this class.
         """
-        # Before the trade: the duplicate-action guard reads the position this syncs
-        # (invariant 2), and the trade below takes the qty and price it acquired under the
-        # halt policy rather than fetching its own (#295).
-        status, position_status, current_price, position_size = self._acquire_pre_trade_state()
+        # One status read per step: the trade below reuses this qty and price rather than
+        # fetching its own, so an outage cannot open a window between the two (#295).
+        _, position_status, current_price, position_size = self._acquire_pre_trade_state()
 
         self._sync_position_from_exchange(position_status)
 
@@ -448,10 +446,6 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
                     if not math.isfinite(mark) or mark <= 0:
                         mark = None
                 except Exception:
-                    # `self.config.symbol`, not `self.symbol`: these envs have no
-                    # `symbol` attribute, so this handler raised AttributeError instead of
-                    # degrading -- the fallback the comment above promises never ran. Only
-                    # reachable when the post-bar mark fetch fails, which nothing tested.
                     logger.warning(
                         "post-bar mark unavailable for %s; the history row will carry the "
                         "pre-trade price", self.config.symbol,

--- a/torchtrade/envs/live/shared/futures_live_base.py
+++ b/torchtrade/envs/live/shared/futures_live_base.py
@@ -153,22 +153,10 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
         # argues the rest.
         new_price = new_price if new_price is not None else current_price
 
-        # History FIRST: the reward function reads it.
-        self.history.record_step(
-            price=new_price,
-            action=desired_action,
-            reward=0.0,
-            portfolio_value=new_portfolio_value,
-            position=new_qty,
+        return self._record_and_score(
+            next_tensordict, price=new_price, action=desired_action,
+            portfolio_value=new_portfolio_value, position=new_qty,
         )
-        reward = float(self.reward_function(self.history))
-        self.history.rewards[-1] = reward
-
-        done = self._check_termination(new_portfolio_value)
-        next_tensordict.set("reward", torch.tensor([reward], dtype=torch.float))
-        self._finalize_step_flags(next_tensordict, terminated=done)
-
-        return next_tensordict
 
     def _finish_futures_init(self) -> None:
         """The tail every futures env ran verbatim after `super().__init__` (#288).

--- a/torchtrade/envs/live/shared/futures_live_base.py
+++ b/torchtrade/envs/live/shared/futures_live_base.py
@@ -29,7 +29,6 @@ from torchtrade.envs.core.state import (
     advance_hold_counter,
     position_direction_from_status,
     position_qty_from_status,
-    PositionState,
 )
 from torchtrade.envs.utils.liquidation import (
     isolated_liquidation_price,

--- a/torchtrade/envs/live/shared/futures_live_base.py
+++ b/torchtrade/envs/live/shared/futures_live_base.py
@@ -149,9 +149,8 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
         self._wait_for_next_timestamp()
 
         new_portfolio_value, new_price, new_qty, next_tensordict = self._acquire_post_bar_state()
-        # None when the account is flat: there is no position mark to read, and fetching
-        # one would add a round-trip that can halt the episode. The pre-trade price is the
-        # honest fallback -- flat rows carry no PnL anyway.
+        # None when the account is flat: no position mark to read. `_acquire_post_bar_state`
+        # argues the rest.
         new_price = new_price if new_price is not None else current_price
 
         # History FIRST: the reward function reads it.

--- a/torchtrade/envs/live/shared/futures_live_base.py
+++ b/torchtrade/envs/live/shared/futures_live_base.py
@@ -130,19 +130,15 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
             make_trader()
 
     def _step(self, tensordict: TensorDictBase) -> TensorDictBase:
-        """One step for the four PLAIN futures envs. Four copies, 100%/96% identical --
-        the 4% was a trailing comment on one line (#288).
+        """One step for the four PLAIN futures envs (#288).
 
-        The SLTP envs do NOT get this: `SLTPMixin` sits ahead of this class in their MRO
-        and owns their own `_step`, which resolves a bracket tuple rather than an action
-        level. Alpaca does not inherit this class at all.
-
-        Ordering here is the contract, not style. The pre-trade read comes first because
-        the duplicate-action guard downstream reads the position it syncs (invariant 2);
-        the trade takes the qty and price that read already acquired under the halt policy,
-        rather than fetching its own (#295); and `record_step` precedes the reward because
-        the reward function scores the history row it just wrote.
+        The SLTP envs override this via SLTPMixin, which precedes this class in their MRO;
+        alpaca does not inherit this class. Ordering is load-bearing, and each constraint
+        is stated where it binds rather than listed here.
         """
+        # Before the trade: the duplicate-action guard reads the position this syncs
+        # (invariant 2), and the trade below takes the qty and price it acquired under the
+        # halt policy rather than fetching its own (#295).
         status, position_status, current_price, position_size = self._acquire_pre_trade_state()
 
         self._sync_position_from_exchange(position_status)

--- a/torchtrade/envs/live/shared/futures_live_base.py
+++ b/torchtrade/envs/live/shared/futures_live_base.py
@@ -129,6 +129,55 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
             make_observer()
             make_trader()
 
+    def _step(self, tensordict: TensorDictBase) -> TensorDictBase:
+        """One step for the four PLAIN futures envs. Four copies, 100%/96% identical --
+        the 4% was a trailing comment on one line (#288).
+
+        The SLTP envs do NOT get this: `SLTPMixin` sits ahead of this class in their MRO
+        and owns their own `_step`, which resolves a bracket tuple rather than an action
+        level. Alpaca does not inherit this class at all.
+
+        Ordering here is the contract, not style. The pre-trade read comes first because
+        the duplicate-action guard downstream reads the position it syncs (invariant 2);
+        the trade takes the qty and price that read already acquired under the halt policy,
+        rather than fetching its own (#295); and `record_step` precedes the reward because
+        the reward function scores the history row it just wrote.
+        """
+        status, position_status, current_price, position_size = self._acquire_pre_trade_state()
+
+        self._sync_position_from_exchange(position_status)
+
+        desired_action = self._resolve_action_level(tensordict)
+        trade_info = self._execute_trade_if_needed(
+            desired_action, current_qty=position_size, current_price=current_price,
+        )
+        self._record_position_after_trade(desired_action, trade_info)
+
+        self._wait_for_next_timestamp()
+
+        new_portfolio_value, new_price, new_qty, next_tensordict = self._acquire_post_bar_state()
+        # None when the account is flat: there is no position mark to read, and fetching
+        # one would add a round-trip that can halt the episode. The pre-trade price is the
+        # honest fallback -- flat rows carry no PnL anyway.
+        new_price = new_price if new_price is not None else current_price
+
+        # History FIRST: the reward function reads it.
+        self.history.record_step(
+            price=new_price,
+            action=desired_action,
+            reward=0.0,
+            portfolio_value=new_portfolio_value,
+            position=new_qty,
+        )
+        reward = float(self.reward_function(self.history))
+        self.history.rewards[-1] = reward
+
+        done = self._check_termination(new_portfolio_value)
+        next_tensordict.set("reward", torch.tensor([reward], dtype=torch.float))
+        self._finalize_step_flags(next_tensordict, terminated=done)
+
+        return next_tensordict
+
     def _finish_futures_init(self) -> None:
         """The tail every futures env ran verbatim after `super().__init__` (#288).
 
@@ -403,9 +452,13 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
                     if not math.isfinite(mark) or mark <= 0:
                         mark = None
                 except Exception:
+                    # `self.config.symbol`, not `self.symbol`: these envs have no
+                    # `symbol` attribute, so this handler raised AttributeError instead of
+                    # degrading -- the fallback the comment above promises never ran. Only
+                    # reachable when the post-bar mark fetch fails, which nothing tested.
                     logger.warning(
                         "post-bar mark unavailable for %s; the history row will carry the "
-                        "pre-trade price", self.symbol,
+                        "pre-trade price", self.config.symbol,
                     )
                     mark = None
             return portfolio_value, mark, self._last_observed_qty, observation

--- a/torchtrade/envs/live/shared/futures_live_base.py
+++ b/torchtrade/envs/live/shared/futures_live_base.py
@@ -134,8 +134,9 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
         The SLTP envs override this via SLTPMixin, which precedes this class in their MRO;
         alpaca does not inherit this class.
         """
-        # One status read per step: the trade below reuses this qty and price rather than
-        # fetching its own, so an outage cannot open a window between the two (#295).
+        # One PRE-TRADE status read: the trade below reuses this qty and price rather
+        # than fetching its own, so an outage cannot open a window between the read and
+        # the trade (#295). The post-bar read is a second, separate one.
         _, position_status, current_price, position_size = self._acquire_pre_trade_state()
 
         self._sync_position_from_exchange(position_status)

--- a/torchtrade/envs/utils/sltp_mixin.py
+++ b/torchtrade/envs/utils/sltp_mixin.py
@@ -101,22 +101,10 @@ class SLTPMixin:
         side, _, _ = action_tuple
         action_value = 1.0 if side == "long" else (-1.0 if side == "short" else 0.0)
 
-        # History FIRST: the reward function reads it.
-        self.history.record_step(
-            price=new_price,
-            action=action_value,
-            reward=0.0,
-            portfolio_value=new_portfolio_value,
-            position=new_qty,
+        return self._record_and_score(
+            next_tensordict, price=new_price, action=action_value,
+            portfolio_value=new_portfolio_value, position=new_qty,
         )
-        reward = float(self.reward_function(self.history))
-        self.history.rewards[-1] = reward
-
-        done = self._check_termination(new_portfolio_value)
-        next_tensordict.set("reward", torch.tensor([reward], dtype=torch.float))
-        self._finalize_step_flags(next_tensordict, terminated=done)
-
-        return next_tensordict
 
     def _sync_position_from_exchange(self, position_status) -> bool:
         """Sync internal position state from exchange and detect SL/TP closures.


### PR DESCRIPTION
Slice 3 of #288. **Net −42**, suite **4209** green.

The four plain futures `_step` bodies were **25 lines each and differed by one trailing comment**:

```
binance vs bitget : 100%
bybit   vs okx    : 100%
across pairs      :  96%   <- the 4% was `# Placeholder, will be set after reward calculation`
```

`env.py`: 438/328/236/228 → **388/278/194/182**.

MRO checked *before* writing: SLTP envs resolve `SLTPMixin` ahead of the futures base and keep their own step; alpaca doesn't inherit the futures base at all.

## A graceful-degradation path that crashed instead

Writing the test for the `new_price` fallback surfaced this in the post-bar mark handler:

```python
except Exception:
    logger.warning("post-bar mark unavailable for %s; the history row will carry the "
                   "pre-trade price", self.symbol)     # <- no such attribute
```

These envs have no `symbol` attribute — it's `self.config.symbol`. So whenever the post-bar mark fetch failed, the handler raised `AttributeError` rather than falling back, which is precisely what the comment two lines above promises. **Pre-existing, unreachable by any test**, and found only because a reviewer flagged the fallback as unpinned.

## Three mutations that failed zero tests

| mutation | before | after |
|---|---|---|
| plain: `new_price` fallback dropped | 0 failed | **1 failed** |
| sltp: `new_price` fallback dropped | 0 failed | **1 failed** |
| plain: history `action` sign flipped | 0 failed | **8 failed** |

The action sign is the one that matters — that row is what the reward function scores, so flipping it inverts the training signal with nothing crashing. I pinned exactly this on the SLTP path in #411 and left the plain one: **this issue's own defect, inside the guard against it.** Both paths now.

## One more guard broken by the move

`test_the_size_an_env_reports_actually_reaches_the_position` scanned the venue's `env.py` for a call that now lives on the base. It's AST over the **resolved** `_step` now — which also fixes a weakness it always had: a substring can't tell `trade_info` from `trade_info["qty"]`, and half-passing is the bug it exists to reject.

## Mutation coverage of the folded step

| mutation | result |
|---|---|
| sync after the trade | 6 failed |
| recorder gets a field, not `trade_info` | 4 failed |
| trade re-reads instead of threading qty | 1 failed |
| `new_price` fallback dropped | 1 failed |
| history action sign flipped | 8 failed |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AWNTLhwczWJBoxbXrPVYJu