### PR TITLE
fix(414): four ways an order got submitted that the venue would reject

### DIFF
--- a/tests/envs/binance/test_futures_order_executor.py
+++ b/tests/envs/binance/test_futures_order_executor.py
@@ -268,7 +268,7 @@ class TestBinanceFuturesOrderClass:
         good = mock_client.futures_exchange_info
         mock_client.futures_exchange_info = MagicMock(side_effect=Exception("503 blip"))
         executor = BinanceFuturesOrderClass(symbol="BTCUSDT", client=mock_client)
-        assert executor.get_lot_size()["min_notional"] == 0.0   # nothing was ever read
+        assert executor.get_lot_size()["min_notional"] is None   # never read != no floor
 
         mock_client.futures_exchange_info = good                # the venue comes back
         assert executor.get_lot_size()["min_notional"] == 5.0, (

--- a/tests/envs/binance/test_futures_order_executor.py
+++ b/tests/envs/binance/test_futures_order_executor.py
@@ -77,6 +77,15 @@ class TestBinanceFuturesOrderClass:
                     # whether the executor read it or hardcoded 0.0 (#414).
                     {"filterType": "MIN_NOTIONAL", "notional": "5"},
                 ],
+            }, {
+                # A SECOND symbol, with a different floor. With one symbol nothing could
+                # tell whether MIN_NOTIONAL is scoped to this symbol or whichever one the
+                # payload happens to list last (#414).
+                "symbol": "ETHUSDT",
+                "filters": [
+                    {"filterType": "LOT_SIZE", "stepSize": "0.01", "minQty": "0.01"},
+                    {"filterType": "MIN_NOTIONAL", "notional": "20"},
+                ],
             }]
         })
 

--- a/tests/envs/binance/test_futures_order_executor.py
+++ b/tests/envs/binance/test_futures_order_executor.py
@@ -247,6 +247,26 @@ class TestBinanceFuturesOrderClass:
         assert order_executor._tick_size == 0.1
         assert order_executor._tick_decimals == 1
 
