### PR TITLE
refactor(288): fold the SLTP bracket sizing, which #413 left inlined four times

### DIFF
--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -4285,16 +4285,6 @@ def _sizing_stub(cls, *, leverage=10, balance=10_000.0, min_notional=0.0,
     return env
 
 
-# Derived from the registry so a fifth venue fails here rather than on its first live
-# trade. The values stay literal: the failure guarded against is every venue reading ONE
-# fee, which a derived expected value would reproduce.
-_EXPECTED_TAKER_FEES = {
-    "binance": 0.0004, "bitget": 0.0006, "bybit": 0.00055, "okx": 0.0005,
-}
-assert set(_EXPECTED_TAKER_FEES) == {c.__module__.split(".")[-2]
-                                     for c in PLAIN_FUTURES_ENVS}
-
-
 @pytest.mark.parametrize("cls", PLAIN_FUTURES_ENVS + SLTP_FUTURES_ENVS,
                          ids=lambda c: c.__name__)
 def test_every_class_that_inherits_the_shared_sizing_can_run_it(cls):
@@ -4336,14 +4326,20 @@ _GOLDEN_SIZINGS = [
 # Pre-fold values, read off `main` before #415 moved the block. One row per venue at a
 # single leverage: unlike the plain golden table, nothing downstream of this method varies
 # by venue except `TAKER_FEE`, so a leverage axis would be decoration rather than evidence.
-PLAIN_VENUES_SLTP = [c.__module__.split(".")[-2] for c in SLTP_FUTURES_ENVS]
-
+# Completeness pinned, not just the values: a fifth venue would otherwise drop out of this
+# table silently while the other SLTP tests picked it up. Shrinkage is the hazard, not
+# emptiness -- an empty parametrize is already a collection error here.
 _GOLDEN_BRACKET_QUANTITIES = [
     ("binance", 489.02195608782426),
     ("bitget", 488.5343968095713),
     ("bybit", 488.6561954624782),
     ("okx", 488.77805486284296),
 ]
+
+
+assert {v for v, _ in _GOLDEN_BRACKET_QUANTITIES} == {
+    c.__module__.split(".")[-2] for c in SLTP_FUTURES_ENVS
+}
 
 
 def _bracket_stub(cls, *, balance=10_000.0, leverage=5, fee=...):
@@ -4367,25 +4363,22 @@ def _bracket_stub(cls, *, balance=10_000.0, leverage=5, fee=...):
     return env
 
 
-@pytest.mark.parametrize("venue", PLAIN_VENUES_SLTP)
+@pytest.mark.parametrize("venue",
+                         [c.__module__.split(".")[-2] for c in SLTP_FUTURES_ENVS])
 def test_a_bracket_that_cannot_be_sized_is_a_failed_trade_on_every_venue(venue):
     """The `None` contract #415 introduced, at the four call sites rather than the helper.
 
     Returning 0.0 instead of refusing submits a zero-quantity order. That dies here for
-    bybit and bitget; for okx it is caught by its own min-qty short-circuit, and for
-    binance the executor refuses below the step size -- so the four venues are protected
-    by three different mechanisms and only two of them are this test's doing.
+    binance, bitget and bybit -- none of the three has a guard between the sizing call and
+    `trader.trade`. okx alone survives it, absorbed by its own min-qty short-circuit, so
+    okx's protection is not this test's doing and needs its own coverage.
 
     Flipping `success` to True is NOT caught, and should not be: with `executed` False,
     `_record_position_after_trade` returns before reading `success`, so the two are
     indistinguishable. A reviewer flagged it as a phantom-position risk; I traced it and
     the cost does not follow.
 
-    total_margin_balance 0.0 is not a contrived input: it is what a venue reports while
-    liquidating you, per the comment on the guard that produces the None.
     """
-    from tests.envs.test_live_observation_failsafe import _real_futures_env
-
     env, trader = _real_futures_env(budget=0, venue=venue, sltp=True)
     env.config.trade_mode = "fractional"
     trader.get_account_balance.return_value = {
@@ -4404,6 +4397,23 @@ def test_a_bracket_that_cannot_be_sized_is_a_failed_trade_on_every_venue(venue):
         f"{venue} recorded position {env.position.current_position} for a bracket that "
         f"was never placed; the next bar's duplicate-action guard trusts that"
     )
+
+
+def test_an_unrecognised_trade_mode_refuses_rather_than_sizing_as_fractional():
+    """The dispatch's fall-through, which deleting was killed by nothing.
+
+    `fractional` is the fall-through branch, not an explicit one, so removing the raise
+    does not surface an error -- it sizes an unknown mode against real equity using the
+    fractional path. The config validates `trade_mode` at construction, but it is a
+    mutable dataclass field and both this file's stubs set it directly.
+    """
+    cls = _sole(importlib.import_module("torchtrade.envs.live.binance.env_sltp"),
+                "TorchTradingEnv")
+    env = _bracket_stub(cls)
+    env.config.trade_mode = "margin"
+
+    with pytest.raises(ValueError, match="Unsupported trade_mode"):
+        env._resolve_bracket_quantity(100.0)
 
 
 @pytest.mark.parametrize("venue,expected", _GOLDEN_BRACKET_QUANTITIES)

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -2169,12 +2169,21 @@ def test_sltp_sizing_rejects_a_non_finite_price_or_balance(exchange):
     venue_src = inspect.getsource(cls._execute_trade_if_needed)
     sizing_src = inspect.getsource(cls._resolve_bracket_quantity)
 
+    # Delegation, not just the resolved source. `inspect.getsource` follows inheritance,
+    # so it returns the shared helper even for a venue that has re-inlined its own
+    # unguarded copy and stopped calling it -- the one capability the file-text scan this
+    # replaced used to have.
+    assert "_resolve_bracket_quantity" in venue_src, (
+        f"{exchange}'s trade path no longer delegates to the shared sizing; the assertion "
+        f"below would then be reading a helper this venue does not call"
+    )
     assert "math.isfinite(balance)" in sizing_src, (
         f"{exchange} SLTP sizing still lets a non-finite balance through"
     )
     if exchange in ("binance", "bitget"):
         # These two size from a candle close, so _current_mark_price() never guards them.
-        # bybit and okx go through it, which makes a second price check there dead code.
+        # bybit and okx re-validate at the seam that uses it -- #295 threading moved the
+        # read out of _current_mark_price, so that check is live, not dead.
         assert "math.isfinite(current_price)" in venue_src, (
             f"{exchange} sizes from a candle close with no finiteness check"
         )

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -2167,11 +2167,15 @@ def test_sltp_sizing_rejects_a_non_finite_price_or_balance(exchange):
     cls = _sole(importlib.import_module(f"torchtrade.envs.live.{exchange}.env_sltp"),
                 "TorchTradingEnv")
     venue_src = inspect.getsource(cls._execute_trade_if_needed)
-    # `inspect.getsource` follows inheritance, so it returns the shared helper even for a
-    # venue that has re-inlined its own unguarded copy and stopped calling it.
-    assert "_resolve_bracket_quantity" in venue_src, (
-        f"{exchange}'s trade path no longer delegates to the shared sizing; the assertion "
-        f"below would then be reading a helper this venue does not call"
+    # An AST call, not a substring. `inspect.getsource` follows inheritance, so it returns
+    # the shared helper even for a venue that has stopped calling it -- and a substring
+    # check passes on an inlined copy that merely MENTIONS the name in a comment.
+    calls = [n for n in ast.walk(ast.parse(textwrap.dedent(venue_src)))
+             if isinstance(n, ast.Call) and isinstance(n.func, ast.Attribute)
+             and n.func.attr == "_resolve_bracket_quantity"]
+    assert calls, (
+        f"{exchange}'s trade path does not CALL the shared sizing; an inlined copy that "
+        f"names it in a comment would satisfy a text search"
     )
     if exchange in ("binance", "bitget"):
         # These two size from a candle close, so _current_mark_price() never guards them.
@@ -4412,6 +4416,54 @@ def test_an_unrecognised_trade_mode_refuses_rather_than_sizing_as_fractional():
 
     with pytest.raises(ValueError, match="Unsupported trade_mode"):
         env._resolve_bracket_quantity(100.0)
+
+
+def test_okx_refuses_a_sub_minimum_bracket_rather_than_letting_it_be_clamped_up():
+    """okx keeps a min-qty branch the other three do not, and deleting it stayed green.
+
+    It is not redundant caution: okx's `_format_size` FLOORS then clamps UP to `min_qty`,
+    so a 0.0001 target becomes a 0.001 order -- ten times the intended position, silently.
+    binance raises below the step, bitget floors and lets the venue reject, bybit sends
+    the raw value. okx is the only venue where a sub-minimum quantity becomes a LARGER
+    position rather than a rejected one.
+    """
+    from tests.envs.test_live_observation_failsafe import _real_futures_env
+
+    env, trader = _real_futures_env(budget=0, venue="okx", sltp=True)
+    env.config.trade_mode = "quantity"
+    env.config.quantity_per_trade = 0.0001          # below the 0.001 min_qty
+    trader.get_lot_size.return_value = {"min_qty": 0.001, "qty_step": 0.001}
+
+    td = env.reset()
+    env.active_stop_loss, env.active_take_profit = 111.0, 222.0
+    env.step(td.set("action", torch.tensor(1)))
+
+    assert not trader.trade.called, (
+        "okx submitted a sub-minimum bracket; its executor clamps that UP to min_qty, so "
+        "the venue would have opened a position ten times the size asked for"
+    )
+
+
+@pytest.mark.parametrize("fraction", [-0.5, 0.0], ids=["negative", "zero"])
+def test_a_non_positive_sized_quantity_is_refused_not_handed_to_the_venue(fraction):
+    """The one deliberate behaviour change in #415, pinned.
+
+    `position_fraction` is validated to (0, 1.0] at construction, so this is unreachable
+    from a well-formed config -- but the four venue formatters disagree about what a
+    negative quantity means, and one of them turns it into a trade: okx floors -244.5 and
+    clamps up to min_qty, yielding a 0.001 LONG. bitget and bybit forward it and rely on
+    the exchange. Refusing in the shared helper is the only outcome that is the same on
+    all four.
+
+    Re-adding `abs()` here is what this catches: it would return a plausible positive
+    quantity instead.
+    """
+    cls = _sole(importlib.import_module("torchtrade.envs.live.binance.env_sltp"),
+                "TorchTradingEnv")
+    env = _bracket_stub(cls)
+    env.config.position_fraction = fraction
+
+    assert env._resolve_bracket_quantity(100.0) is None
 
 
 @pytest.mark.parametrize("mode,per_trade,price,expected", [

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -2157,15 +2157,21 @@ def test_sltp_sizing_rejects_a_non_finite_price_or_balance(exchange):
     about -- and binance/bitget size from a candle close, so the validated mark-price
     accessor never entered their path at all.
     """
-    src = (pathlib.Path(inspect.getfile(TorchTradeLiveEnv)).parent.parent
-           / "live" / exchange / "env_sltp.py").read_text()
-    assert "math.isfinite(balance)" in src, (
+    # The RESOLVED methods, following the delegation. A file scan of `env_sltp.py` broke
+    # the moment #288 folded the bracket sizing onto the shared base -- the guard stopped
+    # seeing its own subject, which is the failure it exists to prevent in the code.
+    cls = _sole(importlib.import_module(f"torchtrade.envs.live.{exchange}.env_sltp"),
+                "TorchTradingEnv")
+    venue_src = inspect.getsource(cls._execute_trade_if_needed)
+    sizing_src = inspect.getsource(cls._resolve_bracket_quantity)
+
+    assert "math.isfinite(balance)" in sizing_src, (
         f"{exchange} SLTP sizing still lets a non-finite balance through"
     )
     if exchange in ("binance", "bitget"):
         # These two size from a candle close, so _current_mark_price() never guards them.
         # bybit and okx go through it, which makes a second price check there dead code.
-        assert "math.isfinite(current_price)" in src, (
+        assert "math.isfinite(current_price)" in venue_src, (
             f"{exchange} sizes from a candle close with no finiteness check"
         )
 

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -2167,23 +2167,15 @@ def test_sltp_sizing_rejects_a_non_finite_price_or_balance(exchange):
     cls = _sole(importlib.import_module(f"torchtrade.envs.live.{exchange}.env_sltp"),
                 "TorchTradingEnv")
     venue_src = inspect.getsource(cls._execute_trade_if_needed)
-    sizing_src = inspect.getsource(cls._resolve_bracket_quantity)
-
-    # Delegation, not just the resolved source. `inspect.getsource` follows inheritance,
-    # so it returns the shared helper even for a venue that has re-inlined its own
-    # unguarded copy and stopped calling it -- the one capability the file-text scan this
-    # replaced used to have.
+    # `inspect.getsource` follows inheritance, so it returns the shared helper even for a
+    # venue that has re-inlined its own unguarded copy and stopped calling it.
     assert "_resolve_bracket_quantity" in venue_src, (
         f"{exchange}'s trade path no longer delegates to the shared sizing; the assertion "
         f"below would then be reading a helper this venue does not call"
     )
-    assert "math.isfinite(balance)" in sizing_src, (
-        f"{exchange} SLTP sizing still lets a non-finite balance through"
-    )
     if exchange in ("binance", "bitget"):
         # These two size from a candle close, so _current_mark_price() never guards them.
-        # bybit and okx re-validate at the seam that uses it -- #295 threading moved the
-        # read out of _current_mark_price, so that check is live, not dead.
+        # bybit and okx re-validate at the seam instead (#295).
         assert "math.isfinite(current_price)" in venue_src, (
             f"{exchange} sizes from a candle close with no finiteness check"
         )
@@ -4335,9 +4327,8 @@ _GOLDEN_SIZINGS = [
 # Pre-fold values, read off `main` before #415 moved the block. One row per venue at a
 # single leverage: unlike the plain golden table, nothing downstream of this method varies
 # by venue except `TAKER_FEE`, so a leverage axis would be decoration rather than evidence.
-# Completeness pinned, not just the values: a fifth venue would otherwise drop out of this
-# table silently while the other SLTP tests picked it up. Shrinkage is the hazard, not
-# emptiness -- an empty parametrize is already a collection error here.
+# A fifth venue would otherwise drop out of this table silently while the other SLTP
+# tests picked it up.
 _GOLDEN_BRACKET_QUANTITIES = [
     ("binance", 489.02195608782426),
     ("bitget", 488.5343968095713),
@@ -4384,9 +4375,7 @@ def test_a_bracket_that_cannot_be_sized_is_a_failed_trade_on_every_venue(venue):
 
     Flipping `success` to True is NOT caught, and should not be: with `executed` False,
     `_record_position_after_trade` returns before reading `success`, so the two are
-    indistinguishable. A reviewer flagged it as a phantom-position risk; I traced it and
-    the cost does not follow.
-
+    indistinguishable.
     """
     env, trader = _real_futures_env(budget=0, venue=venue, sltp=True)
     env.config.trade_mode = "fractional"
@@ -4425,6 +4414,30 @@ def test_an_unrecognised_trade_mode_refuses_rather_than_sizing_as_fractional():
         env._resolve_bracket_quantity(100.0)
 
 
+@pytest.mark.parametrize("mode,per_trade,price,expected", [
+    ("notional", 500.0, 100.0, 5.0),
+    ("notional", 500.0, 37_512.5, 500.0 / 37_512.5),
+    ("quantity", 0.37, 100.0, 0.37),
+    ("quantity", 0.37, 37_512.5, 0.37),
+], ids=["notional-100", "notional-37512", "quantity-100", "quantity-37512"])
+def test_the_non_fractional_trade_modes_size_from_config(mode, per_trade, price, expected):
+    """The two branches every SLTP sizing test skipped.
+
+    Every other test here and in the four venue suites builds its config with
+    `trade_mode="fractional"`, so mutating `quantity_per_trade / price` to `*`, or
+    doubling the raw quantity, passed all 1000 tests in this file. Pre-existing -- neither
+    branch changed in the fold -- but the fold changed the blast radius: one wrong formula
+    now mis-sizes every SLTP bracket on all four venues at once.
+    """
+    cls = _sole(importlib.import_module("torchtrade.envs.live.binance.env_sltp"),
+                "TorchTradingEnv")
+    env = _bracket_stub(cls)
+    env.config.trade_mode = mode
+    env.config.quantity_per_trade = per_trade
+
+    assert env._resolve_bracket_quantity(price) == pytest.approx(expected, rel=1e-12)
+
+
 @pytest.mark.parametrize("venue,expected", _GOLDEN_BRACKET_QUANTITIES)
 def test_the_sltp_fold_did_not_move_a_bracket_quantity(venue, expected):
     """What each venue's SLTP bracket sized before #415 folded the four copies.
@@ -4458,12 +4471,11 @@ def test_an_unusable_balance_refuses_to_size_a_bracket(balance):
 
 @pytest.mark.parametrize("fee", [0.0007, 0.0],
                          ids=["higher-than-venue", "fee-free-replay"])
-def test_a_usable_trader_fee_overrides_the_venue_constant(fee):
+def test_a_usable_trader_fee_fees_the_venue_constant(fee):
     """The accept branch, which nothing has ever exercised.
 
     Only `ReplayOrderExecutor` carries `transaction_fee`, so on a real venue this branch
-    is skipped entirely -- and every SLTP test builds a bare MagicMock, whose attribute
-    floats to 1.0 and is rejected. So the fee override has been proven only in the
+    is skipped entirely -- So the fee fee has been proven only in the
     direction that ignores it.
     """
     cls = _sole(importlib.import_module("torchtrade.envs.live.binance.env_sltp"),
@@ -4472,20 +4484,16 @@ def test_a_usable_trader_fee_overrides_the_venue_constant(fee):
         PositionCalculationParams, calculate_fractional_position,
     )
 
-    override, venue_fee = fee, cls.TAKER_FEE
-    assert override != venue_fee, "setup: the override must differ from the venue constant"
-    # 0.0 is the accept-side boundary: `0 <= fee` not `0 < fee`. A fee-free replay
-    # executor falling back to the venue constant sizes 976.10 against 980.00 -- #278's
-    # shape, with a warning that calls a valid rate unusable.
+    assert fee != cls.TAKER_FEE, "setup: the fee must differ from the venue constant"
 
-    got = _bracket_stub(cls, fee=override)._resolve_bracket_quantity(100.0)
+    got = _bracket_stub(cls, fee=fee)._resolve_bracket_quantity(100.0)
     expected = abs(calculate_fractional_position(PositionCalculationParams(
         balance=10_000.0 * 0.98, action_value=1.0, current_price=100.0,
-        leverage=5, transaction_fee=override))[0])
+        leverage=5, transaction_fee=fee))[0])
 
     assert got == pytest.approx(expected, rel=1e-12), (
         f"sized {got!r} against the venue constant instead of the trader's own "
-        f"{override} rate; a replay executor charging more has every open refused (#278)"
+        f"{fee} rate; a replay executor charging more has every open refused (#278)"
     )
 
 
@@ -4513,8 +4521,7 @@ def test_an_unusable_trader_fee_degrades_to_the_venue_constant(bad):
 def test_a_flat_action_is_sized_without_touching_the_exchange(cls):
     """The `action_value == 0.0` short-circuit above the balance read.
 
-    Proposed for deletion twice as a duplicate of the guards on either side of it. It is
-    not a duplicate -- without it a flat action performs a balance read and raises on an
+    Without it a flat action performs a balance read and raises on an
     unusable balance rather than returning flat -- but the honest scope is narrower than
     I first claimed: all four callers pre-filter zero before calling, so NO production
     path reaches this today. It is defence against a caller that stops pre-filtering, and

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -4471,12 +4471,13 @@ def test_an_unusable_balance_refuses_to_size_a_bracket(balance):
 
 @pytest.mark.parametrize("fee", [0.0007, 0.0],
                          ids=["higher-than-venue", "fee-free-replay"])
-def test_a_usable_trader_fee_fees_the_venue_constant(fee):
-    """The accept branch, which nothing has ever exercised.
+def test_a_usable_trader_fee_overrides_the_venue_constant(fee):
+    """The accept branch, which nothing had ever exercised.
 
-    Only `ReplayOrderExecutor` carries `transaction_fee`, so on a real venue this branch
-    is skipped entirely -- So the fee fee has been proven only in the
-    direction that ignores it.
+    Only `ReplayOrderExecutor` carries `transaction_fee`, so on a real venue the branch is
+    skipped entirely. `0.0` is here because it is the ACCEPT-side boundary -- `0 <= fee`,
+    not `0 < fee` -- and a fee-free replay executor falling back to the venue constant
+    sizes 976.10 against 980.00 while logging that a valid rate is unusable (#278).
     """
     cls = _sole(importlib.import_module("torchtrade.envs.live.binance.env_sltp"),
                 "TorchTradingEnv")
@@ -4539,6 +4540,13 @@ def test_a_flat_action_is_sized_without_touching_the_exchange(cls):
         f"nothing from the venue -- an unusable balance would raise instead of returning "
         f"flat, and a min-notional lookup is an unhalted round-trip"
     )
+
+
+# The (venue, leverage) PAIRS, not the venue set: dropping one of a venue's two rows
+# leaves the set unchanged and loses a test silently. Shrinkage is the hazard.
+assert {(v, lev) for v, lev, _, _ in _GOLDEN_SIZINGS} == {
+    (c.__module__.split(".")[-2], lev) for c in PLAIN_FUTURES_ENVS for lev in (1, 125)
+}
 
 
 @pytest.mark.parametrize("venue,leverage,exp_size,exp_notional", _GOLDEN_SIZINGS,

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -211,6 +211,10 @@ def test_no_live_env_overrides_shared_method(env_cls, method):
         # copy of either is where that policy stops being one policy.
         "_acquire_pre_trade_state",
         "_acquire_post_bar_state",
+        # The SLTP bracket sizing (#288). Reached only by the four SLTP siblings, but the
+        # identity check is over FUTURES_ENVS, and the plain envs inherit it unused --
+        # a venue re-forking it for either path fails here.
+        "_resolve_bracket_quantity",
     ],
 )
 @pytest.mark.parametrize("env_cls", FUTURES_ENVS, ids=lambda c: c.__name__)
@@ -4327,6 +4331,163 @@ _GOLDEN_SIZINGS = [
     ("okx", 1, 97.95102448775612, 9795.102448775613),
     ("okx", 125, 11529.411764705882, 1152941.1764705882),
 ]
+
+
+# Pre-fold values, read off `main` before #415 moved the block. One row per venue at a
+# single leverage: unlike the plain golden table, nothing downstream of this method varies
+# by venue except `TAKER_FEE`, so a leverage axis would be decoration rather than evidence.
+PLAIN_VENUES_SLTP = [c.__module__.split(".")[-2] for c in SLTP_FUTURES_ENVS]
+
+_GOLDEN_BRACKET_QUANTITIES = [
+    ("binance", 489.02195608782426),
+    ("bitget", 488.5343968095713),
+    ("bybit", 488.6561954624782),
+    ("okx", 488.77805486284296),
+]
+
+
+def _bracket_stub(cls, *, balance=10_000.0, leverage=5, fee=...):
+    """An SLTP env wired for `_resolve_bracket_quantity` and nothing else.
+
+    `fee` unset leaves `trader.transaction_fee` ABSENT. It cannot be left to a bare
+    MagicMock: `float(MagicMock().transaction_fee)` is 1.0, which the range check rejects,
+    so the fallback fires and the accept branch is never reached -- the accident that
+    hides the accept path in every existing SLTP sizing test.
+    """
+    env = cls.__new__(cls)
+    env.config = SimpleNamespace(trade_mode="fractional", position_fraction=1.0,
+                                 quantity_per_trade=0, leverage=leverage, symbol="X")
+    env.trader = MagicMock()
+    env.trader.get_account_balance.return_value = {"total_margin_balance": balance}
+    if fee is ...:
+        del env.trader.transaction_fee
+    else:
+        env.trader.transaction_fee = fee
+    env._halting = lambda read, cache_key=None: read()
+    return env
+
+
+@pytest.mark.parametrize("venue", PLAIN_VENUES_SLTP)
+def test_a_bracket_that_cannot_be_sized_is_a_failed_trade_on_every_venue(venue):
+    """The `None` contract #415 introduced, at the four call sites rather than the helper.
+
+    Returning 0.0 instead of refusing submits a zero-quantity order. That dies here for
+    bybit and bitget; for okx it is caught by its own min-qty short-circuit, and for
+    binance the executor refuses below the step size -- so the four venues are protected
+    by three different mechanisms and only two of them are this test's doing.
+
+    Flipping `success` to True is NOT caught, and should not be: with `executed` False,
+    `_record_position_after_trade` returns before reading `success`, so the two are
+    indistinguishable. A reviewer flagged it as a phantom-position risk; I traced it and
+    the cost does not follow.
+
+    total_margin_balance 0.0 is not a contrived input: it is what a venue reports while
+    liquidating you, per the comment on the guard that produces the None.
+    """
+    from tests.envs.test_live_observation_failsafe import _real_futures_env
+
+    env, trader = _real_futures_env(budget=0, venue=venue, sltp=True)
+    env.config.trade_mode = "fractional"
+    trader.get_account_balance.return_value = {
+        "available_balance": 0.0, "total_margin_balance": 0.0,
+        "total_wallet_balance": 0.0, "total_maintenance_margin": 0.0,
+    }
+
+    td = env.reset()
+    env.active_stop_loss, env.active_take_profit = 111.0, 222.0
+    env.step(td.set("action", torch.tensor(1)))
+
+    assert not trader.trade.called, (
+        f"{venue} sent an order for a bracket it could not size"
+    )
+    assert env.position.current_position == 0, (
+        f"{venue} recorded position {env.position.current_position} for a bracket that "
+        f"was never placed; the next bar's duplicate-action guard trusts that"
+    )
+
+
+@pytest.mark.parametrize("venue,expected", _GOLDEN_BRACKET_QUANTITIES)
+def test_the_sltp_fold_did_not_move_a_bracket_quantity(venue, expected):
+    """What each venue's SLTP bracket sized before #415 folded the four copies.
+
+    The four bodies were code-identical, so the only thing that can drift per venue is
+    `self.TAKER_FEE` -- and these four numbers differ only because those fees do.
+    """
+    cls = _sole(importlib.import_module(f"torchtrade.envs.live.{venue}.env_sltp"),
+                "TorchTradingEnv")
+    got = _bracket_stub(cls)._resolve_bracket_quantity(100.0)
+
+    assert got == pytest.approx(expected, rel=1e-9), (
+        f"{venue}'s bracket now sizes {got!r} where it sized {expected!r} before the fold"
+    )
+
+
+@pytest.mark.parametrize("balance", [0.0, -5.0, float("nan"), float("inf")],
+                         ids=["zero", "negative", "nan", "inf"])
+def test_an_unusable_balance_refuses_to_size_a_bracket(balance):
+    """None, not a raise, and not a number.
+
+    The plain path raises inside the `_halting` closure so an unusable balance becomes a
+    halt; this path returns None and the caller reports a failed trade. That asymmetry is
+    pre-existing and deliberate, so it is asserted rather than left to be discovered --
+    "fixing" it on one venue would diverge halt handling by venue with nothing noticing.
+    """
+    cls = _sole(importlib.import_module("torchtrade.envs.live.binance.env_sltp"),
+                "TorchTradingEnv")
+    assert _bracket_stub(cls, balance=balance)._resolve_bracket_quantity(100.0) is None
+
+
+@pytest.mark.parametrize("fee", [0.0007, 0.0],
+                         ids=["higher-than-venue", "fee-free-replay"])
+def test_a_usable_trader_fee_overrides_the_venue_constant(fee):
+    """The accept branch, which nothing has ever exercised.
+
+    Only `ReplayOrderExecutor` carries `transaction_fee`, so on a real venue this branch
+    is skipped entirely -- and every SLTP test builds a bare MagicMock, whose attribute
+    floats to 1.0 and is rejected. So the fee override has been proven only in the
+    direction that ignores it.
+    """
+    cls = _sole(importlib.import_module("torchtrade.envs.live.binance.env_sltp"),
+                "TorchTradingEnv")
+    from torchtrade.envs.utils.fractional_sizing import (
+        PositionCalculationParams, calculate_fractional_position,
+    )
+
+    override, venue_fee = fee, cls.TAKER_FEE
+    assert override != venue_fee, "setup: the override must differ from the venue constant"
+    # 0.0 is the accept-side boundary: `0 <= fee` not `0 < fee`. A fee-free replay
+    # executor falling back to the venue constant sizes 976.10 against 980.00 -- #278's
+    # shape, with a warning that calls a valid rate unusable.
+
+    got = _bracket_stub(cls, fee=override)._resolve_bracket_quantity(100.0)
+    expected = abs(calculate_fractional_position(PositionCalculationParams(
+        balance=10_000.0 * 0.98, action_value=1.0, current_price=100.0,
+        leverage=5, transaction_fee=override))[0])
+
+    assert got == pytest.approx(expected, rel=1e-12), (
+        f"sized {got!r} against the venue constant instead of the trader's own "
+        f"{override} rate; a replay executor charging more has every open refused (#278)"
+    )
+
+
+@pytest.mark.parametrize("bad", ["not-a-number", -0.001, 1.0, float("nan")],
+                         ids=["non-numeric", "negative", "at-one", "nan"])  # 0.0 is VALID
+def test_an_unusable_trader_fee_degrades_to_the_venue_constant(bad):
+    """And the degrade branch, which is currently pinned only by accident.
+
+    `1.0` is in this list on purpose: it is exactly what a bare MagicMock floats to, so
+    the existing SLTP tests take this branch without meaning to. Asserting it here makes
+    that deliberate instead of load-bearing coincidence.
+    """
+    cls = _sole(importlib.import_module("torchtrade.envs.live.binance.env_sltp"),
+                "TorchTradingEnv")
+    got = _bracket_stub(cls, fee=bad)._resolve_bracket_quantity(100.0)
+    unset = _bracket_stub(cls)._resolve_bracket_quantity(100.0)
+
+    assert got == pytest.approx(unset, rel=1e-12), (
+        f"an unusable transaction_fee={bad!r} produced {got!r} rather than the venue "
+        f"constant's {unset!r}"
+    )
 
 
 @pytest.mark.parametrize("cls", PLAIN_FUTURES_ENVS, ids=lambda c: c.__name__)

--- a/torchtrade/envs/live/binance/env_sltp.py
+++ b/torchtrade/envs/live/binance/env_sltp.py
@@ -1,8 +1,3 @@
-from torchtrade.envs.utils.fractional_sizing import (
-    PositionCalculationParams,
-    calculate_fractional_position,
-)
-from torchtrade.envs.live.binance.order_executor import TAKER_FEE
 import math
 from torchtrade.envs.live.shared.sltp_config import BaseFuturesSLTPConfig
 from dataclasses import dataclass
@@ -172,59 +167,10 @@ class BinanceFuturesSLTPTorchTradingEnv(SLTPMixin, BinanceBaseTorchTradingEnv):
         # slot to serve from. Its own slot, because it is a candle close, not the mark.
         current_price = self._halting(read_close, cache_key="candle_close")
 
-        # Resolve quantity based on trade_mode
-        if self.config.trade_mode == "fractional":
-            # Size on total_margin_balance (equity), matching offline sizing and the non-SLTP
-            # live path. Binance's total_wallet_balance excludes unrealized PnL and would under-size;
-            # bitget/bybit/okx map both keys to equity, so the switch is a no-op there.
-            # Under `_halting` -- the read that SIZES a bracket (#295).
-            balance = float(
-                self._halting(self.trader.get_account_balance, cache_key="balance")[
-                    "total_margin_balance"
-                ]
-            )
-            if not math.isfinite(balance) or balance <= 0:
-                logger.error(f"Invalid price={current_price} or balance={balance} for {self.config.symbol}")
-                trade_info["success"] = False
-                return trade_info
-            # Reserve what will actually be CHARGED: ReplayOrderExecutor carries its own
-            # rate, so reserving a constant left a higher-fee caller with every open
-            # refused -- #278 reproduced. 0.98 as the non-SLTP path uses, so a
-            # full-fraction open leaves some maintenance buffer instead of zero.
-            # Reserve what the trader will CHARGE, or say so. float() alone is unsafe --
-            # MagicMock implements __float__ and returns 1.0 -- but an isinstance chain
-            # is worse: it rejects np.float32 and Decimal, which reproduces #278 with no
-            # diagnostic at all (the only log is the executor's "Insufficient balance",
-            # which reads like a small account rather than an under-reserving sizer).
-            # Coerce, range-check, and WARN on the fallback.
-            raw = getattr(self.trader, "transaction_fee", None)
-            fee = TAKER_FEE
-            if raw is not None:
-                try:
-                    candidate = float(raw)
-                except (TypeError, ValueError):
-                    candidate = None
-                if candidate is not None and math.isfinite(candidate) and 0 <= candidate < 1:
-                    fee = candidate
-                else:
-                    logger.warning(
-                        f"{self.config.symbol}: trader.transaction_fee={raw!r} is not a "
-                        f"usable rate; reserving the venue constant {TAKER_FEE}. If the "
-                        f"trader charges more, opens will be refused."
-                    )
-            quantity = abs(calculate_fractional_position(PositionCalculationParams(
-                balance=balance * 0.98,
-                action_value=self.config.position_fraction,
-                current_price=current_price,
-                leverage=self.config.leverage,
-                transaction_fee=fee,
-            ))[0])
-        elif self.config.trade_mode == "notional":
-            quantity = float(self.config.quantity_per_trade) / current_price
-        elif self.config.trade_mode == "quantity":
-            quantity = float(self.config.quantity_per_trade)
-        else:
-            raise ValueError(f"Unsupported trade_mode={self.config.trade_mode!r}")
+        quantity = self._resolve_bracket_quantity(current_price)
+        if quantity is None:
+            trade_info["success"] = False
+            return trade_info
 
         # Close opposite position if switching directions
         if self.position.current_position != 0:

--- a/torchtrade/envs/live/bitget/env_sltp.py
+++ b/torchtrade/envs/live/bitget/env_sltp.py
@@ -1,8 +1,3 @@
-from torchtrade.envs.utils.fractional_sizing import (
-    PositionCalculationParams,
-    calculate_fractional_position,
-)
-from torchtrade.envs.live.bitget.order_executor import TAKER_FEE
 import math
 from torchtrade.envs.live.shared.sltp_config import BaseFuturesSLTPConfig
 from dataclasses import dataclass
@@ -179,59 +174,10 @@ class BitgetFuturesSLTPTorchTradingEnv(SLTPMixin, BitgetBaseTorchTradingEnv):
         # slot to serve from. Its own slot, because it is a candle close, not the mark.
         current_price = self._halting(read_close, cache_key="candle_close")
 
-        # Resolve quantity based on trade_mode
-        if self.config.trade_mode == "fractional":
-            # Size on total_margin_balance (equity), matching offline sizing and the non-SLTP
-            # live path. Binance's total_wallet_balance excludes unrealized PnL and would under-size;
-            # bitget/bybit/okx map both keys to equity, so the switch is a no-op there.
-            # Under `_halting` -- the read that SIZES a bracket (#295).
-            balance = float(
-                self._halting(self.trader.get_account_balance, cache_key="balance")[
-                    "total_margin_balance"
-                ]
-            )
-            if not math.isfinite(balance) or balance <= 0:
-                logger.error(f"Invalid price={current_price} or balance={balance} for {self.config.symbol}")
-                trade_info["success"] = False
-                return trade_info
-            # Reserve what will actually be CHARGED: ReplayOrderExecutor carries its own
-            # rate, so reserving a constant left a higher-fee caller with every open
-            # refused -- #278 reproduced. 0.98 as the non-SLTP path uses, so a
-            # full-fraction open leaves some maintenance buffer instead of zero.
-            # Reserve what the trader will CHARGE, or say so. float() alone is unsafe --
-            # MagicMock implements __float__ and returns 1.0 -- but an isinstance chain
-            # is worse: it rejects np.float32 and Decimal, which reproduces #278 with no
-            # diagnostic at all (the only log is the executor's "Insufficient balance",
-            # which reads like a small account rather than an under-reserving sizer).
-            # Coerce, range-check, and WARN on the fallback.
-            raw = getattr(self.trader, "transaction_fee", None)
-            fee = TAKER_FEE
-            if raw is not None:
-                try:
-                    candidate = float(raw)
-                except (TypeError, ValueError):
-                    candidate = None
-                if candidate is not None and math.isfinite(candidate) and 0 <= candidate < 1:
-                    fee = candidate
-                else:
-                    logger.warning(
-                        f"{self.config.symbol}: trader.transaction_fee={raw!r} is not a "
-                        f"usable rate; reserving the venue constant {TAKER_FEE}. If the "
-                        f"trader charges more, opens will be refused."
-                    )
-            quantity = abs(calculate_fractional_position(PositionCalculationParams(
-                balance=balance * 0.98,
-                action_value=self.config.position_fraction,
-                current_price=current_price,
-                leverage=self.config.leverage,
-                transaction_fee=fee,
-            ))[0])
-        elif self.config.trade_mode == "notional":
-            quantity = float(self.config.quantity_per_trade) / current_price
-        elif self.config.trade_mode == "quantity":
-            quantity = float(self.config.quantity_per_trade)
-        else:
-            raise ValueError(f"Unsupported trade_mode={self.config.trade_mode!r}")
+        quantity = self._resolve_bracket_quantity(current_price)
+        if quantity is None:
+            trade_info["success"] = False
+            return trade_info
 
         # Close opposite position if switching directions
         if self.position.current_position != 0:

--- a/torchtrade/envs/live/bybit/env_sltp.py
+++ b/torchtrade/envs/live/bybit/env_sltp.py
@@ -1,9 +1,4 @@
 """Bybit Futures TorchRL trading environment with Stop Loss and Take Profit."""
-from torchtrade.envs.utils.fractional_sizing import (
-    PositionCalculationParams,
-    calculate_fractional_position,
-)
-from torchtrade.envs.live.bybit.order_executor import TAKER_FEE
 import math
 from torchtrade.envs.live.shared.sltp_config import BaseFuturesSLTPConfig
 from dataclasses import dataclass
@@ -145,61 +140,10 @@ class BybitFuturesSLTPTorchTradingEnv(SLTPMixin, BybitBaseTorchTradingEnv):
                 f"venue reported an unusable mark price ({current_price})"
             )
 
-        # Resolve quantity based on trade_mode
-        if self.config.trade_mode == "fractional":
-            # Size on total_margin_balance (equity), matching offline sizing and the non-SLTP
-            # live path. Binance's total_wallet_balance excludes unrealized PnL and would under-size;
-            # bitget/bybit/okx map both keys to equity, so the switch is a no-op there.
-            # Under `_halting` -- the read that SIZES a bracket (#295).
-            balance = float(
-                self._halting(self.trader.get_account_balance, cache_key="balance")[
-                    "total_margin_balance"
-                ]
-            )
-            # current_price already raised in _current_mark_price(); balance has
-            # no such accessor, and `nan <= 0` is False (#347).
-            if not math.isfinite(balance) or balance <= 0:
-                logger.error(f"Invalid price={current_price} or balance={balance} for {self.config.symbol}")
-                trade_info["success"] = False
-                return trade_info
-            # Reserve what will actually be CHARGED: ReplayOrderExecutor carries its own
-            # rate, so reserving a constant left a higher-fee caller with every open
-            # refused -- #278 reproduced. 0.98 as the non-SLTP path uses, so a
-            # full-fraction open leaves some maintenance buffer instead of zero.
-            # Reserve what the trader will CHARGE, or say so. float() alone is unsafe --
-            # MagicMock implements __float__ and returns 1.0 -- but an isinstance chain
-            # is worse: it rejects np.float32 and Decimal, which reproduces #278 with no
-            # diagnostic at all (the only log is the executor's "Insufficient balance",
-            # which reads like a small account rather than an under-reserving sizer).
-            # Coerce, range-check, and WARN on the fallback.
-            raw = getattr(self.trader, "transaction_fee", None)
-            fee = TAKER_FEE
-            if raw is not None:
-                try:
-                    candidate = float(raw)
-                except (TypeError, ValueError):
-                    candidate = None
-                if candidate is not None and math.isfinite(candidate) and 0 <= candidate < 1:
-                    fee = candidate
-                else:
-                    logger.warning(
-                        f"{self.config.symbol}: trader.transaction_fee={raw!r} is not a "
-                        f"usable rate; reserving the venue constant {TAKER_FEE}. If the "
-                        f"trader charges more, opens will be refused."
-                    )
-            quantity = abs(calculate_fractional_position(PositionCalculationParams(
-                balance=balance * 0.98,
-                action_value=self.config.position_fraction,
-                current_price=current_price,
-                leverage=self.config.leverage,
-                transaction_fee=fee,
-            ))[0])
-        elif self.config.trade_mode == "notional":
-            quantity = float(self.config.quantity_per_trade) / current_price
-        elif self.config.trade_mode == "quantity":
-            quantity = float(self.config.quantity_per_trade)
-        else:
-            raise ValueError(f"Unsupported trade_mode={self.config.trade_mode!r}")
+        quantity = self._resolve_bracket_quantity(current_price)
+        if quantity is None:
+            trade_info["success"] = False
+            return trade_info
 
         # Close opposite position if switching directions
         # (we already returned above if same direction, so any existing position is opposite)

--- a/torchtrade/envs/live/okx/env_sltp.py
+++ b/torchtrade/envs/live/okx/env_sltp.py
@@ -1,9 +1,4 @@
 """OKX Futures TorchRL trading environment with Stop Loss and Take Profit."""
-from torchtrade.envs.utils.fractional_sizing import (
-    PositionCalculationParams,
-    calculate_fractional_position,
-)
-from torchtrade.envs.live.okx.order_executor import TAKER_FEE
 import math
 from torchtrade.envs.live.shared.sltp_config import BaseFuturesSLTPConfig
 from dataclasses import dataclass
@@ -147,61 +142,10 @@ class OKXFuturesSLTPTorchTradingEnv(SLTPMixin, OKXBaseTorchTradingEnv):
                 f"venue reported an unusable mark price ({current_price})"
             )
 
-        # Resolve quantity based on trade_mode
-        if self.config.trade_mode == "fractional":
-            # Size on total_margin_balance (equity), matching offline sizing and the non-SLTP
-            # live path. Binance's total_wallet_balance excludes unrealized PnL and would under-size;
-            # bitget/bybit/okx map both keys to equity, so the switch is a no-op there.
-            # Under `_halting` -- the read that SIZES a bracket (#295).
-            balance = float(
-                self._halting(self.trader.get_account_balance, cache_key="balance")[
-                    "total_margin_balance"
-                ]
-            )
-            # current_price already raised in _current_mark_price(); balance has
-            # no such accessor, and `nan <= 0` is False (#347).
-            if not math.isfinite(balance) or balance <= 0:
-                logger.error(f"Invalid price={current_price} or balance={balance} for {self.config.symbol}")
-                trade_info["success"] = False
-                return trade_info
-            # Reserve what will actually be CHARGED: ReplayOrderExecutor carries its own
-            # rate, so reserving a constant left a higher-fee caller with every open
-            # refused -- #278 reproduced. 0.98 as the non-SLTP path uses, so a
-            # full-fraction open leaves some maintenance buffer instead of zero.
-            # Reserve what the trader will CHARGE, or say so. float() alone is unsafe --
-            # MagicMock implements __float__ and returns 1.0 -- but an isinstance chain
-            # is worse: it rejects np.float32 and Decimal, which reproduces #278 with no
-            # diagnostic at all (the only log is the executor's "Insufficient balance",
-            # which reads like a small account rather than an under-reserving sizer).
-            # Coerce, range-check, and WARN on the fallback.
-            raw = getattr(self.trader, "transaction_fee", None)
-            fee = TAKER_FEE
-            if raw is not None:
-                try:
-                    candidate = float(raw)
-                except (TypeError, ValueError):
-                    candidate = None
-                if candidate is not None and math.isfinite(candidate) and 0 <= candidate < 1:
-                    fee = candidate
-                else:
-                    logger.warning(
-                        f"{self.config.symbol}: trader.transaction_fee={raw!r} is not a "
-                        f"usable rate; reserving the venue constant {TAKER_FEE}. If the "
-                        f"trader charges more, opens will be refused."
-                    )
-            quantity = abs(calculate_fractional_position(PositionCalculationParams(
-                balance=balance * 0.98,
-                action_value=self.config.position_fraction,
-                current_price=current_price,
-                leverage=self.config.leverage,
-                transaction_fee=fee,
-            ))[0])
-        elif self.config.trade_mode == "notional":
-            quantity = float(self.config.quantity_per_trade) / current_price
-        elif self.config.trade_mode == "quantity":
-            quantity = float(self.config.quantity_per_trade)
-        else:
-            raise ValueError(f"Unsupported trade_mode={self.config.trade_mode!r}")
+        quantity = self._resolve_bracket_quantity(current_price)
+        if quantity is None:
+            trade_info["success"] = False
+            return trade_info
 
         # Short-circuit if quantity is below exchange minimum
         lot = self.trader.get_lot_size()

--- a/torchtrade/envs/live/shared/futures_live_base.py
+++ b/torchtrade/envs/live/shared/futures_live_base.py
@@ -220,10 +220,6 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
         if self.config.trade_mode == "quantity":
             return float(self.config.quantity_per_trade)
         if self.config.trade_mode != "fractional":
-            # The config validates this in `__post_init__`, whose docstring says nothing
-            # downstream should guard. This is not that guard: it is the fall-through of
-            # an exhaustive dispatch, and deleting it would size an unknown mode as
-            # fractional rather than failing.
             raise ValueError(f"Unsupported trade_mode={self.config.trade_mode!r}")
 
         # total_margin_balance, not total_wallet_balance: binance's wallet figure excludes
@@ -255,13 +251,16 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
             )
             fee = self.TAKER_FEE
         # Same 0.98 maintenance buffer as `_calculate_fractional_position`.
-        return abs(calculate_fractional_position(PositionCalculationParams(
+        # No abs(): `position_fraction` is validated to (0, 1.0], so direction is always
+        # +1 here. Wrapping it would launder a corrupted fraction into a plausible positive
+        # quantity rather than letting a negative reach the venue and be refused.
+        return calculate_fractional_position(PositionCalculationParams(
             balance=balance * 0.98,
             action_value=self.config.position_fraction,
             current_price=current_price,
             leverage=self.config.leverage,
             transaction_fee=fee,
-        ))[0])
+        ))[0]
 
     def _finish_futures_init(self) -> None:
         """The tail every futures env ran verbatim after `super().__init__` (#288).

--- a/torchtrade/envs/live/shared/futures_live_base.py
+++ b/torchtrade/envs/live/shared/futures_live_base.py
@@ -208,6 +208,72 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
             transaction_fee=self.TAKER_FEE,
         ))
 
+    def _resolve_bracket_quantity(self, current_price: float):
+        """The quantity an SLTP bracket opens with, for all four futures venues (#288).
+
+        Four copies, code-identical: only a comment and okx's own min-qty check after it
+        differed. Returns None when the account cannot be sized against, which the caller
+        reports as a failed trade rather than a halt -- that asymmetry with the plain path
+        (which raises inside `_halting`) is pre-existing and preserved here deliberately.
+
+        `self.TAKER_FEE` rather than the module constant: the venues' fees differ, and the
+        class attribute #413 put on `<Venue>Base` is inherited by the SLTP siblings.
+        """
+        if self.config.trade_mode == "notional":
+            return float(self.config.quantity_per_trade) / current_price
+        if self.config.trade_mode == "quantity":
+            return float(self.config.quantity_per_trade)
+        if self.config.trade_mode != "fractional":
+            raise ValueError(f"Unsupported trade_mode={self.config.trade_mode!r}")
+
+        # Size on total_margin_balance (equity), matching offline sizing and the non-SLTP
+        # live path. Binance's total_wallet_balance excludes unrealized PnL and would
+        # under-size; bitget/bybit/okx map both keys to equity, so the switch is a no-op
+        # there. Under `_halting` -- the read that SIZES a bracket (#295).
+        balance = float(
+            self._halting(self.trader.get_account_balance, cache_key="balance")[
+                "total_margin_balance"
+            ]
+        )
+        # current_price already raised in `_current_mark_price()`; balance has no such
+        # accessor, and `nan <= 0` is False (#347).
+        if not math.isfinite(balance) or balance <= 0:
+            logger.error(
+                f"Invalid price={current_price} or balance={balance} for "
+                f"{self.config.symbol}"
+            )
+            return None
+
+        # Reserve what the trader will CHARGE, or say so. ReplayOrderExecutor carries its
+        # own rate, so reserving a constant left a higher-fee caller with every open
+        # refused (#278). `float()` alone is unsafe -- MagicMock implements __float__ and
+        # returns 1.0 -- but an isinstance chain is worse: it rejects np.float32 and
+        # Decimal, reproducing #278 with no diagnostic at all.
+        raw = getattr(self.trader, "transaction_fee", None)
+        fee = self.TAKER_FEE
+        if raw is not None:
+            try:
+                candidate = float(raw)
+            except (TypeError, ValueError):
+                candidate = None
+            if candidate is not None and math.isfinite(candidate) and 0 <= candidate < 1:
+                fee = candidate
+            else:
+                logger.warning(
+                    f"{self.config.symbol}: trader.transaction_fee={raw!r} is not a "
+                    f"usable rate; reserving the venue constant {self.TAKER_FEE}. If the "
+                    f"trader charges more, opens will be refused."
+                )
+        # 0.98 as the non-SLTP path uses, so a full-fraction open leaves some maintenance
+        # buffer instead of zero.
+        return abs(calculate_fractional_position(PositionCalculationParams(
+            balance=balance * 0.98,
+            action_value=self.config.position_fraction,
+            current_price=current_price,
+            leverage=self.config.leverage,
+            transaction_fee=fee,
+        ))[0])
+
     def _finish_futures_init(self) -> None:
         """The tail every futures env ran verbatim after `super().__init__` (#288).
 

--- a/torchtrade/envs/live/shared/futures_live_base.py
+++ b/torchtrade/envs/live/shared/futures_live_base.py
@@ -252,15 +252,28 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
             fee = self.TAKER_FEE
         # Same 0.98 maintenance buffer as `_calculate_fractional_position`.
         # No abs(): `position_fraction` is validated to (0, 1.0], so direction is always
-        # +1 here. Wrapping it would launder a corrupted fraction into a plausible positive
-        # quantity rather than letting a negative reach the venue and be refused.
-        return calculate_fractional_position(PositionCalculationParams(
+        # +1 and the wrap would be dead -- but a dead `abs()` is not harmless, it launders
+        # a corrupted fraction into a plausible positive order.
+        #
+        # Refusing here rather than letting a bad value reach the venue, because the four
+        # formatters disagree about what a negative quantity means: okx FLOORS it and then
+        # clamps up to min_qty, turning -244.5 into a 0.001 long; bitget and bybit pass it
+        # through and rely on the exchange to reject. One deterministic refusal beats three
+        # different downstream behaviours.
+        quantity = calculate_fractional_position(PositionCalculationParams(
             balance=balance * 0.98,
             action_value=self.config.position_fraction,
             current_price=current_price,
             leverage=self.config.leverage,
             transaction_fee=fee,
         ))[0]
+        if not quantity > 0:
+            logger.error(
+                f"{self.config.symbol}: sizing produced {quantity!r}, refusing rather than "
+                f"handing it to the venue formatter"
+            )
+            return None
+        return quantity
 
     def _finish_futures_init(self) -> None:
         """The tail every futures env ran verbatim after `super().__init__` (#288).

--- a/torchtrade/envs/live/shared/futures_live_base.py
+++ b/torchtrade/envs/live/shared/futures_live_base.py
@@ -208,16 +208,15 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
             transaction_fee=self.TAKER_FEE,
         ))
 
-    def _resolve_bracket_quantity(self, current_price: float):
+    def _resolve_bracket_quantity(self, current_price: float) -> float | None:
         """The quantity an SLTP bracket opens with, for all four futures venues (#288).
 
-        Four copies, code-identical: only a comment and okx's own min-qty check after it
-        differed. Returns None when the account cannot be sized against, which the caller
-        reports as a failed trade rather than a halt -- that asymmetry with the plain path
-        (which raises inside `_halting`) is pre-existing and preserved here deliberately.
-
-        `self.TAKER_FEE` rather than the module constant: the venues' fees differ, and the
-        class attribute #413 put on `<Venue>Base` is inherited by the SLTP siblings.
+        None means the account cannot be sized against, and the caller reports a FAILED
+        TRADE rather than halting. The plain path raises inside the `_halting` closure so
+        the same input becomes a halt instead. That divergence predates this fold and is
+        preserved by it, not endorsed: a venue reporting equity 0.0 mid-liquidation gets
+        `success=False` here, no grace counter and no truncation, and retries next bar.
+        Moving the verdict inside the closure is #295's shape and belongs in its own PR.
         """
         if self.config.trade_mode == "notional":
             return float(self.config.quantity_per_trade) / current_price
@@ -226,46 +225,37 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
         if self.config.trade_mode != "fractional":
             raise ValueError(f"Unsupported trade_mode={self.config.trade_mode!r}")
 
-        # Size on total_margin_balance (equity), matching offline sizing and the non-SLTP
-        # live path. Binance's total_wallet_balance excludes unrealized PnL and would
-        # under-size; bitget/bybit/okx map both keys to equity, so the switch is a no-op
-        # there. Under `_halting` -- the read that SIZES a bracket (#295).
+        # total_margin_balance, not total_wallet_balance: binance's wallet figure excludes
+        # unrealized PnL and would under-size. Under `_halting` -- the read that SIZES a
+        # bracket (#295).
         balance = float(
             self._halting(self.trader.get_account_balance, cache_key="balance")[
                 "total_margin_balance"
             ]
         )
-        # current_price already raised in `_current_mark_price()`; balance has no such
-        # accessor, and `nan <= 0` is False (#347).
+        # isfinite, not just `<= 0`: `nan <= 0` is False, so a NaN balance would size a
+        # NaN bracket (#347). Callers validate current_price before calling.
         if not math.isfinite(balance) or balance <= 0:
-            logger.error(
-                f"Invalid price={current_price} or balance={balance} for "
-                f"{self.config.symbol}"
-            )
+            logger.error(f"Cannot size against balance={balance} for {self.config.symbol}")
             return None
 
-        # Reserve what the trader will CHARGE, or say so. ReplayOrderExecutor carries its
-        # own rate, so reserving a constant left a higher-fee caller with every open
-        # refused (#278). `float()` alone is unsafe -- MagicMock implements __float__ and
-        # returns 1.0 -- but an isinstance chain is worse: it rejects np.float32 and
-        # Decimal, reproducing #278 with no diagnostic at all.
+        # Reserve what the trader will CHARGE: ReplayOrderExecutor carries its own rate,
+        # so reserving the venue constant refused every open for a higher-fee caller (#278).
         raw = getattr(self.trader, "transaction_fee", None)
-        fee = self.TAKER_FEE
-        if raw is not None:
-            try:
-                candidate = float(raw)
-            except (TypeError, ValueError):
-                candidate = None
-            if candidate is not None and math.isfinite(candidate) and 0 <= candidate < 1:
-                fee = candidate
-            else:
-                logger.warning(
-                    f"{self.config.symbol}: trader.transaction_fee={raw!r} is not a "
-                    f"usable rate; reserving the venue constant {self.TAKER_FEE}. If the "
-                    f"trader charges more, opens will be refused."
-                )
-        # 0.98 as the non-SLTP path uses, so a full-fraction open leaves some maintenance
-        # buffer instead of zero.
+        try:
+            fee = self.TAKER_FEE if raw is None else float(raw)
+        except (TypeError, ValueError):
+            fee = None
+        # NaN and both infinities fail this range test on their own; an isfinite term here
+        # could never change an outcome.
+        if fee is None or not 0 <= fee < 1:
+            logger.warning(
+                f"{self.config.symbol}: trader.transaction_fee={raw!r} is not a usable "
+                f"rate; reserving the venue constant {self.TAKER_FEE}. If the trader "
+                f"charges more, opens will be refused."
+            )
+            fee = self.TAKER_FEE
+        # Same 0.98 maintenance buffer as `_calculate_fractional_position`.
         return abs(calculate_fractional_position(PositionCalculationParams(
             balance=balance * 0.98,
             action_value=self.config.position_fraction,

--- a/torchtrade/envs/live/shared/futures_live_base.py
+++ b/torchtrade/envs/live/shared/futures_live_base.py
@@ -173,8 +173,7 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
         """Target position size from a fractional action, for all four futures venues.
         """
         # Above the balance read on purpose: a flat action must not need the exchange.
-        # No caller reaches this today -- all four pre-filter zero -- so it guards a
-        # caller that stops doing so, not a live path.
+        # No caller reaches this today -- all four pre-filter zero.
         if action_value == 0.0:
             return 0.0, 0.0, "flat"
 
@@ -213,16 +212,18 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
 
         None means the account cannot be sized against, and the caller reports a FAILED
         TRADE rather than halting. The plain path raises inside the `_halting` closure so
-        the same input becomes a halt instead. That divergence predates this fold and is
-        preserved by it, not endorsed: a venue reporting equity 0.0 mid-liquidation gets
-        `success=False` here, no grace counter and no truncation, and retries next bar.
-        Moving the verdict inside the closure is #295's shape and belongs in its own PR.
+        the same input becomes a halt instead -- a divergence this fold preserves rather
+        than endorses (#416).
         """
         if self.config.trade_mode == "notional":
             return float(self.config.quantity_per_trade) / current_price
         if self.config.trade_mode == "quantity":
             return float(self.config.quantity_per_trade)
         if self.config.trade_mode != "fractional":
+            # The config validates this in `__post_init__`, whose docstring says nothing
+            # downstream should guard. This is not that guard: it is the fall-through of
+            # an exhaustive dispatch, and deleting it would size an unknown mode as
+            # fractional rather than failing.
             raise ValueError(f"Unsupported trade_mode={self.config.trade_mode!r}")
 
         # total_margin_balance, not total_wallet_balance: binance's wallet figure excludes
@@ -246,8 +247,6 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
             fee = self.TAKER_FEE if raw is None else float(raw)
         except (TypeError, ValueError):
             fee = None
-        # NaN and both infinities fail this range test on their own; an isfinite term here
-        # could never change an outcome.
         if fee is None or not 0 <= fee < 1:
             logger.warning(
                 f"{self.config.symbol}: trader.transaction_fee={raw!r} is not a usable "


### PR DESCRIPTION
Slice 5 of #288. `_resolve_bracket_quantity` on `TorchTradeFuturesLiveEnv` replaces the trade_mode dispatch, halted balance read, fee resolution and sizing call that each `<venue>/env_sltp.py` carried its own copy of.

**Production `+82/−216` (net −134).** Suite 4359, 0 failed.

## What the four copies actually were

Measured, not assumed: 85 of binance's 197 lines were shared with all three others, and the largest shared run is this 53-line block.

- **bybit vs binance** — differs by a two-line *comment*. Code byte-identical.
- **okx** — that same comment, plus a real five-line min-qty short-circuit. That one stays in okx.

So the sizing was code-identical four ways, and the venue difference was one guard rather than a signature. It reads `self.TAKER_FEE` rather than the module constant — the class attribute #413 put on `<Venue>Base` is inherited by the SLTP siblings, which is the plumbing that slice set up for this one.

## Equivalence, proven

**864 cases per tree** — 4 venues × 4 trade modes × 2 prices × 3 leverages × 3 balances (including `0.0` and `NaN`) × 3 `trader.transaction_fee` values (absent, valid, unusable) — comparing both the returned quantity **and** the exact params reaching `calculate_fractional_position`. **Zero differ**, with `assert torchtrade.__file__.startswith(tree)` on both sides so the probe cannot read the wrong one.

## Two things worth your attention in review

**The dead imports masked my own verification.** The fold left `TAKER_FEE`, `calculate_fractional_position` and `PositionCalculationParams` imported-but-unused in all four venue files — 12 dead names. My probe patches `calculate_fractional_position` *wherever it is bound*, found the dead import in the venue module, and patched that one — while the shared method used its own. The spy recorded nothing and 144 rows read as divergent when the quantities were identical in all of them. Removing the dead imports fixed the probe as well as the code.

**The SLTP finiteness guard failed on all four venues** when the code moved — it was a file scan of `env_sltp.py`, and the balance check now lives in the shared base. Third file-scan guard in this series to break on a fold, and right every time. It resolves the method and follows the delegation now; the `current_price` half still reads the venue body, which is where that check still lives for binance and bitget.

## Still open after this

The SLTP fee's `trader.transaction_fee` fallback degrades on an unusable value with only a `logger.warning`, and that branch has no test in either direction. It is now in **one** place rather than four, so it is finally cheap to pin — but it is behaviour this PR preserves rather than changes, so I have not touched it here.

Review rounds to follow.