### PR TITLE
refactor(288): fold the fractional sizing, and the fee that made "identical" a lie

### DIFF
--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -669,7 +669,6 @@ def test_an_outage_stops_the_step_before_it_can_trade(exchange, module):
     and the trade path by hand, in an order _step cannot produce, and so proved nothing
     about production -- _step raises on the status read before it ever reaches the sync.
     """
-    import importlib
     env_mod = importlib.import_module(f"torchtrade.envs.live.{exchange}.{module}")
     # By NAME, not by `"_step" in vars(c)`: #288 moved the SLTP `_step` onto the mixin,
     # and a discovery predicate keyed on where the method LIVES silently stops finding
@@ -2399,7 +2398,6 @@ def test_every_live_config_validates_its_action_levels(exchange):
     """The WIRING, per exchange. Crossing the two dimensions proved the same thing five
     times over: a missing call kills every value row for that exchange together, so the
     values never distinguish anything the rule test above does not already cover."""
-    import importlib
 
     module = importlib.import_module(f"torchtrade.envs.live.{exchange}.env")
     config_cls = _sole(module, "Config")
@@ -2457,7 +2455,6 @@ def test_the_size_an_env_reports_actually_reaches_the_position(exchange):
     # TorchTradeFuturesLiveEnv, so a file scan reads a module that no longer contains the
     # call. And a substring cannot tell `trade_info` from `trade_info["qty"]` -- which is
     # exactly the half-passing this guard exists to reject.
-    import importlib
 
     mod = importlib.import_module(f"torchtrade.envs.live.{exchange}.env")
     cls = _sole(mod, "TorchTradingEnv")
@@ -2501,7 +2498,6 @@ def test_a_real_step_lands_both_size_values_on_the_position(exchange, min_qty):
     existed, the other that the call site named the dict. Only reading the value off the
     position after a real step can tell you it arrived, so this drives `_step` and looks.
     """
-    import importlib
 
     module = importlib.import_module(f"torchtrade.envs.live.{exchange}.env")
     env_cls = _sole(module, "TorchTradingEnv")
@@ -2652,7 +2648,6 @@ def test_the_pre_trade_read_halts_like_the_post_bar_one(exchange, module):
     it. Resolution is the stronger check anyway -- a venue that re-forks `_step` without
     the helper still fails, because `inspect.getsource` then returns ITS copy.
     """
-    import importlib
 
     mod = importlib.import_module(f"torchtrade.envs.live.{exchange}.{module}")
     cls = _sole(mod, "TorchTradingEnv")
@@ -4028,7 +4023,6 @@ def test_each_venue_builds_its_observer_with_the_arguments_it_needs(venue, expec
     `client` is asserted as a CATEGORY, not a value: bybit shares one session between the
     two roles and the other three must not, which is the actual contract.
     """
-    import importlib
 
     # The concrete plain env, not the abstract exchange base: the base still declares
     # `_step`/`_execute_trade_if_needed` abstract, so it cannot be instantiated at all.