+    def test_get_lot_size_recovers_after_a_transient_exchange_info_failure(self, mock_client):
+        """binance was the only venue whose `get_lot_size` never re-fetched.
+
+        `_fetch_symbol_filters` returns early on a transient failure -- BEFORE its own
+        fail-closed "no LOT_SIZE" raise -- so one blip at construction left every cache
+        empty and nothing repaired them. Both floors were then silently 0.0 for the life
+        of the process, which is the fail-open this whole change exists to remove (#414).
+        """
+        from torchtrade.envs.live.binance.order_executor import BinanceFuturesOrderClass
+        good = mock_client.futures_exchange_info
+        mock_client.futures_exchange_info = MagicMock(side_effect=Exception("503 blip"))
+        executor = BinanceFuturesOrderClass(symbol="BTCUSDT", client=mock_client)
+        assert executor.get_lot_size()["min_notional"] == 0.0   # nothing was ever read
+
+        mock_client.futures_exchange_info = good                # the venue comes back
+        assert executor.get_lot_size()["min_notional"] == 5.0, (
+            "the floor never repaired itself; one transient failure at startup disables "
+            "the notional guard permanently"
+        )
+
     def test_get_lot_size_reports_the_venue_minimums_from_the_cached_filters(self, mock_client):
         """binance was the only executor without `get_lot_size`, so the shared sizing
         could not ask it for a notional floor and the SLTP path submitted whatever it

--- a/tests/envs/binance/test_futures_order_executor.py
+++ b/tests/envs/binance/test_futures_order_executor.py
@@ -73,6 +73,9 @@ class TestBinanceFuturesOrderClass:
                 "filters": [
                     {"filterType": "PRICE_FILTER", "tickSize": "0.10"},
                     {"filterType": "LOT_SIZE", "stepSize": "0.001", "minQty": "0.001"},
+                    # Real payloads carry this; the mock omitted it, so nothing could tell
+                    # whether the executor read it or hardcoded 0.0 (#414).
+                    {"filterType": "MIN_NOTIONAL", "notional": "5"},
                 ],
             }]
         })
@@ -243,6 +246,31 @@ class TestBinanceFuturesOrderClass:
         """Tick size should be cached from exchange info at init."""
         assert order_executor._tick_size == 0.1
         assert order_executor._tick_decimals == 1
+
+    def test_get_lot_size_reports_the_venue_minimums_from_the_cached_filters(self, mock_client):
+        """binance was the only executor without `get_lot_size`, so the shared sizing
+        could not ask it for a notional floor and the SLTP path submitted whatever it
+        had computed (#414).
+
+        The values come from filters `_fetch_symbol_filters` already walks, so this adds
+        no API call -- `futures_exchange_info` is still called exactly once, at
+        construction.
+        """
+        from torchtrade.envs.live.binance.order_executor import BinanceFuturesOrderClass
+        executor = BinanceFuturesOrderClass(symbol="BTCUSDT", client=mock_client)
+        calls = mock_client.futures_exchange_info.call_count
+
+        lot = executor.get_lot_size()
+
+        assert lot["min_notional"] == 5.0, (
+            "MIN_NOTIONAL was not captured; the shared guard would read a 0.0 floor and "
+            "refuse nothing"
+        )
+        assert lot["min_qty"] == 0.001
+        assert lot["qty_step"] == 0.001
+        assert mock_client.futures_exchange_info.call_count == calls, (
+            "get_lot_size re-fetched exchange info instead of using the cached filters"
+        )
 
     def test_round_price_without_precision(self, mock_client):
         """When tick size fetch fails, prices pass through unmodified."""

--- a/tests/envs/binance/test_torch_env_futures_sltp.py
+++ b/tests/envs/binance/test_torch_env_futures_sltp.py
@@ -507,8 +507,7 @@ class TestMultipleSteps:
         mock_observer.window_sizes = [10]
 
         mock_trader = MagicMock()
-        # A realistic lot step: `float(MagicMock())` is 1.0, which reads as a 1.0-BTC
-        # lot and floors every real quantity to zero in the shared sizing guard.
+        # Realistic lot step (float(MagicMock()) is 1.0 -- see the note above).
         mock_trader.get_lot_size = MagicMock(
             return_value={"min_qty": 0.001, "qty_step": 0.001, "min_notional": 0.0})
         mock_trader.cancel_open_orders = MagicMock(return_value=True)
@@ -592,8 +591,7 @@ class TestCriticalEdgeCases:
 
         mock_observer = MagicMock(spec=BinanceObservationClass)
         mock_trader = MagicMock(spec=BinanceFuturesOrderClass)
-        # A realistic lot step: `float(MagicMock())` is 1.0, which reads as a 1.0-BTC
-        # lot and floors every real quantity to zero in the shared sizing guard.
+        # Realistic lot step (float(MagicMock()) is 1.0 -- see the note above).
         mock_trader.get_lot_size = MagicMock(
             return_value={"min_qty": 0.001, "qty_step": 0.001, "min_notional": 0.0})
 
@@ -806,8 +804,7 @@ class TestDuplicateActionPrevention:
         mock_observer.window_sizes = [10]
 
         mock_trader = MagicMock()
-        # A realistic lot step: `float(MagicMock())` is 1.0, which reads as a 1.0-BTC
-        # lot and floors every real quantity to zero in the shared sizing guard.
+        # Realistic lot step (float(MagicMock()) is 1.0 -- see the note above).
         mock_trader.get_lot_size = MagicMock(
             return_value={"min_qty": 0.001, "qty_step": 0.001, "min_notional": 0.0})
         mock_trader.cancel_open_orders = MagicMock(return_value=True)
@@ -983,8 +980,7 @@ class TestBinanceSLTPNotionalTradeMode:
         mock_observer.window_sizes = [10]
 
         mock_trader = MagicMock()
-        # A realistic lot step: `float(MagicMock())` is 1.0, which reads as a 1.0-BTC
-        # lot and floors every real quantity to zero in the shared sizing guard.
+        # Realistic lot step (float(MagicMock()) is 1.0 -- see the note above).
         mock_trader.get_lot_size = MagicMock(
             return_value={"min_qty": 0.001, "qty_step": 0.001, "min_notional": 0.0})
         mock_trader.cancel_open_orders = MagicMock(return_value=True)
@@ -1078,8 +1074,7 @@ class TestBinanceSLTPNotionalTradeMode:
         mock_observer.window_sizes = [10]
 
         mock_trader = MagicMock()
-        # A realistic lot step: `float(MagicMock())` is 1.0, which reads as a 1.0-BTC
-        # lot and floors every real quantity to zero in the shared sizing guard.
+        # Realistic lot step (float(MagicMock()) is 1.0 -- see the note above).
         mock_trader.get_lot_size = MagicMock(
             return_value={"min_qty": 0.001, "qty_step": 0.001, "min_notional": 0.0})
         mock_trader.get_mark_price = MagicMock(return_value=50000.0)
@@ -1145,8 +1140,7 @@ class TestBinanceSLTPNotionalTradeMode:
         mock_observer.window_sizes = [10]
 
         mock_trader = MagicMock()
-        # A realistic lot step: `float(MagicMock())` is 1.0, which reads as a 1.0-BTC
-        # lot and floors every real quantity to zero in the shared sizing guard.
+        # Realistic lot step (float(MagicMock()) is 1.0 -- see the note above).
         mock_trader.get_lot_size = MagicMock(
             return_value={"min_qty": 0.001, "qty_step": 0.001, "min_notional": 0.0})
         mock_trader.get_mark_price = MagicMock(return_value=50000.0)
@@ -1215,8 +1209,7 @@ class TestBinanceSLTPLockPosition:
         mock_observer.window_sizes = [10]
 
         mock_trader = MagicMock()
-        # A realistic lot step: `float(MagicMock())` is 1.0, which reads as a 1.0-BTC
-        # lot and floors every real quantity to zero in the shared sizing guard.
+        # Realistic lot step (float(MagicMock()) is 1.0 -- see the note above).
         mock_trader.get_lot_size = MagicMock(
             return_value={"min_qty": 0.001, "qty_step": 0.001, "min_notional": 0.0})
         mock_trader.get_mark_price = MagicMock(return_value=50000.0)

--- a/tests/envs/binance/test_torch_env_futures_sltp.py
+++ b/tests/envs/binance/test_torch_env_futures_sltp.py
@@ -51,6 +51,10 @@ class TestBinanceFuturesSLTPTorchTradingEnv:
     def mock_trader(self):
         """Create a mock trader."""
         trader = MagicMock()
+        # A realistic lot step: `float(MagicMock())` is 1.0, which reads as a 1.0-BTC
+        # lot and floors every real quantity to zero in the shared sizing guard.
+        trader.get_lot_size = MagicMock(
+            return_value={"min_qty": 0.001, "qty_step": 0.001, "min_notional": 0.0})
 
         # Mock methods
         trader.cancel_open_orders = MagicMock(return_value=True)
@@ -503,6 +507,10 @@ class TestMultipleSteps:
         mock_observer.window_sizes = [10]
 
         mock_trader = MagicMock()
+        # A realistic lot step: `float(MagicMock())` is 1.0, which reads as a 1.0-BTC
+        # lot and floors every real quantity to zero in the shared sizing guard.
+        mock_trader.get_lot_size = MagicMock(
+            return_value={"min_qty": 0.001, "qty_step": 0.001, "min_notional": 0.0})
         mock_trader.cancel_open_orders = MagicMock(return_value=True)
         mock_trader.close_position = MagicMock(return_value=True)
         mock_trader.get_account_balance = MagicMock(return_value={
@@ -584,6 +592,10 @@ class TestCriticalEdgeCases:
 
         mock_observer = MagicMock(spec=BinanceObservationClass)
         mock_trader = MagicMock(spec=BinanceFuturesOrderClass)
+        # A realistic lot step: `float(MagicMock())` is 1.0, which reads as a 1.0-BTC
+        # lot and floors every real quantity to zero in the shared sizing guard.
+        mock_trader.get_lot_size = MagicMock(
+            return_value={"min_qty": 0.001, "qty_step": 0.001, "min_notional": 0.0})
 
         def mock_get_observations(return_base_ohlc=False):
             obs = {"1m_10": np.random.randn(10, 4).astype(np.float32)}
@@ -794,6 +806,10 @@ class TestDuplicateActionPrevention:
         mock_observer.window_sizes = [10]
 
         mock_trader = MagicMock()
+        # A realistic lot step: `float(MagicMock())` is 1.0, which reads as a 1.0-BTC
+        # lot and floors every real quantity to zero in the shared sizing guard.
+        mock_trader.get_lot_size = MagicMock(
+            return_value={"min_qty": 0.001, "qty_step": 0.001, "min_notional": 0.0})
         mock_trader.cancel_open_orders = MagicMock(return_value=True)
         mock_trader.close_position = MagicMock(return_value=True)
         mock_trader.get_account_balance = MagicMock(return_value={
@@ -967,6 +983,10 @@ class TestBinanceSLTPNotionalTradeMode:
         mock_observer.window_sizes = [10]
 
         mock_trader = MagicMock()
+        # A realistic lot step: `float(MagicMock())` is 1.0, which reads as a 1.0-BTC
+        # lot and floors every real quantity to zero in the shared sizing guard.
+        mock_trader.get_lot_size = MagicMock(
+            return_value={"min_qty": 0.001, "qty_step": 0.001, "min_notional": 0.0})
         mock_trader.cancel_open_orders = MagicMock(return_value=True)
         mock_trader.close_position = MagicMock(return_value=True)
         mock_trader.get_account_balance = MagicMock(return_value={
@@ -1058,6 +1078,10 @@ class TestBinanceSLTPNotionalTradeMode:
         mock_observer.window_sizes = [10]
 
         mock_trader = MagicMock()
+        # A realistic lot step: `float(MagicMock())` is 1.0, which reads as a 1.0-BTC
+        # lot and floors every real quantity to zero in the shared sizing guard.
+        mock_trader.get_lot_size = MagicMock(
+            return_value={"min_qty": 0.001, "qty_step": 0.001, "min_notional": 0.0})
         mock_trader.get_mark_price = MagicMock(return_value=50000.0)
         mock_trader.cancel_open_orders = MagicMock(return_value=True)
         mock_trader.close_position = MagicMock(return_value=True)
@@ -1121,6 +1145,10 @@ class TestBinanceSLTPNotionalTradeMode:
         mock_observer.window_sizes = [10]
 
         mock_trader = MagicMock()
+        # A realistic lot step: `float(MagicMock())` is 1.0, which reads as a 1.0-BTC
+        # lot and floors every real quantity to zero in the shared sizing guard.
+        mock_trader.get_lot_size = MagicMock(
+            return_value={"min_qty": 0.001, "qty_step": 0.001, "min_notional": 0.0})
         mock_trader.get_mark_price = MagicMock(return_value=50000.0)
         mock_trader.cancel_open_orders = MagicMock(return_value=True)
         mock_trader.close_position = MagicMock(return_value=True)
@@ -1187,6 +1215,10 @@ class TestBinanceSLTPLockPosition:
         mock_observer.window_sizes = [10]
 
         mock_trader = MagicMock()
+        # A realistic lot step: `float(MagicMock())` is 1.0, which reads as a 1.0-BTC
+        # lot and floors every real quantity to zero in the shared sizing guard.
+        mock_trader.get_lot_size = MagicMock(
+            return_value={"min_qty": 0.001, "qty_step": 0.001, "min_notional": 0.0})
         mock_trader.get_mark_price = MagicMock(return_value=50000.0)
         mock_trader.cancel_open_orders = MagicMock(return_value=True)
         mock_trader.close_position = MagicMock(return_value=True)

--- a/tests/envs/bitget/conftest.py
+++ b/tests/envs/bitget/conftest.py
@@ -122,11 +122,11 @@ def mock_ccxt_client():
     _prec = ccxt.bitget()
     _prec.markets = {"BTC/USDT:USDT": {"symbol": "BTC/USDT:USDT",
                      "precision": {"amount": 0.0001, "price": 0.1},
-                     "limits": {"amount": {"min": 0.0001}}}}
+                     "limits": {"amount": {"min": 0.0001}, "cost": {"min": 5.0}}}}
     client.amount_to_precision = MagicMock(side_effect=_prec.amount_to_precision)
     # CCXT unified market info: TICK_SIZE precision -> precision.amount is the qty step
     client.market = MagicMock(return_value={
-        "limits": {"amount": {"min": 0.0001}},
+        "limits": {"amount": {"min": 0.0001}, "cost": {"min": 5.0}},
         "precision": {"amount": 0.0001},
     })
 

--- a/tests/envs/bitget/test_futures_order_executor.py
+++ b/tests/envs/bitget/test_futures_order_executor.py
@@ -483,13 +483,16 @@ class TestBitgetLotSize:
     def test_reads_market_info_and_caches(self, order_executor, mock_ccxt_client):
         mock_ccxt_client.market.reset_mock()
         lot = order_executor.get_lot_size()
-        assert lot == {"min_qty": 0.0001, "qty_step": 0.0001}
+        # min_notional is bitget's minTradeUSDT, which CCXT normalises to limits.cost.min.
+        # It was fetched with the rest of the market info and dropped, so an order under
+        # the floor was submitted and rejected (#414).
+        assert lot == {"min_qty": 0.0001, "qty_step": 0.0001, "min_notional": 5.0}
         order_executor.get_lot_size()  # second call served from cache
         mock_ccxt_client.market.assert_called_once()
 
     def test_falls_back_to_default_on_error(self, order_executor, mock_ccxt_client):
         mock_ccxt_client.market = MagicMock(side_effect=Exception("no market info"))
-        assert order_executor.get_lot_size() == {"min_qty": 0.001, "qty_step": 0.001}
+        assert order_executor.get_lot_size() == {"min_qty": 0.001, "qty_step": 0.001, "min_notional": 0.0}
 
     @pytest.mark.parametrize("amount,expected", [
         (0.00037, 0.0003),   # truncates down to the 0.0001 step (never rounds up -> margin-safe)

--- a/tests/envs/bitget/test_futures_order_executor.py
+++ b/tests/envs/bitget/test_futures_order_executor.py
@@ -492,7 +492,13 @@ class TestBitgetLotSize:
 
     def test_falls_back_to_default_on_error(self, order_executor, mock_ccxt_client):
         mock_ccxt_client.market = MagicMock(side_effect=Exception("no market info"))
-        assert order_executor.get_lot_size() == {"min_qty": 0.001, "qty_step": 0.001, "min_notional": 0.0}
+        # `min_notional` is None, not 0.0: a failed lookup means the floor is UNKNOWN,
+        # and reporting 0.0 made the shared guard skip the check during an outage (#414).
+        assert order_executor.get_lot_size() == {
+            "min_qty": 0.001, "qty_step": 0.001, "min_notional": None
+        }
+        # And the failure is not cached, so a recovered venue is picked up.
+        assert order_executor._lot_size_cache is None
 
     @pytest.mark.parametrize("amount,expected", [
         (0.00037, 0.0003),   # truncates down to the 0.0001 step (never rounds up -> margin-safe)

--- a/tests/envs/bitget/test_torch_env_futures.py
+++ b/tests/envs/bitget/test_torch_env_futures.py
@@ -64,7 +64,7 @@ class TestBitgetFuturesTorchTradingEnv:
         })
 
         trader.get_mark_price = MagicMock(return_value=50000.0)
-        trader.get_lot_size = MagicMock(return_value={"min_qty": 0.001, "qty_step": 0.001})
+        trader.get_lot_size = MagicMock(return_value={"min_qty": 0.001, "qty_step": 0.001, "min_notional": 0.0})
         trader._round_amount = MagicMock(side_effect=lambda amount: amount)
 
         trader.get_status = MagicMock(return_value={
@@ -593,7 +593,7 @@ class TestBitgetFractionalPositionResizing:
             "total_unrealized_profit": 0.0, "total_margin_balance": 1000.0,
         })
         trader.get_mark_price = MagicMock(return_value=50000.0)
-        trader.get_lot_size = MagicMock(return_value={"min_qty": 0.001, "qty_step": 0.001})
+        trader.get_lot_size = MagicMock(return_value={"min_qty": 0.001, "qty_step": 0.001, "min_notional": 0.0})
         trader._round_amount = MagicMock(side_effect=lambda amount: amount)
         trader.get_status = MagicMock(return_value={"position_status": None})
         trader.trade = MagicMock(return_value=True)
@@ -705,7 +705,7 @@ class TestBitgetInitCleanup:
             "total_unrealized_profit": 0.0, "total_margin_balance": 1000.0,
         })
         trader.get_mark_price = MagicMock(return_value=50000.0)
-        trader.get_lot_size = MagicMock(return_value={"min_qty": 0.001, "qty_step": 0.001})
+        trader.get_lot_size = MagicMock(return_value={"min_qty": 0.001, "qty_step": 0.001, "min_notional": 0.0})
         trader._round_amount = MagicMock(side_effect=lambda amount: amount)
         trader.get_status = MagicMock(return_value={"position_status": None})
         return trader

--- a/tests/envs/bitget/test_torch_env_futures_sltp.py
+++ b/tests/envs/bitget/test_torch_env_futures_sltp.py
@@ -66,7 +66,7 @@ class TestBitgetFuturesSLTPTorchTradingEnv:
         })
 
         trader.get_mark_price = MagicMock(return_value=50000.0)
-        trader.get_lot_size = MagicMock(return_value={"min_qty": 0.001, "qty_step": 0.001})
+        trader.get_lot_size = MagicMock(return_value={"min_qty": 0.001, "qty_step": 0.001, "min_notional": 0.0})
         trader._round_amount = MagicMock(side_effect=lambda amount: amount)
 
         trader.get_status = MagicMock(return_value={
@@ -524,7 +524,7 @@ class TestDuplicateActionPrevention:
             "total_margin_balance": 1000.0,
         })
         mock_trader.get_mark_price = MagicMock(return_value=50000.0)
-        mock_trader.get_lot_size = MagicMock(return_value={"min_qty": 0.001, "qty_step": 0.001})
+        mock_trader.get_lot_size = MagicMock(return_value={"min_qty": 0.001, "qty_step": 0.001, "min_notional": 0.0})
         mock_trader._round_amount = MagicMock(side_effect=lambda amount: amount)
         mock_trader.get_status = MagicMock(return_value={"position_status": None})
         mock_trader.trade = MagicMock(return_value=True)
@@ -697,7 +697,7 @@ class TestBitgetSLTPNotionalTradeMode:
             "total_margin_balance": 1000.0,
         })
         mock_trader.get_mark_price = MagicMock(return_value=50000.0)
-        mock_trader.get_lot_size = MagicMock(return_value={"min_qty": 0.001, "qty_step": 0.001})
+        mock_trader.get_lot_size = MagicMock(return_value={"min_qty": 0.001, "qty_step": 0.001, "min_notional": 0.0})
         mock_trader._round_amount = MagicMock(side_effect=lambda amount: amount)
         mock_trader.get_status = MagicMock(return_value={"position_status": None})
         mock_trader.trade = MagicMock(return_value=True)

--- a/tests/envs/bitget/test_torch_env_futures_sltp.py
+++ b/tests/envs/bitget/test_torch_env_futures_sltp.py
@@ -849,8 +849,7 @@ class TestBitgetSLTPNotionalTradeMode:
         mock_observer.window_sizes = [10]
 
         mock_trader = MagicMock()
-        # A realistic lot step: `float(MagicMock())` is 1.0, which reads as a 1.0-BTC
-        # lot and floors every real quantity to zero in the shared sizing guard.
+        # Realistic lot step (float(MagicMock()) is 1.0 -- see the note above).
         mock_trader.get_lot_size = MagicMock(
             return_value={"min_qty": 0.001, "qty_step": 0.001, "min_notional": 0.0})
         mock_trader.get_mark_price = MagicMock(return_value=50000.0)
@@ -919,8 +918,7 @@ class TestBitgetSLTPLockPosition:
         mock_observer.window_sizes = [10]
 
         mock_trader = MagicMock()
-        # A realistic lot step: `float(MagicMock())` is 1.0, which reads as a 1.0-BTC
-        # lot and floors every real quantity to zero in the shared sizing guard.
+        # Realistic lot step (float(MagicMock()) is 1.0 -- see the note above).
         mock_trader.get_lot_size = MagicMock(
             return_value={"min_qty": 0.001, "qty_step": 0.001, "min_notional": 0.0})
         mock_trader.get_mark_price = MagicMock(return_value=50000.0)

--- a/tests/envs/bitget/test_torch_env_futures_sltp.py
+++ b/tests/envs/bitget/test_torch_env_futures_sltp.py
@@ -782,6 +782,10 @@ class TestBitgetSLTPNotionalTradeMode:
         mock_observer.window_sizes = [10]
 
         mock_trader = MagicMock()
+        # A realistic lot step: `float(MagicMock())` is 1.0, which reads as a 1.0-BTC
+        # lot and floors every real quantity to zero in the shared sizing guard.
+        mock_trader.get_lot_size = MagicMock(
+            return_value={"min_qty": 0.001, "qty_step": 0.001, "min_notional": 0.0})
         mock_trader.get_mark_price = MagicMock(return_value=50000.0)
         mock_trader.cancel_open_orders = MagicMock(return_value=True)
         mock_trader.close_position = MagicMock(return_value=True)
@@ -845,6 +849,10 @@ class TestBitgetSLTPNotionalTradeMode:
         mock_observer.window_sizes = [10]
 
         mock_trader = MagicMock()
+        # A realistic lot step: `float(MagicMock())` is 1.0, which reads as a 1.0-BTC
+        # lot and floors every real quantity to zero in the shared sizing guard.
+        mock_trader.get_lot_size = MagicMock(
+            return_value={"min_qty": 0.001, "qty_step": 0.001, "min_notional": 0.0})
         mock_trader.get_mark_price = MagicMock(return_value=50000.0)
         mock_trader.cancel_open_orders = MagicMock(return_value=True)
         mock_trader.close_position = MagicMock(return_value=True)
@@ -911,6 +919,10 @@ class TestBitgetSLTPLockPosition:
         mock_observer.window_sizes = [10]
 
         mock_trader = MagicMock()
+        # A realistic lot step: `float(MagicMock())` is 1.0, which reads as a 1.0-BTC
+        # lot and floors every real quantity to zero in the shared sizing guard.
+        mock_trader.get_lot_size = MagicMock(
+            return_value={"min_qty": 0.001, "qty_step": 0.001, "min_notional": 0.0})
         mock_trader.get_mark_price = MagicMock(return_value=50000.0)
         mock_trader.cancel_open_orders = MagicMock(return_value=True)
         mock_trader.close_position = MagicMock(return_value=True)

--- a/tests/envs/bybit/conftest.py
+++ b/tests/envs/bybit/conftest.py
@@ -104,6 +104,9 @@ def mock_pybit_client():
             "lotSizeFilter": {
                 "minOrderQty": "0.001",
                 "qtyStep": "0.001",
+                # Real payloads carry this; the mock omitted it, so nothing could tell
+                # whether the executor read it or hardcoded 0.0 (#414).
+                "minNotionalValue": "5",
             },
             "priceFilter": {
                 "tickSize": "0.01",
@@ -158,7 +161,7 @@ def mock_env_trader():
     trader.get_mark_price = MagicMock(return_value=50000.0)
     trader.get_status = MagicMock(return_value={"position_status": None})
     trader.trade = MagicMock(return_value=True)
-    trader.get_lot_size = MagicMock(return_value={"min_qty": 0.001, "qty_step": 0.001})
+    trader.get_lot_size = MagicMock(return_value={"min_qty": 0.001, "qty_step": 0.001, "min_notional": 0.0})
     return trader
 
 

--- a/tests/envs/bybit/test_futures_order_executor.py
+++ b/tests/envs/bybit/test_futures_order_executor.py
@@ -654,3 +654,22 @@ class TestBybitFuturesOrderClass:
         })
         status = order_executor.get_status()
         assert status["position_status"] is POSITION_UNKNOWN
+
+
+    def test_the_lazy_lot_size_fetch_also_reports_the_notional_floor(
+        self, order_executor, mock_pybit_client
+    ):
+        """bybit caches the lot size TWICE: once opportunistically in
+        `_fetch_price_precision` at construction, and once lazily in `get_lot_size` when
+        that first call threw.
+
+        The lazy path is taken precisely when the venue was flaky at startup -- so a floor
+        of 0.0 there fails open exactly when you most want it. Mutating only the lazy site
+        survived the whole suite, because every test reaches the init path.
+        """
+        order_executor._lot_size_cache = None          # force the lazy path
+        lot = order_executor.get_lot_size()
+        assert lot["min_notional"] == 5.0, (
+            "the lazy fetch reports no notional floor; after a startup failure bybit "
+            "would submit sub-minimum orders with nothing to refuse them"
+        )

--- a/tests/envs/bybit/test_futures_order_executor.py
+++ b/tests/envs/bybit/test_futures_order_executor.py
@@ -545,6 +545,10 @@ class TestBybitFuturesOrderClass:
 
         lot_size = order_executor.get_lot_size()
         assert lot_size["min_qty"] == 0.001
+
+        # bybit reports minNotionalValue in the SAME lotSizeFilter it already reads.
+        # It was discarded, so the SLTP path submitted sub-minimum orders (#414).
+        assert lot_size["min_notional"] == 5.0
         assert lot_size["qty_step"] == 0.001
 
         # Should use cache from init, no additional API call

--- a/tests/envs/bybit/test_torch_env_futures.py
+++ b/tests/envs/bybit/test_torch_env_futures.py
@@ -59,7 +59,7 @@ class TestBybitFuturesTorchTradingEnv:
         trader.get_mark_price = MagicMock(return_value=50000.0)
         trader.get_status = MagicMock(return_value={"position_status": None})
         trader.trade = MagicMock(return_value=True)
-        trader.get_lot_size = MagicMock(return_value={"min_qty": 0.001, "qty_step": 0.001})
+        trader.get_lot_size = MagicMock(return_value={"min_qty": 0.001, "qty_step": 0.001, "min_notional": 0.0})
         return trader
 
     @pytest.fixture
@@ -659,7 +659,7 @@ class TestBybitFractionalPositionResizing:
             )
         })
         mock_env_trader.get_mark_price = MagicMock(return_value=50000.0)
-        mock_env_trader.get_lot_size = MagicMock(return_value={"min_qty": 0.001, "qty_step": 0.001})
+        mock_env_trader.get_lot_size = MagicMock(return_value={"min_qty": 0.001, "qty_step": 0.001, "min_notional": 0.0})
         mock_env_trader.get_account_balance = MagicMock(return_value={
             "total_wallet_balance": 1000.0, "available_balance": 900.0,
             "total_unrealized_profit": 0.0, "total_margin_balance": 1000.0,

--- a/tests/envs/okx/conftest.py
+++ b/tests/envs/okx/conftest.py
@@ -176,7 +176,7 @@ def mock_env_trader():
     trader.get_mark_price = MagicMock(return_value=50000.0)
     trader.get_status = MagicMock(return_value={"position_status": None})
     trader.trade = MagicMock(return_value=True)
-    trader.get_lot_size = MagicMock(return_value={"min_qty": 0.001, "qty_step": 0.001})
+    trader.get_lot_size = MagicMock(return_value={"min_qty": 0.001, "qty_step": 0.001, "min_notional": 0.0})
     return trader
 
 

--- a/tests/envs/okx/test_futures_order_executor.py
+++ b/tests/envs/okx/test_futures_order_executor.py
@@ -350,3 +350,20 @@ class TestOKXFuturesOrderClass:
         )
         executor.trade(side=side, quantity=0.001, reduce_only=reduce_only)
         assert mock_okx_trade_client.place_order.call_args[1]["posSide"] == expected_pos_side
+
+    def test_the_lazy_lot_size_fetch_also_reports_the_notional_floor(
+        self, order_executor, mock_okx_public_client
+    ):
+        """okx caches the lot size twice, like bybit: once at construction inside the
+        tick-size fetch, once lazily when that first call threw.
+
+        The lazy write was never executed by any test, so a wrong `min_notional` there
+        survived the whole suite -- and 999999.0 would refuse every okx bracket forever,
+        on the path taken precisely when the venue was flaky at startup.
+        """
+        order_executor._lot_size_cache = None          # force the lazy path
+        lot = order_executor.get_lot_size()
+        assert lot["min_notional"] == 0.0, (
+            "the lazy fetch reports a floor okx does not have; its derivatives bind on "
+            "minSz/lotSz"
+        )

--- a/tests/envs/okx/test_futures_order_executor.py
+++ b/tests/envs/okx/test_futures_order_executor.py
@@ -279,6 +279,12 @@ class TestOKXFuturesOrderClass:
         init_call_count = mock_okx_public_client.get_instruments.call_count
         lot_size = order_executor.get_lot_size()
         assert lot_size["min_qty"] == 0.001
+        # 0.0 is a DESIGN DECISION, not an absent value: okx derivatives bind on
+        # minSz/lotSz and have no separate notional floor, so the shared guard's notional
+        # half is deliberately a no-op here. Pinned because only the key's PRESENCE was
+        # enforced -- writing 999999.0 there passed the whole suite and would have refused
+        # every okx bracket, silently, forever (#414).
+        assert lot_size["min_notional"] == 0.0
         lot_size2 = order_executor.get_lot_size()
         assert lot_size2 is lot_size
         assert mock_okx_public_client.get_instruments.call_count == init_call_count

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -5506,7 +5506,7 @@ def test_a_venue_that_reports_no_bracket_status_records_both_legs(venue):
     )
 
 
-def _switch_stub(*, price, min_notional, lot_step, current_qty, target_qty):
+def _switch_stub(*, min_notional, lot_step, target_qty):
     """binance's fractional path, wired so the SUBMITTED quantity is observable.
 
     Everything upstream of the notional check is stubbed to a known value, because the
@@ -5546,8 +5546,7 @@ def test_a_direction_switch_validates_the_quantity_it_actually_sends():
     to a long of 1.0 validates 2.0 (notional 199.98, passes) and sends 1.0 (notional
     99.99, rejected).
     """
-    env, sent = _switch_stub(price=99.99, min_notional=100.0, lot_step=1.0,
-                             current_qty=-1.0, target_qty=1.0)
+    env, sent = _switch_stub(min_notional=100.0, lot_step=1.0, target_qty=1.0)
     closed = []
     env._handle_close_action = lambda q: closed.append(q) or {
         "executed": True, "success": True, "side": "buy", "quantity": abs(q),
@@ -5579,8 +5578,7 @@ def test_the_delta_sent_to_the_venue_is_lot_rounded():
     notional gaps, and invisible because every other test rounds to a step the raw value
     already sits on.
     """
-    env, sent = _switch_stub(price=100.0, min_notional=0.0, lot_step=0.5,
-                             current_qty=0.0, target_qty=1.7)
+    env, sent = _switch_stub(min_notional=0.0, lot_step=0.5, target_qty=1.7)
     env._execute_fractional_action(1.0, current_qty=0.0, current_price=100.0)
 
     assert sent, "nothing was submitted; the stub is not exercising the trade path"
@@ -5627,14 +5625,9 @@ def test_the_sltp_path_refuses_a_bracket_below_the_venue_notional_floor(
     )
 
 
-# `test_every_futures_executor_reports_its_venue_minimums_the_same_way` lived here and is
-# gone. It asserted that each `get_lot_size`'s SOURCE mentions three key strings -- which
-# passes for one that names `min_notional` in a comment and returns nothing, and which
-# hardcoded four venues while a FIFTH implementation (ReplayOrderExecutor) sat two keys
-# short the whole time. Its only unique kill was "okx omits the key", and with the guard
-# reading `.get(..., 0.0)` absent and 0.0 were the same program, so that kill changed no
-# behaviour. The guard now indexes strictly, which turns key-absence into a loud KeyError
-# and makes the property behavioural instead of textual.
+# The source-grep contract test that lived here was replaced by the behavioural
+# degraded-path test below: strict `lot["min_notional"]` makes key-absence a
+# loud KeyError, so the property is behavioural rather than textual.
 
 
 @pytest.mark.parametrize("current_qty,switching,expected_at_target", [
@@ -5691,16 +5684,10 @@ def test_a_refused_switch_does_not_claim_the_account_is_already_at_target(
 def test_get_lot_size_reports_three_keys_when_the_venue_is_down(venue):
     """Every executor, both the happy path and the DEGRADED one, by execution.
 
-    The DEGRADED path specifically, which is where the gap was. An AST test lived here
-    and checked each dict-literal `_lot_size_cache` write; its only unique kill was okx's
-    lazy write, and it was blind to the `_DEFAULT_LOT_SIZE.copy()` fallbacks -- 3 of 5
-    writes on bybit and okx, taken precisely when the venue is flaky, and whose mutants
-    survived the whole suite. Under strict `lot["min_notional"]` a missing key there is a
-    KeyError on every bracket open, on the worst possible day.
-
-    The healthy paths are covered per-venue in each executor's own tests, which can
-    supply that venue's real payload shape; this cannot, and binance correctly raises
-    rather than guessing when handed one it does not recognise.
+    The DEGRADED path specifically: the `_DEFAULT_LOT_SIZE.copy()` fallbacks are 3 of 5
+    cache writes on bybit and okx, are taken precisely when the venue is flaky, and a
+    missing key there is a KeyError on every bracket open. Healthy paths are covered
+    per-venue, where each venue's real payload shape is available.
     """
     mod = importlib.import_module(
         "torchtrade.envs.replay.order_executor" if venue == "replay"
@@ -5712,8 +5699,7 @@ def test_get_lot_size_reports_three_keys_when_the_venue_is_down(venue):
     for attr, val in (("_lot_size_cache", None), ("_qty_steps", {}), ("_min_qtys", {}),
                       ("_min_notional", 0.0), ("_tick_size", None), ("_tick_decimals", None),
                       ("_lot_size_decimals", None)):
-        if hasattr(cls, attr) or True:
-            setattr(ex, attr, val)
+        setattr(ex, attr, val)
     client = MagicMock()
     for m in ("futures_exchange_info", "get_instruments_info", "get_instruments", "market"):
         setattr(client, m, MagicMock(side_effect=Exception("venue down")))
@@ -5761,7 +5747,7 @@ def test_notional_sizing_exactly_at_the_floor_is_not_refused_by_float_error(
     )
 
 
-@pytest.mark.parametrize("venue", ["binance", "bitget", "bybit", "okx"])
+@pytest.mark.parametrize("venue", ["binance", "bitget", "bybit"])
 def test_the_plain_path_also_refuses_below_the_venue_notional_floor(venue):
     """The other execution path. #414 fixed binance's plain path and gave every venue's
     SLTP path a floor -- and left bitget, bybit and okx's PLAIN path with none, on the
@@ -5771,6 +5757,11 @@ def test_the_plain_path_also_refuses_below_the_venue_notional_floor(venue):
 
     That is CLAUDE.md's "apply to ALL environments" rule, and it is the bug the issue
     describes still shipping on three of four venues one path over.
+
+    okx is absent because it CANNOT hit this: its executor writes `min_notional` 0.0 at
+    every one of its three cache sites, since okx derivatives bind on minSz/lotSz. A row
+    for it would stub a 5.0 floor okx cannot produce and assert a fiction -- which is
+    what it did until this was noticed, guarding eight lines that could never fire.
     """
     env, trader = _real_futures_env(budget=0, venue=venue)
     trader.get_lot_size.return_value = {
@@ -5868,9 +5859,39 @@ def test_a_non_finite_target_never_reaches_the_venue():
     Quiet is the problem: the account is untouched, but nothing says the sizing produced
     a number that is not a number.
     """
-    env, sent = _switch_stub(price=100.0, min_notional=0.0, lot_step=0.001,
-                             current_qty=0.0, target_qty=float("nan"))
+    env, sent = _switch_stub(min_notional=0.0, lot_step=0.001, target_qty=float("nan"))
     info = env._execute_fractional_action(1.0, current_qty=0.0, current_price=100.0)
 
     assert not sent, f"a NaN target reached the venue as {sent.get('quantity')!r}"
     assert not info["executed"]
+
+
+@pytest.mark.parametrize("qty,step,price,floor", [
+    (0.29, 0.01, 350.0, 100.0),        # 0.29/0.01 = 28.999999999999996
+    (0.0003, 0.0001, 400_000.0, 100.0),
+    (1.17, 0.01, 100.0, 100.0),
+])
+def test_the_guard_floors_the_way_the_venue_floors(qty, step, price, floor):
+    """A BARE `math.floor(q/step)*step` is a whole lot step below what the venue sends.
+
+    `quantity / step` lands just under an integer for many exact multiples -- 0.29/0.01
+    is 28.999999999999996 -- which is why `round_quantity` carries a relative epsilon and
+    says so in its docstring. Flooring without it made the guard validate one step less
+    than would be submitted and refuse legal orders: the round-2 bug with the sign
+    flipped, admitting nothing illegal but rejecting real money.
+
+    Every stub in this PR reimplemented the guard's own bare floor, so nothing could see
+    it. These are the venue's real numbers instead.
+    """
+    env, trader = _close_env("binance", 0)
+    env.config.trade_mode = "quantity"
+    env.config.quantity_per_trade = qty
+    trader.get_lot_size.return_value = {
+        "min_qty": 0.0, "qty_step": step, "min_notional": floor
+    }
+
+    assert env._resolve_bracket_quantity(price) is not None, (
+        f"{qty} at {price} is {qty * price:.2f} notional against a {floor} floor and was "
+        f"refused: the guard floored to {__import__('math').floor(qty / step) * step!r}, "
+        f"a full step below what the venue would send"
+    )

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -5713,13 +5713,11 @@ def test_get_lot_size_reports_three_keys_when_the_venue_is_down(venue):
 
 
 @pytest.mark.parametrize("price,usd,expect_refused", [
-    # All five tripping prices computed the identical 4.999999999999999, so four were
-    # duplicates of the same arithmetic. One is kept for the round-trip, and the two
-    # rows below it pin what the epsilon must NOT do.
-    (0.61, 5.0, False),      # exactly at the floor, one ulp under after the round-trip
-    (0.61, 4.5, True),       # genuinely 10% under -- must still refuse
-    (0.61, 2.5, True),       # 50% under: `1 - 0.5` as an epsilon would let this through
-], ids=["at-floor", "10pc-under", "50pc-under"])
+    # `50pc-under` was strictly dominated by `10pc-under` -- every epsilon the latter
+    # kills, the former kills a subset of. `at-floor` went with the notional epsilon it
+    # was written for, which flooring made unreachable.
+    (0.61, 4.5, True),
+], ids=["10pc-under"])
 def test_notional_sizing_exactly_at_the_floor_is_not_refused_by_float_error(
     price, usd, expect_refused
 ):
@@ -5783,6 +5781,12 @@ def test_the_plain_path_also_refuses_below_the_venue_notional_floor(venue):
         f"rejects it and the env records a position it does not hold"
     )
     assert not info["executed"]
+    # The flag too, not just the refusal. It is asserted on binance by the
+    # refused-switch test and was unasserted on the two venues copying the same block.
+    assert info.get("at_target") is True, (
+        f"{venue}: a sub-notional refusal must report at_target, so the env records the "
+        f"level instead of re-sending an order the venue already refused every bar"
+    )
 
 
 @pytest.mark.parametrize("venue", _SLTP_VENUES)
@@ -5869,7 +5873,6 @@ def test_a_non_finite_target_never_reaches_the_venue():
 @pytest.mark.parametrize("qty,step,price,floor", [
     (0.29, 0.01, 350.0, 100.0),        # 0.29/0.01 = 28.999999999999996
     (0.0003, 0.0001, 400_000.0, 100.0),
-    (1.17, 0.01, 100.0, 100.0),
 ])
 def test_the_guard_floors_the_way_the_venue_floors(qty, step, price, floor):
     """A BARE `math.floor(q/step)*step` is a whole lot step below what the venue sends.
@@ -5894,4 +5897,116 @@ def test_the_guard_floors_the_way_the_venue_floors(qty, step, price, floor):
         f"{qty} at {price} is {qty * price:.2f} notional against a {floor} floor and was "
         f"refused: the guard floored to {__import__('math').floor(qty / step) * step!r}, "
         f"a full step below what the venue would send"
+    )
+
+
+@pytest.mark.parametrize("venue", ["binance", "bitget", "bybit", "okx"])
+def test_target_tol_is_the_venue_minimum_size_not_a_notional(venue):
+    """`target_tol` is the slack `_sync_position_from_exchange` allows between the target
+    and what the venue actually holds, and binance alone derived it from the notional
+    floor divided by price.
+
+    That worked only because the old `_get_min_notional` fabricated 100.0 on failure.
+    With the executor's real 0.0 it becomes 0.0, and the sync then compares against
+    POSITION_DUST_EPS (1e-9) -- while binance's delta is LOT-ROUNDED and legitimately
+    differs by up to a full step, 1e-3 BTC, six orders of magnitude larger. Every
+    complete fill would read as a divergence, NaN the action level, release the
+    duplicate-action guard, and re-size every bar.
+
+    All four venues now report the same thing: the venue's minimum tradeable size.
+    """
+    env, trader = _real_futures_env(budget=0, venue=venue)
+    trader.get_lot_size.return_value = {
+        "min_qty": 0.001, "qty_step": 0.001, "min_notional": 0.0
+    }
+    if venue == "binance":
+        env._get_min_notional = lambda: 0.0
+    env._execute_market_order = lambda side, quantity: {
+        "executed": True, "success": True, "side": side, "quantity": quantity}
+    env._calculate_fractional_position = lambda av, cp: (0.5, 0.5 * cp, "buy")
+
+    info = env._execute_fractional_action(1.0, current_qty=0.0, current_price=100.0)
+
+    assert info["target_tol"] == 0.001, (
+        f"{venue}: target_tol is {info['target_tol']!r}; at 0.0 the sync compares a "
+        f"lot-rounded fill against a 1e-9 dust epsilon and calls every fill a divergence"
+    )
+
+
+def test_the_flooring_epsilon_never_validates_more_than_the_venue_sends():
+    """The epsilon recovers exact multiples that float division puts just under an
+    integer. Too LARGE and it rounds a quantity UP past what the venue will send, so the
+    guard validates more than is submitted -- the PR's own bug in the dangerous
+    direction, admitting an order the exchange rejects.
+
+    Only the too-small direction was tested: widening it to 1e-3 passed the whole suite.
+    """
+    env, trader = _close_env("binance", 0)
+    env.config.trade_mode = "quantity"
+    # 0.000999 is BELOW one 0.001 step: the venue floors it to 0.0 and rejects.
+    # An epsilon of 1e-3 would round it UP to a full step and validate a real order.
+    env.config.quantity_per_trade = 0.000999
+    trader.get_lot_size.return_value = {
+        "min_qty": 0.0, "qty_step": 0.001, "min_notional": 0.0
+    }
+
+    assert env._resolve_bracket_quantity(100.0) is None, (
+        "0.000999 floors to 0.0 at a 0.001 step; an epsilon large enough to round it up "
+        "makes the guard validate a quantity the venue will never receive"
+    )
+
+
+def test_a_refused_target_does_not_become_an_unrequested_close():
+    """`_calculate_fractional_position` returns 0.0 exactly when binance's own
+    sub-minimum refusal fires. The `target_qty == 0.0` guard catches that.
+
+    Deleting it looks harmless -- with a FLAT account it is equivalent to the
+    `delta == 0` guard below. With a position open it is not: `delta = 0 - current_qty`
+    is a full-size order in the opposite direction, so a refused open silently becomes
+    an unrequested close of the position the agent already held. Zero tests reached that
+    guard, and deleting it passed the whole suite.
+    """
+    env, trader = _real_futures_env(budget=0, venue="binance")
+    env._get_min_notional = lambda: 0.0
+    trader.round_quantity.side_effect = lambda q: q
+    env._calculate_fractional_position = lambda av, cp: (0.0, 0.0, "flat")
+    sent = {}
+    env._execute_market_order = lambda side, quantity: sent.update(
+        side=side, quantity=quantity) or {
+        "executed": True, "success": True, "side": side, "quantity": quantity}
+    env._handle_close_action = lambda q: {"executed": True, "success": True}
+
+    info = env._execute_fractional_action(1.0, current_qty=-1.0, current_price=100.0)
+
+    assert not sent, (
+        f"the sizing refused the target, and the env submitted {sent} anyway -- a "
+        f"full-size close of a position the agent did not ask to exit"
+    )
+    assert not info["executed"]
+
+
+@pytest.mark.parametrize("value,expect_refused", [(100.0, False), (1_000_000.0, True)])
+def test_get_min_notional_reads_the_executor_rather_than_a_constant(value, expect_refused):
+    """binance's `_get_min_notional` used to walk the exchange info itself and fabricate
+    100.0 on failure; it now delegates to the executor's cached filters.
+
+    Nothing observed the delegation: returning a hardcoded 100.0 OR 0.0 both passed the
+    whole suite, because every test that exercises a real floor stubs the method out and
+    every other test reports 0.0 at prices where 0.0 and 100.0 agree.
+    """
+    env, trader = _real_futures_env(budget=0, venue="binance")
+    trader.get_lot_size.return_value = {
+        "min_qty": 0.001, "qty_step": 0.001, "min_notional": value
+    }
+    sent = {}
+    env._execute_market_order = lambda side, quantity: sent.update(
+        side=side, quantity=quantity) or {
+        "executed": True, "success": True, "side": side, "quantity": quantity}
+    env._calculate_fractional_position = lambda av, cp: (5.0, 5.0 * cp, "buy")
+
+    env._execute_fractional_action(1.0, current_qty=0.0, current_price=100.0)
+
+    assert (not sent) is expect_refused, (
+        f"floor {value} from the executor: order was "
+        f"{'refused' if not sent else 'submitted'}; `_get_min_notional` is not reading it"
     )

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -6096,7 +6096,12 @@ def test_the_plain_path_refuses_an_unknown_floor_rather_than_raising(venue):
     env._execute_market_order = lambda side, quantity: sent.update(
         side=side, quantity=quantity) or {
         "executed": True, "success": True, "side": side, "quantity": quantity}
-    env._calculate_fractional_position = lambda av, cp: (0.5, 0.5 * cp, "buy")
+    # NOT stubbed: binance overrides `_calculate_fractional_position` and reads the floor
+    # a SECOND time inside it. Stubbing this bypassed that site entirely, which is how a
+    # `float(None)` survived a test written to catch exactly this (@CharlieHelps).
+    trader.get_account_balance.return_value = {
+        "available_balance": 1e4, "total_margin_balance": 1e4,
+        "total_wallet_balance": 1e4, "total_maintenance_margin": 0.0}
 
     info = env._execute_fractional_action(1.0, current_qty=0.0, current_price=100.0)
 

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -3919,7 +3919,7 @@ def test_a_recovered_venue_does_not_truncate_the_next_episode():
         "total_wallet_balance": 1e4, "total_maintenance_margin": 0.0}
     trader.get_status.return_value = {"position_status": None}
     trader.get_mark_price.return_value = 100.0
-    trader.get_lot_size.return_value = {"min_qty": 0.001, "qty_step": 0.001}
+    trader.get_lot_size.return_value = {"min_qty": 0.001, "qty_step": 0.001, "min_notional": 0.0}
 
     with patch("time.sleep"), patch.object(Env, "_wait_for_next_timestamp"):
         env = Env(config=Config(
@@ -4417,7 +4417,7 @@ def _bracket_stub(cls, *, balance=10_000.0, leverage=5, fee=...):
     # A real lot size, because okx's sizing compares against it. Left to the bare
     # MagicMock, `qty < trader.get_lot_size()["min_qty"]` raises TypeError -- the same
     # family as the `float(MagicMock())` accident this docstring already warns about.
-    env.trader.get_lot_size.return_value = {"min_qty": 0.001, "qty_step": 0.001}
+    env.trader.get_lot_size.return_value = {"min_qty": 0.001, "qty_step": 0.001, "min_notional": 0.0}
     if fee is ...:
         del env.trader.transaction_fee
     else:
@@ -4491,7 +4491,7 @@ def test_okx_refuses_a_sub_minimum_bracket_rather_than_letting_it_be_clamped_up(
     env, trader = _real_futures_env(budget=0, venue="okx", sltp=True)
     env.config.trade_mode = "quantity"
     env.config.quantity_per_trade = 0.0001          # below the 0.001 min_qty
-    trader.get_lot_size.return_value = {"min_qty": 0.001, "qty_step": 0.001}
+    trader.get_lot_size.return_value = {"min_qty": 0.001, "qty_step": 0.001, "min_notional": 0.0}
 
     td = env.reset()
     env.active_stop_loss, env.active_take_profit = 111.0, 222.0
@@ -5574,3 +5574,50 @@ def test_the_delta_sent_to_the_venue_is_lot_rounded():
         f"submitted {q}, which is not a multiple of the 0.5 lot step -- the delta reached "
         f"the venue unrounded"
     )
+
+
+@pytest.mark.parametrize("venue", _SLTP_VENUES)
+def test_the_sltp_path_refuses_a_bracket_below_the_venue_notional_floor(venue):
+    """The SLTP path had no notional check on ANY venue, and bitget and bybit read no
+    notional field at all -- both fetched it with the rest of the market info and dropped
+    it (#414).
+
+    An order under the floor is submitted, rejected, and the env goes on believing it
+    holds a position. Same shape as the direction-switch bug, on the other execution path.
+
+    Refuses rather than rounding UP to the minimum: rounding up allocates more than the
+    action asked for, which is how okx's formatter turns a sub-minimum size into a real
+    position.
+    """
+    env, trader = _close_env(venue, 0)
+    trader.get_lot_size.return_value = {
+        "min_qty": 0.0, "qty_step": 0.001, "min_notional": 1_000_000.0
+    }
+
+    quantity = env._resolve_bracket_quantity(100.0)
+
+    assert quantity is None, (
+        f"{venue}: sized {quantity} at 100.0 = {(quantity or 0) * 100.0:.2f} notional "
+        f"against a 1,000,000 floor -- the venue would reject this order"
+    )
+
+
+@pytest.mark.parametrize("venue", ["binance", "bitget", "bybit", "okx"])
+def test_every_futures_executor_reports_its_venue_minimums_the_same_way(venue):
+    """One accessor shape across four venues, so the shared sizing can ask one question.
+
+    binance was the only executor without `get_lot_size`, which is why the shared path
+    could not ask it for a notional floor. Its values come from filters
+    `_fetch_symbol_filters` already caches, so the accessor adds no API call.
+    """
+    mod = importlib.import_module(f"torchtrade.envs.live.{venue}.order_executor")
+    cls = next(c for k, c in vars(mod).items()
+               if k.endswith("OrderClass") and getattr(c, "__module__", "") == mod.__name__)
+    assert hasattr(cls, "get_lot_size"), (
+        f"{venue}'s executor has no get_lot_size, so the shared sizing cannot ask it for "
+        f"a venue minimum and will submit whatever it computed"
+    )
+    keys = {"min_qty", "qty_step", "min_notional"}
+    src = inspect.getsource(cls.get_lot_size)
+    missing = {k for k in keys if f'"{k}"' not in src}
+    assert not missing, f"{venue}'s get_lot_size never mentions {sorted(missing)}"

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -5680,41 +5680,56 @@ def test_a_refused_switch_does_not_claim_the_account_is_already_at_target(
         )
 
 
-@pytest.mark.parametrize("venue", ["bitget", "bybit", "okx"])
-def test_every_lot_size_cache_write_carries_all_three_keys(venue):
-    """The accessor is not the thing to check -- the WRITES are.
+@pytest.mark.parametrize("venue", ["binance", "bitget", "bybit", "okx", "replay"])
+def test_get_lot_size_reports_three_keys_when_the_venue_is_down(venue):
+    """Every executor, both the happy path and the DEGRADED one, by execution.
 
-    Each of these executors caches its lot size from more than one place: a
-    construction-time write inside the tick-size fetch, a lazy write in `get_lot_size`,
-    and one or more fallbacks. Updating some and not others is how okx came to return a
-    two-key dict at runtime while its `get_lot_size` source mentioned the third key, so a
-    source grep saw a contract that did not hold and the whole suite passed.
+    The DEGRADED path specifically, which is where the gap was. An AST test lived here
+    and checked each dict-literal `_lot_size_cache` write; its only unique kill was okx's
+    lazy write, and it was blind to the `_DEFAULT_LOT_SIZE.copy()` fallbacks -- 3 of 5
+    writes on bybit and okx, taken precisely when the venue is flaky, and whose mutants
+    survived the whole suite. Under strict `lot["min_notional"]` a missing key there is a
+    KeyError on every bracket open, on the worst possible day.
 
-    Once the shared guard indexes `lot["min_notional"]` strictly, a missing key is a
-    KeyError on every bracket open, so this is a crash test, not a style test. Every
-    dict-literal write is checked rather than the one the tests happen to reach.
+    The healthy paths are covered per-venue in each executor's own tests, which can
+    supply that venue's real payload shape; this cannot, and binance correctly raises
+    rather than guessing when handed one it does not recognise.
     """
-    tree = ast.parse(
-        pathlib.Path(f"torchtrade/envs/live/{venue}/order_executor.py").read_text()
+    mod = importlib.import_module(
+        "torchtrade.envs.replay.order_executor" if venue == "replay"
+        else f"torchtrade.envs.live.{venue}.order_executor"
     )
-    writes = [
-        n for n in ast.walk(tree)
-        if isinstance(n, ast.Assign) and len(n.targets) == 1
-        and isinstance(n.targets[0], ast.Attribute)
-        and n.targets[0].attr == "_lot_size_cache"
-        and isinstance(n.value, ast.Dict)
-    ]
-    assert writes, f"{venue} has no dict-literal _lot_size_cache write to check"
-    for w in writes:
-        keys = {k.value for k in w.value.keys if isinstance(k, ast.Constant)}
-        assert keys == {"min_qty", "qty_step", "min_notional"}, (
-            f"{venue}/order_executor.py:{w.lineno} writes {sorted(keys)}; a cache missing "
-            f"min_notional KeyErrors in the shared sizing guard"
-        )
+    cls = _sole(mod, "OrderExecutor" if venue == "replay" else "OrderClass")
+    ex = cls.__new__(cls)
+    ex.symbol = "BTCUSDT"
+    for attr, val in (("_lot_size_cache", None), ("_qty_steps", {}), ("_min_qtys", {}),
+                      ("_min_notional", 0.0), ("_tick_size", None), ("_tick_decimals", None),
+                      ("_lot_size_decimals", None)):
+        if hasattr(cls, attr) or True:
+            setattr(ex, attr, val)
+    client = MagicMock()
+    for m in ("futures_exchange_info", "get_instruments_info", "get_instruments", "market"):
+        setattr(client, m, MagicMock(side_effect=Exception("venue down")))
+    ex.client = ex.public_client = client
+
+    lot = ex.get_lot_size()
+    assert set(lot) >= {"min_qty", "qty_step", "min_notional"}, (
+        f"{venue} returns {sorted(lot)} when the venue is down; a missing key is a "
+        f"KeyError in the shared sizing guard, on every bracket open"
+    )
 
 
-@pytest.mark.parametrize("price", [0.61, 1.22, 2.23, 2.29, 2.44])
-def test_notional_sizing_exactly_at_the_floor_is_not_refused_by_float_error(price):
+@pytest.mark.parametrize("price,usd,expect_refused", [
+    # All five tripping prices computed the identical 4.999999999999999, so four were
+    # duplicates of the same arithmetic. One is kept for the round-trip, and the two
+    # rows below it pin what the epsilon must NOT do.
+    (0.61, 5.0, False),      # exactly at the floor, one ulp under after the round-trip
+    (0.61, 4.5, True),       # genuinely 10% under -- must still refuse
+    (0.61, 2.5, True),       # 50% under: `1 - 0.5` as an epsilon would let this through
+], ids=["at-floor", "10pc-under", "50pc-under"])
+def test_notional_sizing_exactly_at_the_floor_is_not_refused_by_float_error(
+    price, usd, expect_refused
+):
     """`notional` mode computes `qty = usd / price`; the guard re-multiplies by the same
     price. That round-trip is not exact -- for ~1.7% of prices in 0.001-100,
     `(5.0 / p) * p < 5.0` -- and bitget's minTradeUSDT is exactly 5.
@@ -5725,12 +5740,68 @@ def test_notional_sizing_exactly_at_the_floor_is_not_refused_by_float_error(pric
     """
     env, trader = _close_env("bitget", 0)
     env.config.trade_mode = "notional"
-    env.config.quantity_per_trade = 5.0
+    env.config.quantity_per_trade = usd
     trader.get_lot_size.return_value = {
-        "min_qty": 0.0, "qty_step": 1e-9, "min_notional": 5.0
+        "min_qty": 0.0, "qty_step": 1e-12, "min_notional": 5.0
     }
 
-    assert env._resolve_bracket_quantity(price) is not None, (
-        f"sizing exactly 5.0 USD against a 5.0 floor at price {price} was refused: "
-        f"(5.0/{price})*{price} = {(5.0 / price) * price!r}"
+    refused = env._resolve_bracket_quantity(price) is None
+    assert refused is expect_refused, (
+        f"sizing {usd} USD against a 5.0 floor at price {price}: "
+        f"{'refused' if refused else 'accepted'}, expected "
+        f"{'refused' if expect_refused else 'accepted'} -- "
+        f"({usd}/{price})*{price} = {(usd / price) * price!r}"
     )
+
+
+@pytest.mark.parametrize("venue", ["binance", "bitget", "bybit", "okx"])
+def test_the_plain_path_also_refuses_below_the_venue_notional_floor(venue):
+    """The other execution path. #414 fixed binance's plain path and gave every venue's
+    SLTP path a floor -- and left bitget, bybit and okx's PLAIN path with none, on the
+    two venues whose executors this same change taught to fetch the number.
+
+    Measured before the fix, at a 5.00 floor: all three submitted 0.50 notional.
+
+    That is CLAUDE.md's "apply to ALL environments" rule, and it is the bug the issue
+    describes still shipping on three of four venues one path over.
+    """
+    env, trader = _real_futures_env(budget=0, venue=venue)
+    trader.get_lot_size.return_value = {
+        "min_qty": 0.001, "qty_step": 0.001, "min_notional": 5.0
+    }
+    if venue == "binance":
+        env._get_min_notional = lambda: 5.0
+    sent = {}
+    env._execute_market_order = lambda side, quantity: sent.update(
+        side=side, quantity=quantity) or {
+        "executed": True, "success": True, "side": side, "quantity": quantity}
+    env._calculate_fractional_position = lambda av, cp: (0.5, 0.5 * cp, "buy")
+
+    info = env._execute_fractional_action(1.0, current_qty=0.0, current_price=1.0)
+
+    assert not sent, (
+        f"{venue} plain path submitted {sent.get('quantity')} at price 1.0 = "
+        f"{(sent.get('quantity') or 0):.2f} notional against a 5.00 floor; the venue "
+        f"rejects it and the env records a position it does not hold"
+    )
+    assert not info["executed"]
+
+
+@pytest.mark.parametrize("venue", _SLTP_VENUES)
+def test_a_trader_without_a_notional_floor_fails_loudly_rather_than_silently(venue):
+    """The guard indexes `lot["min_notional"]` rather than `.get(..., 0.0)`.
+
+    Defaulting a missing key to "no floor" means any future trader that forgets it
+    silently disables the check -- and that was not hypothetical: `ReplayOrderExecutor`
+    was exactly that trader, a fifth implementation the four-venue contract test could
+    not see. Reverting to `.get` passed the entire suite, so the strictness itself had
+    nothing defending it.
+
+    A KeyError on the money path is the correct outcome. It is loud, it happens on the
+    first bracket rather than the hundredth, and it names the key.
+    """
+    env, trader = _close_env(venue, 0)
+    trader.get_lot_size.return_value = {"min_qty": 0.001, "qty_step": 0.001}
+
+    with pytest.raises(KeyError, match="min_notional"):
+        env._resolve_bracket_quantity(100.0)

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -3923,6 +3923,8 @@ def test_a_recovered_venue_does_not_truncate_the_next_episode():
     trader.get_status.return_value = {"position_status": None}
     trader.get_mark_price.return_value = 100.0
     trader.get_lot_size.return_value = {"min_qty": 0.001, "qty_step": 0.001, "min_notional": 0.0}
+    trader.quantize_quantity.side_effect = (
+        lambda q, _s=0.001: int(float(q) / _s) * _s)
 
     with patch("time.sleep"), patch.object(Env, "_wait_for_next_timestamp"):
         env = Env(config=Config(
@@ -4495,6 +4497,8 @@ def test_okx_refuses_a_sub_minimum_bracket_rather_than_letting_it_be_clamped_up(
     env.config.trade_mode = "quantity"
     env.config.quantity_per_trade = 0.0001          # below the 0.001 min_qty
     trader.get_lot_size.return_value = {"min_qty": 0.001, "qty_step": 0.001, "min_notional": 0.0}
+    trader.quantize_quantity.side_effect = (
+        lambda q, _s=0.001: int(float(q) / _s) * _s)
 
     td = env.reset()
     env.active_stop_loss, env.active_take_profit = 111.0, 222.0
@@ -5620,6 +5624,9 @@ def test_the_sltp_path_refuses_a_bracket_below_the_venue_notional_floor(
     trader.get_lot_size.return_value = {
         "min_qty": 0.0, "qty_step": 0.001, "min_notional": 1_000_000.0
     }
+    # The executor is the authority on what it submits; model its truncation.
+    trader.quantize_quantity.side_effect = (
+        lambda q, _s=0.001: int(float(q) / _s) * _s)
 
     quantity = env._resolve_bracket_quantity(100.0)
 
@@ -5739,6 +5746,9 @@ def test_notional_sizing_exactly_at_the_floor_is_not_refused_by_float_error(
     trader.get_lot_size.return_value = {
         "min_qty": 0.0, "qty_step": 1e-12, "min_notional": 5.0
     }
+    # The executor is the authority on what it submits; model its truncation.
+    trader.quantize_quantity.side_effect = (
+        lambda q, _s=1e-12: int(float(q) / _s) * _s)
 
     refused = env._resolve_bracket_quantity(price) is None
     assert refused is expect_refused, (
@@ -5769,6 +5779,9 @@ def test_the_plain_path_also_refuses_below_the_venue_notional_floor(venue):
     trader.get_lot_size.return_value = {
         "min_qty": 0.001, "qty_step": 0.001, "min_notional": 5.0
     }
+    # The executor is the authority on what it submits; model its truncation.
+    trader.quantize_quantity.side_effect = (
+        lambda q, _s=0.001: int(float(q) / _s) * _s)
     if venue == "binance":
         env._get_min_notional = lambda: 5.0
     sent = {}
@@ -5838,6 +5851,9 @@ def test_a_boundary_quantity_is_judged_after_the_venue_floors_it(qty, price, ste
     trader.get_lot_size.return_value = {
         "min_qty": 0.0, "qty_step": step, "min_notional": floor
     }
+    # The executor is the authority on what it submits; model its truncation.
+    trader.quantize_quantity.side_effect = (
+        lambda q, _s=step: int(float(q) / _s) * _s)
     assert env._resolve_bracket_quantity(price) is None, (
         f"{qty} at {price} is {qty * price:.6f} raw -- above the {floor} floor -- but the "
         f"venue receives the floored value and rejects it"
@@ -5862,6 +5878,9 @@ def test_the_notional_is_checked_against_the_quantity_the_venue_will_receive(ven
     trader.get_lot_size.return_value = {
         "min_qty": 0.0, "qty_step": 0.001, "min_notional": 100.0
     }
+    # The executor is the authority on what it submits; model its truncation.
+    trader.quantize_quantity.side_effect = (
+        lambda q, _s=0.001: int(float(q) / _s) * _s)
 
     assert env._resolve_bracket_quantity(60000.0) is None, (
         f"{venue}: validated {100.0 / 60000.0 * 60000.0:.2f} notional but the venue "
@@ -5883,6 +5902,9 @@ def test_a_quantity_below_one_lot_step_is_refused_rather_than_sent_as_zero(venue
     trader.get_lot_size.return_value = {
         "min_qty": 0.0, "qty_step": 0.001, "min_notional": 0.0
     }
+    # The executor is the authority on what it submits; model its truncation.
+    trader.quantize_quantity.side_effect = (
+        lambda q, _s=0.001: int(float(q) / _s) * _s)
 
     assert env._resolve_bracket_quantity(100.0) is None, (
         f"{venue}: 0.0001 floors to 0.0 at a 0.001 step; submitting it asks the venue "
@@ -5905,36 +5927,6 @@ def test_a_non_finite_target_never_reaches_the_venue():
     assert not info["executed"]
 
 
-@pytest.mark.parametrize("qty,step,price,floor", [
-    (0.29, 0.01, 350.0, 100.0),        # 0.29/0.01 = 28.999999999999996
-    (0.0003, 0.0001, 400_000.0, 100.0),
-])
-def test_the_guard_floors_the_way_the_venue_floors(qty, step, price, floor):
-    """A BARE `math.floor(q/step)*step` is a whole lot step below what the venue sends.
-
-    `quantity / step` lands just under an integer for many exact multiples -- 0.29/0.01
-    is 28.999999999999996 -- which is why `round_quantity` carries a relative epsilon and
-    says so in its docstring. Flooring without it made the guard validate one step less
-    than would be submitted and refuse legal orders: the round-2 bug with the sign
-    flipped, admitting nothing illegal but rejecting real money.
-
-    Every stub in this PR reimplemented the guard's own bare floor, so nothing could see
-    it. These are the venue's real numbers instead.
-    """
-    env, trader = _close_env("binance", 0)
-    env.config.trade_mode = "quantity"
-    env.config.quantity_per_trade = qty
-    trader.get_lot_size.return_value = {
-        "min_qty": 0.0, "qty_step": step, "min_notional": floor
-    }
-
-    assert env._resolve_bracket_quantity(price) is not None, (
-        f"{qty} at {price} is {qty * price:.2f} notional against a {floor} floor and was "
-        f"refused: the guard floored to {__import__('math').floor(qty / step) * step!r}, "
-        f"a full step below what the venue would send"
-    )
-
-
 @pytest.mark.parametrize("venue", ["binance", "bitget", "bybit", "okx"])
 def test_target_tol_is_the_venue_minimum_size_not_a_notional(venue):
     """`target_tol` is the slack `_sync_position_from_exchange` allows between the target
@@ -5954,6 +5946,9 @@ def test_target_tol_is_the_venue_minimum_size_not_a_notional(venue):
     trader.get_lot_size.return_value = {
         "min_qty": 0.001, "qty_step": 0.001, "min_notional": 0.0
     }
+    # The executor is the authority on what it submits; model its truncation.
+    trader.quantize_quantity.side_effect = (
+        lambda q, _s=0.001: int(float(q) / _s) * _s)
     if venue == "binance":
         env._get_min_notional = lambda: 0.0
     env._execute_market_order = lambda side, quantity: {
@@ -5965,29 +5960,6 @@ def test_target_tol_is_the_venue_minimum_size_not_a_notional(venue):
     assert info["target_tol"] == 0.001, (
         f"{venue}: target_tol is {info['target_tol']!r}; at 0.0 the sync compares a "
         f"lot-rounded fill against a 1e-9 dust epsilon and calls every fill a divergence"
-    )
-
-
-def test_the_flooring_epsilon_never_validates_more_than_the_venue_sends():
-    """The epsilon recovers exact multiples that float division puts just under an
-    integer. Too LARGE and it rounds a quantity UP past what the venue will send, so the
-    guard validates more than is submitted -- the PR's own bug in the dangerous
-    direction, admitting an order the exchange rejects.
-
-    Only the too-small direction was tested: widening it to 1e-3 passed the whole suite.
-    """
-    env, trader = _close_env("binance", 0)
-    env.config.trade_mode = "quantity"
-    # 0.000999 is BELOW one 0.001 step: the venue floors it to 0.0 and rejects.
-    # An epsilon of 1e-3 would round it UP to a full step and validate a real order.
-    env.config.quantity_per_trade = 0.000999
-    trader.get_lot_size.return_value = {
-        "min_qty": 0.0, "qty_step": 0.001, "min_notional": 0.0
-    }
-
-    assert env._resolve_bracket_quantity(100.0) is None, (
-        "0.000999 floors to 0.0 at a 0.001 step; an epsilon large enough to round it up "
-        "makes the guard validate a quantity the venue will never receive"
     )
 
 
@@ -6033,6 +6005,9 @@ def test_get_min_notional_reads_the_executor_rather_than_a_constant(value, expec
     trader.get_lot_size.return_value = {
         "min_qty": 0.001, "qty_step": 0.001, "min_notional": value
     }
+    # The executor is the authority on what it submits; model its truncation.
+    trader.quantize_quantity.side_effect = (
+        lambda q, _s=0.001: int(float(q) / _s) * _s)
     sent = {}
     env._execute_market_order = lambda side, quantity: sent.update(
         side=side, quantity=quantity) or {
@@ -6044,4 +6019,60 @@ def test_get_min_notional_reads_the_executor_rather_than_a_constant(value, expec
     assert (not sent) is expect_refused, (
         f"floor {value} from the executor: order was "
         f"{'refused' if not sent else 'submitted'}; `_get_min_notional` is not reading it"
+    )
+
+
+def test_the_guard_validates_what_the_executor_says_it_will_submit():
+    """Not what a shared rule guesses it will submit.
+
+    The four venues quantize differently: binance epsilon-floors (`round_quantity`),
+    bitget truncates through CCXT `amount_to_precision`, okx floors then clamps UP to
+    `min_qty`, bybit sends the raw float. A single shared rule is wrong for three of
+    them -- copying binance's epsilon accepted 0.0499999999999995 as 5.00 that bitget
+    submits as 4.90, which @CharlieHelps found in review.
+
+    So the guard asks the executor. This uses a quantizer that no shared rule would
+    produce: if the guard reimplements flooring, it validates 1.0 and accepts.
+    """
+    env, trader = _close_env("binance", 0)
+    env.config.trade_mode = "quantity"
+    env.config.quantity_per_trade = 1.0
+    trader.get_lot_size.return_value = {
+        "min_qty": 0.0, "qty_step": 0.001, "min_notional": 100.0
+    }
+    # This executor "submits" a tenth of what it is asked. Nothing derivable from
+    # qty_step predicts it -- only asking does.
+    trader.quantize_quantity.side_effect = lambda q: float(q) / 10.0
+
+    assert env._resolve_bracket_quantity(150.0) is None, (
+        "the guard validated 1.0 x 150 = 150.00 against a 100.0 floor, but the executor "
+        "reported it will submit 0.1, which is 15.00 -- the guard is not asking it"
+    )
+
+
+@pytest.mark.parametrize("floor,expect_refused", [
+    (None, True),    # metadata fetch failed -- the floor is UNKNOWN
+    (0.0, False),    # okx: genuinely no notional floor, must still trade
+    (5.0, False),    # a real floor, comfortably cleared
+], ids=["unknown", "genuinely-none", "real-floor"])
+def test_an_unknown_venue_minimum_is_not_treated_as_no_minimum(floor, expect_refused):
+    """A failed metadata fetch used to report `min_notional` 0.0, which is what okx
+    reports when it genuinely has no floor. Collapsing the two turned the guard off
+    during an outage -- when the venue is least predictable, and the one time this PR's
+    invariant matters most. @CharlieHelps caught it in review.
+
+    None now means "not read"; 0.0 still means "no floor" and still trades.
+    """
+    env, trader = _close_env("bitget", 0)
+    env.config.trade_mode = "quantity"
+    env.config.quantity_per_trade = 1.0
+    trader.get_lot_size.return_value = {
+        "min_qty": 0.001, "qty_step": 0.001, "min_notional": floor
+    }
+    trader.quantize_quantity.side_effect = lambda q: float(q)
+
+    refused = env._resolve_bracket_quantity(100.0) is None
+    assert refused is expect_refused, (
+        f"floor={floor!r}: {'refused' if refused else 'accepted'}, expected "
+        f"{'refused' if expect_refused else 'accepted'}"
     )

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -2538,7 +2538,10 @@ def test_a_real_step_lands_both_size_values_on_the_position(exchange, min_qty):
     trader = MagicMock()
     trader.get_status = MagicMock(return_value={"position_status": None})
     trader.get_mark_price = MagicMock(return_value=50000.0)
-    trader.get_lot_size = MagicMock(return_value={"min_qty": min_qty, "qty_step": min_qty})
+    # min_notional too: the shared guard indexes it strictly, so a stub without it
+    # KeyErrors the moment this fixture reaches the sizing path.
+    trader.get_lot_size = MagicMock(
+        return_value={"min_qty": min_qty, "qty_step": min_qty, "min_notional": 0.0})
     trader.get_account_balance = MagicMock(return_value={
         "total_wallet_balance": 10000.0, "available_balance": 10000.0,
         "total_unrealized_profit": 0.0, "total_margin_balance": 10000.0,

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -5678,6 +5678,13 @@ def test_a_refused_switch_does_not_claim_the_account_is_already_at_target(
             "a refused switch latched the action level to the direction it failed to "
             "open; the duplicate-action guard will now suppress every retry"
         )
+    else:
+        # The other half of the contract: the honest at-target refusal SHOULD latch.
+        # Without this the `refused-open` row ran the record call and asserted nothing.
+        assert env.position.current_action_level == 1.0, (
+            "a genuine at-target refusal stopped recording the level, so the env will "
+            "re-send an order the venue already refused, every bar"
+        )
 
 
 @pytest.mark.parametrize("venue", ["binance", "bitget", "bybit", "okx", "replay"])
@@ -5805,3 +5812,65 @@ def test_a_trader_without_a_notional_floor_fails_loudly_rather_than_silently(ven
 
     with pytest.raises(KeyError, match="min_notional"):
         env._resolve_bracket_quantity(100.0)
+
+
+@pytest.mark.parametrize("venue", _SLTP_VENUES)
+def test_the_notional_is_checked_against_the_quantity_the_venue_will_receive(venue):
+    """The guard must validate the FLOORED quantity, not the raw one.
+
+    Every venue formatter truncates to the lot step, so validating before that is the
+    same "validated one number, sent another" bug this PR fixes on the plain path --
+    committed once inside the fix itself, and reverting it passed all 3514 tests.
+
+    The numbers are the ones from that commit message: step 0.001, floor 100, price
+    60000. A quantity of 0.001666... is exactly 100.00 raw and 60.00 once floored, so
+    anything landing in [100, 160) USD passed the guard and was refused by the exchange.
+    """
+    env, trader = _close_env(venue, 0)
+    env.config.trade_mode = "quantity"
+    env.config.quantity_per_trade = 100.0 / 60000.0        # 0.001666..., exactly at 100
+    trader.get_lot_size.return_value = {
+        "min_qty": 0.0, "qty_step": 0.001, "min_notional": 100.0
+    }
+
+    assert env._resolve_bracket_quantity(60000.0) is None, (
+        f"{venue}: validated {100.0 / 60000.0 * 60000.0:.2f} notional but the venue "
+        f"receives 0.001 = 60.00, below the 100.0 floor it would reject"
+    )
+
+
+@pytest.mark.parametrize("venue", ["binance", "bitget", "bybit"])
+def test_a_quantity_below_one_lot_step_is_refused_rather_than_sent_as_zero(venue):
+    """Flooring a sub-step quantity gives 0.0, and submitting nothing is not a trade.
+
+    okx is excluded because its `_resolve_bracket_quantity` override already refuses on
+    `min_qty` -- so the shared refusal is invisible there, which is exactly why the one
+    test reaching this arm could not distinguish it.
+    """
+    env, trader = _close_env(venue, 0)
+    env.config.trade_mode = "quantity"
+    env.config.quantity_per_trade = 0.0001                 # a tenth of one lot step
+    trader.get_lot_size.return_value = {
+        "min_qty": 0.0, "qty_step": 0.001, "min_notional": 0.0
+    }
+
+    assert env._resolve_bracket_quantity(100.0) is None, (
+        f"{venue}: 0.0001 floors to 0.0 at a 0.001 step; submitting it asks the venue "
+        f"for nothing"
+    )
+
+
+def test_a_non_finite_target_never_reaches_the_venue():
+    """binance's plain path has no `isfinite` balance guard, unlike the SLTP sizing which
+    got one for #347. A NaN balance gives a NaN target, a NaN delta, and falls through
+    `> 0`, `< 0` and `== 0` alike into the terminal else -- which returns quietly.
+
+    Quiet is the problem: the account is untouched, but nothing says the sizing produced
+    a number that is not a number.
+    """
+    env, sent = _switch_stub(price=100.0, min_notional=0.0, lot_step=0.001,
+                             current_qty=0.0, target_qty=float("nan"))
+    info = env._execute_fractional_action(1.0, current_qty=0.0, current_price=100.0)
+
+    assert not sent, f"a NaN target reached the venue as {sent.get('quantity')!r}"
+    assert not info["executed"]

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -5501,3 +5501,76 @@ def test_a_venue_that_reports_no_bracket_status_records_both_legs(venue):
         f"{venue}: a venue that reports no per-leg status must be taken at its word that "
         f"both legs placed -- otherwise bybit and okx record no brackets at all."
     )
+
+
+def _switch_stub(*, price, min_notional, lot_step, current_qty, target_qty):
+    """binance's fractional path, wired so the SUBMITTED quantity is observable.
+
+    Everything upstream of the notional check is stubbed to a known value, because the
+    bug is not in how the target is computed -- it is that the quantity validated and the
+    quantity sent are different numbers on one branch.
+    """
+    cls = _sole(importlib.import_module("torchtrade.envs.live.binance.env"),
+                "TorchTradingEnv")
+    env = cls.__new__(cls)
+    env.config = SimpleNamespace(leverage=10, symbol="BTCUSDT")
+    env.trader = MagicMock()
+    env.trader.round_quantity.side_effect = lambda q: (float(q) // lot_step) * lot_step
+    env._get_min_notional = lambda: min_notional
+    env._calculate_fractional_position = lambda av, cp: (
+        target_qty, abs(target_qty) * cp, "buy" if target_qty > 0 else "sell")
+    env._handle_close_action = lambda q: {
+        "executed": True, "success": True, "side": "buy" if q < 0 else "sell",
+        "quantity": abs(q), "closed_position": True}
+    sent = {}
+    env._execute_market_order = lambda side, quantity: sent.update(
+        side=side, quantity=quantity) or {
+        "executed": True, "success": True, "side": side, "quantity": quantity}
+    env._create_trade_info = lambda **kw: {"executed": False, "success": None, **kw}
+    return env, sent
+
+
+def test_a_direction_switch_validates_the_quantity_it_actually_sends():
+    """The notional check ran on the DELTA and the switch branch submitted the TARGET.
+
+    On a switch the two are different numbers -- `|delta| = |target| + |current|` because
+    the signs oppose -- so the larger delta clears the exchange minimum while the smaller
+    target does not. The venue rejects the open, the close has already happened, and the
+    env reports executed/success for a position it does not hold. That is invariant 2
+    inverted, with leverage on it.
+
+    Worked from @CharlieHelps' example: price 99.99, minimum 100. A short of 1.0 switching
+    to a long of 1.0 validates 2.0 (notional 199.98, passes) and sends 1.0 (notional
+    99.99, rejected).
+    """
+    env, sent = _switch_stub(price=99.99, min_notional=100.0, lot_step=1.0,
+                             current_qty=-1.0, target_qty=1.0)
+    info = env._execute_fractional_action(1.0, current_qty=-1.0, current_price=99.99)
+
+    assert not sent, (
+        f"submitted {sent.get('quantity')} at 99.99 = "
+        f"{(sent.get('quantity') or 0) * 99.99:.2f} notional, below the 100.0 minimum the "
+        f"env checked against a different quantity"
+    )
+    assert not info["executed"]
+
+
+def test_the_delta_sent_to_the_venue_is_lot_rounded():
+    """`delta = self.trader.round_quantity(abs(delta)) * sign` had no test at all:
+    replacing the whole line with `delta = delta` passed the entire suite.
+
+    #352 fixed the TARGET rounding for #271 and left the DELTA rounding unpinned, so an
+    un-lot-rounded quantity could reach the venue -- the same rejection class as the
+    notional gaps, and invisible because every other test rounds to a step the raw value
+    already sits on.
+    """
+    env, sent = _switch_stub(price=100.0, min_notional=0.0, lot_step=0.5,
+                             current_qty=0.0, target_qty=1.7)
+    env._execute_fractional_action(1.0, current_qty=0.0, current_price=100.0)
+
+    assert sent, "nothing was submitted; the stub is not exercising the trade path"
+    q = sent["quantity"]
+    assert q == pytest.approx(1.5), (
+        f"submitted {q}, which is not a multiple of the 0.5 lot step -- the delta reached "
+        f"the venue unrounded"
+    )

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -6076,3 +6076,82 @@ def test_an_unknown_venue_minimum_is_not_treated_as_no_minimum(floor, expect_ref
         f"floor={floor!r}: {'refused' if refused else 'accepted'}, expected "
         f"{'refused' if expect_refused else 'accepted'}"
     )
+
+
+@pytest.mark.parametrize("venue", ["binance", "bitget", "bybit"])
+def test_the_plain_path_refuses_an_unknown_floor_rather_than_raising(venue):
+    """The plain paths called `float(min_notional)` directly, so an unknown floor raised
+    TypeError out of the live step instead of the controlled refusal the shared guard
+    gives. @CharlieHelps found it -- the SLTP path was fixed and this one was not.
+
+    A crash in `_step` is not the fail-closed behaviour; it is an unhandled exception on
+    the money path.
+    """
+    env, trader = _real_futures_env(budget=0, venue=venue)
+    trader.get_lot_size.return_value = {
+        "min_qty": 0.001, "qty_step": 0.001, "min_notional": None
+    }
+    trader.quantize_quantity.side_effect = lambda q: float(q)
+    sent = {}
+    env._execute_market_order = lambda side, quantity: sent.update(
+        side=side, quantity=quantity) or {
+        "executed": True, "success": True, "side": side, "quantity": quantity}
+    env._calculate_fractional_position = lambda av, cp: (0.5, 0.5 * cp, "buy")
+
+    info = env._execute_fractional_action(1.0, current_qty=0.0, current_price=100.0)
+
+    assert not sent, f"{venue}: submitted against a floor it could not read"
+    assert not info["executed"]
+
+
+@pytest.mark.parametrize("venue,complete", [
+    ("bitget", False), ("bitget", True),
+    ("bybit", False), ("bybit", True),
+    ("binance", False), ("binance", True),
+], ids=["bitget-incomplete", "bitget-complete", "bybit-incomplete", "bybit-complete",
+        "binance-incomplete", "binance-complete"])
+def test_incomplete_metadata_is_unknown_not_a_zero_floor(venue, complete):
+    """A venue that RESPONDS but omits the notional field is not a venue with no floor.
+
+    Collapsing the two kept the fail-open path alive for every successful-but-incomplete
+    response -- which is most of them for a non-USDT-quoted bitget market, where CCXT
+    simply does not populate `limits.cost.min`.
+    """
+    mod = importlib.import_module(f"torchtrade.envs.live.{venue}.order_executor")
+    cls = _sole(mod, "OrderClass")
+    ex = cls.__new__(cls)
+    ex.symbol = "BTC/USDT:USDT" if venue == "bitget" else "BTCUSDT"
+    ex._lot_size_cache = None
+    ex._qty_steps, ex._min_qtys, ex._min_notional = {}, {}, None
+    ex._tick_size = ex._tick_decimals = ex._lot_size_decimals = None
+    client = MagicMock()
+    if venue == "bitget":
+        limits = {"amount": {"min": 0.001}}
+        if complete:
+            limits["cost"] = {"min": 5.0}
+        client.market = MagicMock(
+            return_value={"limits": limits, "precision": {"amount": 0.001}})
+    elif venue == "bybit":
+        lot = {"minOrderQty": "0.001", "qtyStep": "0.001"}
+        if complete:
+            lot["minNotionalValue"] = "5"
+        client.get_instruments_info = MagicMock(return_value={
+            "retCode": 0, "result": {"list": [
+                {"symbol": "BTCUSDT", "lotSizeFilter": lot,
+                 "priceFilter": {"tickSize": "0.01"}}]}})
+    else:                                   # binance
+        filters = [{"filterType": "LOT_SIZE", "stepSize": "0.001", "minQty": "0.001"},
+                   {"filterType": "PRICE_FILTER", "tickSize": "0.01"}]
+        # A PRESENT filter with an empty `notional` is incomplete, not a zero floor.
+        filters.append({"filterType": "MIN_NOTIONAL",
+                        "notional": "5" if complete else ""})
+        client.futures_exchange_info = MagicMock(
+            return_value={"symbols": [{"symbol": "BTCUSDT", "filters": filters}]})
+    ex.client = ex.public_client = client
+    if venue == "binance":
+        ex._fetch_symbol_filters()
+
+    floor = ex.get_lot_size()["min_notional"]
+    assert (floor is not None) is complete, (
+        f"{venue}: an incomplete payload reported {floor!r}; absent is unknown, not zero"
+    )

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -5821,6 +5821,29 @@ def test_a_trader_without_a_notional_floor_fails_loudly_rather_than_silently(ven
 # override genuinely changes the outcome. The venue axis buys nothing on tests of
 # the ONE shared method: across nine mutants, none ever killed a strict subset of
 # venue rows.
+@pytest.mark.parametrize("qty,price,step,floor", [
+    (100.0 / 60000.0, 60000.0, 0.001, 100.0),   # 0.001666... -> 0.001 = 60.00
+    (1.0005, 99.99, 0.001, 100.0),              # @CharlieHelps: 100.039995 -> 1.000 = 99.99
+])
+def test_a_boundary_quantity_is_judged_after_the_venue_floors_it(qty, price, step, floor):
+    """The raw quantity clears the floor and the floored one does not.
+
+    Row 2 is @CharlieHelps' case from the #420 review: 1.0005 at 99.99 is 100.039995
+    raw, submitted as 1.000, which is 99.99 -- rejected. Row 1 is the same shape at a
+    different scale.
+    """
+    env, trader = _close_env("binance", 0)
+    env.config.trade_mode = "quantity"
+    env.config.quantity_per_trade = qty
+    trader.get_lot_size.return_value = {
+        "min_qty": 0.0, "qty_step": step, "min_notional": floor
+    }
+    assert env._resolve_bracket_quantity(price) is None, (
+        f"{qty} at {price} is {qty * price:.6f} raw -- above the {floor} floor -- but the "
+        f"venue receives the floored value and rejects it"
+    )
+
+
 @pytest.mark.parametrize("venue", ["binance", "okx"])
 def test_the_notional_is_checked_against_the_quantity_the_venue_will_receive(venue):
     """The guard must validate the FLOORED quantity, not the raw one.

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -5589,7 +5589,11 @@ def test_the_delta_sent_to_the_venue_is_lot_rounded():
     )
 
 
-@pytest.mark.parametrize("venue", _SLTP_VENUES)
+# One shared-guard representative plus okx, whose `_resolve_bracket_quantity`
+# override genuinely changes the outcome. The venue axis buys nothing on tests of
+# the ONE shared method: across nine mutants, none ever killed a strict subset of
+# venue rows.
+@pytest.mark.parametrize("venue", ["binance", "okx"])
 @pytest.mark.parametrize("trade_mode,qty_per_trade", [
     ("fractional", 0), ("notional", 10.0), ("quantity", 0.1),
 ])
@@ -5789,7 +5793,11 @@ def test_the_plain_path_also_refuses_below_the_venue_notional_floor(venue):
     )
 
 
-@pytest.mark.parametrize("venue", _SLTP_VENUES)
+# One shared-guard representative plus okx, whose `_resolve_bracket_quantity`
+# override genuinely changes the outcome. The venue axis buys nothing on tests of
+# the ONE shared method: across nine mutants, none ever killed a strict subset of
+# venue rows.
+@pytest.mark.parametrize("venue", ["binance", "okx"])
 def test_a_trader_without_a_notional_floor_fails_loudly_rather_than_silently(venue):
     """The guard indexes `lot["min_notional"]` rather than `.get(..., 0.0)`.
 
@@ -5809,7 +5817,11 @@ def test_a_trader_without_a_notional_floor_fails_loudly_rather_than_silently(ven
         env._resolve_bracket_quantity(100.0)
 
 
-@pytest.mark.parametrize("venue", _SLTP_VENUES)
+# One shared-guard representative plus okx, whose `_resolve_bracket_quantity`
+# override genuinely changes the outcome. The venue axis buys nothing on tests of
+# the ONE shared method: across nine mutants, none ever killed a strict subset of
+# venue rows.
+@pytest.mark.parametrize("venue", ["binance", "okx"])
 def test_the_notional_is_checked_against_the_quantity_the_venue_will_receive(venue):
     """The guard must validate the FLOORED quantity, not the raw one.
 
@@ -5834,7 +5846,7 @@ def test_the_notional_is_checked_against_the_quantity_the_venue_will_receive(ven
     )
 
 
-@pytest.mark.parametrize("venue", ["binance", "bitget", "bybit"])
+@pytest.mark.parametrize("venue", ["binance"])
 def test_a_quantity_below_one_lot_step_is_refused_rather_than_sent_as_zero(venue):
     """Flooring a sub-step quantity gives 0.0, and submitting nothing is not a trade.
 

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -5545,6 +5545,11 @@ def test_a_direction_switch_validates_the_quantity_it_actually_sends():
     """
     env, sent = _switch_stub(price=99.99, min_notional=100.0, lot_step=1.0,
                              current_qty=-1.0, target_qty=1.0)
+    closed = []
+    env._handle_close_action = lambda q: closed.append(q) or {
+        "executed": True, "success": True, "side": "buy", "quantity": abs(q),
+        "closed_position": True}
+
     info = env._execute_fractional_action(1.0, current_qty=-1.0, current_price=99.99)
 
     assert not sent, (
@@ -5552,7 +5557,14 @@ def test_a_direction_switch_validates_the_quantity_it_actually_sends():
         f"{(sent.get('quantity') or 0) * 99.99:.2f} notional, below the 100.0 minimum the "
         f"env checked against a different quantity"
     )
-    assert not info["executed"]
+    # The ORDERING, which the source comment claims and nothing asserted: moving the
+    # check below the close block passed every test, because refusing after the close
+    # still reports executed=False -- while the account has just gone flat. That is the
+    # bug this PR exists to fix, arrived at from the other direction.
+    assert not closed, (
+        "the position was closed and THEN the open was refused: the account is flat and "
+        "trade_info says nothing happened"
+    )
 
 
 def test_the_delta_sent_to_the_venue_is_lot_rounded():
@@ -5577,7 +5589,12 @@ def test_the_delta_sent_to_the_venue_is_lot_rounded():
 
 
 @pytest.mark.parametrize("venue", _SLTP_VENUES)
-def test_the_sltp_path_refuses_a_bracket_below_the_venue_notional_floor(venue):
+@pytest.mark.parametrize("trade_mode,qty_per_trade", [
+    ("fractional", 0), ("notional", 10.0), ("quantity", 0.1),
+])
+def test_the_sltp_path_refuses_a_bracket_below_the_venue_notional_floor(
+    venue, trade_mode, qty_per_trade
+):
     """The SLTP path had no notional check on ANY venue, and bitget and bybit read no
     notional field at all -- both fetched it with the rest of the market info and dropped
     it (#414).
@@ -5589,7 +5606,12 @@ def test_the_sltp_path_refuses_a_bracket_below_the_venue_notional_floor(venue):
     action asked for, which is how okx's formatter turns a sub-minimum size into a real
     position.
     """
+    # ALL THREE modes, because `fractional` is the default and dominant one and deleting
+    # its guard call passed 1963 tests -- the SLTP test only ever reached `quantity`.
+    # "Fixed on all, tested on one" is the shape this whole issue is about.
     env, trader = _close_env(venue, 0)
+    env.config.trade_mode = trade_mode
+    env.config.quantity_per_trade = qty_per_trade
     trader.get_lot_size.return_value = {
         "min_qty": 0.0, "qty_step": 0.001, "min_notional": 1_000_000.0
     }
@@ -5602,22 +5624,110 @@ def test_the_sltp_path_refuses_a_bracket_below_the_venue_notional_floor(venue):
     )
 
 
-@pytest.mark.parametrize("venue", ["binance", "bitget", "bybit", "okx"])
-def test_every_futures_executor_reports_its_venue_minimums_the_same_way(venue):
-    """One accessor shape across four venues, so the shared sizing can ask one question.
+# `test_every_futures_executor_reports_its_venue_minimums_the_same_way` lived here and is
+# gone. It asserted that each `get_lot_size`'s SOURCE mentions three key strings -- which
+# passes for one that names `min_notional` in a comment and returns nothing, and which
+# hardcoded four venues while a FIFTH implementation (ReplayOrderExecutor) sat two keys
+# short the whole time. Its only unique kill was "okx omits the key", and with the guard
+# reading `.get(..., 0.0)` absent and 0.0 were the same program, so that kill changed no
+# behaviour. The guard now indexes strictly, which turns key-absence into a loud KeyError
+# and makes the property behavioural instead of textual.
 
-    binance was the only executor without `get_lot_size`, which is why the shared path
-    could not ask it for a notional floor. Its values come from filters
-    `_fetch_symbol_filters` already caches, so the accessor adds no API call.
+
+@pytest.mark.parametrize("current_qty,switching,expected_at_target", [
+    (-1.0, True, False),   # holding a SHORT, asked for a LONG -> a switch, NOT at target
+    (0.0, False, True),    # flat, opening -> the sub-minimum refusal `at_target` was for
+], ids=["refused-switch", "refused-open"])
+def test_a_refused_switch_does_not_claim_the_account_is_already_at_target(
+    current_qty, switching, expected_at_target
+):
+    """`at_target` means "already there", and `_record_position_after_trade` takes it as
+    permission to write `current_action_level = desired_action`.
+
+    That was honest for the ONLY refusal the flag originally had -- a sub-minimum delta,
+    which does mean at target. The notional reorder gave it a second reachable path: a
+    refused direction SWITCH, where the account is on the opposite side at full size.
+    Claiming at_target there latches the level to a direction the account does not hold,
+    and because `_sync_position_from_exchange` then sees cached and observed agree
+    (both short) it never repairs it -- so the duplicate-action guard suppresses every
+    later retry of that direction, including once price makes the order legal.
+
+    Refusing an order is cheap. Refusing it for the rest of the episode is not.
     """
-    mod = importlib.import_module(f"torchtrade.envs.live.{venue}.order_executor")
-    cls = next(c for k, c in vars(mod).items()
-               if k.endswith("OrderClass") and getattr(c, "__module__", "") == mod.__name__)
-    assert hasattr(cls, "get_lot_size"), (
-        f"{venue}'s executor has no get_lot_size, so the shared sizing cannot ask it for "
-        f"a venue minimum and will submit whatever it computed"
+    env, trader = _real_futures_env(budget=0, venue="binance")
+    env._get_min_notional = lambda: 100.0
+    env.trader.round_quantity.side_effect = lambda q: float(int(q))
+    env._calculate_fractional_position = lambda av, cp: (1.0, 1.0 * cp, "buy")
+    env._handle_close_action = lambda q: {"executed": True, "success": True}
+    env.position.current_position = -1 if current_qty < 0 else 0
+    env.position.current_action_level = -1.0 if current_qty < 0 else 0.0
+
+    info = env._execute_fractional_action(
+        1.0, current_qty=current_qty, current_price=99.99
     )
-    keys = {"min_qty", "qty_step", "min_notional"}
-    src = inspect.getsource(cls.get_lot_size)
-    missing = {k for k in keys if f'"{k}"' not in src}
-    assert not missing, f"{venue}'s get_lot_size never mentions {sorted(missing)}"
+    assert not info["executed"]
+    assert info.get("at_target") is expected_at_target
+
+    level_before = env.position.current_action_level
+    env._record_position_after_trade(1.0, info)
+    if switching:
+        assert env.position.current_action_level == level_before, (
+            "a refused switch latched the action level to the direction it failed to "
+            "open; the duplicate-action guard will now suppress every retry"
+        )
+
+
+@pytest.mark.parametrize("venue", ["bitget", "bybit", "okx"])
+def test_every_lot_size_cache_write_carries_all_three_keys(venue):
+    """The accessor is not the thing to check -- the WRITES are.
+
+    Each of these executors caches its lot size from more than one place: a
+    construction-time write inside the tick-size fetch, a lazy write in `get_lot_size`,
+    and one or more fallbacks. Updating some and not others is how okx came to return a
+    two-key dict at runtime while its `get_lot_size` source mentioned the third key, so a
+    source grep saw a contract that did not hold and the whole suite passed.
+
+    Once the shared guard indexes `lot["min_notional"]` strictly, a missing key is a
+    KeyError on every bracket open, so this is a crash test, not a style test. Every
+    dict-literal write is checked rather than the one the tests happen to reach.
+    """
+    tree = ast.parse(
+        pathlib.Path(f"torchtrade/envs/live/{venue}/order_executor.py").read_text()
+    )
+    writes = [
+        n for n in ast.walk(tree)
+        if isinstance(n, ast.Assign) and len(n.targets) == 1
+        and isinstance(n.targets[0], ast.Attribute)
+        and n.targets[0].attr == "_lot_size_cache"
+        and isinstance(n.value, ast.Dict)
+    ]
+    assert writes, f"{venue} has no dict-literal _lot_size_cache write to check"
+    for w in writes:
+        keys = {k.value for k in w.value.keys if isinstance(k, ast.Constant)}
+        assert keys == {"min_qty", "qty_step", "min_notional"}, (
+            f"{venue}/order_executor.py:{w.lineno} writes {sorted(keys)}; a cache missing "
+            f"min_notional KeyErrors in the shared sizing guard"
+        )
+
+
+@pytest.mark.parametrize("price", [0.61, 1.22, 2.23, 2.29, 2.44])
+def test_notional_sizing_exactly_at_the_floor_is_not_refused_by_float_error(price):
+    """`notional` mode computes `qty = usd / price`; the guard re-multiplies by the same
+    price. That round-trip is not exact -- for ~1.7% of prices in 0.001-100,
+    `(5.0 / p) * p < 5.0` -- and bitget's minTradeUSDT is exactly 5.
+
+    Without an epsilon a user sizing at the venue floor gets intermittent silent refusals
+    that depend on the last bit of the price. These five are the first such prices, and
+    they are ordinary altcoin-perp values.
+    """
+    env, trader = _close_env("bitget", 0)
+    env.config.trade_mode = "notional"
+    env.config.quantity_per_trade = 5.0
+    trader.get_lot_size.return_value = {
+        "min_qty": 0.0, "qty_step": 1e-9, "min_notional": 5.0
+    }
+
+    assert env._resolve_bracket_quantity(price) is not None, (
+        f"sizing exactly 5.0 USD against a 5.0 floor at price {price} was refused: "
+        f"(5.0/{price})*{price} = {(5.0 / price) * price!r}"
+    )

--- a/tests/envs/test_live_observation_failsafe.py
+++ b/tests/envs/test_live_observation_failsafe.py
@@ -188,6 +188,8 @@ def _real_futures_env(budget, venue="binance", sltp=False, position_status=None,
     trader.get_mark_price.return_value = 100.0
     trader.get_lot_size.return_value = {"min_qty": 0.001, "qty_step": 0.001, "min_notional": 0.0}
     trader.round_quantity.side_effect = lambda q: round(float(q), 3)
+    # The executor is the authority on what it will submit; the shared guard asks it.
+    trader.quantize_quantity.side_effect = lambda q: round(float(q), 3)
     trader._round_amount.side_effect = lambda q: round(float(q), 3)   # bitget/okx spelling
     trader.trade.return_value = True
     trader.close_position.return_value = True

--- a/tests/envs/test_live_observation_failsafe.py
+++ b/tests/envs/test_live_observation_failsafe.py
@@ -186,7 +186,7 @@ def _real_futures_env(budget, venue="binance", sltp=False, position_status=None,
         "total_wallet_balance": 1e4, "total_maintenance_margin": 0.0}
     trader.get_status.return_value = {"position_status": position_status}
     trader.get_mark_price.return_value = 100.0
-    trader.get_lot_size.return_value = {"min_qty": 0.001, "qty_step": 0.001}
+    trader.get_lot_size.return_value = {"min_qty": 0.001, "qty_step": 0.001, "min_notional": 0.0}
     trader.round_quantity.side_effect = lambda q: round(float(q), 3)
     trader._round_amount.side_effect = lambda q: round(float(q), 3)   # bitget/okx spelling
     trader.trade.return_value = True

--- a/tests/envs/test_live_trade_state.py
+++ b/tests/envs/test_live_trade_state.py
@@ -74,7 +74,7 @@ class MockTrader:
         return self.mark_price_val
 
     def get_lot_size(self):
-        return {"min_qty": 0.001, "qty_step": 0.001}
+        return {"min_qty": 0.001, "qty_step": 0.001, "min_notional": 0.0}
 
     def _round_amount(self, amount):
         # Floor to the 0.001 step (mirrors CCXT amount_to_precision truncation).

--- a/torchtrade/envs/live/binance/env.py
+++ b/torchtrade/envs/live/binance/env.py
@@ -177,8 +177,16 @@ class BinanceFuturesTorchTradingEnv(BinanceBaseTorchTradingEnv):
             return position_size, notional_value, side
 
         # Below the venue minimum the position is NOT opened, rather than rounded up:
-        # rounding up would allocate beyond what the action asked for.
+        # rounding up would allocate beyond what the action asked for. An UNKNOWN floor
+        # refuses the same way -- this is the second of two call sites, and guarding only
+        # the other one left `float(None)` raising out of the live step here (#414).
         min_notional = self._get_min_notional()
+        if min_notional is None:
+            logger.warning(
+                f"{self.config.symbol}: the venue minimum is not known; not opening "
+                f"rather than assuming there is no floor"
+            )
+            return 0.0, 0.0, "flat"
         if notional_value < min_notional:
             logger.warning(
                 f"Action {action_value} resulted in notional {notional_value:.2f} "

--- a/torchtrade/envs/live/binance/env.py
+++ b/torchtrade/envs/live/binance/env.py
@@ -257,31 +257,14 @@ class BinanceFuturesTorchTradingEnv(BinanceBaseTorchTradingEnv):
         if delta == 0:
             return self._create_trade_info(executed=False)  # Already close enough
 
-        # 8. Check delta notional meets exchange minimum
-        delta_notional = abs(delta) * current_price
-        min_notional = self._get_min_notional()
-        if delta_notional < min_notional:
-            return self._create_trade_info(executed=False, at_target=True)  # Delta too small for exchange
-
-        # 9. Determine trade direction and execute
-        if (current_qty > 0 and target_qty < 0) or (current_qty < 0 and target_qty > 0):
-            # Direction switch: close current, then open opposite
-            #
-            # Edge case handling:
-            #   1. If close fails → Return early, don't open opposite position
-            #      This prevents doubling position size if close is rejected
-            #   2. If close succeeds but open fails → Agent ends up flat instead of target
-            #      Trade info will show close executed=True but may not reflect open failure
-            #   3. Between close and open, account balance changes (from PnL)
-            #      Target calculation uses current balance which may differ
-            #
-            # TODO: Consider tracking partial execution state for observation
-            close_info = self._handle_close_action(current_qty)
-            if not close_info["executed"] or close_info.get("success") is False:
-                logger.warning("Direction switch failed: unable to close current position")
-                return close_info
-
-            # Open new position in opposite direction
+        # 8. Decide what will be SENT before validating anything, because a direction
+        #    switch does not send the delta -- it closes, then opens `abs(target_qty)`.
+        #    Validating the delta and submitting the target is how an order the venue
+        #    rejects gets reported as executed: on a switch the signs oppose, so
+        #    `|delta| = |target| + |current|` and the larger number clears a minimum the
+        #    smaller one does not.
+        switching = (current_qty > 0 and target_qty < 0) or (current_qty < 0 and target_qty > 0)
+        if switching:
             side, amount = ("buy" if target_qty > 0 else "sell"), abs(target_qty)
         elif delta > 0:
             side, amount = "buy", abs(delta)          # increase, or open long from flat
@@ -289,6 +272,21 @@ class BinanceFuturesTorchTradingEnv(BinanceBaseTorchTradingEnv):
             side, amount = "sell", abs(delta)         # decrease, or open short from flat
         else:
             return self._create_trade_info(executed=False)
+
+        # 9. Validate the submitted quantity, and do it BEFORE the switch's close. After
+        #    the close it is too late to refuse: the position is already gone and
+        #    returning "not executed" would describe an account that just changed.
+        min_notional = self._get_min_notional()
+        if amount * current_price < min_notional:
+            return self._create_trade_info(executed=False, at_target=True)
+
+        # 10. A switch closes first. If the close fails, do not open the opposite side --
+        #     that would double the position rather than reverse it.
+        if switching:
+            close_info = self._handle_close_action(current_qty)
+            if not close_info["executed"] or close_info.get("success") is False:
+                logger.warning("Direction switch failed: unable to close current position")
+                return close_info
 
         # One exit, so a new branch cannot skip the target and disable the check.
         info = self._execute_market_order(side, amount)

--- a/torchtrade/envs/live/binance/env.py
+++ b/torchtrade/envs/live/binance/env.py
@@ -153,34 +153,21 @@ class BinanceFuturesTorchTradingEnv(BinanceBaseTorchTradingEnv):
         self.action_spec = Categorical(len(self.action_levels))
 
 
-    def _get_symbol_info(self) -> Dict:
-        """Get exchange symbol information for precision and lot size.
-
-        Binance-specific implementation that queries futures_exchange_info() API.
-        """
-        try:
-            exchange_info = self.trader.client.futures_exchange_info()
-            for symbol in exchange_info['symbols']:
-                if symbol['symbol'] == self.config.symbol:
-                    return symbol
-            raise ValueError(f"Symbol {self.config.symbol} not found in exchange info")
-        except Exception as e:
-            logger.error(f"Error getting symbol info: {e}")
-            # Return defaults if exchange query fails
-            return {
-                'filters': [
-                    {'filterType': 'LOT_SIZE', 'stepSize': '0.001'},
-                    {'filterType': 'MIN_NOTIONAL', 'notional': '100'}
-                ]
-            }
-
     def _get_min_notional(self) -> float:
-        """Get the minimum notional value for orders."""
-        symbol_info = self._get_symbol_info()
-        for filter_item in symbol_info.get('filters', []):
-            if filter_item['filterType'] == 'MIN_NOTIONAL':
-                return float(filter_item.get('notional', 100))
-        return 100.0  # Default fallback
+        """The venue's notional floor, from the executor's cached filters.
+
+        One owner, not two. This method used to walk `futures_exchange_info()` itself --
+        an unhalted REST round-trip on every sized step, twice per step, fetching every
+        symbol on the venue -- and fell back to a fabricated 100.0 while the executor's
+        cache fell back to 0.0. Same symbol, same instant, opposite answers: the plain
+        path refused at 100 and the SLTP path refused nothing (#414).
+
+        100.0 was never a venue constant either; it is BTCUSDT's floor. ETHUSDT is 20 and
+        most alt perps are 5, so it was wrong in the other direction for every other
+        symbol. `get_lot_size` re-fetches on an empty cache, so a transient failure at
+        construction repairs itself rather than pinning a guess.
+        """
+        return float(self.trader.get_lot_size()["min_notional"])
 
     def _calculate_fractional_position(
         self, action_value: float, current_price: float

--- a/torchtrade/envs/live/binance/env.py
+++ b/torchtrade/envs/live/binance/env.py
@@ -278,7 +278,15 @@ class BinanceFuturesTorchTradingEnv(BinanceBaseTorchTradingEnv):
         #    returning "not executed" would describe an account that just changed.
         min_notional = self._get_min_notional()
         if amount * current_price < min_notional:
-            return self._create_trade_info(executed=False, at_target=True)
+            # `at_target` ONLY when not switching. It means "already there", and
+            # `_record_position_after_trade` takes it as permission to write
+            # `current_action_level = desired_action`. On a switch we are on the OPPOSITE
+            # side at full size, so claiming it latches the level to a direction the
+            # account does not hold -- the next sync sees cached and observed agree, never
+            # repairs it, and the duplicate-action guard then suppresses every retry of
+            # that direction for the rest of the episode, including once price makes the
+            # order legal. Refusing an order is cheap; refusing it forever is not.
+            return self._create_trade_info(executed=False, at_target=not switching)
 
         # 10. A switch closes first. If the close fails, do not open the opposite side --
         #     that would double the position rather than reverse it.

--- a/torchtrade/envs/live/binance/env.py
+++ b/torchtrade/envs/live/binance/env.py
@@ -153,10 +153,13 @@ class BinanceFuturesTorchTradingEnv(BinanceBaseTorchTradingEnv):
         self.action_spec = Categorical(len(self.action_levels))
 
 
-    def _get_min_notional(self) -> float:
+    def _get_min_notional(self) -> float | None:
         """The venue's floor, from the executor's cached filters. One owner, not two.
+
+        None means the floor is not known -- the caller must refuse, not assume zero.
         """
-        return float(self.trader.get_lot_size()["min_notional"])
+        raw = self.trader.get_lot_size()["min_notional"]
+        return None if raw is None else float(raw)
 
     def _calculate_fractional_position(
         self, action_value: float, current_price: float
@@ -249,6 +252,12 @@ class BinanceFuturesTorchTradingEnv(BinanceBaseTorchTradingEnv):
         # Before the switch's close: after it, refusing would describe an account that
         # has already changed.
         min_notional = self._get_min_notional()
+        if min_notional is None:
+            logger.warning(
+                f"{self.config.symbol}: the venue minimum is not known; refusing rather "
+                f"than assuming there is no floor"
+            )
+            return self._create_trade_info(executed=False, at_target=not switching)
         if amount * current_price < min_notional:
             # `at_target` means "already there"; on a switch we hold the opposite side
             # at full size, so claiming it latches the level to a direction we do not

--- a/torchtrade/envs/live/binance/env.py
+++ b/torchtrade/envs/live/binance/env.py
@@ -154,18 +154,7 @@ class BinanceFuturesTorchTradingEnv(BinanceBaseTorchTradingEnv):
 
 
     def _get_min_notional(self) -> float:
-        """The venue's notional floor, from the executor's cached filters.
-
-        One owner, not two. This method used to walk `futures_exchange_info()` itself --
-        an unhalted REST round-trip on every sized step, twice per step, fetching every
-        symbol on the venue -- and fell back to a fabricated 100.0 while the executor's
-        cache fell back to 0.0. Same symbol, same instant, opposite answers: the plain
-        path refused at 100 and the SLTP path refused nothing (#414).
-
-        100.0 was never a venue constant either; it is BTCUSDT's floor. ETHUSDT is 20 and
-        most alt perps are 5, so it was wrong in the other direction for every other
-        symbol. `get_lot_size` re-fetches on an empty cache, so a transient failure at
-        construction repairs itself rather than pinning a guess.
+        """The venue's floor, from the executor's cached filters. One owner, not two.
         """
         return float(self.trader.get_lot_size()["min_notional"])
 
@@ -219,37 +208,34 @@ class BinanceFuturesTorchTradingEnv(BinanceBaseTorchTradingEnv):
         Returns:
             trade_info: Dict with execution details
         """
-        # 1. Query actual position from exchange (source of truth)
+        # Query actual position from exchange (source of truth)
         # Threaded from `_step`'s halted read; required, never defaulted (#295).
         if action_value == 0.0:
             if abs(current_qty) > 0:
                 return self._handle_close_action(current_qty)
             return self._create_trade_info(executed=False)
 
-        # 3. Calculate target position
+        # Calculate target position
         target_qty, target_notional, target_side = self._calculate_fractional_position(
             action_value, current_price
         )
 
-        # 4. Check if target is achievable
+        # Check if target is achievable
         if target_qty == 0.0:
             return self._create_trade_info(executed=False)
 
-        # 5. Calculate delta
+        # Calculate delta
         delta = target_qty - current_qty
 
-        # 6. Check if delta is significant enough to trade
+        # Check if delta is significant enough to trade
         sign = 1 if delta > 0 else -1
         delta = self.trader.round_quantity(abs(delta)) * sign
         if delta == 0:
             return self._create_trade_info(executed=False)  # Already close enough
 
-        # 8. Decide what will be SENT before validating anything, because a direction
-        #    switch does not send the delta -- it closes, then opens `abs(target_qty)`.
-        #    Validating the delta and submitting the target is how an order the venue
-        #    rejects gets reported as executed: on a switch the signs oppose, so
-        #    `|delta| = |target| + |current|` and the larger number clears a minimum the
-        #    smaller one does not.
+        # Decide what will be SENT before validating: a switch closes, then opens
+        # `abs(target_qty)`, not the delta. On a switch `|delta| = |target| + |current|`,
+        # so validating the delta clears a floor the submitted quantity does not (#414).
         switching = (current_qty > 0 and target_qty < 0) or (current_qty < 0 and target_qty > 0)
         if switching:
             side, amount = ("buy" if target_qty > 0 else "sell"), abs(target_qty)
@@ -260,23 +246,17 @@ class BinanceFuturesTorchTradingEnv(BinanceBaseTorchTradingEnv):
         else:
             return self._create_trade_info(executed=False)
 
-        # 9. Validate the submitted quantity, and do it BEFORE the switch's close. After
-        #    the close it is too late to refuse: the position is already gone and
-        #    returning "not executed" would describe an account that just changed.
+        # Before the switch's close: after it, refusing would describe an account that
+        # has already changed.
         min_notional = self._get_min_notional()
         if amount * current_price < min_notional:
-            # `at_target` ONLY when not switching. It means "already there", and
-            # `_record_position_after_trade` takes it as permission to write
-            # `current_action_level = desired_action`. On a switch we are on the OPPOSITE
-            # side at full size, so claiming it latches the level to a direction the
-            # account does not hold -- the next sync sees cached and observed agree, never
-            # repairs it, and the duplicate-action guard then suppresses every retry of
-            # that direction for the rest of the episode, including once price makes the
-            # order legal. Refusing an order is cheap; refusing it forever is not.
+            # `at_target` means "already there"; on a switch we hold the opposite side
+            # at full size, so claiming it latches the level to a direction we do not
+            # hold and the duplicate-action guard suppresses every retry (#414).
             return self._create_trade_info(executed=False, at_target=not switching)
 
-        # 10. A switch closes first. If the close fails, do not open the opposite side --
-        #     that would double the position rather than reverse it.
+        # If the close fails, do not open the opposite side -- that doubles rather than
+        # reverses.
         if switching:
             close_info = self._handle_close_action(current_qty)
             if not close_info["executed"] or close_info.get("success") is False:
@@ -286,7 +266,13 @@ class BinanceFuturesTorchTradingEnv(BinanceBaseTorchTradingEnv):
         # One exit, so a new branch cannot skip the target and disable the check.
         info = self._execute_market_order(side, amount)
         info["target_qty"] = target_qty
-        info["target_tol"] = min_notional / current_price
+        # The venue's minimum tradeable size, as the other three venues pass. It was
+        # `min_notional / price`, which the removed 100.0 fallback kept non-zero; with
+        # the executor's real 0.0 it becomes 0.0, and `_sync_position_from_exchange`
+        # then compares against POSITION_DUST_EPS (1e-9). binance's delta is
+        # lot-rounded, so every complete fill would read as a divergence, NaN the
+        # action level, and re-size every bar (#414).
+        info["target_tol"] = float(self.trader.get_lot_size()["min_qty"])
         return info
 
     def _execute_trade_if_needed(

--- a/torchtrade/envs/live/binance/order_executor.py
+++ b/torchtrade/envs/live/binance/order_executor.py
@@ -222,10 +222,14 @@ class BinanceFuturesOrderClass(ExecutorHelpersMixin, TickSizeMixin):
         computed (#414). The values come from filters already cached by
         `_fetch_symbol_filters`; this adds no API call.
         """
-        step = self._qty_steps.get(self.symbol)
+        # The SAME fallback `round_quantity` and `_format_quantity` use. Answering 0.0
+        # here made this file disagree with itself after a transient exchange-info
+        # failure -- `_fetch_symbol_filters` returns early on that path, BEFORE the
+        # missing-LOT_SIZE raise, so the caches stay empty and nothing says so.
+        step = self._qty_steps.get(self.symbol, _FALLBACK_QTY_STEP_PAIR)
         return {
             "min_qty": float(self._min_qtys.get(self.symbol, 0.0)),
-            "qty_step": float(step[0]) if step else 0.0,
+            "qty_step": float(step[0]),
             "min_notional": float(self._min_notional),
         }
 

--- a/torchtrade/envs/live/binance/order_executor.py
+++ b/torchtrade/envs/live/binance/order_executor.py
@@ -189,7 +189,10 @@ class BinanceFuturesOrderClass(ExecutorHelpersMixin, TickSizeMixin):
                         # Read here rather than re-fetched: the env's own
                         # `_get_min_notional` walks these same filters on the plain path,
                         # and the SLTP path had no notional check at all (#414).
-                        self._min_notional = float(f.get('notional') or 0.0)
+                        # A present filter with a missing/empty `notional` is
+                        # incomplete metadata, not a zero floor (#414).
+                        raw = f.get('notional')
+                        self._min_notional = None if raw in (None, '') else float(raw)
                     elif f['filterType'] == 'PRICE_FILTER' and symbol == self.symbol:
                         tick_str = f['tickSize']
                         tick_size = float(tick_str)

--- a/torchtrade/envs/live/binance/order_executor.py
+++ b/torchtrade/envs/live/binance/order_executor.py
@@ -110,7 +110,10 @@ class BinanceFuturesOrderClass(ExecutorHelpersMixin, TickSizeMixin):
         self._min_qtys: Dict[str, float] = {}
         # Always present, so `get_lot_size` needs no getattr fallback: a fail-open
         # default is how a missing floor becomes an unchecked order (#414).
-        self._min_notional: float = 0.0
+        # None = not yet read. 0.0 would mean 'this symbol has no floor', which is
+        # a different claim -- collapsing them makes an outage look like a venue
+        # with no minimum, and the guard then refuses nothing (#414).
+        self._min_notional: float | None = None
         self._tick_decimals: int = 0
 
         # Initialize client
@@ -225,8 +228,14 @@ class BinanceFuturesOrderClass(ExecutorHelpersMixin, TickSizeMixin):
         return {
             "min_qty": float(self._min_qtys.get(self.symbol, 0.0)),
             "qty_step": float(step[0]),
-            "min_notional": float(self._min_notional),
+            "min_notional": (None if self._min_notional is None
+                             else float(self._min_notional)),
         }
+
+    def quantize_quantity(self, quantity: float) -> float:
+        """The quantity this executor will actually submit, for a caller that must
+        validate against it rather than against its own guess (#414)."""
+        return self.round_quantity(quantity)
 
     def round_quantity(self, quantity: float, symbol: Optional[str] = None) -> float:
         """Floor a quantity toward zero to the symbol's LOT_SIZE step.

--- a/torchtrade/envs/live/binance/order_executor.py
+++ b/torchtrade/envs/live/binance/order_executor.py
@@ -226,6 +226,15 @@ class BinanceFuturesOrderClass(ExecutorHelpersMixin, TickSizeMixin):
         # here made this file disagree with itself after a transient exchange-info
         # failure -- `_fetch_symbol_filters` returns early on that path, BEFORE the
         # missing-LOT_SIZE raise, so the caches stay empty and nothing says so.
+        # Lazily re-fetch on an empty cache, like bitget/bybit/okx already do.
+        # `_fetch_symbol_filters` RETURNS EARLY on a transient exchange-info failure --
+        # before its own fail-closed "no LOT_SIZE" raise -- so a single blip at
+        # construction left every cache empty and nothing ever repaired them. binance was
+        # the only venue that never retried, so one bad moment at startup silently
+        # disabled both floors for the life of the process (#414).
+        if self.symbol not in self._qty_steps:
+            self._fetch_symbol_filters()
+
         step = self._qty_steps.get(self.symbol, _FALLBACK_QTY_STEP_PAIR)
         return {
             "min_qty": float(self._min_qtys.get(self.symbol, 0.0)),

--- a/torchtrade/envs/live/binance/order_executor.py
+++ b/torchtrade/envs/live/binance/order_executor.py
@@ -108,6 +108,9 @@ class BinanceFuturesOrderClass(ExecutorHelpersMixin, TickSizeMixin):
         # _fetch_symbol_filters -- close_all_positions closes whatever the account holds.
         self._qty_steps: Dict[str, tuple] = {}
         self._min_qtys: Dict[str, float] = {}
+        # Always present, so `get_lot_size` needs no getattr fallback: a fail-open
+        # default is how a missing floor becomes an unchecked order (#414).
+        self._min_notional: float = 0.0
         self._tick_decimals: int = 0
 
         # Initialize client
@@ -179,6 +182,11 @@ class BinanceFuturesOrderClass(ExecutorHelpersMixin, TickSizeMixin):
                     if f['filterType'] == 'LOT_SIZE':
                         self._qty_steps[symbol] = _step_and_decimals(f['stepSize'])
                         self._min_qtys[symbol] = float(f.get('minQty') or 0.0)
+                    elif f['filterType'] == 'MIN_NOTIONAL' and symbol == self.symbol:
+                        # Read here rather than re-fetched: the env's own
+                        # `_get_min_notional` walks these same filters on the plain path,
+                        # and the SLTP path had no notional check at all (#414).
+                        self._min_notional = float(f.get('notional') or 0.0)
                     elif f['filterType'] == 'PRICE_FILTER' and symbol == self.symbol:
                         tick_str = f['tickSize']
                         tick_size = float(tick_str)
@@ -205,6 +213,21 @@ class BinanceFuturesOrderClass(ExecutorHelpersMixin, TickSizeMixin):
                 f"binance returned no LOT_SIZE for {self.symbol}: not a futures symbol on "
                 f"this venue, or the payload changed shape."
             )
+
+    def get_lot_size(self) -> Dict[str, float]:
+        """The same `{min_qty, qty_step, min_notional}` the other three venues return.
+
+        binance was the only venue without this accessor, so the shared sizing could not
+        ask it for a notional floor and the SLTP path submitted whatever fraction it had
+        computed (#414). The values come from filters already cached by
+        `_fetch_symbol_filters`; this adds no API call.
+        """
+        step = self._qty_steps.get(self.symbol)
+        return {
+            "min_qty": float(self._min_qtys.get(self.symbol, 0.0)),
+            "qty_step": float(step[0]) if step else 0.0,
+            "min_notional": float(self._min_notional),
+        }
 
     def round_quantity(self, quantity: float, symbol: Optional[str] = None) -> float:
         """Floor a quantity toward zero to the symbol's LOT_SIZE step.

--- a/torchtrade/envs/live/binance/order_executor.py
+++ b/torchtrade/envs/live/binance/order_executor.py
@@ -215,23 +215,9 @@ class BinanceFuturesOrderClass(ExecutorHelpersMixin, TickSizeMixin):
             )
 
     def get_lot_size(self) -> Dict[str, float]:
-        """The same `{min_qty, qty_step, min_notional}` the other three venues return.
-
-        binance was the only venue without this accessor, so the shared sizing could not
-        ask it for a notional floor and the SLTP path submitted whatever fraction it had
-        computed (#414). The values come from filters already cached by
-        `_fetch_symbol_filters`; this adds no API call.
-        """
-        # The SAME fallback `round_quantity` and `_format_quantity` use. Answering 0.0
-        # here made this file disagree with itself after a transient exchange-info
-        # failure -- `_fetch_symbol_filters` returns early on that path, BEFORE the
-        # missing-LOT_SIZE raise, so the caches stay empty and nothing says so.
-        # Lazily re-fetch on an empty cache, like bitget/bybit/okx already do.
-        # `_fetch_symbol_filters` RETURNS EARLY on a transient exchange-info failure --
-        # before its own fail-closed "no LOT_SIZE" raise -- so a single blip at
-        # construction left every cache empty and nothing ever repaired them. binance was
-        # the only venue that never retried, so one bad moment at startup silently
-        # disabled both floors for the life of the process (#414).
+        """`{min_qty, qty_step, min_notional}`, from filters already cached (#414)."""
+        # Lazily re-fetch on an empty cache: `_fetch_symbol_filters` returns early on a
+        # transient failure, before its own raise, and binance alone never retried.
         if self.symbol not in self._qty_steps:
             self._fetch_symbol_filters()
 

--- a/torchtrade/envs/live/bitget/env.py
+++ b/torchtrade/envs/live/bitget/env.py
@@ -190,7 +190,7 @@ class BitgetFuturesTorchTradingEnv(BitgetBaseTorchTradingEnv):
 
         # The venue's notional floor, on the floored quantity actually sent (#414).
         min_notional = float(lot_size["min_notional"])
-        if min_notional > 0 and amount * current_price < min_notional * (1 - 1e-9):
+        if min_notional > 0 and amount * current_price < min_notional:
             return self._create_trade_info(executed=False, at_target=True)
 
         # Execute market order

--- a/torchtrade/envs/live/bitget/env.py
+++ b/torchtrade/envs/live/bitget/env.py
@@ -174,7 +174,8 @@ class BitgetFuturesTorchTradingEnv(BitgetBaseTorchTradingEnv):
         delta_qty = target_qty - current_qty
 
         # Query real min-order-size from Bitget market info (not hardcoded)
-        min_qty = self.trader.get_lot_size()["min_qty"]
+        lot_size = self.trader.get_lot_size()
+        min_qty = lot_size["min_qty"]
 
         if abs(delta_qty) < min_qty:
             # Already at target (delta below the minimum tradeable size)
@@ -185,6 +186,14 @@ class BitgetFuturesTorchTradingEnv(BitgetBaseTorchTradingEnv):
         amount = self.trader._round_amount(abs(delta_qty))
 
         if amount < min_qty:
+            return self._create_trade_info(executed=False, at_target=True)
+
+        # The venue's notional floor, on the quantity that is actually sent. This PR
+        # taught the executors to READ it; without this the plain path still submitted
+        # orders the exchange rejects while the env recorded a position it did not hold
+        # -- the same bug on the same venue, one execution path over (#414).
+        min_notional = float(lot_size["min_notional"])
+        if min_notional > 0 and amount * current_price < min_notional * (1 - 1e-9):
             return self._create_trade_info(executed=False, at_target=True)
 
         # Execute market order

--- a/torchtrade/envs/live/bitget/env.py
+++ b/torchtrade/envs/live/bitget/env.py
@@ -189,7 +189,11 @@ class BitgetFuturesTorchTradingEnv(BitgetBaseTorchTradingEnv):
             return self._create_trade_info(executed=False, at_target=True)
 
         # The venue's notional floor, on the floored quantity actually sent (#414).
-        min_notional = float(lot_size["min_notional"])
+        raw_floor = lot_size["min_notional"]
+        if raw_floor is None:
+            # Unknown floor: refuse rather than assume there is none (#414).
+            return self._create_trade_info(executed=False, at_target=True)
+        min_notional = float(raw_floor)
         if min_notional > 0 and amount * current_price < min_notional:
             return self._create_trade_info(executed=False, at_target=True)
 

--- a/torchtrade/envs/live/bitget/env.py
+++ b/torchtrade/envs/live/bitget/env.py
@@ -188,10 +188,7 @@ class BitgetFuturesTorchTradingEnv(BitgetBaseTorchTradingEnv):
         if amount < min_qty:
             return self._create_trade_info(executed=False, at_target=True)
 
-        # The venue's notional floor, on the quantity that is actually sent. This PR
-        # taught the executors to READ it; without this the plain path still submitted
-        # orders the exchange rejects while the env recorded a position it did not hold
-        # -- the same bug on the same venue, one execution path over (#414).
+        # The venue's notional floor, on the floored quantity actually sent (#414).
         min_notional = float(lot_size["min_notional"])
         if min_notional > 0 and amount * current_price < min_notional * (1 - 1e-9):
             return self._create_trade_info(executed=False, at_target=True)

--- a/torchtrade/envs/live/bitget/order_executor.py
+++ b/torchtrade/envs/live/bitget/order_executor.py
@@ -25,7 +25,7 @@ TAKER_FEE = 0.0006
 BITGET_NO_POSITION_ERRORS = ["22002", "40773", "No position to close"]
 
 # Fallback used if the exchange lot-size cannot be read from CCXT market info
-_DEFAULT_LOT_SIZE = {"min_qty": 0.001, "qty_step": 0.001, "min_notional": 0.0}
+_DEFAULT_LOT_SIZE = {"min_qty": 0.001, "qty_step": 0.001, "min_notional": None}
 
 
 class PositionMode(Enum):
@@ -200,7 +200,7 @@ class BitgetFuturesOrderClass(ExecutorHelpersMixin):
             }
         except Exception as e:
             logger.warning(f"Failed to fetch lot size for {self.symbol}: {e}, using defaults")
-            self._lot_size_cache = _DEFAULT_LOT_SIZE.copy()
+            return _DEFAULT_LOT_SIZE.copy()   # NOT cached: retry next call
 
         return self._lot_size_cache
 
@@ -211,6 +211,12 @@ class BitgetFuturesOrderClass(ExecutorHelpersMixin):
         except Exception as e:
             logger.warning(f"price_to_precision failed for {self.symbol}, using unrounded price: {e}")
             return price
+
+    def quantize_quantity(self, quantity: float) -> float:
+        """The quantity this executor will actually submit. CCXT truncates for bitget,
+        which is NOT binance's epsilon floor -- validating against the wrong one accepts
+        orders the venue rejects (#414)."""
+        return self._round_amount(quantity)
 
     def _round_amount(self, amount: float) -> float:
         """Floor a quantity to the exchange's lot-size step using CCXT.

--- a/torchtrade/envs/live/bitget/order_executor.py
+++ b/torchtrade/envs/live/bitget/order_executor.py
@@ -196,7 +196,9 @@ class BitgetFuturesOrderClass(ExecutorHelpersMixin):
             self._lot_size_cache = {
                 "min_qty": float(min_qty) if min_qty is not None else _DEFAULT_LOT_SIZE["min_qty"],
                 "qty_step": float(qty_step) if qty_step is not None else _DEFAULT_LOT_SIZE["qty_step"],
-                "min_notional": float(min_notional) if min_notional is not None else 0.0,
+                # CCXT omits limits.cost.min for non-USDT-quoted markets; that is
+                # unknown, not a zero floor (#414).
+                "min_notional": None if min_notional is None else float(min_notional),
             }
         except Exception as e:
             logger.warning(f"Failed to fetch lot size for {self.symbol}: {e}, using defaults")

--- a/torchtrade/envs/live/bitget/order_executor.py
+++ b/torchtrade/envs/live/bitget/order_executor.py
@@ -25,7 +25,7 @@ TAKER_FEE = 0.0006
 BITGET_NO_POSITION_ERRORS = ["22002", "40773", "No position to close"]
 
 # Fallback used if the exchange lot-size cannot be read from CCXT market info
-_DEFAULT_LOT_SIZE = {"min_qty": 0.001, "qty_step": 0.001}
+_DEFAULT_LOT_SIZE = {"min_qty": 0.001, "qty_step": 0.001, "min_notional": 0.0}
 
 
 class PositionMode(Enum):
@@ -189,9 +189,14 @@ class BitgetFuturesOrderClass(ExecutorHelpersMixin):
             market = self.client.market(self.symbol)
             min_qty = market.get("limits", {}).get("amount", {}).get("min")
             qty_step = market.get("precision", {}).get("amount")
+            # `limits.cost.min` is CCXT's normalisation of bitget's minTradeUSDT. It was
+            # fetched with the rest of the market info and dropped, so an order under the
+            # venue's notional floor was submitted and rejected (#414).
+            min_notional = market.get("limits", {}).get("cost", {}).get("min")
             self._lot_size_cache = {
                 "min_qty": float(min_qty) if min_qty is not None else _DEFAULT_LOT_SIZE["min_qty"],
                 "qty_step": float(qty_step) if qty_step is not None else _DEFAULT_LOT_SIZE["qty_step"],
+                "min_notional": float(min_notional) if min_notional is not None else 0.0,
             }
         except Exception as e:
             logger.warning(f"Failed to fetch lot size for {self.symbol}: {e}, using defaults")

--- a/torchtrade/envs/live/bitget/order_executor.py
+++ b/torchtrade/envs/live/bitget/order_executor.py
@@ -176,7 +176,7 @@ class BitgetFuturesOrderClass(ExecutorHelpersMixin):
             logger.warning(f"Could not load markets for {self.symbol}: {e}")
 
     def get_lot_size(self) -> Dict[str, float]:
-        """Return the symbol's ``{'min_qty', 'qty_step'}`` from CCXT market info (cached).
+        """Return the symbol's ``{'min_qty', 'qty_step', 'min_notional'}`` from CCXT (cached).
 
         Bitget's CCXT precision mode is TICK_SIZE, so ``precision.amount`` is the
         quantity step directly (e.g. 0.0001 for BTC/USDT:USDT). Falls back to

--- a/torchtrade/envs/live/bybit/env.py
+++ b/torchtrade/envs/live/bybit/env.py
@@ -139,7 +139,11 @@ class BybitFuturesTorchTradingEnv(BybitBaseTorchTradingEnv):
             return self._create_trade_info(executed=False, at_target=True)
 
         # The venue's notional floor, on the floored quantity actually sent (#414).
-        min_notional = float(lot_size["min_notional"])
+        raw_floor = lot_size["min_notional"]
+        if raw_floor is None:
+            # Unknown floor: refuse rather than assume there is none (#414).
+            return self._create_trade_info(executed=False, at_target=True)
+        min_notional = float(raw_floor)
         if min_notional > 0 and amount * current_price < min_notional:
             return self._create_trade_info(executed=False, at_target=True)
 

--- a/torchtrade/envs/live/bybit/env.py
+++ b/torchtrade/envs/live/bybit/env.py
@@ -138,6 +138,14 @@ class BybitFuturesTorchTradingEnv(BybitBaseTorchTradingEnv):
         if amount < min_qty:
             return self._create_trade_info(executed=False, at_target=True)
 
+        # The venue's notional floor, on the quantity that is actually sent. This PR
+        # taught the executors to READ it; without this the plain path still submitted
+        # orders the exchange rejects while the env recorded a position it did not hold
+        # -- the same bug on the same venue, one execution path over (#414).
+        min_notional = float(lot_size["min_notional"])
+        if min_notional > 0 and amount * current_price < min_notional * (1 - 1e-9):
+            return self._create_trade_info(executed=False, at_target=True)
+
         info = self._execute_market_order(side, amount)
         info["target_qty"] = target_qty
         info["target_tol"] = lot_size["min_qty"]

--- a/torchtrade/envs/live/bybit/env.py
+++ b/torchtrade/envs/live/bybit/env.py
@@ -140,7 +140,7 @@ class BybitFuturesTorchTradingEnv(BybitBaseTorchTradingEnv):
 
         # The venue's notional floor, on the floored quantity actually sent (#414).
         min_notional = float(lot_size["min_notional"])
-        if min_notional > 0 and amount * current_price < min_notional * (1 - 1e-9):
+        if min_notional > 0 and amount * current_price < min_notional:
             return self._create_trade_info(executed=False, at_target=True)
 
         info = self._execute_market_order(side, amount)

--- a/torchtrade/envs/live/bybit/env.py
+++ b/torchtrade/envs/live/bybit/env.py
@@ -138,10 +138,7 @@ class BybitFuturesTorchTradingEnv(BybitBaseTorchTradingEnv):
         if amount < min_qty:
             return self._create_trade_info(executed=False, at_target=True)
 
-        # The venue's notional floor, on the quantity that is actually sent. This PR
-        # taught the executors to READ it; without this the plain path still submitted
-        # orders the exchange rejects while the env recorded a position it did not hold
-        # -- the same bug on the same venue, one execution path over (#414).
+        # The venue's notional floor, on the floored quantity actually sent (#414).
         min_notional = float(lot_size["min_notional"])
         if min_notional > 0 and amount * current_price < min_notional * (1 - 1e-9):
             return self._create_trade_info(executed=False, at_target=True)

--- a/torchtrade/envs/live/bybit/order_executor.py
+++ b/torchtrade/envs/live/bybit/order_executor.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 # Venue taker rate, read by env.py and env_sltp.py alike (#278).
 TAKER_FEE = 0.00055
 
-_DEFAULT_LOT_SIZE = {"min_qty": 0.001, "qty_step": 0.001, "min_notional": 0.0}
+_DEFAULT_LOT_SIZE = {"min_qty": 0.001, "qty_step": 0.001, "min_notional": None}
 
 
 class PositionMode(Enum):
@@ -506,6 +506,12 @@ class BybitFuturesOrderClass(ExecutorHelpersMixin, TickSizeMixin):
 
         raise RuntimeError(f"No ticker data for {self.symbol}")
 
+    def quantize_quantity(self, quantity: float) -> float:
+        """bybit submits `str(quantity)` unquantized, so this is the identity -- stated
+        rather than assumed, because the shared guard must not floor what the venue will
+        not floor (#414)."""
+        return float(quantity)
+
     def get_lot_size(self) -> Dict[str, float]:
         """
         Get and cache lot size constraints for the symbol.
@@ -524,7 +530,7 @@ class BybitFuturesOrderClass(ExecutorHelpersMixin, TickSizeMixin):
             if ret_code is not None and int(ret_code) != 0:
                 ret_msg = response.get("retMsg", "unknown error")
                 logger.warning(f"get_instruments_info failed (retCode={ret_code}): {ret_msg}, using defaults")
-                self._lot_size_cache = _DEFAULT_LOT_SIZE.copy()
+                return _DEFAULT_LOT_SIZE.copy()   # NOT cached: retry next call
                 return self._lot_size_cache
             instruments = response.get("result", {}).get("list", [])
             if instruments:
@@ -537,10 +543,10 @@ class BybitFuturesOrderClass(ExecutorHelpersMixin, TickSizeMixin):
                 }
             else:
                 logger.warning(f"No instrument info for {self.symbol}, using defaults")
-                self._lot_size_cache = _DEFAULT_LOT_SIZE.copy()
+                return _DEFAULT_LOT_SIZE.copy()   # NOT cached: retry next call
         except Exception as e:
             logger.warning(f"Failed to fetch lot size for {self.symbol}: {e}, using defaults")
-            self._lot_size_cache = _DEFAULT_LOT_SIZE.copy()
+            return _DEFAULT_LOT_SIZE.copy()   # NOT cached: retry next call
 
         return self._lot_size_cache
 

--- a/torchtrade/envs/live/bybit/order_executor.py
+++ b/torchtrade/envs/live/bybit/order_executor.py
@@ -152,7 +152,10 @@ class BybitFuturesOrderClass(ExecutorHelpersMixin, TickSizeMixin):
                     "min_qty": float(lot_filter.get("minOrderQty", 0.001)),
                     "qty_step": float(lot_filter.get("qtyStep", 0.001)),
                     # Same filter, read at the same time, previously discarded (#414).
-                    "min_notional": float(lot_filter.get("minNotionalValue", 0.0)),
+                    # Absent means the payload did not carry it -- unknown, not zero.
+                    "min_notional": (
+                        None if lot_filter.get("minNotionalValue") in (None, "")
+                        else float(lot_filter["minNotionalValue"])),
                 }
         except Exception as e:
             logger.warning(f"Could not fetch tick size for {self.symbol}: {e}")
@@ -539,7 +542,10 @@ class BybitFuturesOrderClass(ExecutorHelpersMixin, TickSizeMixin):
                     "min_qty": float(lot_filter.get("minOrderQty", 0.001)),
                     "qty_step": float(lot_filter.get("qtyStep", 0.001)),
                     # Same filter, read at the same time, previously discarded (#414).
-                    "min_notional": float(lot_filter.get("minNotionalValue", 0.0)),
+                    # Absent means the payload did not carry it -- unknown, not zero.
+                    "min_notional": (
+                        None if lot_filter.get("minNotionalValue") in (None, "")
+                        else float(lot_filter["minNotionalValue"])),
                 }
             else:
                 logger.warning(f"No instrument info for {self.symbol}, using defaults")

--- a/torchtrade/envs/live/bybit/order_executor.py
+++ b/torchtrade/envs/live/bybit/order_executor.py
@@ -511,7 +511,7 @@ class BybitFuturesOrderClass(ExecutorHelpersMixin, TickSizeMixin):
         Get and cache lot size constraints for the symbol.
 
         Returns:
-            Dictionary with 'min_qty' and 'qty_step' for the symbol.
+            Dictionary with 'min_qty', 'qty_step' and 'min_notional' for the symbol.
         """
         if self._lot_size_cache is not None:
             return self._lot_size_cache

--- a/torchtrade/envs/live/bybit/order_executor.py
+++ b/torchtrade/envs/live/bybit/order_executor.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 # Venue taker rate, read by env.py and env_sltp.py alike (#278).
 TAKER_FEE = 0.00055
 
-_DEFAULT_LOT_SIZE = {"min_qty": 0.001, "qty_step": 0.001}
+_DEFAULT_LOT_SIZE = {"min_qty": 0.001, "qty_step": 0.001, "min_notional": 0.0}
 
 
 class PositionMode(Enum):
@@ -151,6 +151,8 @@ class BybitFuturesOrderClass(ExecutorHelpersMixin, TickSizeMixin):
                 self._lot_size_cache = {
                     "min_qty": float(lot_filter.get("minOrderQty", 0.001)),
                     "qty_step": float(lot_filter.get("qtyStep", 0.001)),
+                    # Same filter, read at the same time, previously discarded (#414).
+                    "min_notional": float(lot_filter.get("minNotionalValue", 0.0)),
                 }
         except Exception as e:
             logger.warning(f"Could not fetch tick size for {self.symbol}: {e}")
@@ -530,6 +532,8 @@ class BybitFuturesOrderClass(ExecutorHelpersMixin, TickSizeMixin):
                 self._lot_size_cache = {
                     "min_qty": float(lot_filter.get("minOrderQty", 0.001)),
                     "qty_step": float(lot_filter.get("qtyStep", 0.001)),
+                    # Same filter, read at the same time, previously discarded (#414).
+                    "min_notional": float(lot_filter.get("minNotionalValue", 0.0)),
                 }
             else:
                 logger.warning(f"No instrument info for {self.symbol}, using defaults")

--- a/torchtrade/envs/live/okx/env.py
+++ b/torchtrade/envs/live/okx/env.py
@@ -124,14 +124,6 @@ class OKXFuturesTorchTradingEnv(OKXBaseTorchTradingEnv):
         if abs(delta_qty) < lot_size["min_qty"]:
             return self._create_trade_info(executed=False, at_target=True)
 
-        # The venue's notional floor, on the quantity that is actually sent. This PR
-        # taught the executors to READ it; without this the plain path still submitted
-        # orders the exchange rejects while the env recorded a position it did not hold
-        # -- the same bug on the same venue, one execution path over (#414).
-        min_notional = float(lot_size["min_notional"])
-        if min_notional > 0 and abs(delta_qty) * current_price < min_notional * (1 - 1e-9):
-            return self._create_trade_info(executed=False, at_target=True)
-
         side = "buy" if delta_qty > 0 else "sell"
         # _format_size() in trade() handles lot-step quantization
         info = self._execute_market_order(side, abs(delta_qty))

--- a/torchtrade/envs/live/okx/env.py
+++ b/torchtrade/envs/live/okx/env.py
@@ -124,6 +124,14 @@ class OKXFuturesTorchTradingEnv(OKXBaseTorchTradingEnv):
         if abs(delta_qty) < lot_size["min_qty"]:
             return self._create_trade_info(executed=False, at_target=True)
 
+        # The venue's notional floor, on the quantity that is actually sent. This PR
+        # taught the executors to READ it; without this the plain path still submitted
+        # orders the exchange rejects while the env recorded a position it did not hold
+        # -- the same bug on the same venue, one execution path over (#414).
+        min_notional = float(lot_size["min_notional"])
+        if min_notional > 0 and abs(delta_qty) * current_price < min_notional * (1 - 1e-9):
+            return self._create_trade_info(executed=False, at_target=True)
+
         side = "buy" if delta_qty > 0 else "sell"
         # _format_size() in trade() handles lot-step quantization
         info = self._execute_market_order(side, abs(delta_qty))

--- a/torchtrade/envs/live/okx/order_executor.py
+++ b/torchtrade/envs/live/okx/order_executor.py
@@ -173,7 +173,13 @@ class OKXFuturesOrderClass(ExecutorHelpersMixin, TickSizeMixin):
                 min_qty = float(instrument.get("minSz", 0.001))
                 lot_decimals = decimals_for_step(lot_sz_str)
                 self._lot_size_decimals = lot_decimals
-                self._lot_size_cache = {"min_qty": min_qty, "qty_step": qty_step}
+                # Three keys, like every other write of this cache. Updating the
+                # fallback branch and not THIS one -- the construction-time write --
+                # is how okx would have returned a two-key dict at runtime and
+                # KeyError'd on every bracket open once the guard indexed strictly.
+                self._lot_size_cache = {
+                    "min_qty": min_qty, "qty_step": qty_step, "min_notional": 0.0,
+                }
         except Exception as e:
             logger.warning(f"Could not fetch tick size for {self.symbol}: {e}")
 
@@ -539,7 +545,7 @@ class OKXFuturesOrderClass(ExecutorHelpersMixin, TickSizeMixin):
         Get and cache lot size constraints for the symbol.
 
         Returns:
-            Dictionary with 'min_qty' and 'qty_step' for the symbol.
+            Dictionary with 'min_qty', 'qty_step' and 'min_notional' for the symbol.
         """
         if self._lot_size_cache is not None:
             return self._lot_size_cache

--- a/torchtrade/envs/live/okx/order_executor.py
+++ b/torchtrade/envs/live/okx/order_executor.py
@@ -28,7 +28,7 @@ TAKER_FEE = 0.0005
 
 # okx derivatives bind on minSz/lotSz; there is no separate notional floor, so
 # this is 0.0 rather than absent -- the shared guard reads one key on every venue.
-_DEFAULT_LOT_SIZE = {"min_qty": 0.001, "qty_step": 0.001, "min_notional": 0.0}
+_DEFAULT_LOT_SIZE = {"min_qty": 0.001, "qty_step": 0.001, "min_notional": None}
 
 
 class PositionMode(Enum):
@@ -182,6 +182,11 @@ class OKXFuturesOrderClass(ExecutorHelpersMixin, TickSizeMixin):
                 }
         except Exception as e:
             logger.warning(f"Could not fetch tick size for {self.symbol}: {e}")
+
+    def quantize_quantity(self, quantity: float) -> float:
+        """The quantity this executor will actually submit. Note `_format_size` clamps UP
+        to `min_qty`, so this can exceed what was asked -- the caller must see that."""
+        return float(self._format_size(quantity))
 
     def _format_size(self, qty: float) -> str:
         """Quantize quantity to lot size step, enforce minimum, and format as string."""
@@ -558,7 +563,7 @@ class OKXFuturesOrderClass(ExecutorHelpersMixin, TickSizeMixin):
             if str(code) != "0":
                 msg = response.get("msg", "unknown error")
                 logger.warning(f"get_instruments failed (code={code}): {msg}, using defaults")
-                self._lot_size_cache = _DEFAULT_LOT_SIZE.copy()
+                return _DEFAULT_LOT_SIZE.copy()   # NOT cached: retry next call
                 return self._lot_size_cache
             instruments = response.get("data", [])
             if instruments:
@@ -570,10 +575,10 @@ class OKXFuturesOrderClass(ExecutorHelpersMixin, TickSizeMixin):
                 }
             else:
                 logger.warning(f"No instrument info for {self.symbol}, using defaults")
-                self._lot_size_cache = _DEFAULT_LOT_SIZE.copy()
+                return _DEFAULT_LOT_SIZE.copy()   # NOT cached: retry next call
         except Exception as e:
             logger.warning(f"Failed to fetch lot size for {self.symbol}: {e}, using defaults")
-            self._lot_size_cache = _DEFAULT_LOT_SIZE.copy()
+            return _DEFAULT_LOT_SIZE.copy()   # NOT cached: retry next call
 
         return self._lot_size_cache
 

--- a/torchtrade/envs/live/okx/order_executor.py
+++ b/torchtrade/envs/live/okx/order_executor.py
@@ -26,7 +26,9 @@ logger = logging.getLogger(__name__)
 # Venue taker rate, read by env.py and env_sltp.py alike (#278).
 TAKER_FEE = 0.0005
 
-_DEFAULT_LOT_SIZE = {"min_qty": 0.001, "qty_step": 0.001}
+# okx derivatives bind on minSz/lotSz; there is no separate notional floor, so
+# this is 0.0 rather than absent -- the shared guard reads one key on every venue.
+_DEFAULT_LOT_SIZE = {"min_qty": 0.001, "qty_step": 0.001, "min_notional": 0.0}
 
 
 class PositionMode(Enum):
@@ -558,6 +560,7 @@ class OKXFuturesOrderClass(ExecutorHelpersMixin, TickSizeMixin):
                 self._lot_size_cache = {
                     "min_qty": float(instrument.get("minSz", 0.001)),
                     "qty_step": float(instrument.get("lotSz", 0.001)),
+                    "min_notional": 0.0,
                 }
             else:
                 logger.warning(f"No instrument info for {self.symbol}, using defaults")

--- a/torchtrade/envs/live/shared/futures_live_base.py
+++ b/torchtrade/envs/live/shared/futures_live_base.py
@@ -215,10 +215,18 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
         the same input becomes a halt instead -- a divergence this fold preserves rather
         than endorses (#416).
         """
+        # Every mode goes through the venue-minimum refusal below. The two fixed-size
+        # modes returned early and skipped it, which is the same "validated one thing,
+        # sent another" shape as the direction-switch bug -- here it was "validated
+        # nothing at all" for two of the three modes.
         if self.config.trade_mode == "notional":
-            return float(self.config.quantity_per_trade) / current_price
+            return self._refuse_below_venue_minimums(
+                float(self.config.quantity_per_trade) / current_price, current_price
+            )
         if self.config.trade_mode == "quantity":
-            return float(self.config.quantity_per_trade)
+            return self._refuse_below_venue_minimums(
+                float(self.config.quantity_per_trade), current_price
+            )
         if self.config.trade_mode != "fractional":
             raise ValueError(f"Unsupported trade_mode={self.config.trade_mode!r}")
 
@@ -271,6 +279,37 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
             logger.error(
                 f"{self.config.symbol}: sizing produced {quantity!r}, refusing rather than "
                 f"handing it to the venue formatter"
+            )
+            return None
+        return self._refuse_below_venue_minimums(quantity, current_price)
+
+    def _refuse_below_venue_minimums(
+        self, quantity: float, current_price: float
+    ) -> float | None:
+        """Refuse a quantity the venue will reject, rather than submitting it (#414).
+
+        The SLTP path had NO notional check on any venue, and bitget and bybit never read
+        their exchanges' notional fields at all -- both were fetched with the rest of the
+        market info and dropped. An order under the floor is submitted, rejected, and the
+        env goes on believing it holds a position: invariant 2 inverted.
+
+        Refuse, never round UP to the minimum. Rounding up allocates more than the action
+        asked for, which is how okx's formatter turns a sub-minimum size into a real
+        position; the plain path has refused rather than rounded since #271.
+
+        NOTIONAL only. The min-QUANTITY floor is okx's `_resolve_bracket_quantity`
+        override and stays there: promoting it to all four is a behaviour change for the
+        other three that #414 does not ask for, and okx reports `min_notional` 0.0 anyway
+        because its derivatives bind on minSz/lotSz.
+        """
+        lot = self.trader.get_lot_size()
+        notional = quantity * current_price
+        min_notional = float(lot.get("min_notional", 0.0))
+        if min_notional > 0 and notional < min_notional:
+            logger.warning(
+                f"{self.config.symbol}: notional {notional:.2f} is below the venue "
+                f"minimum {min_notional:.2f}; refusing rather than submitting an order "
+                f"the exchange will reject"
             )
             return None
         return quantity

--- a/torchtrade/envs/live/shared/futures_live_base.py
+++ b/torchtrade/envs/live/shared/futures_live_base.py
@@ -302,10 +302,18 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
         other three that #414 does not ask for, and okx reports `min_notional` 0.0 anyway
         because its derivatives bind on minSz/lotSz.
         """
+        # Strict indexing, not `.get(..., 0.0)`: defaulting a missing key to "no floor"
+        # means any future trader that forgets it silently disables the check, which is
+        # the fail-open this guard exists to remove. All five executors report the key.
         lot = self.trader.get_lot_size()
         notional = quantity * current_price
-        min_notional = float(lot.get("min_notional", 0.0))
-        if min_notional > 0 and notional < min_notional:
+        min_notional = float(lot["min_notional"])
+        # A relative epsilon, because `notional` mode computes `qty = usd / price` and this
+        # re-multiplies by the same price. That round-trip is not exact: for ~1.7% of
+        # prices in 0.001-100, `(5.0 / p) * p < 5.0`. bitget's minTradeUSDT is exactly 5,
+        # so a user sizing at the floor would be refused or not depending on the last bit
+        # of the price. The epsilon is far below any real venue increment.
+        if min_notional > 0 and notional < min_notional * (1 - 1e-9):
             logger.warning(
                 f"{self.config.symbol}: notional {notional:.2f} is below the venue "
                 f"minimum {min_notional:.2f}; refusing rather than submitting an order "

--- a/torchtrade/envs/live/shared/futures_live_base.py
+++ b/torchtrade/envs/live/shared/futures_live_base.py
@@ -293,29 +293,33 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
         """
         lot = self.trader.get_lot_size()
 
-        # Validate what the venue will receive. binance/bitget/okx truncate to the step;
-        # bybit sends the raw float, so flooring for it is conservative, never wrong.
-        # Return `quantity`, not `sendable` -- re-flooring an already-floored float
-        # shaves a step (2.001 -> 2.0 in 1463 of the first 200k multiples of 0.001).
-        step = float(lot["qty_step"])
-        sendable = quantity
-        if step > 0 and math.isfinite(step):
-            # The SAME epsilon `round_quantity` uses, and for the reason its docstring
-            # gives: `quantity / step` lands just under an integer for many exact
-            # multiples (0.29/0.01 is 28.999999999999996). A bare floor is a whole step
-            # below what the venue actually sends, so it refuses legal orders -- the
-            # round-2 bug with the sign flipped.
-            ratio = quantity / step
-            sendable = math.floor(ratio + max(1e-9, ratio * 1e-12)) * step
-            if not sendable > 0:
-                logger.warning(
-                    f"{self.config.symbol}: quantity {quantity} floors to {sendable} at "
-                    f"lot step {step}; refusing rather than submitting nothing"
-                )
-                return None
+        # Ask the executor what it will submit, rather than reproducing its rule here.
+        # A shared floor is wrong per venue: binance epsilon-floors, bitget truncates via
+        # CCXT, okx clamps UP to min_qty, bybit sends the raw float. Copying one venue's
+        # arithmetic accepted 0.0499999999999995 as 5.00 that bitget submits as 4.90.
+        sendable = float(self.trader.quantize_quantity(quantity))
+        if not sendable > 0:
+            logger.warning(
+                f"{self.config.symbol}: quantity {quantity} quantizes to {sendable}; "
+                f"refusing rather than submitting nothing"
+            )
+            return None
 
         notional = sendable * current_price
-        min_notional = float(lot["min_notional"])
+
+        # UNKNOWN is not "no floor". A failed metadata fetch used to report 0.0, which
+        # skipped the check entirely -- so the guard was off precisely during an outage,
+        # which is when the venue is least predictable. None means "not read yet";
+        # refuse until it is. okx reports a real 0.0 (its derivatives bind on minSz).
+        raw_floor = lot["min_notional"]
+        if raw_floor is None:
+            logger.warning(
+                f"{self.config.symbol}: the venue minimum is not known (metadata fetch "
+                f"failed); refusing rather than assuming there is no floor"
+            )
+            return None
+
+        min_notional = float(raw_floor)
         if min_notional > 0 and notional < min_notional:
             logger.warning(
                 f"{self.config.symbol}: notional {notional:.2f} is below the venue "

--- a/torchtrade/envs/live/shared/futures_live_base.py
+++ b/torchtrade/envs/live/shared/futures_live_base.py
@@ -316,9 +316,7 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
 
         notional = sendable * current_price
         min_notional = float(lot["min_notional"])
-        # Relative epsilon: `notional` mode computes `usd / price` and this
-        # re-multiplies, and bitget's floor is exactly 5, so the round-trip matters.
-        if min_notional > 0 and notional < min_notional * (1 - 1e-9):
+        if min_notional > 0 and notional < min_notional:
             logger.warning(
                 f"{self.config.symbol}: notional {notional:.2f} is below the venue "
                 f"minimum {min_notional:.2f}; refusing rather than submitting an order "

--- a/torchtrade/envs/live/shared/futures_live_base.py
+++ b/torchtrade/envs/live/shared/futures_live_base.py
@@ -288,36 +288,25 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
     ) -> float | None:
         """Refuse a quantity the venue will reject, rather than submitting it (#414).
 
-        The SLTP path had NO notional check on any venue, and bitget and bybit never read
-        their exchanges' notional fields at all -- both were fetched with the rest of the
-        market info and dropped. An order under the floor is submitted, rejected, and the
-        env goes on believing it holds a position: invariant 2 inverted.
-
-        Refuse, never round UP to the minimum. Rounding up allocates more than the action
-        asked for, which is how okx's formatter turns a sub-minimum size into a real
-        position; the plain path has refused rather than rounded since #271.
-
-        NOTIONAL only. The min-QUANTITY floor is okx's `_resolve_bracket_quantity`
-        override and stays there: promoting it to all four is a behaviour change for the
-        other three that #414 does not ask for, and okx reports `min_notional` 0.0 anyway
-        because its derivatives bind on minSz/lotSz.
+        Refuse, never round UP: rounding up allocates more than the action asked for.
+        NOTIONAL only -- the min-quantity floor is okx's `_resolve_bracket_quantity`.
         """
-        # Strict indexing, not `.get(..., 0.0)`: defaulting a missing key to "no floor"
-        # means any future trader that forgets it silently disables the check, which is
-        # the fail-open this guard exists to remove. All five executors report the key.
         lot = self.trader.get_lot_size()
 
-        # Floor to the lot step FIRST, and validate -- and return -- the floored value.
-        # Validating the pre-rounded quantity was the same "validated one number, sent
-        # another" bug this PR fixes on the plain path: every venue formatter floors, so
-        # at step 0.001 / floor 100 / price 60000 a quantity of 0.001666... validated at
-        # exactly 100.00 and arrived at the venue as 0.001 -- 60.00, rejected. Anything
-        # landing in [100, 160) USD passed the guard and was refused by the exchange.
-        # bybit sends the raw float and is exact; binance, okx and bitget all truncate.
+        # Validate what the venue will receive. binance/bitget/okx truncate to the step;
+        # bybit sends the raw float, so flooring for it is conservative, never wrong.
+        # Return `quantity`, not `sendable` -- re-flooring an already-floored float
+        # shaves a step (2.001 -> 2.0 in 1463 of the first 200k multiples of 0.001).
         step = float(lot["qty_step"])
         sendable = quantity
         if step > 0 and math.isfinite(step):
-            sendable = math.floor(quantity / step) * step
+            # The SAME epsilon `round_quantity` uses, and for the reason its docstring
+            # gives: `quantity / step` lands just under an integer for many exact
+            # multiples (0.29/0.01 is 28.999999999999996). A bare floor is a whole step
+            # below what the venue actually sends, so it refuses legal orders -- the
+            # round-2 bug with the sign flipped.
+            ratio = quantity / step
+            sendable = math.floor(ratio + max(1e-9, ratio * 1e-12)) * step
             if not sendable > 0:
                 logger.warning(
                     f"{self.config.symbol}: quantity {quantity} floors to {sendable} at "
@@ -325,17 +314,10 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
                 )
                 return None
 
-        # `sendable`, not `quantity`: the venue formatter floors, so this is the number
-        # the exchange will actually see. The caller still receives the unfloored value
-        # and the formatter re-derives the same result -- what matters is that the
-        # validation and the submission agree.
         notional = sendable * current_price
         min_notional = float(lot["min_notional"])
-        # A relative epsilon, because `notional` mode computes `qty = usd / price` and this
-        # re-multiplies by the same price. That round-trip is not exact: for ~1.7% of
-        # prices in 0.001-100, `(5.0 / p) * p < 5.0`. bitget's minTradeUSDT is exactly 5,
-        # so a user sizing at the floor would be refused or not depending on the last bit
-        # of the price. The epsilon is far below any real venue increment.
+        # Relative epsilon: `notional` mode computes `usd / price` and this
+        # re-multiplies, and bitget's floor is exactly 5, so the round-trip matters.
         if min_notional > 0 and notional < min_notional * (1 - 1e-9):
             logger.warning(
                 f"{self.config.symbol}: notional {notional:.2f} is below the venue "

--- a/torchtrade/envs/live/shared/futures_live_base.py
+++ b/torchtrade/envs/live/shared/futures_live_base.py
@@ -306,7 +306,30 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
         # means any future trader that forgets it silently disables the check, which is
         # the fail-open this guard exists to remove. All five executors report the key.
         lot = self.trader.get_lot_size()
-        notional = quantity * current_price
+
+        # Floor to the lot step FIRST, and validate -- and return -- the floored value.
+        # Validating the pre-rounded quantity was the same "validated one number, sent
+        # another" bug this PR fixes on the plain path: every venue formatter floors, so
+        # at step 0.001 / floor 100 / price 60000 a quantity of 0.001666... validated at
+        # exactly 100.00 and arrived at the venue as 0.001 -- 60.00, rejected. Anything
+        # landing in [100, 160) USD passed the guard and was refused by the exchange.
+        # bybit sends the raw float and is exact; binance, okx and bitget all truncate.
+        step = float(lot["qty_step"])
+        sendable = quantity
+        if step > 0 and math.isfinite(step):
+            sendable = math.floor(quantity / step) * step
+            if not sendable > 0:
+                logger.warning(
+                    f"{self.config.symbol}: quantity {quantity} floors to {sendable} at "
+                    f"lot step {step}; refusing rather than submitting nothing"
+                )
+                return None
+
+        # `sendable`, not `quantity`: the venue formatter floors, so this is the number
+        # the exchange will actually see. The caller still receives the unfloored value
+        # and the formatter re-derives the same result -- what matters is that the
+        # validation and the submission agree.
+        notional = sendable * current_price
         min_notional = float(lot["min_notional"])
         # A relative epsilon, because `notional` mode computes `qty = usd / price` and this
         # re-multiplies by the same price. That round-trip is not exact: for ~1.7% of

--- a/torchtrade/envs/replay/order_executor.py
+++ b/torchtrade/envs/replay/order_executor.py
@@ -394,6 +394,11 @@ class ReplayOrderExecutor:
         """
         return {"min_qty": 0.000001, "qty_step": 0.000001, "min_notional": 0.0}
 
+    def quantize_quantity(self, quantity: float) -> float:
+        """What replay would submit, so a live env backtested here sees the same
+        refusals it would see live (#414)."""
+        return self._round_amount(quantity)
+
     def _round_amount(self, amount: float) -> float:
         """Floor a quantity to the replay lot step (never rounds up — margin-safe,
         matching the live truncation path)."""

--- a/torchtrade/envs/replay/order_executor.py
+++ b/torchtrade/envs/replay/order_executor.py
@@ -386,8 +386,13 @@ class ReplayOrderExecutor:
         return []
 
     def get_lot_size(self) -> Dict[str, float]:
-        """Get lot size constraints (permissive in replay)."""
-        return {"min_qty": 0.000001, "qty_step": 0.000001}
+        """Get lot size constraints (permissive in replay).
+
+        `min_notional` 0.0 because replay has no venue to reject an order -- but the key
+        is PRESENT, so the shared guard can index it strictly instead of defaulting a
+        missing key to "no floor" (#414).
+        """
+        return {"min_qty": 0.000001, "qty_step": 0.000001, "min_notional": 0.0}
 
     def _round_amount(self, amount: float) -> float:
         """Floor a quantity to the replay lot step (never rounds up — margin-safe,


### PR DESCRIPTION
Closes #414. All four gaps share one shape: **an order the env believes it placed and the venue rejected** — invariant 2 inverted, which this repo has already paid for twice.

## 1. binance validated one quantity and sent another

The min-notional check ran on the **delta**; the direction-switch branch submits `abs(target_qty)`. On a switch the signs oppose, so `|delta| = |target| + |current|` — the larger number clears a minimum the smaller one does not.

Reproduced from @CharlieHelps' worked example (price 99.99, minimum 100, short 1.0 → long 1.0):

| | value | notional | |
|---|---|---|---|
| delta **validated** | 2.0 | 199.98 | passes |
| amount **sent** | 1.0 | 99.99 | **venue rejects** |
| env believes | | | `executed=True success=True` |

The close has already happened at that point, so the account is flat while the env reports a position.

The fix is an **ordering** change, not a second check: decide what will be sent, validate *that*, then perform the switch's close. Validating after the close is too late to refuse — the position is already gone and "not executed" would describe an account that just changed.

## 2 & 3. No notional check on the SLTP path, on any venue

`_get_min_notional` lives on binance's **plain** env; its SLTP sibling doesn't inherit it and the other three never had one. And bitget and bybit read no notional field at all despite having it in hand — CCXT normalises bitget's `minTradeUSDT` to `limits.cost.min`, and bybit's `minNotionalValue` is in the same `lotSizeFilter` it already parses.

One shared guard rather than four venue copies — four copies of a money check is what #288 spent six PRs undoing. binance gains the `get_lot_size` accessor the other three already had (from filters it already caches; **no new API call**), and okx reports `0.0` because its derivatives bind on `minSz`/`lotSz` — stated rather than absent, so the guard reads one key everywhere.

It **refuses**, never rounds up to the minimum. Rounding up allocates more than the action asked for, which is how okx's formatter turns a sub-minimum size into a real position.

## 4. The delta lot-rounding had no test

Replacing `delta = self.trader.round_quantity(abs(delta)) * sign` with `delta = delta` passed **all 4493 tests**. #352 fixed the *target* rounding for #271 and left the *delta* rounding unpinned. Invisible because every other test rounds to a step the raw value already sits on; the new test uses a 0.5 step and a 1.7 target.

## Found while fixing

The `notional` and `quantity` trade modes **returned before the check** — two of three modes validated nothing at all, the same "sent something other than what was validated" shape as bug 1. All three now pass through it.

## Verification

Seven mutants, every one of which survived the suite before this PR:

| mutant | now |
|---|---|
| restore the delta-based notional check | 1 failed |
| remove the delta lot-rounding | 1 failed |
| disable the notional refusal | 4 failed |
| round **up** to the floor instead of refusing | 4 failed |
| bitget / bybit / binance each drop its notional field | 1 failed each |

The venue mocks had to model the notional fields first — **none of them carried it**, so nothing could tell whether an executor read the value or hardcoded `0.0`.

Suite: **4504 passed**, 16 skipped.
