### PR TITLE
refactor(288): fold the last two SLTP executors; the split was one line

### DIFF
--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -282,7 +282,7 @@ def test_non_sltp_step_syncs_before_it_trades(env_cls):
     """
     step = env_cls._step
     sync = _first_call_position(step, {"_sync_position_from_exchange"})
-    # NOT `_dispatch_sltp_trade`: this is parametrized over NON_SLTP_ENVS, which cannot
+    # NOT the SLTP executor: this is parametrized over NON_SLTP_ENVS, which cannot
     # contain an SLTP env, so adding it read as coverage that could never bind.
     trade = _first_call_position(step, {"_execute_trade_if_needed"})
 
@@ -328,13 +328,13 @@ def test_every_live_step_validates_its_action_before_it_trades(env_cls):
     step = env_cls._step
     resolve = _first_call_position(step, {
         "_resolve_action_level", "_resolve_action_index", "_resolve_action_tuple"})
-    # `_dispatch_sltp_trade` is the SLTP trade call as of #288: the shared `_step` hands
+    # `_execute_trade_if_needed` is the SLTP trade call: the shared `_step` hands
     # off through it so bybit/okx can thread the mark. Naming only the executor made this
     # guard find no trade call at all on the four SLTP venues, which is a TypeError rather
     # than a missed ordering -- loud, but only because the list that feeds it was fixed
     # first. Keyed on the wrong name it would simply have stopped constraining anything.
     trade = _first_call_position(
-        step, {"_execute_trade_if_needed", "_dispatch_sltp_trade"}
+        step, {"_execute_trade_if_needed"}
     )
 
     assert resolve is not None, (
@@ -2694,7 +2694,7 @@ def test_the_pre_trade_read_halts_like_the_post_bar_one(exchange, module):
     # this already existed two hundred lines up; I reached for `in source` anyway.
     acquire = _first_call_position(cls._step, {"_acquire_pre_trade_state"})
     trade = _first_call_position(
-        cls._step, {"_execute_trade_if_needed", "_dispatch_sltp_trade"}
+        cls._step, {"_execute_trade_if_needed"}
     )
     assert acquire is not None, (
         f"{exchange}/{module}'s resolved _step reads the venue before trading without "
@@ -4242,10 +4242,9 @@ def test_dependency_injection_still_skips_construction_entirely():
 # would hand a spot env the futures step.
 # Per OWNER, because the two own different method sets.
 #
-# `_dispatch_sltp_trade` is deliberately ABSENT. It is the venue-variation hook -- its own
-# docstring calls it "the ONE thing `_step` varies by venue" -- and bybit and okx really do
-# override it, to thread the price rather than re-read it (#295). Guarding it would demand
-# a fold of the one method that exists not to be folded.
+# `_dispatch_sltp_trade` is gone: once `_bracket_entry_price` took over the venue
+# split it was a forwarder with one caller and zero overrides, so `_step` calls
+# the executor directly now.
 _SHARED_METHOD_OWNERSHIP = [
     # `_record_and_score` is owned by TorchTradeLiveEnv and reached by all TEN stepping
     # envs, alpaca included -- the only tail in this file that alpaca shares (#288).
@@ -4268,7 +4267,7 @@ _SHARED_METHOD_OWNERSHIP = [
         # bybit+okx split that no longer exists -- so they guarded nothing on the two
         # venues the fold had just changed. A faithful copy of the executor pasted back
         # onto bybit passed all 3445 tests while those guards were still in place.
-        "_dispatch_sltp_trade", "_execute_trade_if_needed",
+        "_execute_trade_if_needed",
     )),
 ]
 # By NAME, not by count. Dropping `_reset` from the matrix above passed 936 tests: the
@@ -4286,7 +4285,6 @@ assert {(owner.__name__, method) for _, owner, method in _SHARED_METHOD_OWNERSHI
     ("SLTPMixin", "_record_sltp_position"),
     ("SLTPMixin", "_reset_sltp_state"),
     ("SLTPMixin", "_close_action"),
-    ("SLTPMixin", "_dispatch_sltp_trade"),
     ("SLTPMixin", "_execute_trade_if_needed"),
 }
 
@@ -4819,7 +4817,7 @@ def test_a_refused_sltp_bracket_does_not_write_a_phantom_position(trade_info,
     duplication costs, in the gate rather than in the code.
     """
     env, trader = _real_futures_env(budget=0, venue="binance", sltp=True)
-    env._dispatch_sltp_trade = lambda action_tuple, current_price: trade_info
+    env._execute_trade_if_needed = lambda action_tuple, current_price=None: trade_info
 
     td = env.reset()
     assert env.position.current_position == 0, "setup: expected to start flat"
@@ -5115,10 +5113,9 @@ def _fire_close(env):
     assert env.action_map[1] == ("close", None, None), (
         f"slot 1 is {env.action_map[1]}, not CLOSE"
     )
-    # Through `_dispatch_sltp_trade`, the seam `_step` uses: it has uniform arity on all
-    # four venues and already owns the `*, current_price` split. Sniffing the signature
-    # here re-derived that split in the test, which is the duplication #288 removes.
-    return env._dispatch_sltp_trade(env.action_map[1], 100.0)
+    # Through the executor with the mark threaded, exactly as `_step` calls it. Sniffing
+    # the signature here re-derived a venue split the test has no business knowing.
+    return env._execute_trade_if_needed(env.action_map[1], current_price=100.0)
 
 
 @pytest.mark.parametrize("venue", _SLTP_VENUES)