@@ -4108,7 +4102,6 @@ def test_init_trading_clients_wires_each_venue_as_before(
     session, so it must be built second; okx must NOT, because its trader client is a
     Trade API and klines live on the MarketData one -- the round-1 regression.
     """
-    import importlib
 
     module = importlib.import_module(f"torchtrade.envs.live.{venue}.env")
     cls = _sole(module, "TorchTradingEnv")
@@ -4244,10 +4237,7 @@ def test_binance_extends_the_shared_sizing_rather_than_replacing_it():
         cls._calculate_fractional_position
     ), "binance's sizing no longer delegates to the shared implementation"
 
-    # By BEHAVIOUR, not by grepping the body for `_get_min_notional`: neutering the `if`
-    # that uses it left the name in the source and the string check passed.
     env = _sizing_stub(cls, min_notional=1e12)   # nothing can clear this
-    env.trader.round_quantity.side_effect = lambda q: round(float(q), 3)
     assert env._calculate_fractional_position(1.0, 100.0) == (0.0, 0.0, "flat"), (
         "binance opened a position whose notional is below the venue minimum; the "
         "exchange rejects it and the env then believes it holds one"
@@ -4255,9 +4245,7 @@ def test_binance_extends_the_shared_sizing_rather_than_replacing_it():
 
     env._get_min_notional = lambda: 0.0
     env.trader.round_quantity.side_effect = lambda q: 0.123456
-    # Signed, and both directions. `abs(size)` discarded precisely the expression under
-    # test -- `position_qty * (1 if position_size > 0 else -1)` -- and only long was run,
-    # so the short branch was never entered at all.
+    # Signed, and both directions.
     for action, expected in ((1.0, 0.123456), (-1.0, -0.123456)):
         size, _, _ = env._calculate_fractional_position(action, 100.0)
         assert size == pytest.approx(expected), (
@@ -4288,38 +4276,14 @@ def _sizing_stub(cls, *, leverage=10, balance=10_000.0, min_notional=0.0):
     return env
 
 
-# Derived from the registry and pinned by NAME, so a fifth venue fails here rather than
-# on its first live trade. The values stay literal: the failure being guarded is every
-# venue reading ONE fee, which a derived expected value would reproduce.
+# Derived from the registry so a fifth venue fails here rather than on its first live
+# trade. The values stay literal: the failure guarded against is every venue reading ONE
+# fee, which a derived expected value would reproduce.
 _EXPECTED_TAKER_FEES = {
     "binance": 0.0004, "bitget": 0.0006, "bybit": 0.00055, "okx": 0.0005,
 }
 assert set(_EXPECTED_TAKER_FEES) == {c.__module__.split(".")[-2]
                                      for c in PLAIN_FUTURES_ENVS}
-
-
-# `env_sltp` only. The plain classes' fees are pinned harder by the golden notionals,
-# which assert the arithmetic those fees produce; the SLTP classes are not in that table,
-# and `test_every_class_that_inherits_the_shared_sizing_can_run_it` would pass them at
-# TAKER_FEE = 0.0 since it only checks the method runs. This is their sole value check.
-@pytest.mark.parametrize("venue,fee", sorted(_EXPECTED_TAKER_FEES.items()))
-def test_each_sltp_class_keeps_its_venues_taker_fee(venue, fee):
-    module = "env_sltp"
-    """The four sizing bodies were byte-identical TEXT and not identical BEHAVIOUR.
-
-    `TAKER_FEE` resolved to a different value in each module, so folding them without
-    lifting the fee onto the class would have silently re-priced three venues. Sizing is
-    `1 + leverage * fee`, so at 125x the binance and bitget fees size a position ~2.3%
-    apart. Pinned by VALUE, because the failure mode is one shared constant that looks
-    right on the venue you happen to test.
-    """
-    cls = _sole(importlib.import_module(f"torchtrade.envs.live.{venue}.{module}"),
-                "TorchTradingEnv")
-    assert getattr(cls, "TAKER_FEE", None) == pytest.approx(fee), (
-        f"{cls.__name__}'s taker fee is {getattr(cls, 'TAKER_FEE', None)}, not {fee}; "
-        f"every venue reading one fee is what a careless fold of the sizing bodies would "
-        f"produce, and a fee only the plain sibling can see is what a careless fix does"
-    )
 
 
 @pytest.mark.parametrize("cls", PLAIN_FUTURES_ENVS + SLTP_FUTURES_ENVS,
@@ -4332,7 +4296,6 @@ def test_every_class_that_inherits_the_shared_sizing_can_run_it(cls):
     reached it yet, which is exactly why no test noticed: a landmine rather than a bug.
     """
     env = _sizing_stub(cls)
-    env.trader.round_quantity.side_effect = lambda q: round(float(q), 3)
 
     size, notional, side = env._calculate_fractional_position(1.0, 100.0)
 
@@ -4347,10 +4310,9 @@ def test_every_class_that_inherits_the_shared_sizing_can_run_it(cls):
 # At 125x the four venues diverge by ~2.3%, which is the whole reason the fee could not be
 # folded along with the bodies.
 _GOLDEN_SIZINGS = [
-    # (venue, leverage, position_size, notional). SIZE as well as notional: notional alone
-    # is blind to binance's override, which transforms only the size -- deleting that
-    # override entirely left a notional-only golden 8/8 green. binance's sizes below are
-    # lot-rounded (97.961) where the other three are not, which is the override showing.
+    # (venue, leverage, position_size, notional), as sized BEFORE the fold. Size as well
+    # as notional: binance's override transforms only the size, so a notional-only pin
+    # cannot see it -- its rows are lot-rounded where the other three are not.
     ("binance", 1, 97.961, 9796.08156737305),
     ("binance", 125, 11666.667, 1166666.6666666665),
     ("bitget", 1, 97.9412352588447, 9794.12352588447),
@@ -4360,6 +4322,26 @@ _GOLDEN_SIZINGS = [
     ("okx", 1, 97.95102448775612, 9795.102448775613),
     ("okx", 125, 11529.411764705882, 1152941.1764705882),
 ]
+
+
+def test_a_flat_action_is_sized_without_touching_the_exchange():
+    """The `action_value == 0.0` short-circuit above the balance read.
+
+    It looks like a duplicate -- the four callers short-circuit first, and the free
+    function guards zero again underneath -- and has been proposed for deletion twice.
+    It is not a duplicate: without it a flat action performs a balance read, and against
+    an unusable balance raises instead of returning flat. That is the liquidation case
+    #295 exists for, and no other test reaches this method with a zero action.
+    """
+    cls = _sole(importlib.import_module("torchtrade.envs.live.bybit.env"),
+                "TorchTradingEnv")
+    env = _sizing_stub(cls, balance=float("nan"))
+
+    assert env._calculate_fractional_position(0.0, 100.0) == (0.0, 0.0, "flat")
+    assert not env.trader.get_account_balance.called, (
+        "a flat action read the exchange balance; with an unusable balance that raises "
+        "rather than returning flat"
+    )
 
 
 @pytest.mark.parametrize("venue,leverage,exp_size,exp_notional", _GOLDEN_SIZINGS,
@@ -4382,7 +4364,6 @@ def test_the_fold_did_not_move_a_single_sized_position(venue, leverage, exp_size
 
     # rel=1e-9, not 1e-12: reassociating the shared formula -- `capital * lev / mult` vs
     # `(capital / mult) * lev` -- is behaviourally identical and can move the last ULPs.
-    # The smallest change that SHOULD fail here is a 0.01% buffer edit, six orders larger.
     assert notional == pytest.approx(exp_notional, rel=1e-9), (
         f"{venue} at {leverage}x now sizes a notional of {notional!r} where it sized "
         f"{exp_notional!r} before the fold"

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -14,6 +14,7 @@ import ast
 import dataclasses
 import pathlib
 import re
+import importlib
 import inspect
 import textwrap
 import math
@@ -1946,8 +1947,17 @@ def test_futures_sizing_rejects_a_non_finite_balance(exchange):
     mid-step. The alpaca sibling written in the same commit is safe only because it
     isfinite-checks its inputs first.
     """
-    src = (pathlib.Path(inspect.getfile(TorchTradeLiveEnv)).parent.parent
-           / "live" / exchange / "env.py").read_text()
+    # The RESOLVED method, following one hop through `super()`. A file scan of
+    # `live/<venue>/env.py` broke the moment #288 folded the sizing onto the shared base:
+    # the guard could no longer see its own subject, which is the failure it exists to
+    # prevent in the code. binance still overrides, so its own body is scanned too.
+    cls = _sole(importlib.import_module(f"torchtrade.envs.live.{exchange}.env"),
+                "TorchTradingEnv")
+    src = inspect.getsource(cls._calculate_fractional_position)
+    if "super()._calculate_fractional_position" in src:
+        src += inspect.getsource(
+            TorchTradeFuturesLiveEnv._calculate_fractional_position
+        )
     assert "if not (total_balance > 0):" not in src, (
         f"{exchange} sizes against a balance guarded by `not (x > 0)`, which +inf passes"
     )
@@ -4202,6 +4212,141 @@ assert {(owner.__name__, method) for _, owner, method in _SHARED_METHOD_OWNERSHI
     ("SLTPMixin", "_record_sltp_position"),
     ("SLTPMixin", "_reset_sltp_state"),
 }
+
+
+# bitget/bybit/okx inherit the shared sizing; binance extends it. Same split shape as the
+# dispatch hook below, and guarded the same way: identity for the inheritors, behaviour for
+# the extender.
+_SIZING_INHERITORS = [c for c in PLAIN_FUTURES_ENVS
+                      if c.__module__.split(".")[-2] != "binance"]
+assert len(_SIZING_INHERITORS) == 3
+
+
+@pytest.mark.parametrize("cls", _SIZING_INHERITORS, ids=lambda c: c.__name__)
+def test_the_sizing_inheritors_do_not_refork_it(cls):
+    """Three of the four bodies were byte-identical; only binance had a reason to differ."""
+    assert (cls._calculate_fractional_position
+            is TorchTradeFuturesLiveEnv._calculate_fractional_position), (
+        f"{cls.__name__} re-forks _calculate_fractional_position; only binance extends it "
+        f"(min-notional refusal and target rounding), and it does so via super()"
+    )
+
+
+def test_binance_extends_the_shared_sizing_rather_than_replacing_it():
+    """binance's override must still run the shared arithmetic underneath its extras.
+
+    Replacing rather than extending is how the halt-policy balance read, the isfinite
+    guard and the 2% buffer would quietly stop applying to the one venue whose sizing has
+    the most steps in it.
+    """
+    cls = _sole(importlib.import_module("torchtrade.envs.live.binance.env"),
+                "TorchTradingEnv")
+    assert "super()._calculate_fractional_position" in inspect.getsource(
+        cls._calculate_fractional_position
+    ), "binance's sizing no longer delegates to the shared implementation"
+
+    # By BEHAVIOUR, not by grepping the body for `_get_min_notional`: neutering the `if`
+    # that uses it left the name in the source and the string check passed.
+    env = cls.__new__(cls)
+    env.config = SimpleNamespace(leverage=10)
+    env.trader = MagicMock()
+    env.trader.get_account_balance.return_value = {"total_margin_balance": 10_000.0}
+    env.trader.round_quantity.side_effect = lambda q: round(float(q), 3)
+    env._halting = lambda read, cache_key=None: read()
+
+    env._get_min_notional = lambda: 1e12          # nothing can clear this
+    assert env._calculate_fractional_position(1.0, 100.0) == (0.0, 0.0, "flat"), (
+        "binance opened a position whose notional is below the venue minimum; the "
+        "exchange rejects it and the env then believes it holds one"
+    )
+
+    env._get_min_notional = lambda: 0.0
+    env.trader.round_quantity.side_effect = lambda q: 0.123456
+    size, _, _ = env._calculate_fractional_position(1.0, 100.0)
+    assert abs(size) == pytest.approx(0.123456), (
+        f"binance sized {size} rather than the executor's rounded quantity; an unrounded "
+        f"target is rejected by the venue's lot-size filter (#271)"
+    )
+
+
+@pytest.mark.parametrize("venue,fee", [
+    ("binance", 0.0004), ("bitget", 0.0006), ("bybit", 0.00055), ("okx", 0.0005),
+])
+def test_each_venue_keeps_its_own_taker_fee(venue, fee):
+    """The four sizing bodies were byte-identical TEXT and not identical BEHAVIOUR.
+
+    `TAKER_FEE` resolved to a different value in each module, so folding them without
+    lifting the fee onto the class would have silently re-priced three venues. Sizing is
+    `1 + leverage * fee`, so at 125x the binance and bitget fees size a position ~2.3%
+    apart. Pinned by VALUE, because the failure mode is one shared constant that looks
+    right on the venue you happen to test.
+    """
+    cls = _sole(importlib.import_module(f"torchtrade.envs.live.{venue}.env"),
+                "TorchTradingEnv")
+    assert cls.TAKER_FEE == pytest.approx(fee), (
+        f"{venue}'s taker fee is {cls.TAKER_FEE}, not {fee}; every venue reading one "
+        f"fee is what a careless fold of the sizing bodies would produce"
+    )
+
+
+def test_the_sizing_reserves_the_maintenance_margin_buffer():
+    """The 2% haircut on the balance. Dropping it failed ZERO tests.
+
+    It is the venue's maintenance-margin headroom: sizing against the full balance leaves
+    nothing between the position and a margin call on the first adverse tick. Asserted as
+    a ratio between two sizings rather than a magic notional, so it survives a change to
+    the fee or the leverage.
+    """
+    cls = _sole(importlib.import_module("torchtrade.envs.live.bybit.env"),
+                "TorchTradingEnv")
+
+    def notional_for(balance):
+        env = cls.__new__(cls)
+        env.config = SimpleNamespace(leverage=10)
+        env.trader = MagicMock()
+        env.trader.get_account_balance.return_value = {"total_margin_balance": balance}
+        env._halting = lambda read, cache_key=None: read()
+        return env._calculate_fractional_position(1.0, 100.0)[1]
+
+    # Against an INDEPENDENT expected value, not a ratio between two of the env's own
+    # sizings: sizing is linear in the balance, so `n(B) == n(B/0.98) * 0.98` holds whether
+    # or not the buffer exists. That first version passed with the buffer deleted.
+    from torchtrade.envs.utils.fractional_sizing import (
+        PositionCalculationParams, calculate_fractional_position,
+    )
+    expected = calculate_fractional_position(PositionCalculationParams(
+        balance=10_000.0 * 0.98, action_value=1.0, current_price=100.0,
+        leverage=10, transaction_fee=cls.TAKER_FEE,
+    ))[1]
+    assert notional_for(10_000.0) == pytest.approx(expected), (
+        f"sized against the full balance rather than 98% of it: the 2% maintenance-margin "
+        f"headroom is what keeps the first adverse tick from being a margin call"
+    )
+
+
+def test_the_shared_sizing_actually_uses_the_venues_fee():
+    """And the fee must reach the arithmetic, not merely be declared on the class.
+
+    Pinning the four constants proves they differ; this proves the shared body reads
+    `self.TAKER_FEE` rather than a module-level one it closed over.
+    """
+    sizes = {}
+    for venue in ("binance", "bitget", "bybit", "okx"):
+        cls = _sole(importlib.import_module(f"torchtrade.envs.live.{venue}.env"),
+                    "TorchTradingEnv")
+        env = cls.__new__(cls)
+        env.config = SimpleNamespace(leverage=125)
+        env.trader = MagicMock()
+        env.trader.get_account_balance.return_value = {"total_margin_balance": 10_000.0}
+        env.trader.round_quantity.side_effect = lambda q: q
+        env._halting = lambda read, cache_key=None: read()
+        env._get_min_notional = lambda: 0.0
+        sizes[venue] = env._calculate_fractional_position(1.0, 100.0)[1]
+
+    assert len(set(round(v, 6) for v in sizes.values())) == 4, (
+        f"four venues with four different taker fees produced {sizes}; identical notionals "
+        f"mean the shared body is not reading self.TAKER_FEE"
+    )
 
 
 # binance and bitget take the mixin's `_dispatch_sltp_trade`; bybit and okx override it to

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -4259,7 +4259,8 @@ def test_binance_extends_the_shared_sizing_rather_than_replacing_it():
 # plain leaf. Setting the fee on the leaf resolved it for four of the eight classes that
 # inherit the shared sizing and AttributeError'd for the other four, and every test I wrote
 # for the fee iterated the plain list only.
-def _sizing_stub(cls, *, leverage=10, balance=10_000.0, min_notional=0.0):
+def _sizing_stub(cls, *, leverage=10, balance=10_000.0, min_notional=0.0,
+                 stub_min_notional=True):
     """A futures env wired for `_calculate_fractional_position` and nothing else.
 
     `__new__` rather than a constructor: instantiating an EnvBase subclass runs venue
@@ -4272,7 +4273,10 @@ def _sizing_stub(cls, *, leverage=10, balance=10_000.0, min_notional=0.0):
     env.trader.get_account_balance.return_value = {"total_margin_balance": balance}
     env.trader.round_quantity.side_effect = lambda q: round(float(q), 3)
     env._halting = lambda read, cache_key=None: read()
-    env._get_min_notional = lambda: min_notional
+    # Optional: binance's flat branch is only observable when this is NOT stubbed, since
+    # the stub swallows the exchange-info round-trip that the branch exists to skip.
+    if stub_min_notional:
+        env._get_min_notional = lambda: min_notional
     return env
 
 
@@ -4324,23 +4328,28 @@ _GOLDEN_SIZINGS = [
 ]
 
 
-def test_a_flat_action_is_sized_without_touching_the_exchange():
+@pytest.mark.parametrize("cls", PLAIN_FUTURES_ENVS, ids=lambda c: c.__name__)
+def test_a_flat_action_is_sized_without_touching_the_exchange(cls):
     """The `action_value == 0.0` short-circuit above the balance read.
 
-    It looks like a duplicate -- the four callers short-circuit first, and the free
-    function guards zero again underneath -- and has been proposed for deletion twice.
-    It is not a duplicate: without it a flat action performs a balance read, and against
-    an unusable balance raises instead of returning flat. That is the liquidation case
-    #295 exists for, and no other test reaches this method with a zero action.
+    Proposed for deletion twice as a duplicate of the guards on either side of it. It is
+    not a duplicate -- without it a flat action performs a balance read and raises on an
+    unusable balance rather than returning flat -- but the honest scope is narrower than
+    I first claimed: all four callers pre-filter zero before calling, so NO production
+    path reaches this today. It is defence against a caller that stops pre-filtering, and
+    this test is the only thing that currently exercises it.
     """
-    cls = _sole(importlib.import_module("torchtrade.envs.live.bybit.env"),
-                "TorchTradingEnv")
-    env = _sizing_stub(cls, balance=float("nan"))
+    # `_get_min_notional` unstubbed, and EVERY trader call counted -- not just the balance
+    # read. Stubbing it hid binance's own flat branch: deleting that early return sends a
+    # `futures_exchange_info()` call down the one path this test exists to keep
+    # exchange-free, and a balance-only assertion passed straight through it.
+    env = _sizing_stub(cls, balance=float("nan"), stub_min_notional=False)
 
     assert env._calculate_fractional_position(0.0, 100.0) == (0.0, 0.0, "flat")
-    assert not env.trader.get_account_balance.called, (
-        "a flat action read the exchange balance; with an unusable balance that raises "
-        "rather than returning flat"
+    assert env.trader.mock_calls == [], (
+        f"a flat action called the exchange: {env.trader.mock_calls}. It must need "
+        f"nothing from the venue -- an unusable balance would raise instead of returning "
+        f"flat, and a min-notional lookup is an unhalted round-trip"
     )
 
 

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -4282,7 +4282,7 @@ def _sizing_stub(cls, *, leverage=10, balance=10_000.0, min_notional=0.0):
     env.config = SimpleNamespace(leverage=leverage)
     env.trader = MagicMock()
     env.trader.get_account_balance.return_value = {"total_margin_balance": balance}
-    env.trader.round_quantity.side_effect = lambda q: q
+    env.trader.round_quantity.side_effect = lambda q: round(float(q), 3)
     env._halting = lambda read, cache_key=None: read()
     env._get_min_notional = lambda: min_notional
     return env
@@ -4298,9 +4298,13 @@ assert set(_EXPECTED_TAKER_FEES) == {c.__module__.split(".")[-2]
                                      for c in PLAIN_FUTURES_ENVS}
 
 
-@pytest.mark.parametrize("module", ["env", "env_sltp"])
+# `env_sltp` only. The plain classes' fees are pinned harder by the golden notionals,
+# which assert the arithmetic those fees produce; the SLTP classes are not in that table,
+# and `test_every_class_that_inherits_the_shared_sizing_can_run_it` would pass them at
+# TAKER_FEE = 0.0 since it only checks the method runs. This is their sole value check.
 @pytest.mark.parametrize("venue,fee", sorted(_EXPECTED_TAKER_FEES.items()))
-def test_each_venue_keeps_its_own_taker_fee(venue, fee, module):
+def test_each_sltp_class_keeps_its_venues_taker_fee(venue, fee):
+    module = "env_sltp"
     """The four sizing bodies were byte-identical TEXT and not identical BEHAVIOUR.
 
     `TAKER_FEE` resolved to a different value in each module, so folding them without
@@ -4342,17 +4346,26 @@ def test_every_class_that_inherits_the_shared_sizing_can_run_it(cls):
 # no evidence at all once it is deleted -- these eight numbers are the part worth keeping.
 # At 125x the four venues diverge by ~2.3%, which is the whole reason the fee could not be
 # folded along with the bodies.
-_GOLDEN_NOTIONALS = [
-    ("binance", 1, 9796.08156737305), ("binance", 125, 1166666.6666666665),
-    ("bitget", 1, 9794.12352588447),  ("bitget", 125, 1139534.8837209304),
-    ("bybit", 1, 9794.61296287042),   ("bybit", 125, 1146198.8304093566),
-    ("okx", 1, 9795.102448775613),    ("okx", 125, 1152941.1764705882),
+_GOLDEN_SIZINGS = [
+    # (venue, leverage, position_size, notional). SIZE as well as notional: notional alone
+    # is blind to binance's override, which transforms only the size -- deleting that
+    # override entirely left a notional-only golden 8/8 green. binance's sizes below are
+    # lot-rounded (97.961) where the other three are not, which is the override showing.
+    ("binance", 1, 97.961, 9796.08156737305),
+    ("binance", 125, 11666.667, 1166666.6666666665),
+    ("bitget", 1, 97.9412352588447, 9794.12352588447),
+    ("bitget", 125, 11395.348837209304, 1139534.8837209304),
+    ("bybit", 1, 97.94612962870419, 9794.61296287042),
+    ("bybit", 125, 11461.988304093566, 1146198.8304093566),
+    ("okx", 1, 97.95102448775612, 9795.102448775613),
+    ("okx", 125, 11529.411764705882, 1152941.1764705882),
 ]
 
 
-@pytest.mark.parametrize("venue,leverage,expected", _GOLDEN_NOTIONALS,
-                         ids=[f"{v}-{l}x" for v, l, _ in _GOLDEN_NOTIONALS])
-def test_the_fold_did_not_move_a_single_sized_notional(venue, leverage, expected):
+@pytest.mark.parametrize("venue,leverage,exp_size,exp_notional", _GOLDEN_SIZINGS,
+                         ids=[f"{v}-{l}x" for v, l, _, _ in _GOLDEN_SIZINGS])
+def test_the_fold_did_not_move_a_single_sized_position(venue, leverage, exp_size,
+                                                       exp_notional):
     """What the four bodies sized before #288 folded them, to the last float bit.
 
     A refactor's claim is that behaviour did not change, and the evidence for that claim
@@ -4365,11 +4378,18 @@ def test_the_fold_did_not_move_a_single_sized_notional(venue, leverage, expected
                 "TorchTradingEnv")
     env = _sizing_stub(cls, leverage=leverage)
 
-    _, notional, _ = env._calculate_fractional_position(1.0, 100.0)
+    size, notional, _ = env._calculate_fractional_position(1.0, 100.0)
 
-    assert notional == pytest.approx(expected, rel=1e-12), (
-        f"{venue} at {leverage}x now sizes {notional!r} where it sized {expected!r} before "
-        f"the fold"
+    # rel=1e-9, not 1e-12: reassociating the shared formula -- `capital * lev / mult` vs
+    # `(capital / mult) * lev` -- is behaviourally identical and can move the last ULPs.
+    # The smallest change that SHOULD fail here is a 0.01% buffer edit, six orders larger.
+    assert notional == pytest.approx(exp_notional, rel=1e-9), (
+        f"{venue} at {leverage}x now sizes a notional of {notional!r} where it sized "
+        f"{exp_notional!r} before the fold"
+    )
+    assert size == pytest.approx(exp_size, rel=1e-9), (
+        f"{venue} at {leverage}x now returns a position size of {size!r} where it returned "
+        f"{exp_size!r} before the fold"
     )
 
 

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -4254,11 +4254,6 @@ def test_binance_extends_the_shared_sizing_rather_than_replacing_it():
         )
 
 
-# BOTH module axes. The plain and SLTP classes are siblings, not parent and child -- the
-# SLTP MRO runs SLTPMixin -> <Venue>Base -> TorchTradeFuturesLiveEnv and never touches the
-# plain leaf. Setting the fee on the leaf resolved it for four of the eight classes that
-# inherit the shared sizing and AttributeError'd for the other four, and every test I wrote
-# for the fee iterated the plain list only.
 def _sizing_stub(cls, *, leverage=10, balance=10_000.0, min_notional=0.0,
                  stub_min_notional=True):
     """A futures env wired for `_calculate_fractional_position` and nothing else.

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -1941,15 +1941,7 @@ def test_alpaca_sizing_refuses_a_non_finite_position_quantity():
 @pytest.mark.parametrize("balance", [0.0, -5.0, float("nan"), float("inf")],
                          ids=["zero", "negative", "nan", "inf"])
 def test_an_unusable_balance_cannot_size_a_trade(balance):
-    """The guard BEHAVIOURALLY. Its sibling below only greps the source for two strings.
-
-    Four mutations kept both grep strings intact and passed:
-      `isfinite(x) and x <= 0`   NaN and +inf now size a trade -- this IS #277
-      `x <= 0` -> `x < 0`        ZERO equity accepted, which is what a venue reports
-                                 while liquidating you -- the moment the comment on the
-                                 guard says is the worst one to keep trading through
-      `raise` -> `logger.warning` nothing is ever rejected
-      guard hoisted out of the closure   the #295 regression, named in that same comment
+    """Zero, negative, NaN and +inf equity must all refuse to size a trade.
 
     Raising LiveObservationHalt rather than ValueError is the third and fourth of those:
     `_halting` converts the ValueError only if it is raised INSIDE the closure it wraps.
@@ -1983,34 +1975,6 @@ def test_the_sizing_uses_the_whole_portfolio_not_the_free_margin():
     assert notional > 5_000.0, (
         f"sized a notional of {notional:.2f} against a 10,000 portfolio: that is the free "
         f"margin, and sizing against it makes a held position re-buy every bar"
-    )
-
-
-@pytest.mark.parametrize("exchange", ["binance", "bitget", "bybit", "okx"])
-def test_futures_sizing_rejects_a_non_finite_balance(exchange):
-    """`not (x > 0)` catches NaN but passes +inf, and these four lines are this PR's own.
-
-    An inf balance sizes an inf target: bitget's amount rounding then yields NaN and hands
-    it to create_order, while binance and bybit raise an undiagnosable OverflowError
-    mid-step. The alpaca sibling written in the same commit is safe only because it
-    isfinite-checks its inputs first.
-    """
-    # The RESOLVED method, following one hop through `super()`. A file scan of
-    # `live/<venue>/env.py` broke the moment #288 folded the sizing onto the shared base:
-    # the guard could no longer see its own subject, which is the failure it exists to
-    # prevent in the code. binance still overrides, so its own body is scanned too.
-    cls = _sole(importlib.import_module(f"torchtrade.envs.live.{exchange}.env"),
-                "TorchTradingEnv")
-    src = inspect.getsource(cls._calculate_fractional_position)
-    if "super()._calculate_fractional_position" in src:
-        src += inspect.getsource(
-            TorchTradeFuturesLiveEnv._calculate_fractional_position
-        )
-    assert "if not (total_balance > 0):" not in src, (
-        f"{exchange} sizes against a balance guarded by `not (x > 0)`, which +inf passes"
-    )
-    assert "math.isfinite(total_balance)" in src, (
-        f"{exchange} does not check that the sizing balance is finite"
     )
 
 
@@ -4282,14 +4246,8 @@ def test_binance_extends_the_shared_sizing_rather_than_replacing_it():
 
     # By BEHAVIOUR, not by grepping the body for `_get_min_notional`: neutering the `if`
     # that uses it left the name in the source and the string check passed.
-    env = cls.__new__(cls)
-    env.config = SimpleNamespace(leverage=10)
-    env.trader = MagicMock()
-    env.trader.get_account_balance.return_value = {"total_margin_balance": 10_000.0}
+    env = _sizing_stub(cls, min_notional=1e12)   # nothing can clear this
     env.trader.round_quantity.side_effect = lambda q: round(float(q), 3)
-    env._halting = lambda read, cache_key=None: read()
-
-    env._get_min_notional = lambda: 1e12          # nothing can clear this
     assert env._calculate_fractional_position(1.0, 100.0) == (0.0, 0.0, "flat"), (
         "binance opened a position whose notional is below the venue minimum; the "
         "exchange rejects it and the env then believes it holds one"
@@ -4313,6 +4271,23 @@ def test_binance_extends_the_shared_sizing_rather_than_replacing_it():
 # plain leaf. Setting the fee on the leaf resolved it for four of the eight classes that
 # inherit the shared sizing and AttributeError'd for the other four, and every test I wrote
 # for the fee iterated the plain list only.
+def _sizing_stub(cls, *, leverage=10, balance=10_000.0, min_notional=0.0):
+    """A futures env wired for `_calculate_fractional_position` and nothing else.
+
+    `__new__` rather than a constructor: instantiating an EnvBase subclass runs venue
+    wiring this method does not use, and `nn.Module.__init__` never runs, so there is no
+    `_modules`. The three attributes below are exactly what the sizing path reads.
+    """
+    env = cls.__new__(cls)
+    env.config = SimpleNamespace(leverage=leverage)
+    env.trader = MagicMock()
+    env.trader.get_account_balance.return_value = {"total_margin_balance": balance}
+    env.trader.round_quantity.side_effect = lambda q: q
+    env._halting = lambda read, cache_key=None: read()
+    env._get_min_notional = lambda: min_notional
+    return env
+
+
 # Derived from the registry and pinned by NAME, so a fifth venue fails here rather than
 # on its first live trade. The values stay literal: the failure being guarded is every
 # venue reading ONE fee, which a derived expected value would reproduce.
@@ -4352,67 +4327,13 @@ def test_every_class_that_inherits_the_shared_sizing_can_run_it(cls):
     the fee sat on the plain leaf, so calling it raised AttributeError mid-sizing. Nothing
     reached it yet, which is exactly why no test noticed: a landmine rather than a bug.
     """
-    env = cls.__new__(cls)
-    env.config = SimpleNamespace(leverage=10)
-    env.trader = MagicMock()
-    env.trader.get_account_balance.return_value = {"total_margin_balance": 10_000.0}
+    env = _sizing_stub(cls)
     env.trader.round_quantity.side_effect = lambda q: round(float(q), 3)
-    env._halting = lambda read, cache_key=None: read()
-    env._get_min_notional = lambda: 0.0
 
     size, notional, side = env._calculate_fractional_position(1.0, 100.0)
 
     assert side == "long" and size > 0 and notional > 0, (
         f"{cls.__name__} inherits the shared sizing but produced {(size, notional, side)}"
-    )
-
-
-def test_a_venue_without_a_taker_fee_fails_at_construction():
-    """Boundary, not rule. Without this the failure is an AttributeError raised the first
-    time a nonzero action is sized -- mid-`_step`, with a position possibly already open.
-    """
-    # Everything the tail touches AFTER the check, so the TypeError is what fails rather
-    # than the first missing attribute. A venue that forgets the fee has a real config.
-    env = SimpleNamespace(
-        config=SimpleNamespace(execute_on="1m", close_position_on_init=False),
-        trader=MagicMock(),
-    )
-    with pytest.raises(TypeError, match="does not set TAKER_FEE"):
-        TorchTradeFuturesLiveEnv._finish_futures_init(env)
-
-
-def test_the_sizing_reserves_the_maintenance_margin_buffer():
-    """The 2% haircut on the balance. Dropping it failed ZERO tests.
-
-    It is the venue's maintenance-margin headroom: sizing against the full balance leaves
-    nothing between the position and a margin call on the first adverse tick. Asserted as
-    a ratio between two sizings rather than a magic notional, so it survives a change to
-    the fee or the leverage.
-    """
-    cls = _sole(importlib.import_module("torchtrade.envs.live.bybit.env"),
-                "TorchTradingEnv")
-
-    def notional_for(balance):
-        env = cls.__new__(cls)
-        env.config = SimpleNamespace(leverage=10)
-        env.trader = MagicMock()
-        env.trader.get_account_balance.return_value = {"total_margin_balance": balance}
-        env._halting = lambda read, cache_key=None: read()
-        return env._calculate_fractional_position(1.0, 100.0)[1]
-
-    # Against an INDEPENDENT expected value, not a ratio between two of the env's own
-    # sizings: sizing is linear in the balance, so `n(B) == n(B/0.98) * 0.98` holds whether
-    # or not the buffer exists. That first version passed with the buffer deleted.
-    from torchtrade.envs.utils.fractional_sizing import (
-        PositionCalculationParams, calculate_fractional_position,
-    )
-    expected = calculate_fractional_position(PositionCalculationParams(
-        balance=10_000.0 * 0.98, action_value=1.0, current_price=100.0,
-        leverage=10, transaction_fee=cls.TAKER_FEE,
-    ))[1]
-    assert notional_for(10_000.0) == pytest.approx(expected), (
-        f"sized against the full balance rather than 98% of it: the 2% maintenance-margin "
-        f"headroom is what keeps the first adverse tick from being a margin call"
     )
 
 
@@ -4442,44 +4363,13 @@ def test_the_fold_did_not_move_a_single_sized_notional(venue, leverage, expected
     """
     cls = _sole(importlib.import_module(f"torchtrade.envs.live.{venue}.env"),
                 "TorchTradingEnv")
-    env = cls.__new__(cls)
-    env.config = SimpleNamespace(leverage=leverage)
-    env.trader = MagicMock()
-    env.trader.get_account_balance.return_value = {"total_margin_balance": 10_000.0}
-    env.trader.round_quantity.side_effect = lambda q: q
-    env._halting = lambda read, cache_key=None: read()
-    env._get_min_notional = lambda: 0.0
+    env = _sizing_stub(cls, leverage=leverage)
 
     _, notional, _ = env._calculate_fractional_position(1.0, 100.0)
 
     assert notional == pytest.approx(expected, rel=1e-12), (
         f"{venue} at {leverage}x now sizes {notional!r} where it sized {expected!r} before "
         f"the fold"
-    )
-
-
-def test_the_shared_sizing_actually_uses_the_venues_fee():
-    """And the fee must reach the arithmetic, not merely be declared on the class.
-
-    Pinning the four constants proves they differ; this proves the shared body reads
-    `self.TAKER_FEE` rather than a module-level one it closed over.
-    """
-    sizes = {}
-    for venue in ("binance", "bitget", "bybit", "okx"):
-        cls = _sole(importlib.import_module(f"torchtrade.envs.live.{venue}.env"),
-                    "TorchTradingEnv")
-        env = cls.__new__(cls)
-        env.config = SimpleNamespace(leverage=125)
-        env.trader = MagicMock()
-        env.trader.get_account_balance.return_value = {"total_margin_balance": 10_000.0}
-        env.trader.round_quantity.side_effect = lambda q: q
-        env._halting = lambda read, cache_key=None: read()
-        env._get_min_notional = lambda: 0.0
-        sizes[venue] = env._calculate_fractional_position(1.0, 100.0)[1]
-
-    assert len(set(round(v, 6) for v in sizes.values())) == 4, (
-        f"four venues with four different taker fees produced {sizes}; identical notionals "
-        f"mean the shared body is not reading self.TAKER_FEE"
     )
 
 

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -1938,6 +1938,54 @@ def test_alpaca_sizing_refuses_a_non_finite_position_quantity():
     assert submitted == [], f"an order was submitted from a NaN quantity: {submitted}"
 
 
+@pytest.mark.parametrize("balance", [0.0, -5.0, float("nan"), float("inf")],
+                         ids=["zero", "negative", "nan", "inf"])
+def test_an_unusable_balance_cannot_size_a_trade(balance):
+    """The guard BEHAVIOURALLY. Its sibling below only greps the source for two strings.
+
+    Four mutations kept both grep strings intact and passed:
+      `isfinite(x) and x <= 0`   NaN and +inf now size a trade -- this IS #277
+      `x <= 0` -> `x < 0`        ZERO equity accepted, which is what a venue reports
+                                 while liquidating you -- the moment the comment on the
+                                 guard says is the worst one to keep trading through
+      `raise` -> `logger.warning` nothing is ever rejected
+      guard hoisted out of the closure   the #295 regression, named in that same comment
+
+    Raising LiveObservationHalt rather than ValueError is the third and fourth of those:
+    `_halting` converts the ValueError only if it is raised INSIDE the closure it wraps.
+    A guard hoisted one frame up sends a bare ValueError out of `_step`.
+    """
+    env, trader = _real_futures_env(budget=0, venue="binance")
+    trader.get_account_balance.return_value = {
+        "available_balance": balance, "total_margin_balance": balance,
+        "total_wallet_balance": balance, "total_maintenance_margin": 0.0,
+    }
+    with pytest.raises(LiveObservationHalt):
+        env._calculate_fractional_position(1.0, 100.0)
+
+
+def test_the_sizing_uses_the_whole_portfolio_not_the_free_margin():
+    """total_margin_balance, not available_balance.
+
+    available_balance shrinks as positions grow, so a held action=1.0 re-sized against it
+    buys again every bar. A `.get("available_balance", total)` fallback survives every
+    other test in this file: with the two values equal in the fixture, nothing can tell
+    which one was read.
+    """
+    env, trader = _real_futures_env(budget=0, venue="binance")
+    trader.get_account_balance.return_value = {
+        "available_balance": 1_000.0,          # what is free right now
+        "total_margin_balance": 10_000.0,      # what the portfolio is worth
+        "total_wallet_balance": 10_000.0, "total_maintenance_margin": 0.0,
+    }
+    _, notional, _ = env._calculate_fractional_position(1.0, 100.0)
+
+    assert notional > 5_000.0, (
+        f"sized a notional of {notional:.2f} against a 10,000 portfolio: that is the free "
+        f"margin, and sizing against it makes a held position re-buy every bar"
+    )
+
+
 @pytest.mark.parametrize("exchange", ["binance", "bitget", "bybit", "okx"])
 def test_futures_sizing_rejects_a_non_finite_balance(exchange):
     """`not (x > 0)` catches NaN but passes +inf, and these four lines are this PR's own.
@@ -4193,6 +4241,10 @@ _SHARED_METHOD_OWNERSHIP = [
     *((c, TorchTradeLiveEnv, "_record_and_score") for c in STEPPING_ENVS),
     *((c, TorchTradeFuturesLiveEnv, m)
       for c in PLAIN_FUTURES_ENVS for m in ("_step", "_reset")),
+    # binance is absent by design: it EXTENDS the sizing via super() (min-notional refusal
+    # and target rounding), which its own behavioural test pins.
+    *((c, TorchTradeFuturesLiveEnv, "_calculate_fractional_position")
+      for c in PLAIN_FUTURES_ENVS if c.__module__.split(".")[-2] != "binance"),
     *((c, SLTPMixin, m) for c in SLTP_FUTURES_ENVS for m in (
         "_step", "_reset", "_resolve_action_tuple", "_record_sltp_position",
         "_reset_sltp_state",
@@ -4206,30 +4258,13 @@ assert {(owner.__name__, method) for _, owner, method in _SHARED_METHOD_OWNERSHI
     ("TorchTradeLiveEnv", "_record_and_score"),
     ("TorchTradeFuturesLiveEnv", "_step"),
     ("TorchTradeFuturesLiveEnv", "_reset"),
+    ("TorchTradeFuturesLiveEnv", "_calculate_fractional_position"),
     ("SLTPMixin", "_step"),
     ("SLTPMixin", "_reset"),
     ("SLTPMixin", "_resolve_action_tuple"),
     ("SLTPMixin", "_record_sltp_position"),
     ("SLTPMixin", "_reset_sltp_state"),
 }
-
-
-# bitget/bybit/okx inherit the shared sizing; binance extends it. Same split shape as the
-# dispatch hook below, and guarded the same way: identity for the inheritors, behaviour for
-# the extender.
-_SIZING_INHERITORS = [c for c in PLAIN_FUTURES_ENVS
-                      if c.__module__.split(".")[-2] != "binance"]
-assert len(_SIZING_INHERITORS) == 3
-
-
-@pytest.mark.parametrize("cls", _SIZING_INHERITORS, ids=lambda c: c.__name__)
-def test_the_sizing_inheritors_do_not_refork_it(cls):
-    """Three of the four bodies were byte-identical; only binance had a reason to differ."""
-    assert (cls._calculate_fractional_position
-            is TorchTradeFuturesLiveEnv._calculate_fractional_position), (
-        f"{cls.__name__} re-forks _calculate_fractional_position; only binance extends it "
-        f"(min-notional refusal and target rounding), and it does so via super()"
-    )
 
 
 def test_binance_extends_the_shared_sizing_rather_than_replacing_it():
@@ -4262,17 +4297,35 @@ def test_binance_extends_the_shared_sizing_rather_than_replacing_it():
 
     env._get_min_notional = lambda: 0.0
     env.trader.round_quantity.side_effect = lambda q: 0.123456
-    size, _, _ = env._calculate_fractional_position(1.0, 100.0)
-    assert abs(size) == pytest.approx(0.123456), (
-        f"binance sized {size} rather than the executor's rounded quantity; an unrounded "
-        f"target is rejected by the venue's lot-size filter (#271)"
-    )
+    # Signed, and both directions. `abs(size)` discarded precisely the expression under
+    # test -- `position_qty * (1 if position_size > 0 else -1)` -- and only long was run,
+    # so the short branch was never entered at all.
+    for action, expected in ((1.0, 0.123456), (-1.0, -0.123456)):
+        size, _, _ = env._calculate_fractional_position(action, 100.0)
+        assert size == pytest.approx(expected), (
+            f"binance sized {size} for action {action}, not the executor's rounded "
+            f"quantity with the direction re-applied (#271)"
+        )
 
 
-@pytest.mark.parametrize("venue,fee", [
-    ("binance", 0.0004), ("bitget", 0.0006), ("bybit", 0.00055), ("okx", 0.0005),
-])
-def test_each_venue_keeps_its_own_taker_fee(venue, fee):
+# BOTH module axes. The plain and SLTP classes are siblings, not parent and child -- the
+# SLTP MRO runs SLTPMixin -> <Venue>Base -> TorchTradeFuturesLiveEnv and never touches the
+# plain leaf. Setting the fee on the leaf resolved it for four of the eight classes that
+# inherit the shared sizing and AttributeError'd for the other four, and every test I wrote
+# for the fee iterated the plain list only.
+# Derived from the registry and pinned by NAME, so a fifth venue fails here rather than
+# on its first live trade. The values stay literal: the failure being guarded is every
+# venue reading ONE fee, which a derived expected value would reproduce.
+_EXPECTED_TAKER_FEES = {
+    "binance": 0.0004, "bitget": 0.0006, "bybit": 0.00055, "okx": 0.0005,
+}
+assert set(_EXPECTED_TAKER_FEES) == {c.__module__.split(".")[-2]
+                                     for c in PLAIN_FUTURES_ENVS}
+
+
+@pytest.mark.parametrize("module", ["env", "env_sltp"])
+@pytest.mark.parametrize("venue,fee", sorted(_EXPECTED_TAKER_FEES.items()))
+def test_each_venue_keeps_its_own_taker_fee(venue, fee, module):
     """The four sizing bodies were byte-identical TEXT and not identical BEHAVIOUR.
 
     `TAKER_FEE` resolved to a different value in each module, so folding them without
@@ -4281,12 +4334,51 @@ def test_each_venue_keeps_its_own_taker_fee(venue, fee):
     apart. Pinned by VALUE, because the failure mode is one shared constant that looks
     right on the venue you happen to test.
     """
-    cls = _sole(importlib.import_module(f"torchtrade.envs.live.{venue}.env"),
+    cls = _sole(importlib.import_module(f"torchtrade.envs.live.{venue}.{module}"),
                 "TorchTradingEnv")
-    assert cls.TAKER_FEE == pytest.approx(fee), (
-        f"{venue}'s taker fee is {cls.TAKER_FEE}, not {fee}; every venue reading one "
-        f"fee is what a careless fold of the sizing bodies would produce"
+    assert getattr(cls, "TAKER_FEE", None) == pytest.approx(fee), (
+        f"{cls.__name__}'s taker fee is {getattr(cls, 'TAKER_FEE', None)}, not {fee}; "
+        f"every venue reading one fee is what a careless fold of the sizing bodies would "
+        f"produce, and a fee only the plain sibling can see is what a careless fix does"
     )
+
+
+@pytest.mark.parametrize("cls", PLAIN_FUTURES_ENVS + SLTP_FUTURES_ENVS,
+                         ids=lambda c: c.__name__)
+def test_every_class_that_inherits_the_shared_sizing_can_run_it(cls):
+    """Resolving `self.TAKER_FEE` is not enough -- the method has to actually execute.
+
+    The SLTP classes inherit `_calculate_fractional_position` from the futures base while
+    the fee sat on the plain leaf, so calling it raised AttributeError mid-sizing. Nothing
+    reached it yet, which is exactly why no test noticed: a landmine rather than a bug.
+    """
+    env = cls.__new__(cls)
+    env.config = SimpleNamespace(leverage=10)
+    env.trader = MagicMock()
+    env.trader.get_account_balance.return_value = {"total_margin_balance": 10_000.0}
+    env.trader.round_quantity.side_effect = lambda q: round(float(q), 3)
+    env._halting = lambda read, cache_key=None: read()
+    env._get_min_notional = lambda: 0.0
+
+    size, notional, side = env._calculate_fractional_position(1.0, 100.0)
+
+    assert side == "long" and size > 0 and notional > 0, (
+        f"{cls.__name__} inherits the shared sizing but produced {(size, notional, side)}"
+    )
+
+
+def test_a_venue_without_a_taker_fee_fails_at_construction():
+    """Boundary, not rule. Without this the failure is an AttributeError raised the first
+    time a nonzero action is sized -- mid-`_step`, with a position possibly already open.
+    """
+    # Everything the tail touches AFTER the check, so the TypeError is what fails rather
+    # than the first missing attribute. A venue that forgets the fee has a real config.
+    env = SimpleNamespace(
+        config=SimpleNamespace(execute_on="1m", close_position_on_init=False),
+        trader=MagicMock(),
+    )
+    with pytest.raises(TypeError, match="does not set TAKER_FEE"):
+        TorchTradeFuturesLiveEnv._finish_futures_init(env)
 
 
 def test_the_sizing_reserves_the_maintenance_margin_buffer():

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -4416,6 +4416,48 @@ def test_the_sizing_reserves_the_maintenance_margin_buffer():
     )
 
 
+# Computed on `main` before the fold and re-verified after it, on a 144-point grid of
+# venues x actions x prices x leverages. The grid itself was a throwaway script, which is
+# no evidence at all once it is deleted -- these eight numbers are the part worth keeping.
+# At 125x the four venues diverge by ~2.3%, which is the whole reason the fee could not be
+# folded along with the bodies.
+_GOLDEN_NOTIONALS = [
+    ("binance", 1, 9796.08156737305), ("binance", 125, 1166666.6666666665),
+    ("bitget", 1, 9794.12352588447),  ("bitget", 125, 1139534.8837209304),
+    ("bybit", 1, 9794.61296287042),   ("bybit", 125, 1146198.8304093566),
+    ("okx", 1, 9795.102448775613),    ("okx", 125, 1152941.1764705882),
+]
+
+
+@pytest.mark.parametrize("venue,leverage,expected", _GOLDEN_NOTIONALS,
+                         ids=[f"{v}-{l}x" for v, l, _ in _GOLDEN_NOTIONALS])
+def test_the_fold_did_not_move_a_single_sized_notional(venue, leverage, expected):
+    """What the four bodies sized before #288 folded them, to the last float bit.
+
+    A refactor's claim is that behaviour did not change, and the evidence for that claim
+    normally evaporates with the branch that made it. These are the pre-fold numbers,
+    committed, so the claim stays checkable and any later drift in the shared arithmetic
+    -- the fee, the buffer, the leverage term, the fee_multiplier form -- fails here with
+    the venue and the leverage named.
+    """
+    cls = _sole(importlib.import_module(f"torchtrade.envs.live.{venue}.env"),
+                "TorchTradingEnv")
+    env = cls.__new__(cls)
+    env.config = SimpleNamespace(leverage=leverage)
+    env.trader = MagicMock()
+    env.trader.get_account_balance.return_value = {"total_margin_balance": 10_000.0}
+    env.trader.round_quantity.side_effect = lambda q: q
+    env._halting = lambda read, cache_key=None: read()
+    env._get_min_notional = lambda: 0.0
+
+    _, notional, _ = env._calculate_fractional_position(1.0, 100.0)
+
+    assert notional == pytest.approx(expected, rel=1e-12), (
+        f"{venue} at {leverage}x now sizes {notional!r} where it sized {expected!r} before "
+        f"the fold"
+    )
+
+
 def test_the_shared_sizing_actually_uses_the_venues_fee():
     """And the fee must reach the arithmetic, not merely be declared on the class.
 

--- a/torchtrade/envs/live/alpaca/env.py
+++ b/torchtrade/envs/live/alpaca/env.py
@@ -3,7 +3,6 @@ from typing import Dict, List, Optional, Union, Callable
 import logging
 import math
 
-
 logger = logging.getLogger(__name__)
 from torchtrade.envs.utils.fractional_sizing import validate_action_levels
 from torchtrade.envs.utils.timeframe import TimeFrame

--- a/torchtrade/envs/live/alpaca/env.py
+++ b/torchtrade/envs/live/alpaca/env.py
@@ -3,7 +3,6 @@ from typing import Dict, List, Optional, Union, Callable
 import logging
 import math
 
-import torch
 
 logger = logging.getLogger(__name__)
 from torchtrade.envs.utils.fractional_sizing import validate_action_levels

--- a/torchtrade/envs/live/alpaca/env_sltp.py
+++ b/torchtrade/envs/live/alpaca/env_sltp.py
@@ -3,7 +3,6 @@ from dataclasses import dataclass
 from typing import Dict, List, Optional, Tuple, Union, Callable
 import logging
 
-import torch
 
 logger = logging.getLogger(__name__)
 from torchtrade.envs.core.state import position_qty_from_status

--- a/torchtrade/envs/live/alpaca/env_sltp.py
+++ b/torchtrade/envs/live/alpaca/env_sltp.py
@@ -3,7 +3,6 @@ from dataclasses import dataclass
 from typing import Dict, List, Optional, Tuple, Union, Callable
 import logging
 
-
 logger = logging.getLogger(__name__)
 from torchtrade.envs.core.state import position_qty_from_status
 from torchtrade.envs.utils.timeframe import TimeFrame

--- a/torchtrade/envs/live/binance/base.py
+++ b/torchtrade/envs/live/binance/base.py
@@ -16,12 +16,7 @@ class BinanceBaseTorchTradingEnv(TorchTradeFuturesLiveEnv):
     contract, and `_trader_kwargs` below for what is genuinely Binance-specific.
     """
 
-    # On the BASE, not the plain leaf: the SLTP sibling's MRO runs
-    # SLTPMixin -> this class -> TorchTradeFuturesLiveEnv and never touches the
-    # plain leaf, so a fee set there resolves for half the classes that inherit
-    # the shared sizing and AttributeErrors for the other half.
     TAKER_FEE = TAKER_FEE
-
 
     OBSERVER_CLS = BinanceObservationClass
     TRADER_CLS = BinanceFuturesOrderClass

--- a/torchtrade/envs/live/binance/base.py
+++ b/torchtrade/envs/live/binance/base.py
@@ -2,6 +2,7 @@
 
 from typing import Callable, Optional
 
+from .order_executor import TAKER_FEE
 from torchtrade.envs.live.binance.observation import BinanceObservationClass
 from torchtrade.envs.live.binance.order_executor import BinanceFuturesOrderClass
 from torchtrade.envs.live.shared.futures_live_base import TorchTradeFuturesLiveEnv
@@ -14,6 +15,12 @@ class BinanceBaseTorchTradingEnv(TorchTradeFuturesLiveEnv):
     TorchTradeFuturesLiveEnv. See `ACCOUNT_STATE` on TorchTradeLiveEnv for the observation
     contract, and `_trader_kwargs` below for what is genuinely Binance-specific.
     """
+
+    # On the BASE, not the plain leaf: the SLTP sibling's MRO runs
+    # SLTPMixin -> this class -> TorchTradeFuturesLiveEnv and never touches the
+    # plain leaf, so a fee set there resolves for half the classes that inherit
+    # the shared sizing and AttributeErrors for the other half.
+    TAKER_FEE = TAKER_FEE
 
 
     OBSERVER_CLS = BinanceObservationClass

--- a/torchtrade/envs/live/binance/base.py
+++ b/torchtrade/envs/live/binance/base.py
@@ -2,9 +2,11 @@
 
 from typing import Callable, Optional
 
-from .order_executor import TAKER_FEE
 from torchtrade.envs.live.binance.observation import BinanceObservationClass
-from torchtrade.envs.live.binance.order_executor import BinanceFuturesOrderClass
+from torchtrade.envs.live.binance.order_executor import (
+    TAKER_FEE,
+    BinanceFuturesOrderClass,
+)
 from torchtrade.envs.live.shared.futures_live_base import TorchTradeFuturesLiveEnv
 
 class BinanceBaseTorchTradingEnv(TorchTradeFuturesLiveEnv):

--- a/torchtrade/envs/live/binance/base.py
+++ b/torchtrade/envs/live/binance/base.py
@@ -19,7 +19,6 @@ class BinanceBaseTorchTradingEnv(TorchTradeFuturesLiveEnv):
     """
 
     TAKER_FEE = TAKER_FEE
-
     OBSERVER_CLS = BinanceObservationClass
     TRADER_CLS = BinanceFuturesOrderClass
 

--- a/torchtrade/envs/live/binance/env.py
+++ b/torchtrade/envs/live/binance/env.py
@@ -1,4 +1,3 @@
-import math
 from dataclasses import dataclass
 from typing import Dict, List, Optional, Union, Callable
 import logging
@@ -14,7 +13,6 @@ from torchtrade.envs.core.live import (
 )
 from torchtrade.envs.live.binance.observation import BinanceObservationClass
 from torchtrade.envs.live.binance.order_executor import (
-    TAKER_FEE,
     BinanceFuturesOrderClass,
     MarginMode,
 )
@@ -22,8 +20,6 @@ from torchtrade.envs.live.binance.base import BinanceBaseTorchTradingEnv
 from torchtrade.envs.utils.fractional_sizing import (
     validate_action_levels,
     build_default_action_levels,
-    calculate_fractional_position,
-    PositionCalculationParams,
 )
 
 
@@ -123,7 +119,6 @@ class BinanceFuturesTorchTradingEnv(BinanceBaseTorchTradingEnv):
      leverage, distance_to_liquidation]
     """
 
-    TAKER_FEE = TAKER_FEE   # venue-specific; the shared sizing reads self.TAKER_FEE
 
     def __init__(
         self,

--- a/torchtrade/envs/live/binance/env.py
+++ b/torchtrade/envs/live/binance/env.py
@@ -119,7 +119,6 @@ class BinanceFuturesTorchTradingEnv(BinanceBaseTorchTradingEnv):
      leverage, distance_to_liquidation]
     """
 
-
     def __init__(
         self,
         config: BinanceFuturesTradingEnvConfig,

--- a/torchtrade/envs/live/binance/env.py
+++ b/torchtrade/envs/live/binance/env.py
@@ -123,6 +123,8 @@ class BinanceFuturesTorchTradingEnv(BinanceBaseTorchTradingEnv):
      leverage, distance_to_liquidation]
     """
 
+    TAKER_FEE = TAKER_FEE   # venue-specific; the shared sizing reads self.TAKER_FEE
+
     def __init__(
         self,
         config: BinanceFuturesTradingEnvConfig,
@@ -187,80 +189,22 @@ class BinanceFuturesTorchTradingEnv(BinanceBaseTorchTradingEnv):
         return 100.0  # Default fallback
 
     def _calculate_fractional_position(
-        self,
-        action_value: float,
-        current_price: float
+        self, action_value: float, current_price: float
     ) -> tuple[float, float, str]:
-        """Calculate position size from fractional action value for live trading.
+        """The shared sizing, plus the two things only binance does at this stage.
 
-        Uses shared utility function for consistent position sizing across all environments.
-        Applies exchange-specific validation and rounding constraints.
-
-        Args:
-            action_value: Action from [-1.0, 1.0] representing fraction of balance
-            current_price: Current market price
-
-        Returns:
-            Tuple of (position_size, notional_value, side):
-            - position_size: Quantity rounded to exchange step size
-            - notional_value: Absolute value in quote currency
-            - side: "long", "short", or "flat"
+        The other three venues apply their min-qty floor and lot-size rounding to the
+        DELTA inside `_execute_fractional_action`; binance refuses below min-NOTIONAL and
+        rounds the TARGET here. Both are real, neither is the other's bug.
         """
-        # Handle neutral case
-        if action_value == 0.0:
-            return 0.0, 0.0, "flat"
-
-        # Query actual balance from exchange
-        # Use total_margin_balance (not available_balance) so the target reflects
-        # the full portfolio, including margin already locked in open positions.
-        # available_balance only shows free margin, which shrinks as positions grow,
-        # causing repeated buys when the agent keeps requesting action=1.0.
-        # The VERDICT is inside the closure, not just the read. `_halting` catches
-        # ValueError precisely so an impossible account state becomes a halt; raising one
-        # frame above it sent that straight out of `_step`. `equity == 0.0` is what a
-        # venue reports while liquidating you -- the worst moment to crash rather than
-        # halt under policy (#295).
-        def read_balance():
-            info = self.trader.get_account_balance()
-            total_balance = info["total_margin_balance"]
-            # isfinite, not `not (x > 0)`: that catches NaN but passes +inf, and an inf
-            # balance sizes an inf target (#277). The name is load-bearing:
-            # test_futures_sizing_rejects_a_non_finite_balance greps for it.
-            if not math.isfinite(total_balance) or total_balance <= 0:
-                raise ValueError(
-                    f"cannot size a trade against a portfolio value of {total_balance}"
-                )
-            return info
-
-        balance_info = self._halting(read_balance, cache_key="balance")
-        total_balance = balance_info["total_margin_balance"]
-
-        # Use shared utility for core position calculation
-        # Reserve 2% buffer for exchange maintenance margin requirements
-        effective_balance = total_balance * 0.98
-        params = PositionCalculationParams(
-            balance=effective_balance,
-            action_value=action_value,
-            current_price=current_price,
-            leverage=self.config.leverage,
-            transaction_fee=TAKER_FEE,
+        position_size, notional_value, side = super()._calculate_fractional_position(
+            action_value, current_price
         )
-        position_size, notional_value, side = calculate_fractional_position(params)
+        if side == "flat":
+            return position_size, notional_value, side
 
-        # Apply exchange-specific validation
-        # Check minimum notional requirement
-        #
-        # Edge case: If calculated position is below exchange minimum, we return "flat"
-        # instead of rounding up to minimum. This means:
-        #   - Agent selects small action (e.g., 0.1 = 10% allocation)
-        #   - Calculation results in notional < min_notional
-        #   - Position is NOT opened (returns flat)
-        #   - Agent receives warning in logs but no position state change
-        #
-        # Alternative approaches considered:
-        #   1. Round up to minimum notional → Could overallocate beyond action intent
-        #   2. Expose rejection in observation → Would require state schema change
-        #   3. Current: Fail gracefully with warning → Simple, predictable behavior
+        # Below the venue minimum the position is NOT opened, rather than rounded up:
+        # rounding up would allocate beyond what the action asked for.
         min_notional = self._get_min_notional()
         if notional_value < min_notional:
             logger.warning(
@@ -274,12 +218,7 @@ class BinanceFuturesTorchTradingEnv(BinanceBaseTorchTradingEnv):
         # floor with a bare int(), which shaves a whole step off exact multiples --
         # 0.29 -> 0.28 (#271). One owner of lot-size knowledge, not two.
         position_qty = self.trader.round_quantity(abs(position_size))
-
-        # Apply direction
-        direction = 1 if position_size > 0 else -1
-        position_size = position_qty * direction
-
-        return position_size, notional_value, side
+        return position_qty * (1 if position_size > 0 else -1), notional_value, side
 
     def _execute_fractional_action(
         self, action_value: float, *, current_qty: float, current_price: float,

--- a/torchtrade/envs/live/bitget/base.py
+++ b/torchtrade/envs/live/bitget/base.py
@@ -19,7 +19,6 @@ class BitgetBaseTorchTradingEnv(TorchTradeFuturesLiveEnv):
     """
 
     TAKER_FEE = TAKER_FEE
-
     OBSERVER_CLS = BitgetObservationClass
     TRADER_CLS = BitgetFuturesOrderClass
 

--- a/torchtrade/envs/live/bitget/base.py
+++ b/torchtrade/envs/live/bitget/base.py
@@ -2,9 +2,11 @@
 
 from typing import Callable, Optional
 
-from .order_executor import TAKER_FEE
 from torchtrade.envs.live.bitget.observation import BitgetObservationClass
-from torchtrade.envs.live.bitget.order_executor import BitgetFuturesOrderClass
+from torchtrade.envs.live.bitget.order_executor import (
+    TAKER_FEE,
+    BitgetFuturesOrderClass,
+)
 from torchtrade.envs.live.shared.futures_live_base import TorchTradeFuturesLiveEnv
 
 class BitgetBaseTorchTradingEnv(TorchTradeFuturesLiveEnv):

--- a/torchtrade/envs/live/bitget/base.py
+++ b/torchtrade/envs/live/bitget/base.py
@@ -2,6 +2,7 @@
 
 from typing import Callable, Optional
 
+from .order_executor import TAKER_FEE
 from torchtrade.envs.live.bitget.observation import BitgetObservationClass
 from torchtrade.envs.live.bitget.order_executor import BitgetFuturesOrderClass
 from torchtrade.envs.live.shared.futures_live_base import TorchTradeFuturesLiveEnv
@@ -14,6 +15,12 @@ class BitgetBaseTorchTradingEnv(TorchTradeFuturesLiveEnv):
     comes from TorchTradeFuturesLiveEnv; `ACCOUNT_STATE` on TorchTradeLiveEnv is the
     observation contract.
     """
+
+    # On the BASE, not the plain leaf: the SLTP sibling's MRO runs
+    # SLTPMixin -> this class -> TorchTradeFuturesLiveEnv and never touches the
+    # plain leaf, so a fee set there resolves for half the classes that inherit
+    # the shared sizing and AttributeErrors for the other half.
+    TAKER_FEE = TAKER_FEE
 
 
     OBSERVER_CLS = BitgetObservationClass

--- a/torchtrade/envs/live/bitget/base.py
+++ b/torchtrade/envs/live/bitget/base.py
@@ -16,12 +16,7 @@ class BitgetBaseTorchTradingEnv(TorchTradeFuturesLiveEnv):
     observation contract.
     """
 
-    # On the BASE, not the plain leaf: the SLTP sibling's MRO runs
-    # SLTPMixin -> this class -> TorchTradeFuturesLiveEnv and never touches the
-    # plain leaf, so a fee set there resolves for half the classes that inherit
-    # the shared sizing and AttributeErrors for the other half.
     TAKER_FEE = TAKER_FEE
-
 
     OBSERVER_CLS = BitgetObservationClass
     TRADER_CLS = BitgetFuturesOrderClass

--- a/torchtrade/envs/live/bitget/env.py
+++ b/torchtrade/envs/live/bitget/env.py
@@ -116,6 +116,8 @@ class BitgetFuturesTorchTradingEnv(BitgetBaseTorchTradingEnv):
      leverage, distance_to_liquidation]
     """
 
+    TAKER_FEE = TAKER_FEE   # venue-specific; the shared sizing reads self.TAKER_FEE
+
     def __init__(
         self,
         config: BitgetFuturesTradingEnvConfig,
@@ -151,62 +153,6 @@ class BitgetFuturesTorchTradingEnv(BitgetBaseTorchTradingEnv):
         self.action_levels = config.action_levels
         self.action_spec = Categorical(len(self.action_levels))
 
-
-    def _calculate_fractional_position(self, action_value: float, current_price: float) -> tuple[float, float, str]:
-        """Calculate target position size from fractional action.
-
-        Uses shared utility function for consistent position sizing across all environments.
-        This fixes the fee calculation bug in the previous implementation.
-
-        Args:
-            action_value: Action from [-1.0, 1.0] representing fraction of balance
-            current_price: Current market price
-
-        Returns:
-            Tuple of (position_size, notional_value, side):
-            - position_size: Target position quantity (positive=long, negative=short, 0=flat)
-            - notional_value: Absolute value in quote currency
-            - side: "long", "short", or "flat"
-        """
-        if action_value == 0.0:
-            return 0.0, 0.0, "flat"
-
-        # Get actual balance from exchange
-        # Use total_margin_balance (not available_balance) so the target reflects
-        # the full portfolio, including margin already locked in open positions.
-        # The VERDICT is inside the closure, not just the read. `_halting` catches
-        # ValueError precisely so an impossible account state becomes a halt; raising one
-        # frame above it sent that straight out of `_step`. `equity == 0.0` is what a
-        # venue reports while liquidating you -- the worst moment to crash rather than
-        # halt under policy (#295).
-        def read_balance():
-            info = self.trader.get_account_balance()
-            total_balance = info["total_margin_balance"]
-            # isfinite, not `not (x > 0)`: that catches NaN but passes +inf, and an inf
-            # balance sizes an inf target (#277). The name is load-bearing:
-            # test_futures_sizing_rejects_a_non_finite_balance greps for it.
-            if not math.isfinite(total_balance) or total_balance <= 0:
-                raise ValueError(
-                    f"cannot size a trade against a portfolio value of {total_balance}"
-                )
-            return info
-
-        balance_info = self._halting(read_balance, cache_key="balance")
-        total_balance = balance_info["total_margin_balance"]
-
-        # Use shared utility for core position calculation
-        # Reserve 2% buffer for exchange maintenance margin requirements
-        effective_balance = total_balance * 0.98
-        params = PositionCalculationParams(
-            balance=effective_balance,
-            action_value=action_value,
-            current_price=current_price,
-            leverage=self.config.leverage,
-            transaction_fee=TAKER_FEE,
-        )
-        position_size, notional_value, side = calculate_fractional_position(params)
-
-        return position_size, notional_value, side
 
     def _execute_fractional_action(
         self, action_value: float, *, current_qty: float, current_price: float,

--- a/torchtrade/envs/live/bitget/env.py
+++ b/torchtrade/envs/live/bitget/env.py
@@ -1,4 +1,3 @@
-import math
 from dataclasses import dataclass
 from typing import List, Optional, Union, Callable, Dict
 
@@ -6,7 +5,6 @@ from torchrl.data import Categorical
 
 from torchtrade.envs.live.bitget.observation import BitgetObservationClass
 from torchtrade.envs.live.bitget.order_executor import (
-    TAKER_FEE,
     BitgetFuturesOrderClass,
     MarginMode,
     PositionMode,
@@ -18,8 +16,6 @@ from torchtrade.envs.core.live import (
 )
 from torchtrade.envs.utils.fractional_sizing import (
     validate_action_levels,
-    calculate_fractional_position,
-    PositionCalculationParams,
 )
 
 
@@ -116,7 +112,6 @@ class BitgetFuturesTorchTradingEnv(BitgetBaseTorchTradingEnv):
      leverage, distance_to_liquidation]
     """
 
-    TAKER_FEE = TAKER_FEE   # venue-specific; the shared sizing reads self.TAKER_FEE
 
     def __init__(
         self,

--- a/torchtrade/envs/live/bitget/env.py
+++ b/torchtrade/envs/live/bitget/env.py
@@ -112,7 +112,6 @@ class BitgetFuturesTorchTradingEnv(BitgetBaseTorchTradingEnv):
      leverage, distance_to_liquidation]
     """
 
-
     def __init__(
         self,
         config: BitgetFuturesTradingEnvConfig,

--- a/torchtrade/envs/live/bitget/observation.py
+++ b/torchtrade/envs/live/bitget/observation.py
@@ -3,7 +3,7 @@ import pandas as pd
 import ccxt
 
 from torchtrade.envs.live.shared.futures_base_obs import BaseFuturesObservationClass
-from torchtrade.envs.utils.timeframe import TimeFrame, TimeFrameUnit
+from torchtrade.envs.utils.timeframe import TimeFrame
 from torchtrade.envs.live.bitget.utils import timeframe_to_bitget, BITGET_INTERVAL_MAP, normalize_symbol
 
 

--- a/torchtrade/envs/live/bybit/base.py
+++ b/torchtrade/envs/live/bybit/base.py
@@ -15,12 +15,7 @@ class BybitBaseTorchTradingEnv(TorchTradeFuturesLiveEnv):
     TorchTradeLiveEnv is the observation contract.
     """
 
-    # On the BASE, not the plain leaf: the SLTP sibling's MRO runs
-    # SLTPMixin -> this class -> TorchTradeFuturesLiveEnv and never touches the
-    # plain leaf, so a fee set there resolves for half the classes that inherit
-    # the shared sizing and AttributeErrors for the other half.
     TAKER_FEE = TAKER_FEE
-
 
     OBSERVER_CLS = BybitObservationClass
     TRADER_CLS = BybitFuturesOrderClass

--- a/torchtrade/envs/live/bybit/base.py
+++ b/torchtrade/envs/live/bybit/base.py
@@ -2,9 +2,11 @@
 
 from typing import Callable, Optional
 
-from .order_executor import TAKER_FEE
 from torchtrade.envs.live.bybit.observation import BybitObservationClass
-from torchtrade.envs.live.bybit.order_executor import BybitFuturesOrderClass
+from torchtrade.envs.live.bybit.order_executor import (
+    TAKER_FEE,
+    BybitFuturesOrderClass,
+)
 from torchtrade.envs.live.shared.futures_live_base import TorchTradeFuturesLiveEnv
 
 class BybitBaseTorchTradingEnv(TorchTradeFuturesLiveEnv):

--- a/torchtrade/envs/live/bybit/base.py
+++ b/torchtrade/envs/live/bybit/base.py
@@ -18,7 +18,6 @@ class BybitBaseTorchTradingEnv(TorchTradeFuturesLiveEnv):
     """
 
     TAKER_FEE = TAKER_FEE
-
     OBSERVER_CLS = BybitObservationClass
     TRADER_CLS = BybitFuturesOrderClass
     TRADER_FIRST = True

--- a/torchtrade/envs/live/bybit/base.py
+++ b/torchtrade/envs/live/bybit/base.py
@@ -2,6 +2,7 @@
 
 from typing import Callable, Optional
 
+from .order_executor import TAKER_FEE
 from torchtrade.envs.live.bybit.observation import BybitObservationClass
 from torchtrade.envs.live.bybit.order_executor import BybitFuturesOrderClass
 from torchtrade.envs.live.shared.futures_live_base import TorchTradeFuturesLiveEnv
@@ -13,6 +14,12 @@ class BybitBaseTorchTradingEnv(TorchTradeFuturesLiveEnv):
     reuses the trader's session, which is why TRADER_FIRST is set here. `ACCOUNT_STATE` on
     TorchTradeLiveEnv is the observation contract.
     """
+
+    # On the BASE, not the plain leaf: the SLTP sibling's MRO runs
+    # SLTPMixin -> this class -> TorchTradeFuturesLiveEnv and never touches the
+    # plain leaf, so a fee set there resolves for half the classes that inherit
+    # the shared sizing and AttributeErrors for the other half.
+    TAKER_FEE = TAKER_FEE
 
 
     OBSERVER_CLS = BybitObservationClass

--- a/torchtrade/envs/live/bybit/env.py
+++ b/torchtrade/envs/live/bybit/env.py
@@ -1,5 +1,4 @@
 """Bybit Futures TorchRL trading environment with fractional position sizing."""
-import math
 
 from torchtrade.envs.utils.precision import decimals_for_step
 from dataclasses import dataclass
@@ -9,7 +8,6 @@ from torchrl.data import Categorical
 
 from torchtrade.envs.live.bybit.observation import BybitObservationClass
 from torchtrade.envs.live.bybit.order_executor import (
-    TAKER_FEE,
     BybitFuturesOrderClass,
     MarginMode,
     PositionMode,
@@ -21,8 +19,6 @@ from torchtrade.envs.core.live import (
 )
 from torchtrade.envs.utils.fractional_sizing import (
     validate_action_levels,
-    calculate_fractional_position,
-    PositionCalculationParams,
 )
 
 
@@ -94,7 +90,6 @@ class BybitFuturesTorchTradingEnv(BybitBaseTorchTradingEnv):
     Default action_levels: [-1.0, -0.5, 0.0, 0.5, 1.0]
     """
 
-    TAKER_FEE = TAKER_FEE   # venue-specific; the shared sizing reads self.TAKER_FEE
 
     def __init__(
         self,

--- a/torchtrade/envs/live/bybit/env.py
+++ b/torchtrade/envs/live/bybit/env.py
@@ -94,6 +94,8 @@ class BybitFuturesTorchTradingEnv(BybitBaseTorchTradingEnv):
     Default action_levels: [-1.0, -0.5, 0.0, 0.5, 1.0]
     """
 
+    TAKER_FEE = TAKER_FEE   # venue-specific; the shared sizing reads self.TAKER_FEE
+
     def __init__(
         self,
         config: BybitFuturesTradingEnvConfig,
@@ -112,41 +114,6 @@ class BybitFuturesTorchTradingEnv(BybitBaseTorchTradingEnv):
         self.action_levels = config.action_levels
         self.action_spec = Categorical(len(self.action_levels))
 
-
-    def _calculate_fractional_position(self, action_value: float, current_price: float) -> tuple[float, float, str]:
-        """Calculate target position size from fractional action."""
-        if action_value == 0.0:
-            return 0.0, 0.0, "flat"
-
-        # The VERDICT is inside the closure, not just the read. `_halting` catches
-        # ValueError precisely so an impossible account state becomes a halt; raising one
-        # frame above it sent that straight out of `_step`. `equity == 0.0` is what a
-        # venue reports while liquidating you -- the worst moment to crash rather than
-        # halt under policy (#295).
-        def read_balance():
-            info = self.trader.get_account_balance()
-            total_balance = info["total_margin_balance"]
-            # isfinite, not `not (x > 0)`: that catches NaN but passes +inf, and an inf
-            # balance sizes an inf target (#277). The name is load-bearing:
-            # test_futures_sizing_rejects_a_non_finite_balance greps for it.
-            if not math.isfinite(total_balance) or total_balance <= 0:
-                raise ValueError(
-                    f"cannot size a trade against a portfolio value of {total_balance}"
-                )
-            return info
-
-        balance_info = self._halting(read_balance, cache_key="balance")
-        total_balance = balance_info["total_margin_balance"]
-
-        effective_balance = total_balance * 0.98
-        params = PositionCalculationParams(
-            balance=effective_balance,
-            action_value=action_value,
-            current_price=current_price,
-            leverage=self.config.leverage,
-            transaction_fee=TAKER_FEE,
-        )
-        return calculate_fractional_position(params)
 
     def _execute_fractional_action(
         self, action_value: float, *, current_qty: float, current_price: float,

--- a/torchtrade/envs/live/bybit/env.py
+++ b/torchtrade/envs/live/bybit/env.py
@@ -90,7 +90,6 @@ class BybitFuturesTorchTradingEnv(BybitBaseTorchTradingEnv):
     Default action_levels: [-1.0, -0.5, 0.0, 0.5, 1.0]
     """
 
-
     def __init__(
         self,
         config: BybitFuturesTradingEnvConfig,

--- a/torchtrade/envs/live/okx/base.py
+++ b/torchtrade/envs/live/okx/base.py
@@ -2,9 +2,11 @@
 
 from typing import Callable, Optional
 
-from .order_executor import TAKER_FEE
 from torchtrade.envs.live.okx.observation import OKXObservationClass
-from torchtrade.envs.live.okx.order_executor import OKXFuturesOrderClass
+from torchtrade.envs.live.okx.order_executor import (
+    TAKER_FEE,
+    OKXFuturesOrderClass,
+)
 from torchtrade.envs.live.shared.futures_live_base import TorchTradeFuturesLiveEnv
 
 class OKXBaseTorchTradingEnv(TorchTradeFuturesLiveEnv):

--- a/torchtrade/envs/live/okx/base.py
+++ b/torchtrade/envs/live/okx/base.py
@@ -19,7 +19,6 @@ class OKXBaseTorchTradingEnv(TorchTradeFuturesLiveEnv):
     """
 
     TAKER_FEE = TAKER_FEE
-
     OBSERVER_CLS = OKXObservationClass
     TRADER_CLS = OKXFuturesOrderClass
     # Trader first, as before the fold. NOT for client sharing -- okx keeps market

--- a/torchtrade/envs/live/okx/base.py
+++ b/torchtrade/envs/live/okx/base.py
@@ -16,12 +16,7 @@ class OKXBaseTorchTradingEnv(TorchTradeFuturesLiveEnv):
     contract.
     """
 
-    # On the BASE, not the plain leaf: the SLTP sibling's MRO runs
-    # SLTPMixin -> this class -> TorchTradeFuturesLiveEnv and never touches the
-    # plain leaf, so a fee set there resolves for half the classes that inherit
-    # the shared sizing and AttributeErrors for the other half.
     TAKER_FEE = TAKER_FEE
-
 
     OBSERVER_CLS = OKXObservationClass
     TRADER_CLS = OKXFuturesOrderClass

--- a/torchtrade/envs/live/okx/base.py
+++ b/torchtrade/envs/live/okx/base.py
@@ -2,6 +2,7 @@
 
 from typing import Callable, Optional
 
+from .order_executor import TAKER_FEE
 from torchtrade.envs.live.okx.observation import OKXObservationClass
 from torchtrade.envs.live.okx.order_executor import OKXFuturesOrderClass
 from torchtrade.envs.live.shared.futures_live_base import TorchTradeFuturesLiveEnv
@@ -14,6 +15,12 @@ class OKXBaseTorchTradingEnv(TorchTradeFuturesLiveEnv):
     live on the MarketData one. `ACCOUNT_STATE` on TorchTradeLiveEnv is the observation
     contract.
     """
+
+    # On the BASE, not the plain leaf: the SLTP sibling's MRO runs
+    # SLTPMixin -> this class -> TorchTradeFuturesLiveEnv and never touches the
+    # plain leaf, so a fee set there resolves for half the classes that inherit
+    # the shared sizing and AttributeErrors for the other half.
+    TAKER_FEE = TAKER_FEE
 
 
     OBSERVER_CLS = OKXObservationClass

--- a/torchtrade/envs/live/okx/env.py
+++ b/torchtrade/envs/live/okx/env.py
@@ -92,6 +92,8 @@ class OKXFuturesTorchTradingEnv(OKXBaseTorchTradingEnv):
     Default action_levels: [-1.0, -0.5, 0.0, 0.5, 1.0]
     """
 
+    TAKER_FEE = TAKER_FEE   # venue-specific; the shared sizing reads self.TAKER_FEE
+
     def __init__(
         self,
         config: OKXFuturesTradingEnvConfig,
@@ -111,41 +113,6 @@ class OKXFuturesTorchTradingEnv(OKXBaseTorchTradingEnv):
         self.action_levels = config.action_levels
         self.action_spec = Categorical(len(self.action_levels))
 
-
-    def _calculate_fractional_position(self, action_value: float, current_price: float) -> tuple[float, float, str]:
-        """Calculate target position size from fractional action."""
-        if action_value == 0.0:
-            return 0.0, 0.0, "flat"
-
-        # The VERDICT is inside the closure, not just the read. `_halting` catches
-        # ValueError precisely so an impossible account state becomes a halt; raising one
-        # frame above it sent that straight out of `_step`. `equity == 0.0` is what a
-        # venue reports while liquidating you -- the worst moment to crash rather than
-        # halt under policy (#295).
-        def read_balance():
-            info = self.trader.get_account_balance()
-            total_balance = info["total_margin_balance"]
-            # isfinite, not `not (x > 0)`: that catches NaN but passes +inf, and an inf
-            # balance sizes an inf target (#277). The name is load-bearing:
-            # test_futures_sizing_rejects_a_non_finite_balance greps for it.
-            if not math.isfinite(total_balance) or total_balance <= 0:
-                raise ValueError(
-                    f"cannot size a trade against a portfolio value of {total_balance}"
-                )
-            return info
-
-        balance_info = self._halting(read_balance, cache_key="balance")
-        total_balance = balance_info["total_margin_balance"]
-
-        effective_balance = total_balance * 0.98
-        params = PositionCalculationParams(
-            balance=effective_balance,
-            action_value=action_value,
-            current_price=current_price,
-            leverage=self.config.leverage,
-            transaction_fee=TAKER_FEE,
-        )
-        return calculate_fractional_position(params)
 
     def _execute_fractional_action(
         self, action_value: float, *, current_qty: float, current_price: float,

--- a/torchtrade/envs/live/okx/env.py
+++ b/torchtrade/envs/live/okx/env.py
@@ -1,5 +1,4 @@
 """OKX Futures TorchRL trading environment with fractional position sizing."""
-import math
 from dataclasses import dataclass
 from typing import List, Optional, Union, Callable, Dict
 
@@ -7,7 +6,6 @@ from torchrl.data import Categorical
 
 from torchtrade.envs.live.okx.observation import OKXObservationClass
 from torchtrade.envs.live.okx.order_executor import (
-    TAKER_FEE,
     OKXFuturesOrderClass,
     MarginMode,
     PositionMode,
@@ -19,8 +17,6 @@ from torchtrade.envs.core.live import (
 )
 from torchtrade.envs.utils.fractional_sizing import (
     validate_action_levels,
-    calculate_fractional_position,
-    PositionCalculationParams,
 )
 
 
@@ -92,7 +88,6 @@ class OKXFuturesTorchTradingEnv(OKXBaseTorchTradingEnv):
     Default action_levels: [-1.0, -0.5, 0.0, 0.5, 1.0]
     """
 
-    TAKER_FEE = TAKER_FEE   # venue-specific; the shared sizing reads self.TAKER_FEE
 
     def __init__(
         self,

--- a/torchtrade/envs/live/okx/env.py
+++ b/torchtrade/envs/live/okx/env.py
@@ -88,7 +88,6 @@ class OKXFuturesTorchTradingEnv(OKXBaseTorchTradingEnv):
     Default action_levels: [-1.0, -0.5, 0.0, 0.5, 1.0]
     """
 
-
     def __init__(
         self,
         config: OKXFuturesTradingEnvConfig,

--- a/torchtrade/envs/live/shared/futures_live_base.py
+++ b/torchtrade/envs/live/shared/futures_live_base.py
@@ -163,16 +163,8 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
             portfolio_value=new_portfolio_value, position=new_qty,
         )
 
-    # Set by each venue's <Venue>BaseTorchTradingEnv, NOT by the plain leaf: the SLTP
-    # sibling's MRO runs SLTPMixin -> <Venue>Base -> here and never touches the leaf, so a
-    # fee set there resolves for half the classes that inherit this sizing and
-    # AttributeErrors for the other half.
-    #
-    # The four bodies this replaced were byte-identical TEXT with this name resolving to a
-    # different value per module -- 0.0004 / 0.0006 / 0.00055 / 0.0005. Folding them
-    # without lifting the fee would have silently re-priced three venues:
-    # `fee_multiplier = 1 + leverage * fee`, so at 125x binance and bitget size ~2.3%
-    # apart. The eight pre-fold notionals are pinned by test.
+    # Set on each venue's <Venue>BaseTorchTradingEnv, NOT on the plain leaf: the SLTP
+    # sibling's MRO runs SLTPMixin -> <Venue>Base -> here and never touches the leaf.
     TAKER_FEE: float
 
     def _calculate_fractional_position(
@@ -180,9 +172,6 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
     ) -> tuple[float, float, str]:
         """Target position size from a fractional action, for all four futures venues.
 
-        binance extends this (min-notional refusal, then rounding the TARGET to lot size);
-        the other three round the DELTA at execution instead. That placement difference is
-        real and stays per venue -- only the sizing arithmetic is shared here.
         """
         if action_value == 0.0:
             return 0.0, 0.0, "flat"
@@ -196,8 +185,7 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
             info = self.trader.get_account_balance()
             total_balance = info["total_margin_balance"]
             # isfinite, not `not (x > 0)`: that catches NaN but passes +inf, and an inf
-            # balance sizes an inf target (#277). The name is load-bearing:
-            # test_futures_sizing_rejects_a_non_finite_balance greps for it.
+            # balance sizes an inf target (#277).
             if not math.isfinite(total_balance) or total_balance <= 0:
                 raise ValueError(
                     f"cannot size a trade against a portfolio value of {total_balance}"

--- a/torchtrade/envs/live/shared/futures_live_base.py
+++ b/torchtrade/envs/live/shared/futures_live_base.py
@@ -171,7 +171,6 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
         self, action_value: float, current_price: float
     ) -> tuple[float, float, str]:
         """Target position size from a fractional action, for all four futures venues.
-
         """
         if action_value == 0.0:
             return 0.0, 0.0, "flat"

--- a/torchtrade/envs/live/shared/futures_live_base.py
+++ b/torchtrade/envs/live/shared/futures_live_base.py
@@ -172,6 +172,9 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
     ) -> tuple[float, float, str]:
         """Target position size from a fractional action, for all four futures venues.
         """
+        # Above the balance read on purpose: a flat action must not need the exchange.
+        # No caller reaches this today -- all four pre-filter zero -- so it guards a
+        # caller that stops doing so, not a live path.
         if action_value == 0.0:
             return 0.0, 0.0, "flat"
 

--- a/torchtrade/envs/live/shared/futures_live_base.py
+++ b/torchtrade/envs/live/shared/futures_live_base.py
@@ -30,6 +30,10 @@ from torchtrade.envs.core.state import (
     position_direction_from_status,
     position_qty_from_status,
 )
+from torchtrade.envs.utils.fractional_sizing import (
+    PositionCalculationParams,
+    calculate_fractional_position,
+)
 from torchtrade.envs.utils.liquidation import (
     isolated_liquidation_price,
     nearest_liquidation_price,
@@ -158,6 +162,57 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
             next_tensordict, price=new_price, action=desired_action,
             portfolio_value=new_portfolio_value, position=new_qty,
         )
+
+    # Each venue sets its OWN. The four bodies below were byte-identical text, but this
+    # name resolved to a different value in each module -- 0.0004 / 0.0006 / 0.00055 /
+    # 0.0005 -- so folding them without lifting the fee out would have silently re-priced
+    # three venues. `fee_multiplier = 1 + leverage * fee`, so at 125x the binance and
+    # bitget fees size a position ~2.3% apart. Exact values are pinned by a test.
+    TAKER_FEE: float
+
+    def _calculate_fractional_position(
+        self, action_value: float, current_price: float
+    ) -> tuple[float, float, str]:
+        """Target position size from a fractional action, for all four futures venues.
+
+        binance extends this (min-notional refusal, then rounding the TARGET to lot size);
+        the other three round the DELTA at execution instead. That placement difference is
+        real and stays per venue -- only the sizing arithmetic is shared here.
+        """
+        if action_value == 0.0:
+            return 0.0, 0.0, "flat"
+
+        # The VERDICT is inside the closure, not just the read. `_halting` catches
+        # ValueError precisely so an impossible account state becomes a halt; raising one
+        # frame above it sent that straight out of `_step`. `equity == 0.0` is what a
+        # venue reports while liquidating you -- the worst moment to crash rather than
+        # halt under policy (#295).
+        def read_balance():
+            info = self.trader.get_account_balance()
+            total_balance = info["total_margin_balance"]
+            # isfinite, not `not (x > 0)`: that catches NaN but passes +inf, and an inf
+            # balance sizes an inf target (#277). The name is load-bearing:
+            # test_futures_sizing_rejects_a_non_finite_balance greps for it.
+            if not math.isfinite(total_balance) or total_balance <= 0:
+                raise ValueError(
+                    f"cannot size a trade against a portfolio value of {total_balance}"
+                )
+            return info
+
+        balance_info = self._halting(read_balance, cache_key="balance")
+
+        # total_margin_balance, not available_balance: the target must reflect the whole
+        # portfolio including margin already locked in open positions. available_balance
+        # shrinks as positions grow, which made a held action=1.0 buy repeatedly.
+        # The 2% buffer is the venue's maintenance-margin headroom.
+        effective_balance = balance_info["total_margin_balance"] * 0.98
+        return calculate_fractional_position(PositionCalculationParams(
+            balance=effective_balance,
+            action_value=action_value,
+            current_price=current_price,
+            leverage=self.config.leverage,
+            transaction_fee=self.TAKER_FEE,
+        ))
 
     def _finish_futures_init(self) -> None:
         """The tail every futures env ran verbatim after `super().__init__` (#288).

--- a/torchtrade/envs/live/shared/futures_live_base.py
+++ b/torchtrade/envs/live/shared/futures_live_base.py
@@ -220,6 +220,16 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
         Ordering is load-bearing and was identical in all four: flatten before the
         baseline, so the baseline is the balance the episode actually starts from.
         """
+        # At the boundary, not in the sizing rule. `TAKER_FEE: float` on this class is a
+        # bare annotation and creates no attribute, so a venue that forgets it would
+        # otherwise raise the first time it sizes a nonzero action -- mid-`_step`, with a
+        # position possibly already open.
+        if not hasattr(self, "TAKER_FEE"):
+            raise TypeError(
+                f"{type(self).__name__} does not set TAKER_FEE; the shared fractional "
+                f"sizing reads it, and the venues' fees differ"
+            )
+
         self.execute_on = self.config.execute_on
 
         self.trader.cancel_open_orders()

--- a/torchtrade/envs/live/shared/futures_live_base.py
+++ b/torchtrade/envs/live/shared/futures_live_base.py
@@ -163,11 +163,16 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
             portfolio_value=new_portfolio_value, position=new_qty,
         )
 
-    # Each venue sets its OWN. The four bodies below were byte-identical text, but this
-    # name resolved to a different value in each module -- 0.0004 / 0.0006 / 0.00055 /
-    # 0.0005 -- so folding them without lifting the fee out would have silently re-priced
-    # three venues. `fee_multiplier = 1 + leverage * fee`, so at 125x the binance and
-    # bitget fees size a position ~2.3% apart. Exact values are pinned by a test.
+    # Set by each venue's <Venue>BaseTorchTradingEnv, NOT by the plain leaf: the SLTP
+    # sibling's MRO runs SLTPMixin -> <Venue>Base -> here and never touches the leaf, so a
+    # fee set there resolves for half the classes that inherit this sizing and
+    # AttributeErrors for the other half.
+    #
+    # The four bodies this replaced were byte-identical TEXT with this name resolving to a
+    # different value per module -- 0.0004 / 0.0006 / 0.00055 / 0.0005. Folding them
+    # without lifting the fee would have silently re-priced three venues:
+    # `fee_multiplier = 1 + leverage * fee`, so at 125x binance and bitget size ~2.3%
+    # apart. The eight pre-fold notionals are pinned by test.
     TAKER_FEE: float
 
     def _calculate_fractional_position(
@@ -202,8 +207,7 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
         balance_info = self._halting(read_balance, cache_key="balance")
 
         # total_margin_balance, not available_balance: the target must reflect the whole
-        # portfolio including margin already locked in open positions. available_balance
-        # shrinks as positions grow, which made a held action=1.0 buy repeatedly.
+        # portfolio including margin already locked in open positions.
         # The 2% buffer is the venue's maintenance-margin headroom.
         effective_balance = balance_info["total_margin_balance"] * 0.98
         return calculate_fractional_position(PositionCalculationParams(
@@ -220,16 +224,6 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
         Ordering is load-bearing and was identical in all four: flatten before the
         baseline, so the baseline is the balance the episode actually starts from.
         """
-        # At the boundary, not in the sizing rule. `TAKER_FEE: float` on this class is a
-        # bare annotation and creates no attribute, so a venue that forgets it would
-        # otherwise raise the first time it sizes a nonzero action -- mid-`_step`, with a
-        # position possibly already open.
-        if not hasattr(self, "TAKER_FEE"):
-            raise TypeError(
-                f"{type(self).__name__} does not set TAKER_FEE; the shared fractional "
-                f"sizing reads it, and the venues' fees differ"
-            )
-
         self.execute_on = self.config.execute_on
 
         self.trader.cancel_open_orders()


### PR DESCRIPTION
Slice 4 of #288. Four `_calculate_fractional_position` bodies (54–100% similar) fold onto `TorchTradeFuturesLiveEnv`; binance extends via `super()`.

**Production `+76/−202` (net −126).** Suite 4344, 0 failed.

## The reason this slice was not a mechanical fold

The four bodies are **byte-identical text and different behaviour**. `TAKER_FEE` resolved to a different value in each module:

| binance | bitget | bybit | okx |
|---|---|---|---|
| 0.0004 | 0.0006 | 0.00055 | 0.0005 |

Folding them without lifting the fee would bind one constant in the shared module and silently re-price three venues. Sizing is `1 + leverage × fee`, so at 125× binance and bitget size a position **~2.3% apart**.

Worth stating plainly: my own similarity measurement called bybit and okx **100% identical**. They differ by 10% in fee. The metric was measuring text; the money was in the name resolution.

The fee is now a per-venue class attribute the shared body reads — pinned by value, plus a test that four different fees produce four different notionals, so "declared on the class" cannot decay into "declared and ignored".

## binance extends rather than inherits, and that is correct

binance refuses below min-**notional** and rounds the **target**. The other three floor the **delta** against min-qty inside `_execute_fractional_action`. Different placement in the pipeline, not a gap in three venues — I verified that before folding, because a fold is exactly where that distinction gets flattened by accident.

## Behaviour is unchanged, proved not asserted

144 sizings — 4 venues × 6 actions × 2 prices × 3 leverages — computed on this branch and on `main`. **Zero differ.**

## What the review rounds should look at

- The `not (x > 0)` guard failed on all four venues when the code moved: it was a **file scan** of `live/<venue>/env.py` and could no longer find its own subject. Third time a file-scan guard has broken on a fold in this series, and the third time it was right to. It now reads the resolved method and follows one hop through `super()`.
- **Two of my own new assertions were too weak**, and the mutation battery caught both: grepping the body for `_get_min_notional` passed with the `if` that uses it neutered, and the 2% buffer test compared two of the env's *own* sizings — a ratio invariant to the buffer, so it passed with the buffer deleted. Both now assert behaviour against an independent expected value.

7 mutations across the fold, all killed. Review rounds to follow.