@@ -5250,7 +5247,7 @@ def test_a_failed_flatten_does_not_send_the_entry_that_follows_it(venue, outcome
     else:
         trader.close_position.side_effect = RuntimeError("venue refused the flatten")
 
-    info = env._dispatch_sltp_trade(("short", 0.03, -0.02), 100.0)
+    info = env._execute_trade_if_needed(("short", 0.03, -0.02), current_price=100.0)
 
     assert not trader.trade.called, (
         f"{venue}: the flatten failed but the entry was sent anyway -- the venue now holds "
@@ -5300,7 +5297,7 @@ def test_a_bracket_leg_the_venue_rejected_is_not_recorded_as_live(venue, sl_plac
     trader.bracket_status = {"sl_placed": sl_placed, "tp_placed": tp_placed}
     trader.trade.return_value = True
 
-    info = env._dispatch_sltp_trade(("long", -0.02, 0.03), 100.0)
+    info = env._execute_trade_if_needed(("long", -0.02, 0.03), current_price=100.0)
     assert info["executed"], f"{venue}: setup failed, the entry never went out"
 
     assert (env.active_stop_loss != 0.0) is sl_placed, (
@@ -5324,7 +5321,7 @@ def test_a_policy_can_still_flatten_when_the_feed_is_degraded(venue):
     env, trader = _close_env(venue, 1)
     env.observer.get_observations.side_effect = ValueError("stale bar")
 
-    info = env._dispatch_sltp_trade(env.action_map[1], 100.0)
+    info = env._execute_trade_if_needed(env.action_map[1], current_price=100.0)
 
     assert trader.close_position.called, (
         f"{venue}: the feed went stale and the close was blocked with it -- the policy "
@@ -5358,7 +5355,7 @@ def test_an_unrecognised_side_reaches_no_venue_call_at_all(venue, sizeable):
         env._resolve_bracket_quantity = lambda price: None
 
     with pytest.raises(ValueError, match="Invalid side"):
-        env._dispatch_sltp_trade(("bogus", -0.02, 0.03), 100.0)
+        env._execute_trade_if_needed(("bogus", -0.02, 0.03), current_price=100.0)
 
     assert not trader.close_position.called, (
         f"{venue}: a bad side flattened the position before raising."
@@ -5381,7 +5378,7 @@ def test_a_completed_switch_arms_the_new_positions_brackets(venue):
     trader.close_position.return_value = True
     trader.trade.return_value = True
 
-    env._dispatch_sltp_trade(("short", 0.03, -0.02), 100.0)
+    env._execute_trade_if_needed(("short", 0.03, -0.02), current_price=100.0)
 
     expected_sl, expected_tp = calculate_bracket_prices("short", 100.0, 0.03, -0.02)
     assert (env.active_stop_loss, env.active_take_profit) == (expected_sl, expected_tp), (
@@ -5413,7 +5410,7 @@ def test_a_flatten_takes_the_old_positions_brackets_with_it(venue, entry):
     else:
         trader.trade.side_effect = RuntimeError("venue rejected the entry")
 
-    env._dispatch_sltp_trade(("short", 0.03, -0.02), 100.0)
+    env._execute_trade_if_needed(("short", 0.03, -0.02), current_price=100.0)
 
     assert trader.close_position.called and env.position.current_position == 0
     # Without this the test passes on a mutant that returns between the close and the
@@ -5445,7 +5442,7 @@ def test_an_unusable_entry_price_refuses_instead_of_sizing_from_it(venue, bad):
         # The threaded mark is validated directly: no halt policy wraps it, because
         # `_step` already took it under one.
         expected = ValueError
-        drive = lambda: env._dispatch_sltp_trade(("long", -0.02, 0.03), bad)
+        drive = lambda: env._execute_trade_if_needed(("long", -0.02, 0.03), current_price=bad)
     else:
         # The candle read runs INSIDE `_halting`, which converts the guard's ValueError
         # into the halt type so a degraded feed truncates rather than crashing (#295).
@@ -5457,7 +5454,7 @@ def test_an_unusable_entry_price_refuses_instead_of_sizing_from_it(venue, bad):
         env.observer.get_observations.side_effect = None
         env.observer.get_observations.return_value = {
             "base_features": np.full((10, 4), bad, dtype=np.float64)}
-        drive = lambda: env._dispatch_sltp_trade(("long", -0.02, 0.03), 100.0)
+        drive = lambda: env._execute_trade_if_needed(("long", -0.02, 0.03), current_price=100.0)
 
     with pytest.raises(expected):
         drive()

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -4011,13 +4011,6 @@ def test_every_successful_close_invalidates_the_cached_balance():
     # `_finish_futures_init` runs at CONSTRUCTION, before any read has been cached, so
     # its startup flatten has nothing to invalidate -- same ordering argument as `_reset`.
     EXEMPT = {"_halting", "_reset", "_finish_futures_init"}
-    # `_mark_flat` is where the pop now lives, so it is asserted directly rather than
-    # trusted: accepting a call to it above is only safe while it really does invalidate.
-    from torchtrade.envs.utils.sltp_mixin import SLTPMixin as _Mixin
-    assert '.pop("balance"' in inspect.getsource(_Mixin._mark_flat), (
-        "_mark_flat stopped invalidating the cached balance, and every caller that "
-        "delegates to it silently stopped invalidating too"
-    )
     root = pathlib.Path(inspect.getfile(TorchTradeLiveEnv)).parent.parent / "live"
     offenders = []
     # The mixin is in the list because #288 MOVED the close there: globbing only
@@ -4267,7 +4260,11 @@ _SHARED_METHOD_OWNERSHIP = [
         # bybit+okx split that no longer exists -- so they guarded nothing on the two
         # venues the fold had just changed. A faithful copy of the executor pasted back
         # onto bybit passed all 3445 tests while those guards were still in place.
-        "_execute_trade_if_needed",
+        # `_bracket_entry_price` could only join once the venue split moved from two bound
+        # implementations to one method reading `_PRICES_OFF_THREADED_MARK`. Being the one
+        # shared method that could NOT sit in this table is exactly the condition that
+        # left it needing a bespoke guard, which is how the round-1 gap happened.
+        "_execute_trade_if_needed", "_bracket_entry_price",
     )),
 ]
 # By NAME, not by count. Dropping `_reset` from the matrix above passed 936 tests: the
@@ -4286,6 +4283,7 @@ assert {(owner.__name__, method) for _, owner, method in _SHARED_METHOD_OWNERSHI
     ("SLTPMixin", "_reset_sltp_state"),
     ("SLTPMixin", "_close_action"),
     ("SLTPMixin", "_execute_trade_if_needed"),
+    ("SLTPMixin", "_bracket_entry_price"),
 }
 
 
@@ -4710,16 +4708,10 @@ def test_each_venue_prices_its_bracket_from_the_source_it_intends(cls):
     price brackets off a value their `_step` never validated.
     """
     venue = cls.__module__.split(".")[-2]
-    resolved = cls._bracket_entry_price
-    if venue in _MARK_PRICED:
-        assert resolved is SLTPMixin._validated_mark_price, (
-            f"{cls.__name__} no longer prices off the threaded mark -- it re-reads the "
-            f"observer inside the trade path, which is the #295 regression"
-        )
-    else:
-        assert resolved is SLTPMixin._bracket_entry_price, (
-            f"{cls.__name__} stopped using the shared candle-close read"
-        )
+    assert cls._PRICES_OFF_THREADED_MARK is (venue in _MARK_PRICED), (
+        f"{cls.__name__} has _PRICES_OFF_THREADED_MARK="
+        f"{cls._PRICES_OFF_THREADED_MARK}, which is backwards for this venue"
+    )
 
 
 @pytest.mark.parametrize("cls,owner,method", _SHARED_METHOD_OWNERSHIP,
@@ -4861,9 +4853,8 @@ def test_the_trade_takes_the_qty_and_price_the_pre_trade_read_acquired():
     It does not prove a venue's executor then uses those values rather than re-reading;
     that is the venues' own contract, covered behaviourally by the SLTP grace-bar tests.
 
-    `_execute_trade_if_needed` is shared by binance and bitget as of #288 and overridden
-    by bybit/okx, so this contract belongs where the shared `_step` is owned rather than
-    in one venue's file -- and more so now that two venues resolve it from the mixin.
+    `_execute_trade_if_needed` is shared by all four venues as of #288, so this contract
+    belongs where the shared `_step` is owned rather than in one venue's file.
 
     The venue reports something DIFFERENT after the first read. That is the whole design:
     with the fixture's constant mocks a re-read returns the identical value, so the first

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -2196,14 +2196,11 @@ def test_sltp_sizing_rejects_a_non_finite_price_or_balance(exchange):
         f"{exchange}'s trade path does not CALL the shared sizing; an inlined copy that "
         f"names it in a comment would satisfy a text search"
     )
-    # WHICH implementation each venue uses is pinned by identity in
-    # `test_each_venue_prices_its_bracket_from_the_source_it_intends`; the substring pair
-    # that used to live here said the same thing more weakly. What remains is the only
-    # assertion in this test with a unique kill: dropping `isfinite` from either
-    # implementation dies here and nowhere else in 4465 tests.
-    assert "math.isfinite" in inspect.getsource(cls._bracket_entry_price), (
-        f"{exchange} resolves its entry price with no finiteness check"
-    )
+    # The finiteness grep that used to live here is gone. It was dominated by
+    # `test_an_unusable_entry_price_refuses_instead_of_sizing_from_it`, added the same
+    # round: a guard that NAMES math.isfinite and refuses nothing passes the grep and
+    # fails the behavioural test, and a correct guard written without the literal fails
+    # the grep on working code. It generated false positives in both directions.
 
 
 @pytest.mark.parametrize("exchange,side_key,side", [
@@ -4255,6 +4252,11 @@ _SHARED_METHOD_OWNERSHIP = [
     *((c, SLTPMixin, m) for c in SLTP_FUTURES_ENVS for m in (
         "_step", "_reset", "_resolve_action_tuple", "_record_sltp_position",
         "_reset_sltp_state", "_close_action",
+        # `_mark_flat` is here because it was introduced UNGUARDED three commits into this
+        # PR and a verbatim copy pasted onto bybit passed the whole suite -- the round-1
+        # finding, reproduced on the method written to fix the round-1 finding. It has
+        # three callers now, so a private copy would silently drift on one of them.
+        "_mark_flat",
         # Both joined the uniform table when the fold removed the last venue overrides.
         # They had their own inheritor/overrider guards, keyed on a binance+bitget vs
         # bybit+okx split that no longer exists -- so they guarded nothing on the two
@@ -4282,6 +4284,7 @@ assert {(owner.__name__, method) for _, owner, method in _SHARED_METHOD_OWNERSHI
     ("SLTPMixin", "_record_sltp_position"),
     ("SLTPMixin", "_reset_sltp_state"),
     ("SLTPMixin", "_close_action"),
+    ("SLTPMixin", "_mark_flat"),
     ("SLTPMixin", "_execute_trade_if_needed"),
     ("SLTPMixin", "_bracket_entry_price"),
 }
@@ -5371,6 +5374,13 @@ def test_a_completed_switch_arms_the_new_positions_brackets(venue):
 
     env._execute_trade_if_needed(("short", 0.03, -0.02), current_price=100.0)
 
+    # The pop is pinned from the CLOSE site by the close tests; from here it was pinned
+    # only by a source grep. `_resolve_bracket_quantity` caches the balance BEFORE the
+    # flatten, so the invalidation is genuinely last and this observes it.
+    assert "balance" not in env._last_confirmed_read, (
+        f"{venue}: the flatten realised P&L but the cached sizing balance survived it"
+    )
+
     expected_sl, expected_tp = calculate_bracket_prices("short", 100.0, 0.03, -0.02)
     assert (env.active_stop_loss, env.active_take_profit) == (expected_sl, expected_tp), (
         f"{venue}: switched into a short but the bracket levels are "
@@ -5451,4 +5461,27 @@ def test_an_unusable_entry_price_refuses_instead_of_sizing_from_it(venue, bad):
         drive()
     assert not trader.trade.called, (
         f"{venue}: sized and priced a bracket from {bad!r}"
+    )
+
+
+@pytest.mark.parametrize("venue", _SLTP_VENUES)
+def test_a_venue_that_reports_no_bracket_status_records_both_legs(venue):
+    """The `getattr(trader, "bracket_status", {both True})` default, which no test reached.
+
+    `_real_futures_env` builds the trader as a MagicMock, and a MagicMock auto-creates any
+    attribute — so `getattr` always found one and the default branch was dead in every
+    test. That default is not a fallback for bybit and okx: their executors never set the
+    attribute, so it IS their production path, and it decides whether they record their
+    brackets at all. Flipping it to False survived the whole suite.
+    """
+    env, trader = _close_env(venue, 0)
+    del trader.bracket_status
+    trader.trade.return_value = True
+
+    env._execute_trade_if_needed(("long", -0.02, 0.03), current_price=100.0)
+
+    sl, tp = calculate_bracket_prices("long", 100.0, -0.02, 0.03)
+    assert (env.active_stop_loss, env.active_take_profit) == (sl, tp), (
+        f"{venue}: a venue that reports no per-leg status must be taken at its word that "
+        f"both legs placed -- otherwise bybit and okx record no brackets at all."
     )

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -5376,3 +5376,34 @@ def test_an_unrecognised_side_reaches_no_venue_call_at_all(venue, sizeable):
     )
     assert not trader.trade.called
     assert env.position.current_position == 1
+
+
+@pytest.mark.parametrize("venue", _SLTP_VENUES)
+@pytest.mark.parametrize("entry", ["refused", "raised"])
+def test_a_flatten_takes_the_old_positions_brackets_with_it(venue, entry):
+    """Switching directions closes, then opens. If the OPEN fails after the close
+    succeeded, the account is flat but `active_stop_loss`/`active_take_profit` still hold
+    the closed position's levels -- and the next sync is flat -> flat, so
+    `_sync_position_from_exchange` never clears them either. They read as live protection
+    on a position that no longer exists.
+
+    okx alone cleared them before #288 folded the executors; the fold dropped that and the
+    other three never had it. Found by @CharlieHelps, and missed by a 324-case
+    differential probe that initialised both fields to 0.0 -- the same value a correct
+    clear produces, so "cleared" and "never set" were indistinguishable in every case.
+    The non-zero setup below is the entire point of the test.
+    """
+    env, trader = _close_env(venue, 1)                 # long open, brackets at 90/110
+    trader.close_position.return_value = True          # the flatten SUCCEEDS
+    if entry == "refused":
+        trader.trade.return_value = False              # the replacement entry does not
+    else:
+        trader.trade.side_effect = RuntimeError("venue rejected the entry")
+
+    env._dispatch_sltp_trade(("short", 0.03, -0.02), 100.0)
+
+    assert trader.close_position.called and env.position.current_position == 0
+    assert env.active_stop_loss == 0.0 and env.active_take_profit == 0.0, (
+        f"{venue}: flat after the flatten, but the closed position's brackets survive as "
+        f"sl={env.active_stop_loss} tp={env.active_take_profit} -- nothing clears them now."
+    )

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -4021,6 +4021,13 @@ def test_every_successful_close_invalidates_the_cached_balance():
     # `_finish_futures_init` runs at CONSTRUCTION, before any read has been cached, so
     # its startup flatten has nothing to invalidate -- same ordering argument as `_reset`.
     EXEMPT = {"_halting", "_reset", "_finish_futures_init"}
+    # `_mark_flat` is where the pop now lives, so it is asserted directly rather than
+    # trusted: accepting a call to it above is only safe while it really does invalidate.
+    from torchtrade.envs.utils.sltp_mixin import SLTPMixin as _Mixin
+    assert '.pop("balance"' in inspect.getsource(_Mixin._mark_flat), (
+        "_mark_flat stopped invalidating the cached balance, and every caller that "
+        "delegates to it silently stopped invalidating too"
+    )
     root = pathlib.Path(inspect.getfile(TorchTradeLiveEnv)).parent.parent / "live"
     offenders = []
     # The mixin is in the list because #288 MOVED the close there: globbing only
@@ -4039,11 +4046,17 @@ def test_every_successful_close_invalidates_the_cached_balance():
                       and n.func.attr == "close_position"]
             if not closes:
                 continue
+            # A direct `.pop("balance")` OR a call to `_mark_flat`, which is the one
+            # place that pop is allowed to live. Counting only the literal pop made this
+            # guard fail the moment the pop was folded into a helper -- the third time in
+            # this issue that a structural check stopped finding its subject because the
+            # subject moved. Delegation is the thing being asserted, so accept it.
             invalidations = [n for n in ast.walk(fn)
                              if isinstance(n, ast.Call) and isinstance(n.func, ast.Attribute)
-                             and n.func.attr == "pop" and n.args
-                             and isinstance(n.args[0], ast.Constant)
-                             and n.args[0].value == "balance"]
+                             and ((n.func.attr == "pop" and n.args
+                                   and isinstance(n.args[0], ast.Constant)
+                                   and n.args[0].value == "balance")
+                                  or n.func.attr == "_mark_flat")]
             if len(invalidations) < len(closes):
                 offenders.append(f"{path.parent.name}/{path.name}::{fn.name} "
                                  f"({len(closes)} closes, {len(invalidations)} invalidations)")
@@ -4260,6 +4273,12 @@ _SHARED_METHOD_OWNERSHIP = [
     *((c, SLTPMixin, m) for c in SLTP_FUTURES_ENVS for m in (
         "_step", "_reset", "_resolve_action_tuple", "_record_sltp_position",
         "_reset_sltp_state", "_close_action",
+        # Both joined the uniform table when the fold removed the last venue overrides.
+        # They had their own inheritor/overrider guards, keyed on a binance+bitget vs
+        # bybit+okx split that no longer exists -- so they guarded nothing on the two
+        # venues the fold had just changed. A faithful copy of the executor pasted back
+        # onto bybit passed all 3445 tests while those guards were still in place.
+        "_dispatch_sltp_trade", "_execute_trade_if_needed",
     )),
 ]
 # By NAME, not by count. Dropping `_reset` from the matrix above passed 936 tests: the
@@ -4277,6 +4296,8 @@ assert {(owner.__name__, method) for _, owner, method in _SHARED_METHOD_OWNERSHI
     ("SLTPMixin", "_record_sltp_position"),
     ("SLTPMixin", "_reset_sltp_state"),
     ("SLTPMixin", "_close_action"),
+    ("SLTPMixin", "_dispatch_sltp_trade"),
+    ("SLTPMixin", "_execute_trade_if_needed"),
 }
 
 
@@ -4676,76 +4697,41 @@ def test_the_fold_did_not_move_a_single_sized_position(venue, leverage, exp_size
     )
 
 
-# binance and bitget take the mixin's `_dispatch_sltp_trade`; bybit and okx override it to
-# thread the price (#295). That split is intended, so the hook is out of the uniform table
-# above -- but "intended for two venues" is not "unguarded for the other two": a later
-# private override in binance or bitget would otherwise evade every guard in this file.
-_DISPATCH_INHERITORS = [c for c in SLTP_FUTURES_ENVS
-                        if c.__module__.split(".")[-2] in ("binance", "bitget")]
-_DISPATCH_OVERRIDERS = [c for c in SLTP_FUTURES_ENVS
-                        if c.__module__.split(".")[-2] in ("bybit", "okx")]
-assert len(_DISPATCH_INHERITORS) == len(_DISPATCH_OVERRIDERS) == 2
+# `_dispatch_sltp_trade` and `_execute_trade_if_needed` used to split binance/bitget from
+# bybit/okx, and had their own inheritor/overrider lists here. That split is gone: the mixin
+# forwards the mark unconditionally and `_bracket_entry_price` decides whether to use it, so
+# both methods now live in the uniform table above and a private copy on ANY venue fails.
+#
+# The variation did not disappear, it moved -- and a guard that does not move with it stops
+# guarding. Appending a faithful copy of the shared executor back onto bybit passed all 3445
+# tests while the old lists were still keyed on the pre-fold split.
+_MARK_PRICED = ("bybit", "okx")
 
 
-@pytest.mark.parametrize("cls", _DISPATCH_INHERITORS, ids=lambda c: c.__name__)
-def test_the_dispatch_hook_is_inherited_where_it_is_not_deliberately_overridden(cls):
-    """The venue-variation hook is still owned, for the venues that do not vary.
+@pytest.mark.parametrize("cls", SLTP_FUTURES_ENVS, ids=lambda c: c.__name__)
+def test_each_venue_prices_its_bracket_from_the_source_it_intends(cls):
+    """`_bracket_entry_price` is the one thing the four SLTP venues vary (#288).
 
-    bybit and okx override `_dispatch_sltp_trade` to pass the threaded price rather than
-    let the executor re-read it (#295). binance and bitget price their brackets off a
-    candle close and take the mixin's default -- so for them a private copy is a re-fork
-    like any other, and nothing said so.
+    bybit and okx must resolve `_validated_mark_price` -- the mark `_step` already took
+    under the halt policy. Re-reading it inside the trade path is what #295 removed, and
+    an accidental fall-back to the mixin default is exactly that regression: it would read
+    the observer again, silently, and still pass every behavioural test because the mocked
+    close and the mocked mark agree.
+
+    binance and bitget must resolve the default. Assigning them the mark version would
+    price brackets off a value their `_step` never validated.
     """
-    assert cls._dispatch_sltp_trade is SLTPMixin._dispatch_sltp_trade, (
-        f"{cls.__name__} defines its own _dispatch_sltp_trade. Only bybit and okx have a "
-        f"reason to (the #295 threaded price); if this venue now needs one too, move it "
-        f"into _DISPATCH_OVERRIDERS deliberately rather than letting the hook drift"
-    )
-
-
-@pytest.mark.parametrize("cls", _DISPATCH_INHERITORS, ids=lambda c: c.__name__)
-def test_the_folded_executor_is_inherited_and_not_re_forked(cls):
-    """`_execute_trade_if_needed` joined the mixin in #288, and nothing guarded it.
-
-    It cannot go in `_SHARED_METHOD_OWNERSHIP` -- bybit and okx legitimately override it
-    for the `*, current_price` fork -- so it needs this split form, the same one
-    `_dispatch_sltp_trade` already has. Verified the gap was real: appending a full copy
-    of the mixin's body back onto binance passed all 1202 tests. The sizing test only
-    greps the resolved source for `_resolve_bracket_quantity`, which a faithful re-fork
-    still contains.
-
-    This is the method the close-action bug lived in. A private copy is where the next
-    shared fix silently fails to land.
-    """
-    assert cls._execute_trade_if_needed is SLTPMixin._execute_trade_if_needed, (
-        f"{cls.__name__} defines its own _execute_trade_if_needed. Only bybit and okx "
-        f"have a reason to (the keyword-only current_price); if this venue now needs one, "
-        f"move it into _DISPATCH_OVERRIDERS deliberately rather than re-forking the copy "
-        f"that #288 just folded"
-    )
-
-
-@pytest.mark.parametrize("cls", _DISPATCH_OVERRIDERS, ids=lambda c: c.__name__)
-def test_the_dispatch_overriders_thread_the_price_they_were_given(cls):
-    """And the two that DO override must consume the threaded price, not re-read it.
-
-    Excluding them from the ownership table costs the identity check; this replaces it
-    with what identity was standing in for.
-    """
-    call = next(
-        (n for n in ast.walk(ast.parse(
-            inspect.getsource(cls._dispatch_sltp_trade).lstrip()))
-         if isinstance(n, ast.Call) and isinstance(n.func, ast.Attribute)
-         and n.func.attr == "_execute_trade_if_needed"),
-        None,
-    )
-    assert call is not None, f"{cls.__name__}'s override never dispatches the trade"
-    assert any(kw.arg == "current_price" and isinstance(kw.value, ast.Name)
-               for kw in call.keywords), (
-        f"{cls.__name__} overrides _dispatch_sltp_trade but does not forward the threaded "
-        f"current_price -- the only reason the override exists (#295); re-reading it "
-        f"inside the trade path bypasses the halt policy"
-    )
+    venue = cls.__module__.split(".")[-2]
+    resolved = cls._bracket_entry_price
+    if venue in _MARK_PRICED:
+        assert resolved is SLTPMixin._validated_mark_price, (
+            f"{cls.__name__} no longer prices off the threaded mark -- it re-reads the "
+            f"observer inside the trade path, which is the #295 regression"
+        )
+    else:
+        assert resolved is SLTPMixin._bracket_entry_price, (
+            f"{cls.__name__} stopped using the shared candle-close read"
+        )
 
 
 @pytest.mark.parametrize("cls,owner,method", _SHARED_METHOD_OWNERSHIP,
@@ -5108,7 +5094,7 @@ def test_a_flat_bar_falls_back_to_the_pre_trade_price(sltp):
 
 # Derived, not listed: a fifth venue joins these tests by existing rather than by
 # tripping an assert that tells someone to go edit a list. The inheritor/overrider split
-# is already expressed once, at _DISPATCH_INHERITORS.
+# is already expressed once, at _MARK_PRICED.
 _SLTP_VENUES = sorted(c.__module__.split(".")[-2] for c in SLTP_FUTURES_ENVS)
 
 
@@ -5302,10 +5288,16 @@ def test_a_bracket_leg_the_venue_rejected_is_not_recorded_as_live(venue, sl_plac
 
     okx used to be excluded here: it attaches brackets atomically (`attachAlgoOrds`) and
     its own executor never sets `bracket_status`, so it recorded both legs unconditionally.
-    Folding it onto the shared executor put it behind the same gate, which changes nothing
-    for a real okx trader (108/108 differential cases identical, the attribute is absent so
-    the all-True default applies) and FIXES the injected case: `ReplayOrderExecutor` does
-    report per-leg status, and okx was recording a stop it had been told was not placed.
+    The fold puts it behind the same gate.
+
+    This pins a CONTRACT; it does not fix an observed failure, and an earlier version of
+    this docstring claimed it did. No trader in the repo can currently report a rejected
+    leg on this path: bybit's and okx's executors never set `bracket_status` at all, and
+    `ReplayOrderExecutor` sets `sl_placed = stop_loss is not None` while
+    `calculate_bracket_prices` always returns two floats -- so replay reports all-True
+    too. The only producer is the injected stub below. The gate is worth having because
+    binance and bitget DO place the legs separately, and a venue that starts doing so
+    should not need this test written for it afterwards.
     """
     env, trader = _close_env(venue, 0)
     trader.bracket_status = {"sl_placed": sl_placed, "tp_placed": tp_placed}

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -3377,7 +3377,7 @@ SLTP_CONFIGS = [
 
 # Reproduced from main before the extraction. One literal now sets each of these for four
 # live venues, so a typo moves all four at once: mutating bankrupt_threshold 0.1 -> 0.5
-# (a 5x move in every venue's force-close point) passed 1432 tests before this pin.
+# (a 5x move in every venue's force-close point) passed the whole suite before this pin.
 SHARED_DEFAULTS = {
     "time_frames": [TimeFrame(1, TimeFrameUnit.Hour)],
     "execute_on": TimeFrame(1, TimeFrameUnit.Hour),
@@ -4018,6 +4018,10 @@ def test_every_successful_close_invalidates_the_cached_balance():
         root / "shared" / "futures_live_base.py",
         root.parent / "utils" / "sltp_mixin.py",
     ]:
+        # alpaca/base.py is omitted ON PURPOSE and would fail if added: its two
+        # `close_position()` calls are construction-time and in `_reset`, both exempt by
+        # the ordering argument above -- but EXEMPT is keyed by function NAME and one of
+        # them lives in `__init__`. Stated so the next reader does not "fix" the list.
         for fn in ast.walk(ast.parse(path.read_text())):
             if not isinstance(fn, ast.FunctionDef) or fn.name in EXEMPT:
                 continue
@@ -4261,7 +4265,7 @@ _SHARED_METHOD_OWNERSHIP = [
         # They had their own inheritor/overrider guards, keyed on a binance+bitget vs
         # bybit+okx split that no longer exists -- so they guarded nothing on the two
         # venues the fold had just changed. A faithful copy of the executor pasted back
-        # onto bybit passed all 3445 tests while those guards were still in place.
+        # onto bybit passed the whole suite while those guards were still in place.
         # `_bracket_entry_price` could only join once the venue split moved from two bound
         # implementations to one method reading `_PRICES_OFF_THREADED_MARK`. Being the one
         # shared method that could NOT sit in this table is exactly the condition that
@@ -4269,7 +4273,7 @@ _SHARED_METHOD_OWNERSHIP = [
         "_execute_trade_if_needed", "_bracket_entry_price",
     )),
 ]
-# By NAME, not by count. Dropping `_reset` from the matrix above passed 936 tests: the
+# By NAME, not by count. Dropping `_reset` from the matrix above passed everything: the
 # registry-length pins guard the ENV axis, and nothing guarded the METHOD axis. This also
 # says out loud what is meant to be shared, so adding a genuinely shared method is a
 # deliberate edit here rather than an arithmetic fix.
@@ -4532,7 +4536,7 @@ def test_the_non_fractional_trade_modes_size_from_config(mode, per_trade, price,
 
     Every other test here and in the four venue suites builds its config with
     `trade_mode="fractional"`, so mutating `quantity_per_trade / price` to `*`, or
-    doubling the raw quantity, passed all 1000 tests in this file. Pre-existing -- neither
+    doubling the raw quantity, passed this whole file. Pre-existing -- neither
     branch changed in the fold -- but the fold changed the blast radius: one wrong formula
     now mis-sizes every SLTP bracket on all four venues at once.
     """
@@ -4689,11 +4693,12 @@ def test_the_fold_did_not_move_a_single_sized_position(venue, leverage, exp_size
 # `_dispatch_sltp_trade` and `_execute_trade_if_needed` used to split binance/bitget from
 # bybit/okx, and had their own inheritor/overrider lists here. That split is gone: the mixin
 # forwards the mark unconditionally and `_bracket_entry_price` decides whether to use it, so
-# both methods now live in the uniform table above and a private copy on ANY venue fails.
+# `_execute_trade_if_needed` lives in the uniform table above, so a private copy on ANY
+# venue fails; `_dispatch_sltp_trade` is gone entirely.
 #
 # The variation did not disappear, it moved -- and a guard that does not move with it stops
-# guarding. Appending a faithful copy of the shared executor back onto bybit passed all 3445
-# tests while the old lists were still keyed on the pre-fold split.
+# guarding. Appending a faithful copy of the shared executor back onto bybit passed the
+# whole suite while the old lists were still keyed on the pre-fold split.
 _MARK_PRICED = ("bybit", "okx")
 
 
@@ -4714,6 +4719,17 @@ def test_each_venue_prices_its_bracket_from_the_source_it_intends(cls):
     assert cls._PRICES_OFF_THREADED_MARK is (venue in _MARK_PRICED), (
         f"{cls.__name__} has _PRICES_OFF_THREADED_MARK="
         f"{cls._PRICES_OFF_THREADED_MARK}, which is backwards for this venue"
+    )
+    # The list above is hand-maintained, so a FIFTH mark-priced venue that forgets the
+    # flag would pass the check by being absent from it. That is the #295 shape, so it is
+    # asserted from the other direction too: a venue whose `_step` threads a mark it never
+    # uses is either mis-flagged or has a dead argument, and both want a human.
+    threads_mark = "current_price" in inspect.signature(
+        cls._execute_trade_if_needed
+    ).parameters
+    assert threads_mark, (
+        f"{cls.__name__} no longer takes the threaded mark at all; _MARK_PRICED and the "
+        f"flag can no longer mean anything for it"
     )
 
 
@@ -4769,7 +4785,7 @@ def test_no_sltp_env_writes_the_dead_position_closed_field():
 def test_the_history_row_records_the_side_actually_traded(side_idx, expected):
     """`action_value` is what the reward function reads out of `history.actions`.
 
-    Flipping the long/short sign here fails ZERO of 4196 tests -- found while mutating the
+    Flipping the long/short sign here fails ZERO tests -- found while mutating the
     freshly-folded `_step`, and pre-existing rather than introduced by the fold. It is the
     worst shape of bug this repo records: plausible numbers at the wrong sign, so the
     reward inverts silently and nothing crashes.
@@ -5256,7 +5272,7 @@ def test_a_failed_flatten_does_not_send_the_entry_that_follows_it(venue, outcome
     )
     # The exact inverse of the bug the sibling test pins: clearing here would report a
     # position the venue still holds, with its brackets still resting, as unprotected.
-    # Hoisting the clear above the `if not close_success` check survived all 3445 tests.
+    # Hoisting the clear above the `if not close_success` check survived the whole suite.
     assert env.active_stop_loss == 90.0 and env.active_take_profit == 110.0, (
         f"{venue}: brackets cleared on a flatten the venue refused -- the position and "
         f"its bracket legs are both still live at the exchange."
@@ -5364,7 +5380,7 @@ def test_a_completed_switch_arms_the_new_positions_brackets(venue):
     not left at the zeros the flatten wrote.
 
     Wiping both fields at the end of the function whenever a flatten had happened survived
-    all 3445 tests -- the only test asserting post-entry bracket state starts from a FLAT
+    the whole suite -- the only test asserting post-entry bracket state starts from a FLAT
     account, so it never crosses the flatten at all. This is what pins the clear to its
     position before the trade block rather than after it.
     """

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -214,6 +214,10 @@ def test_no_live_env_overrides_shared_method(env_cls, method):
         # The SLTP bracket sizing (#288). Reached only by the four SLTP siblings, but the
         # identity check is over FUTURES_ENVS, and the plain envs inherit it unused --
         # a venue re-forking it for either path fails here.
+        #
+        # okx is exempted below, the same way binance is for `_calculate_fractional_position`:
+        # it EXTENDS via super() to refuse a sub-minimum quantity, which is behaviour it
+        # already had inline. Extending is not re-forking; a full copy still fails.
         "_resolve_bracket_quantity",
     ],
 )
@@ -226,6 +230,20 @@ def test_no_futures_env_reforks_the_shared_observation(env_cls, method):
     account_state test still passes -- so fail here instead. (alpaca is spot: it keeps its own
     _get_observation and is correctly absent from FUTURES_ENVS.)
     """
+    # The exemption is keyed on the CLASS that defines an override, not on the venue:
+    # keyed on the venue it also swallowed okx's two plain envs, which define nothing and
+    # would have passed while asserting nothing about them.
+    if method == "_resolve_bracket_quantity" and method in vars(env_cls):
+        assert env_cls.__name__ == "OKXFuturesSLTPTorchTradingEnv", (
+            f"{env_cls.__name__} overrides {method}; only okx's SLTP env is exempt "
+            f"(sub-minimum refusal, #414). Add it here deliberately or drop the override."
+        )
+        # Exempt, but not unguarded: it must still DELEGATE, which a re-forked copy of the
+        # arithmetic would not. Same bargain binance's sizing override makes.
+        assert "super()._resolve_bracket_quantity" in inspect.getsource(
+            env_cls._resolve_bracket_quantity
+        ), "okx's sizing override no longer delegates -- it is a re-fork now"
+        return
     assert getattr(env_cls, method) is getattr(TorchTradeFuturesLiveEnv, method), (
         f"{env_cls.__name__} re-forks {method} instead of sharing TorchTradeFuturesLiveEnv's. "
         f"Drop the override, or the unification no longer covers it."
@@ -2177,11 +2195,24 @@ def test_sltp_sizing_rejects_a_non_finite_price_or_balance(exchange):
         f"{exchange}'s trade path does not CALL the shared sizing; an inlined copy that "
         f"names it in a comment would satisfy a text search"
     )
+    # The guard lives on `_bracket_entry_price` as of the bybit/okx fold, and this scan
+    # follows it there rather than naming a method. That is the second time this test's
+    # subject moved out from under it: once when #288 folded the sizing onto the shared
+    # base, once here. Resolve-then-scan, never a file or a fixed method name.
+    price_src = inspect.getsource(cls._bracket_entry_price)
+    assert "math.isfinite" in price_src, (
+        f"{exchange} resolves its entry price with no finiteness check"
+    )
     if exchange in ("binance", "bitget"):
         # These two size from a candle close, so _current_mark_price() never guards them.
-        # bybit and okx re-validate at the seam instead (#295).
-        assert "math.isfinite(current_price)" in venue_src, (
-            f"{exchange} sizes from a candle close with no finiteness check"
+        # bybit and okx re-validate the threaded mark instead (#295).
+        assert "get_observations" in price_src, (
+            f"{exchange} should price off its own candle close, not a threaded mark"
+        )
+    else:
+        assert "get_observations" not in price_src, (
+            f"{exchange} re-reads the observer inside the trade path, which is exactly "
+            f"what #295 removed -- it must use the mark `_step` already acquired"
         )
 
 
@@ -4369,6 +4400,10 @@ def _bracket_stub(cls, *, balance=10_000.0, leverage=5, fee=...):
                                  quantity_per_trade=0, leverage=leverage, symbol="X")
     env.trader = MagicMock()
     env.trader.get_account_balance.return_value = {"total_margin_balance": balance}
+    # A real lot size, because okx's sizing compares against it. Left to the bare
+    # MagicMock, `qty < trader.get_lot_size()["min_qty"]` raises TypeError -- the same
+    # family as the `float(MagicMock())` accident this docstring already warns about.
+    env.trader.get_lot_size.return_value = {"min_qty": 0.001, "qty_step": 0.001}
     if fee is ...:
         del env.trader.transaction_fee
     else:
@@ -5254,7 +5289,7 @@ def test_a_failed_flatten_does_not_send_the_entry_that_follows_it(venue, outcome
     )
 
 
-@pytest.mark.parametrize("venue", ["binance", "bitget", "bybit"])
+@pytest.mark.parametrize("venue", _SLTP_VENUES)
 @pytest.mark.parametrize("sl_placed,tp_placed", [(True, False), (False, True), (False, False)],
                          ids=["tp-rejected", "sl-rejected", "both-rejected"])
 def test_a_bracket_leg_the_venue_rejected_is_not_recorded_as_live(venue, sl_placed, tp_placed):
@@ -5265,8 +5300,12 @@ def test_a_bracket_leg_the_venue_rejected_is_not_recorded_as_live(venue, sl_plac
     that does not exist. Every one of these three mutants survived the whole suite before
     this test: alpaca was the only SLTP env pinning it.
 
-    okx is excluded, not forgotten -- its brackets attach atomically (`attachAlgoOrds`),
-    so it has no per-leg status to misread.
+    okx used to be excluded here: it attaches brackets atomically (`attachAlgoOrds`) and
+    its own executor never sets `bracket_status`, so it recorded both legs unconditionally.
+    Folding it onto the shared executor put it behind the same gate, which changes nothing
+    for a real okx trader (108/108 differential cases identical, the attribute is absent so
+    the all-True default applies) and FIXES the injected case: `ReplayOrderExecutor` does
+    report per-leg status, and okx was recording a stop it had been told was not placed.
     """
     env, trader = _close_env(venue, 0)
     trader.bracket_status = {"sl_placed": sl_placed, "tp_placed": tp_placed}

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -38,6 +38,7 @@ from torchtrade.envs.core.live import (
     TorchTradeLiveEnv,
 )
 from torchtrade.envs.live.shared.futures_live_base import TorchTradeFuturesLiveEnv
+from torchtrade.envs.utils.sltp_helpers import calculate_bracket_prices
 from torchtrade.envs.utils.sltp_mixin import SLTPMixin
 from torchtrade.envs.utils.liquidation import (
     cross_liquidation_price,
@@ -2195,25 +2196,14 @@ def test_sltp_sizing_rejects_a_non_finite_price_or_balance(exchange):
         f"{exchange}'s trade path does not CALL the shared sizing; an inlined copy that "
         f"names it in a comment would satisfy a text search"
     )
-    # The guard lives on `_bracket_entry_price` as of the bybit/okx fold, and this scan
-    # follows it there rather than naming a method. That is the second time this test's
-    # subject moved out from under it: once when #288 folded the sizing onto the shared
-    # base, once here. Resolve-then-scan, never a file or a fixed method name.
-    price_src = inspect.getsource(cls._bracket_entry_price)
-    assert "math.isfinite" in price_src, (
+    # WHICH implementation each venue uses is pinned by identity in
+    # `test_each_venue_prices_its_bracket_from_the_source_it_intends`; the substring pair
+    # that used to live here said the same thing more weakly. What remains is the only
+    # assertion in this test with a unique kill: dropping `isfinite` from either
+    # implementation dies here and nowhere else in 4465 tests.
+    assert "math.isfinite" in inspect.getsource(cls._bracket_entry_price), (
         f"{exchange} resolves its entry price with no finiteness check"
     )
-    if exchange in ("binance", "bitget"):
-        # These two size from a candle close, so _current_mark_price() never guards them.
-        # bybit and okx re-validate the threaded mark instead (#295).
-        assert "get_observations" in price_src, (
-            f"{exchange} should price off its own candle close, not a threaded mark"
-        )
-    else:
-        assert "get_observations" not in price_src, (
-            f"{exchange} re-reads the observer inside the trade path, which is exactly "
-            f"what #295 removed -- it must use the mark `_step` already acquired"
-        )
 
 
 @pytest.mark.parametrize("exchange,side_key,side", [
@@ -5273,6 +5263,13 @@ def test_a_failed_flatten_does_not_send_the_entry_that_follows_it(venue, outcome
         f"{venue}: a refused flatten returns success={info['success']!r}, which is what "
         f"HOLD returns -- indistinguishable from doing nothing."
     )
+    # The exact inverse of the bug the sibling test pins: clearing here would report a
+    # position the venue still holds, with its brackets still resting, as unprotected.
+    # Hoisting the clear above the `if not close_success` check survived all 3445 tests.
+    assert env.active_stop_loss == 90.0 and env.active_take_profit == 110.0, (
+        f"{venue}: brackets cleared on a flatten the venue refused -- the position and "
+        f"its bracket legs are both still live at the exchange."
+    )
 
 
 @pytest.mark.parametrize("venue", _SLTP_VENUES)
@@ -5371,6 +5368,30 @@ def test_an_unrecognised_side_reaches_no_venue_call_at_all(venue, sizeable):
 
 
 @pytest.mark.parametrize("venue", _SLTP_VENUES)
+def test_a_completed_switch_arms_the_new_positions_brackets(venue):
+    """The other side of the clear: when the entry SUCCEEDS, the new levels must be armed,
+    not left at the zeros the flatten wrote.
+
+    Wiping both fields at the end of the function whenever a flatten had happened survived
+    all 3445 tests -- the only test asserting post-entry bracket state starts from a FLAT
+    account, so it never crosses the flatten at all. This is what pins the clear to its
+    position before the trade block rather than after it.
+    """
+    env, trader = _close_env(venue, 1)                 # long open, brackets at 90/110
+    trader.close_position.return_value = True
+    trader.trade.return_value = True
+
+    env._dispatch_sltp_trade(("short", 0.03, -0.02), 100.0)
+
+    expected_sl, expected_tp = calculate_bracket_prices("short", 100.0, 0.03, -0.02)
+    assert (env.active_stop_loss, env.active_take_profit) == (expected_sl, expected_tp), (
+        f"{venue}: switched into a short but the bracket levels are "
+        f"{env.active_stop_loss}/{env.active_take_profit}, not the new position's "
+        f"{expected_sl}/{expected_tp}."
+    )
+
+
+@pytest.mark.parametrize("venue", _SLTP_VENUES)
 @pytest.mark.parametrize("entry", ["refused", "raised"])
 def test_a_flatten_takes_the_old_positions_brackets_with_it(venue, entry):
     """Switching directions closes, then opens. If the OPEN fails after the close
@@ -5395,7 +5416,51 @@ def test_a_flatten_takes_the_old_positions_brackets_with_it(venue, entry):
     env._dispatch_sltp_trade(("short", 0.03, -0.02), 100.0)
 
     assert trader.close_position.called and env.position.current_position == 0
+    # Without this the test passes on a mutant that returns between the close and the
+    # entry -- the flatten would be the whole story and "the entry failed" untrue.
+    assert trader.trade.called, (
+        f"{venue}: the entry was never attempted, so this test is not exercising the "
+        f"close-succeeded-entry-failed path it claims to"
+    )
     assert env.active_stop_loss == 0.0 and env.active_take_profit == 0.0, (
         f"{venue}: flat after the flatten, but the closed position's brackets survive as "
         f"sl={env.active_stop_loss} tp={env.active_take_profit} -- nothing clears them now."
+    )
+
+
+@pytest.mark.parametrize("venue", _SLTP_VENUES)
+@pytest.mark.parametrize("bad", [float("nan"), float("inf"), 0.0, -1.0],
+                         ids=["nan", "inf", "zero", "negative"])
+def test_an_unusable_entry_price_refuses_instead_of_sizing_from_it(venue, bad):
+    """Behavioural, because the source scan cannot tell a real guard from a mentioned one:
+    `if math.isfinite(p) or True` satisfies the grep and refuses nothing.
+
+    `nan <= 0` is False, which is exactly the input #347 is about -- a bare `<= 0` check
+    reads as protection and passes nan straight through to size the order and price both
+    bracket legs. Both implementations of `_bracket_entry_price` are covered: bybit and
+    okx get the bad value as the threaded mark, binance and bitget as their candle close.
+    """
+    env, trader = _close_env(venue, 0)
+    if venue in _MARK_PRICED:
+        # The threaded mark is validated directly: no halt policy wraps it, because
+        # `_step` already took it under one.
+        expected = ValueError
+        drive = lambda: env._dispatch_sltp_trade(("long", -0.02, 0.03), bad)
+    else:
+        # The candle read runs INSIDE `_halting`, which converts the guard's ValueError
+        # into the halt type so a degraded feed truncates rather than crashing (#295).
+        # Asserting ValueError here would have been asserting the policy away.
+        expected = LiveObservationHalt
+        # side_effect wins over return_value, and `_real_futures_env` installs one --
+        # leaving it set meant the observer kept returning a healthy 100.0 and the test
+        # asserted nothing for two of the four bad values.
+        env.observer.get_observations.side_effect = None
+        env.observer.get_observations.return_value = {
+            "base_features": np.full((10, 4), bad, dtype=np.float64)}
+        drive = lambda: env._dispatch_sltp_trade(("long", -0.02, 0.03), 100.0)
+
+    with pytest.raises(expected):
+        drive()
+    assert not trader.trade.called, (
+        f"{venue}: sized and priced a bracket from {bad!r}"
     )

--- a/tests/envs/test_sltp_mixin.py
+++ b/tests/envs/test_sltp_mixin.py
@@ -19,6 +19,11 @@ class FakeSLTPEnv(SLTPMixin):
         self.position = PositionState()
         self.active_stop_loss = 0.0
         self.active_take_profit = 0.0
+        # Real envs get this from TorchTradeLiveEnv.__init__. Without it the mixin needed
+        # a `getattr(self, "_last_confirmed_read", {})` fail-open, which silently skipped
+        # the cache invalidation for anything that forgot the attribute -- a guard in the
+        # rule to accommodate a stub, which is CLAUDE.md invariant 4 inverted.
+        self._last_confirmed_read = {}
 
 
 class TestSyncPositionFromExchange:

--- a/torchtrade/envs/live/alpaca/env_sltp.py
+++ b/torchtrade/envs/live/alpaca/env_sltp.py
@@ -131,8 +131,7 @@ class AlpacaSLTPTorchTradingEnv(SLTPMixin, AlpacaBaseTorchTradingEnv):
         self.action_spec = Categorical(len(self.action_map))
 
         # Track active SL/TP levels for current position
-        self.active_stop_loss = 0.0
-        self.active_take_profit = 0.0
+        self._reset_sltp_state()
 
     def _step(self, tensordict: TensorDictBase) -> TensorDictBase:
         """Execute one environment step."""

--- a/torchtrade/envs/live/binance/env_sltp.py
+++ b/torchtrade/envs/live/binance/env_sltp.py
@@ -102,6 +102,5 @@ class BinanceFuturesSLTPTorchTradingEnv(SLTPMixin, BinanceBaseTorchTradingEnv):
         self.action_spec = Categorical(len(self.action_map))
 
         # Track active SL/TP levels for current position
-        self.active_stop_loss = 0.0
-        self.active_take_profit = 0.0
+        self._reset_sltp_state()
 

--- a/torchtrade/envs/live/bitget/env_sltp.py
+++ b/torchtrade/envs/live/bitget/env_sltp.py
@@ -108,6 +108,5 @@ class BitgetFuturesSLTPTorchTradingEnv(SLTPMixin, BitgetBaseTorchTradingEnv):
         self.action_spec = Categorical(len(self.action_map))
 
         # Track active SL/TP levels for current position
-        self.active_stop_loss = 0.0
-        self.active_take_profit = 0.0
+        self._reset_sltp_state()
 

--- a/torchtrade/envs/live/bybit/env_sltp.py
+++ b/torchtrade/envs/live/bybit/env_sltp.py
@@ -1,8 +1,7 @@
 """Bybit Futures TorchRL trading environment with Stop Loss and Take Profit."""
 from torchtrade.envs.live.shared.sltp_config import BaseFuturesSLTPConfig
 from dataclasses import dataclass
-from typing import Dict, Optional, Tuple, Callable
-import logging
+from typing import Optional, Callable
 
 from torchrl.data import Categorical
 
@@ -16,9 +15,7 @@ from torchtrade.envs.live.bybit.utils import normalize_bybit_timeframe_config
 from torchtrade.envs.live.bybit.base import BybitBaseTorchTradingEnv
 from torchtrade.envs.utils.action_maps import create_sltp_action_map
 from torchtrade.envs.utils.sltp_mixin import SLTPMixin
-from torchtrade.envs.utils.sltp_helpers import calculate_bracket_prices
 
-logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -81,8 +78,3 @@ class BybitFuturesSLTPTorchTradingEnv(SLTPMixin, BybitBaseTorchTradingEnv):
     # Priced off the mark `_step` threaded in, not a fresh read (#295).
     _bracket_entry_price = SLTPMixin._validated_mark_price
 
-    def _dispatch_sltp_trade(self, action_tuple, current_price: float):
-        # Threaded, not re-read: re-reading the mark inside the trade path bypassed the
-        # halt policy, so a grace bar that priced a bracket died instead of truncating
-        # (#295). binance and bitget price off a candle close and take the default.
-        return self._execute_trade_if_needed(action_tuple, current_price=current_price)

--- a/torchtrade/envs/live/bybit/env_sltp.py
+++ b/torchtrade/envs/live/bybit/env_sltp.py
@@ -1,5 +1,4 @@
 """Bybit Futures TorchRL trading environment with Stop Loss and Take Profit."""
-import math
 from torchtrade.envs.live.shared.sltp_config import BaseFuturesSLTPConfig
 from dataclasses import dataclass
 from typing import Dict, Optional, Tuple, Callable
@@ -79,115 +78,8 @@ class BybitFuturesSLTPTorchTradingEnv(SLTPMixin, BybitBaseTorchTradingEnv):
         self.active_stop_loss = 0.0
         self.active_take_profit = 0.0
 
-    def _execute_trade_if_needed(
-        self, action_tuple: Tuple[Optional[str], Optional[float], Optional[float]],
-        *, current_price: float,
-    ) -> Dict:
-        """Execute trade if position change is needed."""
-        trade_info = {
-            "executed": False,
-            "quantity": 0,
-            "side": None,
-            "success": None,
-            "closed_position": False,
-        }
-
-        side, stop_loss_pct, take_profit_pct = action_tuple
-
-        # HOLD action
-        if side is None:
-            return trade_info
-
-        # Position locking: ignore all actions while in position
-        if self.config.lock_position_until_sltp and self.position.current_position != 0:
-            return trade_info
-
-        if side == "close":
-            return self._close_action(trade_info)
-
-        # Same boundary guard as SLTPMixin's -- see there for why it is not left to
-        # `calculate_bracket_prices` further down.
-        if side not in self.SIDE_DIRECTION:
-            raise ValueError(f"Invalid side: {side}. Must be 'long' or 'short'.")
-
-        if side in self.SIDE_DIRECTION and self.position.current_position == self.SIDE_DIRECTION[side]:
-            return trade_info
-
-        # Get current mark price (more accurate than candle close for bracket orders)
-        # Threaded from `_step`'s halted read; required, never defaulted (#295).
-        current_price = float(current_price)
-        # Re-validated at the seam that USES it, not just where it was read. Threading
-        # moved the read out of this method, and with it `_current_mark_price`'s
-        # `isfinite`/`<= 0` guard -- a 0.0 divides in the sizing path below.
-        if not math.isfinite(current_price) or current_price <= 0:
-            raise ValueError(
-                f"venue reported an unusable mark price ({current_price})"
-            )
-
-        quantity = self._resolve_bracket_quantity(current_price)
-        if quantity is None:
-            trade_info["success"] = False
-            return trade_info
-
-        # Close opposite position if switching directions
-        # (we already returned above if same direction, so any existing position is opposite)
-        if self.position.current_position != 0:
-            try:
-                close_success = self.trader.close_position()
-            except Exception as e:
-                logger.error(f"Close position failed for {self.config.symbol}: {e}")
-                trade_info["success"] = False
-                return trade_info
-            if not close_success:
-                # Same contract as `_close_action`: a refused flatten must not read as
-                # HOLD, and the entry below must NOT go out.
-                trade_info["success"] = False
-                return trade_info
-            # A realised close moves equity; the cached balance is now wrong by the
-            # trade's P&L. Reached only on success (#295).
-            self._last_confirmed_read.pop("balance", None)
-            self.position.current_position = 0
-
-        # Map position side to trade side
-        trade_side = "buy" if side == "long" else "sell"
-
-        stop_loss_price, take_profit_price = calculate_bracket_prices(
-            side, current_price, stop_loss_pct, take_profit_pct
-        )
-
-        try:
-            success = self.trader.trade(
-                side=trade_side,
-                quantity=quantity,
-                order_type="market",
-                take_profit=take_profit_price,
-                stop_loss=stop_loss_price,
-            )
-
-            if success:
-                # Only record SL/TP levels that actually placed on-exchange
-                bs = getattr(self.trader, 'bracket_status', {"tp_placed": True, "sl_placed": True})
-                self.active_stop_loss = stop_loss_price if bs["sl_placed"] else 0.0
-                self.active_take_profit = take_profit_price if bs["tp_placed"] else 0.0
-
-            trade_info.update({
-                "executed": True,
-                "quantity": quantity,
-                "side": trade_side,
-                "success": success,
-                "stop_loss": stop_loss_price,
-                "take_profit": take_profit_price,
-            })
-        except Exception as e:
-            logger.error(
-                f"{side.capitalize()} trade failed for {self.config.symbol}: "
-                f"quantity={quantity}, "
-                f"SL={stop_loss_price:.2f}, TP={take_profit_price:.2f}, error={e}"
-            )
-            trade_info["success"] = False
-            return trade_info
-
-        return trade_info
+    # Priced off the mark `_step` threaded in, not a fresh read (#295).
+    _bracket_entry_price = SLTPMixin._validated_mark_price
 
     def _dispatch_sltp_trade(self, action_tuple, current_price: float):
         # Threaded, not re-read: re-reading the mark inside the trade path bypassed the

--- a/torchtrade/envs/live/bybit/env_sltp.py
+++ b/torchtrade/envs/live/bybit/env_sltp.py
@@ -75,6 +75,6 @@ class BybitFuturesSLTPTorchTradingEnv(SLTPMixin, BybitBaseTorchTradingEnv):
         self.active_stop_loss = 0.0
         self.active_take_profit = 0.0
 
-    # Priced off the mark `_step` threaded in, not a fresh read (#295).
-    _bracket_entry_price = SLTPMixin._validated_mark_price
+    # `_step` already took the mark under the halt policy; never read again (#295).
+    _PRICES_OFF_THREADED_MARK = True
 

--- a/torchtrade/envs/live/bybit/env_sltp.py
+++ b/torchtrade/envs/live/bybit/env_sltp.py
@@ -72,8 +72,7 @@ class BybitFuturesSLTPTorchTradingEnv(SLTPMixin, BybitBaseTorchTradingEnv):
 
         self.action_spec = Categorical(len(self.action_map))
 
-        self.active_stop_loss = 0.0
-        self.active_take_profit = 0.0
+        self._reset_sltp_state()
 
     # `_step` already took the mark under the halt policy; never read again (#295).
     _PRICES_OFF_THREADED_MARK = True

--- a/torchtrade/envs/live/okx/env_sltp.py
+++ b/torchtrade/envs/live/okx/env_sltp.py
@@ -73,8 +73,7 @@ class OKXFuturesSLTPTorchTradingEnv(SLTPMixin, OKXBaseTorchTradingEnv):
 
         self.action_spec = Categorical(len(self.action_map))
 
-        self.active_stop_loss = 0.0
-        self.active_take_profit = 0.0
+        self._reset_sltp_state()
 
     # `_step` already took the mark under the halt policy; never read again (#295).
     _PRICES_OFF_THREADED_MARK = True

--- a/torchtrade/envs/live/okx/env_sltp.py
+++ b/torchtrade/envs/live/okx/env_sltp.py
@@ -76,8 +76,8 @@ class OKXFuturesSLTPTorchTradingEnv(SLTPMixin, OKXBaseTorchTradingEnv):
         self.active_stop_loss = 0.0
         self.active_take_profit = 0.0
 
-    # Priced off the mark `_step` threaded in, not a fresh read (#295).
-    _bracket_entry_price = SLTPMixin._validated_mark_price
+    # `_step` already took the mark under the halt policy; never read again (#295).
+    _PRICES_OFF_THREADED_MARK = True
 
     def _resolve_bracket_quantity(self, current_price):
         """okx alone refuses a sub-minimum bracket instead of letting the venue reject it.

--- a/torchtrade/envs/live/okx/env_sltp.py
+++ b/torchtrade/envs/live/okx/env_sltp.py
@@ -1,5 +1,4 @@
 """OKX Futures TorchRL trading environment with Stop Loss and Take Profit."""
-import math
 from torchtrade.envs.live.shared.sltp_config import BaseFuturesSLTPConfig
 from dataclasses import dataclass
 from typing import Dict, Optional, Tuple, Callable
@@ -81,121 +80,20 @@ class OKXFuturesSLTPTorchTradingEnv(SLTPMixin, OKXBaseTorchTradingEnv):
         self.active_stop_loss = 0.0
         self.active_take_profit = 0.0
 
-    def _execute_trade_if_needed(
-        self, action_tuple: Tuple[Optional[str], Optional[float], Optional[float]],
-        *, current_price: float,
-    ) -> Dict:
-        """Execute trade if position change is needed."""
-        trade_info = {
-            "executed": False,
-            "quantity": 0,
-            "side": None,
-            "success": None,
-            "closed_position": False,
-        }
+    # Priced off the mark `_step` threaded in, not a fresh read (#295).
+    _bracket_entry_price = SLTPMixin._validated_mark_price
 
-        side, stop_loss_pct, take_profit_pct = action_tuple
+    def _resolve_bracket_quantity(self, current_price):
+        """okx alone refuses a sub-minimum bracket instead of letting the venue reject it.
 
-        # HOLD action
-        if side is None:
-            return trade_info
-
-        # Position locking: ignore all actions while in position
-        if self.config.lock_position_until_sltp and self.position.current_position != 0:
-            return trade_info
-
-        if side == "close":
-            return self._close_action(trade_info)
-
-        # Same boundary guard as SLTPMixin's -- see there for why it is not left to
-        # `calculate_bracket_prices` further down.
-        if side not in self.SIDE_DIRECTION:
-            raise ValueError(f"Invalid side: {side}. Must be 'long' or 'short'.")
-
-        if side in self.SIDE_DIRECTION and self.position.current_position == self.SIDE_DIRECTION[side]:
-            return trade_info
-
-        # Get current mark price (more accurate than candle close for bracket orders)
-        # Threaded from `_step`'s halted read; required, never defaulted (#295).
-        current_price = float(current_price)
-        # Re-validated at the seam that USES it, not just where it was read. Threading
-        # moved the read out of this method, and with it `_current_mark_price`'s
-        # `isfinite`/`<= 0` guard -- a 0.0 divides in the sizing path below.
-        if not math.isfinite(current_price) or current_price <= 0:
-            raise ValueError(
-                f"venue reported an unusable mark price ({current_price})"
-            )
-
-        quantity = self._resolve_bracket_quantity(current_price)
-        if quantity is None:
-            trade_info["success"] = False
-            return trade_info
-
-        # Short-circuit if quantity is below exchange minimum
-        lot = self.trader.get_lot_size()
-        if quantity < lot["min_qty"]:
-            trade_info["success"] = False
-            return trade_info
-
-        # Close opposite position if switching directions
-        if self.position.current_position != 0:
-            try:
-                close_success = self.trader.close_position()
-            except Exception as e:
-                logger.error(f"Close position failed for {self.config.symbol}: {e}")
-                trade_info["success"] = False
-                return trade_info
-            if not close_success:
-                # Same contract as `_close_action`: a refused flatten must not read as
-                # HOLD, and the entry below must NOT go out.
-                trade_info["success"] = False
-                return trade_info
-            # A realised close moves equity; the cached balance is now wrong by the
-            # trade's P&L. Reached only on success (#295).
-            self._last_confirmed_read.pop("balance", None)
-            self.position.current_position = 0
-            self.active_stop_loss = 0.0
-            self.active_take_profit = 0.0
-
-        # Map position side to trade side
-        trade_side = "buy" if side == "long" else "sell"
-
-        stop_loss_price, take_profit_price = calculate_bracket_prices(
-            side, current_price, stop_loss_pct, take_profit_pct
-        )
-
-        try:
-            success = self.trader.trade(
-                side=trade_side,
-                quantity=quantity,
-                order_type="market",
-                take_profit=take_profit_price,
-                stop_loss=stop_loss_price,
-            )
-
-            if success:
-                # OKX attachAlgoOrds is atomic — SL/TP succeed or fail with the main order
-                self.active_stop_loss = stop_loss_price
-                self.active_take_profit = take_profit_price
-
-            trade_info.update({
-                "executed": True,
-                "quantity": quantity,
-                "side": trade_side,
-                "success": success,
-                "stop_loss": stop_loss_price,
-                "take_profit": take_profit_price,
-            })
-        except Exception as e:
-            logger.error(
-                f"{side.capitalize()} trade failed for {self.config.symbol}: "
-                f"quantity={quantity}, "
-                f"SL={stop_loss_price:.2f}, TP={take_profit_price:.2f}, error={e}"
-            )
-            trade_info["success"] = False
-            return trade_info
-
-        return trade_info
+        Kept as a sizing override rather than inlined in the executor, which is what let
+        okx keep a private ~115-line copy of it. Whether the other three should refuse too
+        is #414's question, not this fold's.
+        """
+        quantity = super()._resolve_bracket_quantity(current_price)
+        if quantity is None or quantity < self.trader.get_lot_size()["min_qty"]:
+            return None
+        return quantity
 
     def _dispatch_sltp_trade(self, action_tuple, current_price: float):
         # Threaded, not re-read: re-reading the mark inside the trade path bypassed the

--- a/torchtrade/envs/live/okx/env_sltp.py
+++ b/torchtrade/envs/live/okx/env_sltp.py
@@ -17,7 +17,6 @@ from torchtrade.envs.utils.action_maps import create_sltp_action_map
 from torchtrade.envs.utils.sltp_mixin import SLTPMixin
 
 
-
 @dataclass
 class OKXFuturesSLTPTradingEnvConfig(BaseFuturesSLTPConfig):
     """Configuration for OKX Futures SLTP Trading Environment.
@@ -83,9 +82,7 @@ class OKXFuturesSLTPTorchTradingEnv(SLTPMixin, OKXBaseTorchTradingEnv):
     def _resolve_bracket_quantity(self, current_price):
         """okx alone refuses a sub-minimum bracket instead of letting the venue reject it.
 
-        Kept as a sizing override rather than inlined in the executor, which is what let
-        okx keep a private ~115-line copy of it. Whether the other three should refuse too
-        is #414's question, not this fold's.
+        Whether the other three should refuse too is #414's question, not this fold's.
         """
         quantity = super()._resolve_bracket_quantity(current_price)
         if quantity is None or quantity < self.trader.get_lot_size()["min_qty"]:

--- a/torchtrade/envs/live/okx/env_sltp.py
+++ b/torchtrade/envs/live/okx/env_sltp.py
@@ -1,8 +1,7 @@
 """OKX Futures TorchRL trading environment with Stop Loss and Take Profit."""
 from torchtrade.envs.live.shared.sltp_config import BaseFuturesSLTPConfig
 from dataclasses import dataclass
-from typing import Dict, Optional, Tuple, Callable
-import logging
+from typing import Optional, Callable
 
 from torchrl.data import Categorical
 
@@ -16,9 +15,7 @@ from torchtrade.envs.live.okx.utils import normalize_okx_timeframe_config
 from torchtrade.envs.live.okx.base import OKXBaseTorchTradingEnv
 from torchtrade.envs.utils.action_maps import create_sltp_action_map
 from torchtrade.envs.utils.sltp_mixin import SLTPMixin
-from torchtrade.envs.utils.sltp_helpers import calculate_bracket_prices
 
-logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -95,8 +92,3 @@ class OKXFuturesSLTPTorchTradingEnv(SLTPMixin, OKXBaseTorchTradingEnv):
             return None
         return quantity
 
-    def _dispatch_sltp_trade(self, action_tuple, current_price: float):
-        # Threaded, not re-read: re-reading the mark inside the trade path bypassed the
-        # halt policy, so a grace bar that priced a bracket died instead of truncating
-        # (#295). binance and bitget price off a candle close and take the default.
-        return self._execute_trade_if_needed(action_tuple, current_price=current_price)

--- a/torchtrade/envs/utils/sltp_mixin.py
+++ b/torchtrade/envs/utils/sltp_mixin.py
@@ -259,7 +259,9 @@ class SLTPMixin:
 
         `current_price` is the mark `_step` acquired, passed by the venues that price off
         it and ignored by the ones that read their own candle -- see
-        `_bracket_entry_price`, the only thing that ever varied here.
+        `_bracket_entry_price`, the price source. okx additionally varies
+        `_resolve_bracket_quantity` (sub-minimum refusal), so there are two seams,
+        not one -- this PR's own structural test exempts the second by name.
 
         Args:
             action_tuple: (side, stop_loss_pct, take_profit_pct); (None, None, None) is HOLD.

--- a/torchtrade/envs/utils/sltp_mixin.py
+++ b/torchtrade/envs/utils/sltp_mixin.py
@@ -20,10 +20,10 @@ class SLTPMixin:
     -- alpaca included, which is why deleting its own `_reset` mattered: with both in the
     MRO, `_reset_sltp_state` ran twice per reset.
 
-    The one venue-specific piece is `_bracket_entry_price`: bybit and okx use the mark
-    `_step` already acquired under the halt policy, binance and bitget price off their own
-    candle close. That split is deliberate (#409/#295) and is the ONLY thing that varies --
-    naming it is what let the last two ~110-line executor copies go.
+    Two venue-specific pieces remain, both deliberate: `_bracket_entry_price` (bybit and
+    okx use the mark `_step` already acquired under the halt policy; binance and bitget
+    price off their own candle close -- #409/#295), and okx's `_resolve_bracket_quantity`
+    override, which refuses a sub-minimum bracket instead of letting the venue reject it.
 
     Required of the inheriting class -- the full list, because owning `_step` means this
     mixin now depends on the whole live-env surface, not just SLTP state:
@@ -196,9 +196,9 @@ class SLTPMixin:
     def _mark_flat(self) -> None:
         """Record that the position is gone: cache, direction, and both bracket legs.
 
-        Cache first because a realised close moves equity, so the cached balance is now
-        wrong by the trade's P&L. Callers must only reach this after `close_position()`
-        returned truthy -- a failed close leaves the position (#295).
+        The balance goes because a realised close moves equity and the cached sizing
+        balance is now wrong by the trade's P&L. Callers must only reach this after
+        `close_position()` returned truthy -- a failed close leaves the position (#295).
         """
         self._last_confirmed_read.pop("balance", None)
         self.position.current_position = 0
@@ -217,7 +217,11 @@ class SLTPMixin:
     def _bracket_entry_price(self, current_price: Optional[float]) -> float:
         """The price that sizes the order and prices both brackets.
 
-        The one thing the four SLTP venues disagree about; everything downstream is shared.
+        The price source is the venue split; everything downstream of it is shared.
+
+        The mark branch's raise is unreachable from `_step`: `_current_mark_price` already
+        carries the identical guard inside `_halting`, and the grace path serves a
+        previously validated value. Only a direct caller reaches it.
         """
         if self._PRICES_OFF_THREADED_MARK:
             current_price = float(current_price)

--- a/torchtrade/envs/utils/sltp_mixin.py
+++ b/torchtrade/envs/utils/sltp_mixin.py
@@ -333,6 +333,12 @@ class SLTPMixin:
                 return trade_info
             self._last_confirmed_read.pop("balance", None)
             self.position.current_position = 0
+            # The closed position's brackets go with it. If the replacement entry below
+            # then fails, the next sync is flat -> flat, so `_sync_position_from_exchange`
+            # never clears them and they read as live on a position that no longer exists.
+            # okx alone did this before the fold; the other three inherited the gap.
+            self.active_stop_loss = 0.0
+            self.active_take_profit = 0.0
 
         trade_side = "buy" if side == "long" else "sell"
         stop_loss_price, take_profit_price = calculate_bracket_prices(

--- a/torchtrade/envs/utils/sltp_mixin.py
+++ b/torchtrade/envs/utils/sltp_mixin.py
@@ -53,16 +53,6 @@ class SLTPMixin:
         """The position the ACTION targets, never the order side (#276)."""
         self.position.current_position = self.SIDE_DIRECTION.get(side, 0)
 
-    def _dispatch_sltp_trade(self, action_tuple, current_price: float):
-        """Hand the action to the executor, with the mark `_step` already acquired.
-
-        Passed unconditionally: `_bracket_entry_price` decides whether to use it, so the
-        venues that price off their own candle simply ignore it. That is what let both
-        venue overrides of this method go -- forwarding a value the callee may ignore is
-        cheaper than two copies of a one-line forward.
-        """
-        return self._execute_trade_if_needed(action_tuple, current_price=current_price)
-
     def _reset(self, tensordict: TensorDictBase, **kwargs) -> TensorDictBase:
         """Four byte-identical copies (#288)."""
         result = super()._reset(tensordict, **kwargs)
@@ -71,7 +61,7 @@ class SLTPMixin:
 
     def _step(self, tensordict: TensorDictBase) -> TensorDictBase:
         """One step. Four copies, 100% identical within each venue pair and 88% across --
-        the 12% was solely the dispatch call, which `_dispatch_sltp_trade` now owns (#288).
+        the 12% was solely the price source, which `_bracket_entry_price` now owns (#288).
 
         This is the file where #295 kept finding a fix applied to some copies and not
         others: the unguarded balance read, the mark re-read, the close that left the
@@ -86,7 +76,9 @@ class SLTPMixin:
 
         action_tuple = self._resolve_action_tuple(tensordict)
 
-        trade_info = self._dispatch_sltp_trade(action_tuple, current_price)
+        trade_info = self._execute_trade_if_needed(
+            action_tuple, current_price=current_price
+        )
 
         # Eagerly update position from the trade result so the rest of this step sees the
         # new state without waiting for the next sync cycle.
@@ -206,11 +198,6 @@ class SLTPMixin:
     def _mark_flat(self) -> None:
         """Record that the position is gone: cache, direction, and both bracket legs.
 
-        Two callers -- the close action and the switch-directions flatten -- and they were
-        drifting already: okx cleared the brackets in one and not the other, which is the
-        regression #419 shipped. Three lines in two places is how the four executors this
-        issue is about got started.
-
         Cache first because a realised close moves equity, so the cached balance is now
         wrong by the trade's P&L. Callers must only reach this after `close_position()`
         returned truthy -- a failed close leaves the position (#295).
@@ -250,12 +237,6 @@ class SLTPMixin:
 
     def _validated_mark_price(self, current_price: Optional[float]) -> float:
         """The other implementation of `_bracket_entry_price`: use the threaded mark.
-
-        Lives here rather than in bybit's and okx's files because it was byte-identical in
-        both -- two copies is how this method got to two ~110-line copies in the first
-        place. The venues that want it say so with one line:
-
-            _bracket_entry_price = SLTPMixin._validated_mark_price
 
         Re-reading the price instead is what #295 removed: the second read bypassed the
         halt policy, so a halted bar still traded. Validated because a venue can report a

--- a/torchtrade/envs/utils/sltp_mixin.py
+++ b/torchtrade/envs/utils/sltp_mixin.py
@@ -207,15 +207,65 @@ class SLTPMixin:
             trade_info["success"] = False
         return trade_info
 
-    def _execute_trade_if_needed(
-        self, action_tuple: Tuple[Optional[str], Optional[float], Optional[float]]
-    ) -> Dict:
-        """Place the bracket for the venues that price it off their own candle.
+    def _bracket_entry_price(self, current_price: Optional[float]) -> float:
+        """The price that sizes the order and prices both brackets.
 
-        The four SLTP venues split by SIGNATURE, not by exchange: binance and bitget price
-        the bracket off the observer's own candle, while bybit and okx require the mark
-        threaded in by the caller (`*, current_price`) -- see #295, where re-reading it
-        inside the trade path bypassed the halt policy. Those two override this.
+        THE one thing the four SLTP venues disagreed about, and the reason they carried
+        two ~110-line copies of the executor between them (#288). binance and bitget read
+        their own candle close under the halt policy; bybit and okx are handed the mark
+        `_step` already acquired and must not re-read it (#295, where re-reading inside
+        the trade path bypassed the policy). Everything downstream is identical.
+        """
+        def read_close():
+            obs = self.observer.get_observations(return_base_ohlc=True)
+            price = float(obs["base_features"][-1, 3])
+            # This price divides the notional sizing AND prices both brackets in every
+            # mode, including the "quantity" default which checked nothing. dropna() does
+            # not clear a candle close of inf (#347). The name is load-bearing:
+            # test_sltp_sizing_rejects_a_non_finite_price_or_balance greps for it.
+            if not math.isfinite(price) or price <= 0:
+                raise ValueError(
+                    f"unusable close price ({price}) for {self.config.symbol}"
+                )
+            return price
+
+        # cache_key is load-bearing, not decoration: without it `cached` is None, grace
+        # cannot apply, and this still raises -- it just raises a nicer type. The claimed
+        # behaviour is "serve the last CONFIRMED close and flag the bar", which needs a
+        # slot to serve from. Its own slot, because it is a candle close, not the mark.
+        return self._halting(read_close, cache_key="candle_close")
+
+    def _validated_mark_price(self, current_price: Optional[float]) -> float:
+        """The other implementation of `_bracket_entry_price`: use the threaded mark.
+
+        Lives here rather than in bybit's and okx's files because it was byte-identical in
+        both -- two copies is how this method got to two ~110-line copies in the first
+        place. The venues that want it say so with one line:
+
+            _bracket_entry_price = SLTPMixin._validated_mark_price
+
+        Re-reading the price instead is what #295 removed: the second read bypassed the
+        halt policy, so a halted bar still traded. Validated because a venue can report a
+        nonsense mark, and this value both sizes the order and prices both brackets.
+        """
+        current_price = float(current_price)
+        if not math.isfinite(current_price) or current_price <= 0:
+            raise ValueError(
+                f"venue reported an unusable mark price ({current_price})"
+            )
+        return current_price
+
+    def _execute_trade_if_needed(
+        self,
+        action_tuple: Tuple[Optional[str], Optional[float], Optional[float]],
+        *,
+        current_price: Optional[float] = None,
+    ) -> Dict:
+        """Place the bracket. One copy for all four futures SLTP venues (#288).
+
+        `current_price` is the mark `_step` acquired, passed by the venues that price off
+        it and ignored by the ones that read their own candle -- see
+        `_bracket_entry_price`, the only thing that ever varied here.
 
         Args:
             action_tuple: (side, stop_loss_pct, take_profit_pct); (None, None, None) is HOLD.
@@ -258,24 +308,7 @@ class SLTPMixin:
         # Read AND verdict under `_halting` (#295): `get_observations` raises on a short
         # window or a stale bar, and outside the policy that escapes as a bare ValueError.
         # bybit/okx take a threaded mark; these two price off the candle close on purpose.
-        def read_close():
-            obs = self.observer.get_observations(return_base_ohlc=True)
-            current_price = float(obs["base_features"][-1, 3])
-            # This price divides the notional sizing AND prices both brackets in every
-            # mode, including the "quantity" default which checked nothing. dropna() does
-            # not clear a candle close of inf (#347). The name is load-bearing:
-            # test_sltp_sizing_rejects_a_non_finite_price_or_balance greps for it.
-            if not math.isfinite(current_price) or current_price <= 0:
-                raise ValueError(
-                    f"unusable close price ({current_price}) for {self.config.symbol}"
-                )
-            return current_price
-
-        # cache_key is load-bearing, not decoration: without it `cached` is None, grace
-        # cannot apply, and this still raises -- it just raises a nicer type. The claimed
-        # behaviour is "serve the last CONFIRMED close and flag the bar", which needs a
-        # slot to serve from. Its own slot, because it is a candle close, not the mark.
-        current_price = self._halting(read_close, cache_key="candle_close")
+        current_price = self._bracket_entry_price(current_price)
 
         quantity = self._resolve_bracket_quantity(current_price)
         if quantity is None:

--- a/torchtrade/envs/utils/sltp_mixin.py
+++ b/torchtrade/envs/utils/sltp_mixin.py
@@ -134,13 +134,11 @@ class SLTPMixin:
         position_closed = (prev_position != 0 and self.position.current_position == 0)
         if position_closed:
             logger.info("Position closed by SL/TP or external action")
-            self.active_stop_loss = 0.0
-            self.active_take_profit = 0.0
-            # The exchange closed it, so the realised P&L has already moved equity and the
-            # cached sizing balance is stale by exactly that amount. This closure path is
-            # the one the ENV never asked for -- a bracket firing, or a manual close -- so
-            # it has no `close_position()` call for the close-site guard to find (#295).
-            getattr(self, "_last_confirmed_read", {}).pop("balance", None)
+            # Third caller. This closure is the one the ENV never asked for -- a bracket
+            # firing, or a manual close -- so it has no `close_position()` call for the
+            # close-site guard to find (#295), but the realised P&L moved equity just the
+            # same. `current_position` is already 0 here via position_direction_from_status.
+            self._mark_flat()
 
         # Detect direction flip (e.g., long→short via external action).
         # Reset SL/TP since the old bracket levels are stale for the new direction.
@@ -207,15 +205,28 @@ class SLTPMixin:
         self.active_stop_loss = 0.0
         self.active_take_profit = 0.0
 
+    # bybit and okx set True: `_step` already took the mark under the halt policy and the
+    # trade path must not read a price again (#295). A class attribute rather than two
+    # implementations, because binding one as `_bracket_entry_price = SLTPMixin.<other>`
+    # meant a subclass calling `super()._bracket_entry_price()` silently got the CANDLE
+    # version -- the exact regression the split exists to prevent. It also keeps
+    # `_bracket_entry_price` a single shared method, so it sits in the uniform ownership
+    # table instead of needing a bespoke guard of its own.
+    _PRICES_OFF_THREADED_MARK = False
+
     def _bracket_entry_price(self, current_price: Optional[float]) -> float:
         """The price that sizes the order and prices both brackets.
 
-        THE one thing the four SLTP venues disagreed about, and the reason they carried
-        two ~110-line copies of the executor between them (#288). binance and bitget read
-        their own candle close under the halt policy; bybit and okx are handed the mark
-        `_step` already acquired and must not re-read it (#295, where re-reading inside
-        the trade path bypassed the policy). Everything downstream is identical.
+        The one thing the four SLTP venues disagree about; everything downstream is shared.
         """
+        if self._PRICES_OFF_THREADED_MARK:
+            current_price = float(current_price)
+            if not math.isfinite(current_price) or current_price <= 0:
+                raise ValueError(
+                    f"venue reported an unusable mark price ({current_price})"
+                )
+            return current_price
+
         def read_close():
             obs = self.observer.get_observations(return_base_ohlc=True)
             price = float(obs["base_features"][-1, 3])
@@ -230,24 +241,9 @@ class SLTPMixin:
             return price
 
         # cache_key is load-bearing, not decoration: without it `cached` is None, grace
-        # cannot apply, and this still raises -- it just raises a nicer type. The claimed
-        # behaviour is "serve the last CONFIRMED close and flag the bar", which needs a
-        # slot to serve from. Its own slot, because it is a candle close, not the mark.
+        # cannot apply, and this still raises -- it just raises a nicer type. Its own slot,
+        # because it is a candle close, not the mark.
         return self._halting(read_close, cache_key="candle_close")
-
-    def _validated_mark_price(self, current_price: Optional[float]) -> float:
-        """The other implementation of `_bracket_entry_price`: use the threaded mark.
-
-        Re-reading the price instead is what #295 removed: the second read bypassed the
-        halt policy, so a halted bar still traded. Validated because a venue can report a
-        nonsense mark, and this value both sizes the order and prices both brackets.
-        """
-        current_price = float(current_price)
-        if not math.isfinite(current_price) or current_price <= 0:
-            raise ValueError(
-                f"venue reported an unusable mark price ({current_price})"
-            )
-        return current_price
 
     def _execute_trade_if_needed(
         self,
@@ -299,9 +295,6 @@ class SLTPMixin:
         if side in self.SIDE_DIRECTION and self.position.current_position == self.SIDE_DIRECTION[side]:
             return trade_info
 
-        # Read AND verdict under `_halting` (#295): `get_observations` raises on a short
-        # window or a stale bar, and outside the policy that escapes as a bare ValueError.
-        # bybit/okx take a threaded mark; these two price off the candle close on purpose.
         current_price = self._bracket_entry_price(current_price)
 
         quantity = self._resolve_bracket_quantity(current_price)

--- a/torchtrade/envs/utils/sltp_mixin.py
+++ b/torchtrade/envs/utils/sltp_mixin.py
@@ -20,10 +20,10 @@ class SLTPMixin:
     -- alpaca included, which is why deleting its own `_reset` mattered: with both in the
     MRO, `_reset_sltp_state` ran twice per reset.
 
-    The one venue-specific piece is `_dispatch_sltp_trade`. bybit and okx forward the
-    mark `_step` already acquired under the halt policy; binance and bitget price their
-    brackets off a candle close and take the default. That split is deliberate and is a
-    #409 decision, not an accident to unify here.
+    The one venue-specific piece is `_bracket_entry_price`: bybit and okx use the mark
+    `_step` already acquired under the halt policy, binance and bitget price off their own
+    candle close. That split is deliberate (#409/#295) and is the ONLY thing that varies --
+    naming it is what let the last two ~110-line executor copies go.
 
     Required of the inheriting class -- the full list, because owning `_step` means this
     mixin now depends on the whole live-env surface, not just SLTP state:
@@ -54,13 +54,14 @@ class SLTPMixin:
         self.position.current_position = self.SIDE_DIRECTION.get(side, 0)
 
     def _dispatch_sltp_trade(self, action_tuple, current_price: float):
-        """Hand the action to the venue's executor. The ONE thing `_step` varies by venue.
+        """Hand the action to the executor, with the mark `_step` already acquired.
 
-        Default: the venue prices its own bracket off a candle close and does not want the
-        mark (binance, bitget). bybit and okx take the threaded price -- see #295, where
-        re-reading it inside the trade path bypassed the halt policy.
+        Passed unconditionally: `_bracket_entry_price` decides whether to use it, so the
+        venues that price off their own candle simply ignore it. That is what let both
+        venue overrides of this method go -- forwarding a value the callee may ignore is
+        cheaper than two copies of a one-line forward.
         """
-        return self._execute_trade_if_needed(action_tuple)
+        return self._execute_trade_if_needed(action_tuple, current_price=current_price)
 
     def _reset(self, tensordict: TensorDictBase, **kwargs) -> TensorDictBase:
         """Four byte-identical copies (#288)."""
@@ -190,13 +191,8 @@ class SLTPMixin:
             trade_info["success"] = False
             return trade_info
         if success:
-            # A realised close moves equity; the cached balance is now wrong by the
-            # trade's P&L. SUCCESS only -- a failed close leaves the position (#295).
-            self._last_confirmed_read.pop("balance", None)
             close_side = "sell" if self.position.current_position > 0 else "buy"
-            self.position.current_position = 0
-            self.active_stop_loss = 0.0
-            self.active_take_profit = 0.0
+            self._mark_flat()
             trade_info.update({
                 "executed": True, "side": close_side,
                 "success": True, "closed_position": True,
@@ -206,6 +202,23 @@ class SLTPMixin:
             # the refusal is invisible to the caller.
             trade_info["success"] = False
         return trade_info
+
+    def _mark_flat(self) -> None:
+        """Record that the position is gone: cache, direction, and both bracket legs.
+
+        Two callers -- the close action and the switch-directions flatten -- and they were
+        drifting already: okx cleared the brackets in one and not the other, which is the
+        regression #419 shipped. Three lines in two places is how the four executors this
+        issue is about got started.
+
+        Cache first because a realised close moves equity, so the cached balance is now
+        wrong by the trade's P&L. Callers must only reach this after `close_position()`
+        returned truthy -- a failed close leaves the position (#295).
+        """
+        self._last_confirmed_read.pop("balance", None)
+        self.position.current_position = 0
+        self.active_stop_loss = 0.0
+        self.active_take_profit = 0.0
 
     def _bracket_entry_price(self, current_price: Optional[float]) -> float:
         """The price that sizes the order and prices both brackets.
@@ -331,14 +344,10 @@ class SLTPMixin:
                 # opposite position is still open at the venue.
                 trade_info["success"] = False
                 return trade_info
-            self._last_confirmed_read.pop("balance", None)
-            self.position.current_position = 0
-            # The closed position's brackets go with it. If the replacement entry below
-            # then fails, the next sync is flat -> flat, so `_sync_position_from_exchange`
-            # never clears them and they read as live on a position that no longer exists.
-            # okx alone did this before the fold; the other three inherited the gap.
-            self.active_stop_loss = 0.0
-            self.active_take_profit = 0.0
+            # Brackets go with the position. If the replacement entry below then fails,
+            # the next sync is flat -> flat, so `_sync_position_from_exchange` never
+            # clears them and they are left stale. okx alone did this before the fold.
+            self._mark_flat()
 
         trade_side = "buy" if side == "long" else "sell"
         stop_loss_price, take_profit_price = calculate_bracket_prices(


### PR DESCRIPTION
The last of #288's SLTP duplication. bybit and okx each kept a ~110-line `_execute_trade_if_needed` that differed from the shared one in **exactly one thing**: where the entry price comes from. Everything downstream — guards, close, duplicate check, sizing, flatten, bracket, trade, exception handling — was already identical.

## The hook

`_bracket_entry_price` is that one thing. binance and bitget read their own candle close under the halt policy; bybit and okx use the mark `_step` already acquired and must **not** re-read it (#295, where re-reading inside the trade path bypassed the policy). Both venues pick the alternative with one line rather than a copy:

```python
_bracket_entry_price = SLTPMixin._validated_mark_price
```

That line exists because my first pass gave bybit and okx a 14-line hook each — byte-identical to one another. Two copies of a thing is how this method reached two 110-line copies, so it didn't survive its own diff.

okx's sub-minimum refusal moves to a `_resolve_bracket_quantity` override that delegates via `super()` — the same shape binance's sizing already uses, exempted from the identity guard the same way. Keyed on the overriding **class**, not the venue: keyed on the venue it also swallowed okx's two plain envs, which override nothing and would have passed while asserting nothing about them. Whether the other three should refuse sub-minimum quantities too is **#414's** question, not this fold's.

## Equivalence

324 cases per tree — 2 venues × 3 positions × 3 sides × sizeable/not × {trade ok, refused, raised} × 3 `bracket_status` shapes — run differentially against `main`:

| | cases | differing |
|---|---|---|
| real-trader (`bracket_status` absent) | 108 | **0** |
| total | 324 | **4** |

All four differences are okx with an **injected** `bracket_status` reporting a rejected leg, which no live okx trader produces — its executor never sets the attribute, so the all-True default applies and behaviour is identical.

**Correction (round 1).** I originally wrote that this *fixes* `ReplayOrderExecutor`. It does not, and the torchrl reviewer was right to refute it: replay sets `sl_placed = stop_loss is not None`, and `calculate_bracket_prices` always returns two floats, so replay reports all-True on this path too. **No trader in the repo can currently report a rejected leg here** — the only producer is the injected stub in the test.

The gate is still worth having, because binance and bitget *do* place the legs separately, and a venue that starts doing so should not need the test written for it afterwards. But it pins a contract rather than fixing an observed failure, and the test docstring now says so.

(An earlier version of this probe monkeypatched `_resolve_bracket_quantity` to force a sub-minimum quantity and reported 40 differences. That method is exactly where okx's check moved, so replacing it deleted the behaviour under comparison. The corrected probe drives a real sub-minimum quantity through real sizing.)

## One test needed repointing

`test_sltp_sizing_rejects_a_non_finite_price_or_balance` greps the resolved source for the price guard — which moved to `_bracket_entry_price`. That's the **second** time this test's subject has moved out from under it (the first was #288 folding the sizing onto the shared base; its own comment records that). It now resolves-then-scans, and pins both halves of the split: that binance/bitget read the observer, and that bybit/okx do not.

## What's left in #288 after this

| target | copies | lines | similarity |
|---|---|---|---|
| plain `_execute_trade_if_needed` | 4 | 53 | bybit/okx 100%, binance/bitget 77% |
| plain `__post_init__` | 4 | 56 | 61–80% |

Plus the test-side consolidation, [measured here](https://github.com/TorchTrade/torchtrade/issues/288#issuecomment-5437804225).

## Round 1 (five agents) — what it changed

Two agents independently found that **the guard did not follow the fold**: `_execute_trade_if_needed` became shared by all four venues while the test protecting it was still keyed on the pre-fold split. A faithful copy of the shared executor pasted back onto bybit **passed all 3445 tests** — the un-folding of the exact method this PR folds was invisible, on the two venues it just changed.

The fix was a deletion: both methods moved into the uniform `_SHARED_METHOD_OWNERSHIP` table and the 72-line `_DISPATCH_INHERITORS`/`_DISPATCH_OVERRIDERS` block went with them, since its premise ("bybit and okx legitimately override") stopped being true here. The variation moved rather than vanished, so a new identity guard pins `_bracket_entry_price` at its new home.

Three mutants that were surviving the whole suite now die:

| mutant | was | now |
|---|---|---|
| a **refused** flatten also clears the brackets | 3445 passed | 4 failures |
| a **successful** switch arms nothing | 3445 passed | 15 failures |
| `isfinite` dropped from either price guard | killed by a *grep* only | 4 failures, behavioural |

Also: `_mark_flat()` folds the flatten triplet that `_close_action` and the direction-switch flatten were doing 140 lines apart — and had **already drifted**, which is precisely the regression Charlie caught.

Net **−51**. Suite: **4485 passed**, 16 skipped.

