### PR TITLE
fix(416): the SLTP balance verdict was one frame above the closure that needed it

### DIFF
--- a/docs/environments/online.md
+++ b/docs/environments/online.md
@@ -831,7 +831,7 @@ emergency flatten:
 | position read at the top of `_step()` (position sync, duplicate-action guard) | `PositionUnknownError` |
 | the initial read inside `_reset()` | `ValueError`, or `PositionUnknownError` if the position is the unreadable part |
 | `_current_mark_price()` at the **sizing** call sites in `_execute_fractional_action` / `_execute_trade_if_needed` | `ValueError` |
-| the sizing balance / portfolio checks | `ValueError` |
+| the sizing balance / portfolio checks | `LiveObservationHalt` on the four futures venues, whose verdict is inside the `_halting` closure ([#416](https://github.com/TorchTrade/torchtrade/issues/416)); bare `ValueError` on alpaca, which has no halt policy |
 | the candle close that prices SL/TP brackets | `ValueError` |
 
 So `except LiveObservationHalt` covers the two state reads and nothing else. Catch

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -4500,45 +4500,104 @@ def test_an_unusable_balance_halts_the_sltp_sizing_too(balance):
         env._resolve_bracket_quantity(100.0)
 
 
-def test_a_string_balance_sizes_rather_than_crashing_the_step():
+@pytest.mark.parametrize("sltp", [False, True], ids=["plain", "sltp"])
+def test_a_string_balance_sizes_rather_than_crashing_the_sizing_path(sltp):
     """`float()` before `math.isfinite`, because isfinite raises TypeError on a str.
 
-    An adapter that reports numbers as strings -- which is what several venue REST APIs
-    do -- crashed the plain sizing path out of `_step` on a perfectly good balance, since
-    `math.isfinite("1000.0")` is a TypeError, not False. The conversion has to come first.
-    A string that is not a number is a different case and still halts, below.
+    An adapter that reports numbers as strings -- which several venue REST APIs do --
+    crashed sizing on a perfectly good balance, since `math.isfinite("1000.0")` is a
+    TypeError, not False. TypeError is not in `_halting`'s catch tuple, so it left the
+    halt policy entirely.
+
+    BOTH entry points, because the helper returns the adapter's dict untouched and each
+    caller re-coerces: dropping the conversion in `_calculate_fractional_position` killed
+    no test at all while the SLTP twin was covered.
+
+    Scoped to the sizing path on purpose -- `_get_observation` still hands the raw value
+    to `math.isfinite`, so a string-reporting adapter cannot yet complete a step. That is
+    a separate read with a separate rule (it must accept <= 0 so `is_bankrupt` can see it)
+    and is deliberately not fixed here.
     """
-    env, trader = _real_futures_env(budget=0, venue="binance", sltp=True)
+    env, trader = _real_futures_env(budget=0, venue="binance", sltp=sltp)
     env.config.trade_mode = "fractional"
     trader.get_account_balance.return_value = {
         "available_balance": "1000.0", "total_margin_balance": "1000.0",
         "total_wallet_balance": "1000.0", "total_maintenance_margin": 0.0,
     }
 
-    assert env._resolve_bracket_quantity(100.0) > 0
+    if sltp:
+        assert env._resolve_bracket_quantity(100.0) > 0
+    else:
+        assert env._calculate_fractional_position(1.0, 100.0)[0] > 0
 
     trader.get_account_balance.return_value["total_margin_balance"] = "n/a"
     with pytest.raises(LiveObservationHalt):
-        env._resolve_bracket_quantity(100.0)
+        if sltp:
+            env._resolve_bracket_quantity(100.0)
+        else:
+            env._calculate_fractional_position(1.0, 100.0)
 
 
-def test_reset_cannot_seed_the_balance_cache_with_a_value_sizing_would_refuse():
+@pytest.mark.parametrize("balance", [0.0, -5.0, float("nan")],
+                         ids=["zero", "negative", "nan"])
+def test_reset_cannot_seed_the_balance_cache_with_a_value_sizing_would_refuse(balance):
     """`_reset` writes the same cache slot the sizing paths read (#416).
 
     It used to pass the bare callable, so the slot had one writer but two standards: a
-    NaN stored at reset was served, unvalidated, into sizing on the next failed read --
+    value stored at reset was served, unvalidated, into sizing on the next failed read --
     the poisoning this issue is about, arriving through the one door that had no guard.
+
+    0.0 and -5.0 are the values that matter. NaN already aborted the reset via
+    `_get_observation`'s own isfinite guard, so it never reached a trade; zero and
+    negative equity STARTED an episode and left an unusable entry in the slot.
     """
     env, trader = _real_futures_env(budget=0, venue="binance", sltp=True)
     trader.get_account_balance.return_value = {
-        "available_balance": float("nan"), "total_margin_balance": float("nan"),
-        "total_wallet_balance": float("nan"), "total_maintenance_margin": 0.0,
+        "available_balance": balance, "total_margin_balance": balance,
+        "total_wallet_balance": balance, "total_maintenance_margin": 0.0,
     }
 
     with pytest.raises(LiveObservationHalt):
         env.reset()
 
     assert "balance" not in env._last_confirmed_read
+
+
+@pytest.mark.parametrize("sltp", [False, True], ids=["plain", "sltp"])
+def test_a_grace_budget_does_not_ride_out_an_account_the_venue_says_is_empty(sltp):
+    """Grace is for a venue that cannot be READ, not for an answer we dislike.
+
+    An unusable balance raises inside the `_halting` closure so it is never cached -- but
+    that alone made it indistinguishable from a read FAILURE, so `_halting` caught it,
+    found a healthy balance from an earlier bar, and sized a live order against
+    pre-liquidation equity. Measured on main before this fix: a venue reporting 0.0
+    produced a 97.96-unit long on the plain path.
+
+    Both paths, because the fold made it one line and the plain path had the bug first.
+    """
+    env, trader = _real_futures_env(budget=2, venue="binance", sltp=sltp)
+    env.config.trade_mode = "fractional"
+    healthy = {"available_balance": 10000.0, "total_margin_balance": 10000.0,
+               "total_wallet_balance": 10000.0, "total_maintenance_margin": 0.0}
+    trader.get_account_balance.return_value = healthy
+    env.reset()
+    assert "balance" in env._last_confirmed_read, "setup: a healthy read must be cached"
+
+    # The venue ANSWERS, and the answer is that the account is gone.
+    trader.get_account_balance.return_value = dict(
+        healthy, total_margin_balance=0.0, available_balance=0.0
+    )
+
+    with pytest.raises(LiveObservationHalt):
+        if sltp:
+            env._resolve_bracket_quantity(100.0)
+        else:
+            env._calculate_fractional_position(1.0, 100.0)
+
+    assert not trader.trade.called, "sized an order against equity the venue disowned"
+    assert "balance" not in env._last_confirmed_read, (
+        "the stale balance is still there for the next grace bar to serve"
+    )
 
 
 def _refused_sizing_env():
@@ -4569,9 +4628,15 @@ def test_an_unusable_balance_is_not_stored_as_the_last_confirmed_read():
 
 
 def test_an_unusable_balance_counts_as_an_outage():
-    """#416(2). Nothing raised means the bar is never flagged, so the outage counter
-    never advances and a permanently broken feed refuses every open forever without
-    truncating. This is the only assertion in the file that pins the flag for this path.
+    """#416(2). The read produced nothing usable, so the bar is unconfirmed and must say
+    so -- the old code returned successfully and left the flag clear.
+
+    Deliberately asserts the FLAG and not truncation. I tried to pin the whole chain and
+    could not: the counter advances in `_finalize_step_flags`, which only runs if `_step`
+    completes, and a balance-feed outage does not get that far because
+    `_get_portfolio_value` reads the balance OUTSIDE the halt policy and dies with a raw
+    RuntimeError first. So the flag is what is true here; claiming truncation would be
+    claiming a chain that is currently broken elsewhere.
     """
     env = _refused_sizing_env()
 

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -4446,11 +4446,12 @@ def test_a_bracket_that_cannot_be_sized_is_a_failed_trade_on_every_venue(venue):
     indistinguishable.
     """
     env, trader = _real_futures_env(budget=0, venue=venue, sltp=True)
-    env.config.trade_mode = "fractional"
-    trader.get_account_balance.return_value = {
-        "available_balance": 0.0, "total_margin_balance": 0.0,
-        "total_wallet_balance": 0.0, "total_maintenance_margin": 0.0,
-    }
+    # An ORDER-level refusal: the account is fine, the quantity is below what the venue
+    # will accept. It used to be a 0.0 balance, but that is an ACCOUNT-level failure and
+    # now halts under policy like the plain path's (#416) -- a different contract, tested
+    # directly below. Sizing has to fail for a reason the caller can report.
+    env.config.trade_mode = "quantity"
+    env.config.quantity_per_trade = 1e-9
 
     td = env.reset()
     env.active_stop_loss, env.active_take_profit = 111.0, 222.0
@@ -4463,6 +4464,69 @@ def test_a_bracket_that_cannot_be_sized_is_a_failed_trade_on_every_venue(venue):
         f"{venue} recorded position {env.position.current_position} for a bracket that "
         f"was never placed; the next bar's duplicate-action guard trusts that"
     )
+
+
+@pytest.mark.parametrize("venue",
+                         [c.__module__.split(".")[-2] for c in SLTP_FUTURES_ENVS])
+@pytest.mark.parametrize("balance", [0.0, -1.0, float("nan"), float("inf")],
+                         ids=["zero", "negative", "nan", "inf"])
+def test_an_unusable_balance_halts_the_sltp_sizing_too(venue, balance):
+    """An unusable ACCOUNT halts, on the SLTP path as on the plain one (#416).
+
+    The verdict has to be raised INSIDE the `_halting` closure. Hoisted one frame up --
+    which is what this path did -- the closure returns successfully and two things go
+    wrong at once, both of them silent. This asserts the halt; the two tests below assert
+    the consequences, because the halt alone does not prove either.
+    """
+    env, trader = _real_futures_env(budget=0, venue=venue, sltp=True)
+    env.config.trade_mode = "fractional"
+    trader.get_account_balance.return_value = {
+        "available_balance": balance, "total_margin_balance": balance,
+        "total_wallet_balance": balance, "total_maintenance_margin": 0.0,
+    }
+
+    with pytest.raises(LiveObservationHalt):
+        env._resolve_bracket_quantity(100.0)
+
+
+def test_an_unusable_balance_is_not_stored_as_the_last_confirmed_read():
+    """#416(1): the value the guard just rejected must not be what a grace period serves.
+
+    `_halting` stores on the way OUT of a successful read, so a verdict reached after it
+    returns has already been overtaken -- and `_reset` reads `available_balance` from
+    that same slot. `equity == 0.0` is what a venue reports while liquidating you.
+    """
+    env, trader = _real_futures_env(budget=0, venue="binance", sltp=True)
+    env.config.trade_mode = "fractional"
+    trader.get_account_balance.return_value = {
+        "available_balance": 0.0, "total_margin_balance": 0.0,
+        "total_wallet_balance": 0.0, "total_maintenance_margin": 0.0,
+    }
+
+    with pytest.raises(LiveObservationHalt):
+        env._resolve_bracket_quantity(100.0)
+
+    assert "balance" not in env._last_confirmed_read
+
+
+def test_an_unusable_balance_counts_as_an_outage():
+    """#416(2): a read that produces nothing usable is an outage, and must be counted.
+
+    Because the old closure returned successfully, `_status_unknown_this_step` was never
+    set: a permanently broken balance feed failed every SLTP open forever, with no
+    `status_unknown` in the observation and no truncation. The plain path truncates.
+    """
+    env, trader = _real_futures_env(budget=0, venue="binance", sltp=True)
+    env.config.trade_mode = "fractional"
+    trader.get_account_balance.return_value = {
+        "available_balance": 0.0, "total_margin_balance": 0.0,
+        "total_wallet_balance": 0.0, "total_maintenance_margin": 0.0,
+    }
+
+    with pytest.raises(LiveObservationHalt):
+        env._resolve_bracket_quantity(100.0)
+
+    assert env._status_unknown_this_step is True
 
 
 def test_an_unrecognised_trade_mode_refuses_rather_than_sizing_as_fractional():
@@ -4570,21 +4634,6 @@ def test_the_sltp_fold_did_not_move_a_bracket_quantity(venue, expected):
     assert got == pytest.approx(expected, rel=1e-9), (
         f"{venue}'s bracket now sizes {got!r} where it sized {expected!r} before the fold"
     )
-
-
-@pytest.mark.parametrize("balance", [0.0, -5.0, float("nan"), float("inf")],
-                         ids=["zero", "negative", "nan", "inf"])
-def test_an_unusable_balance_refuses_to_size_a_bracket(balance):
-    """None, not a raise, and not a number.
-
-    The plain path raises inside the `_halting` closure so an unusable balance becomes a
-    halt; this path returns None and the caller reports a failed trade. That asymmetry is
-    pre-existing and deliberate, so it is asserted rather than left to be discovered --
-    "fixing" it on one venue would diverge halt handling by venue with nothing noticing.
-    """
-    cls = _sole(importlib.import_module("torchtrade.envs.live.binance.env_sltp"),
-                "TorchTradingEnv")
-    assert _bracket_stub(cls, balance=balance)._resolve_bracket_quantity(100.0) is None
 
 
 @pytest.mark.parametrize("fee", [0.0007, 0.0],

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -4600,6 +4600,38 @@ def test_a_grace_budget_does_not_ride_out_an_account_the_venue_says_is_empty(slt
     )
 
 
+def test_flatten_closes_once_and_sends_no_bracket_on_an_unusable_balance():
+    """@CharlieHelps' follow-up: pin the sharp edge of FLATTEN + a dead account.
+
+    FLATTEN bypasses grace by design -- "get me out while I cannot see the account" and
+    "ride it out" are contradictory postures -- so this behaves the same before and after
+    the eviction. One close request, no bracket, and the balance ValueError preserved as
+    the halt's cause so an operator can tell WHY it flattened.
+    """
+    from torchtrade.envs.core.live import ObservationFailurePolicy
+
+    env, trader = _real_futures_env(budget=2, venue="binance", sltp=True)
+    env.config.trade_mode = "fractional"
+    healthy = {"available_balance": 10000.0, "total_margin_balance": 10000.0,
+               "total_wallet_balance": 10000.0, "total_maintenance_margin": 0.0}
+    trader.get_account_balance.return_value = healthy
+    env.reset()
+    env.config.observation_failure_policy = ObservationFailurePolicy.FLATTEN
+    trader.close_position.reset_mock()
+    trader.trade.reset_mock()
+    trader.get_account_balance.return_value = dict(
+        healthy, total_margin_balance=0.0, available_balance=0.0
+    )
+
+    with pytest.raises(LiveObservationHalt) as halt:
+        env._resolve_bracket_quantity(100.0)
+
+    assert trader.close_position.call_count == 1, "FLATTEN must request exactly one close"
+    assert not trader.trade.called, "no bracket may go out behind the flatten"
+    assert isinstance(halt.value.__cause__, ValueError)
+    assert "portfolio value of 0.0" in str(halt.value.__cause__)
+
+
 def _refused_sizing_env():
     """An SLTP env whose balance read produces nothing usable."""
     env, trader = _real_futures_env(budget=0, venue="binance", sltp=True)

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -4588,11 +4588,14 @@ def test_a_grace_budget_does_not_ride_out_an_account_the_venue_says_is_empty(slt
         healthy, total_margin_balance=0.0, available_balance=0.0
     )
 
+    # Through the method that actually reaches `trader.trade`, not the sizing helper --
+    # `_resolve_bracket_quantity` and `_calculate_fractional_position` cannot submit an
+    # order at all, so asserting `not trader.trade.called` on them asserts nothing.
     with pytest.raises(LiveObservationHalt):
         if sltp:
-            env._resolve_bracket_quantity(100.0)
+            env._execute_trade_if_needed(("long", -0.02, 0.03), current_price=100.0)
         else:
-            env._calculate_fractional_position(1.0, 100.0)
+            env._execute_fractional_action(1.0, current_qty=0.0, current_price=100.0)
 
     assert not trader.trade.called, "sized an order against equity the venue disowned"
     assert "balance" not in env._last_confirmed_read, (

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -3522,7 +3522,11 @@ class _ResetStub:
         class _Trader:
             def cancel_open_orders(self): return cancel_ok
             def close_position(self): return close_ok
-            def get_account_balance(self): return {"available_balance": 1000.0}
+            def get_account_balance(self):
+                # total_margin_balance too: every real adapter returns it, and reset now
+                # reads the balance through the same verdict sizing does (#416), so a
+                # stub that omits it is testing a venue that cannot exist.
+                return {"available_balance": 1000.0, "total_margin_balance": 1000.0}
             def get_status(self): return {"position_status": None}
 
         class _Observer:
@@ -3536,9 +3540,15 @@ class _ResetStub:
             lambda: TorchTradeLiveEnv._reset_outage_state(self)
         )
         self._max_unknown_status_steps = 0
-        # The reset read runs under the halt policy as of #295.
+        # The reset read runs under the halt policy as of #295, and through the same
+        # verdict the sizing paths use as of #416 -- so the real reader is bound here
+        # rather than stubbed, or this would assert reset's cache write is validated
+        # while never running the code that validates it.
         self._halting = lambda read, cache_key=None: (
             TorchTradeFuturesLiveEnv._halting(self, read, cache_key)
+        )
+        self._read_sizing_balance = lambda: (
+            TorchTradeFuturesLiveEnv._read_sizing_balance(self)
         )
         self.trader, self.observer = _Trader(), _Observer()
         self.history = SimpleNamespace(reset=lambda: setattr(
@@ -4466,11 +4476,9 @@ def test_a_bracket_that_cannot_be_sized_is_a_failed_trade_on_every_venue(venue):
     )
 
 
-@pytest.mark.parametrize("venue",
-                         [c.__module__.split(".")[-2] for c in SLTP_FUTURES_ENVS])
 @pytest.mark.parametrize("balance", [0.0, -1.0, float("nan"), float("inf")],
                          ids=["zero", "negative", "nan", "inf"])
-def test_an_unusable_balance_halts_the_sltp_sizing_too(venue, balance):
+def test_an_unusable_balance_halts_the_sltp_sizing_too(balance):
     """An unusable ACCOUNT halts, on the SLTP path as on the plain one (#416).
 
     The verdict has to be raised INSIDE the `_halting` closure. Hoisted one frame up --
@@ -4478,7 +4486,10 @@ def test_an_unusable_balance_halts_the_sltp_sizing_too(venue, balance):
     wrong at once, both of them silent. This asserts the halt; the two tests below assert
     the consequences, because the halt alone does not prove either.
     """
-    env, trader = _real_futures_env(budget=0, venue=venue, sltp=True)
+    # One venue, not four: only okx overrides `_resolve_bracket_quantity`, and its first
+    # line delegates to super(). Reverting the fix failed all sixteen rows identically,
+    # so the venue axis asserted nothing the shared method does not already give.
+    env, trader = _real_futures_env(budget=0, venue="binance", sltp=True)
     env.config.trade_mode = "fractional"
     trader.get_account_balance.return_value = {
         "available_balance": balance, "total_margin_balance": balance,
@@ -4489,12 +4500,59 @@ def test_an_unusable_balance_halts_the_sltp_sizing_too(venue, balance):
         env._resolve_bracket_quantity(100.0)
 
 
-def test_an_unusable_balance_is_not_stored_as_the_last_confirmed_read():
-    """#416(1): the value the guard just rejected must not be what a grace period serves.
+def test_a_string_balance_sizes_rather_than_crashing_the_step():
+    """`float()` before `math.isfinite`, because isfinite raises TypeError on a str.
 
-    `_halting` stores on the way OUT of a successful read, so a verdict reached after it
-    returns has already been overtaken -- and `_reset` reads `available_balance` from
-    that same slot. `equity == 0.0` is what a venue reports while liquidating you.
+    An adapter that reports numbers as strings -- which is what several venue REST APIs
+    do -- crashed the plain sizing path out of `_step` on a perfectly good balance, since
+    `math.isfinite("1000.0")` is a TypeError, not False. The conversion has to come first.
+    A string that is not a number is a different case and still halts, below.
+    """
+    env, trader = _real_futures_env(budget=0, venue="binance", sltp=True)
+    env.config.trade_mode = "fractional"
+    trader.get_account_balance.return_value = {
+        "available_balance": "1000.0", "total_margin_balance": "1000.0",
+        "total_wallet_balance": "1000.0", "total_maintenance_margin": 0.0,
+    }
+
+    assert env._resolve_bracket_quantity(100.0) > 0
+
+    trader.get_account_balance.return_value["total_margin_balance"] = "n/a"
+    with pytest.raises(LiveObservationHalt):
+        env._resolve_bracket_quantity(100.0)
+
+
+def test_reset_cannot_seed_the_balance_cache_with_a_value_sizing_would_refuse():
+    """`_reset` writes the same cache slot the sizing paths read (#416).
+
+    It used to pass the bare callable, so the slot had one writer but two standards: a
+    NaN stored at reset was served, unvalidated, into sizing on the next failed read --
+    the poisoning this issue is about, arriving through the one door that had no guard.
+    """
+    env, trader = _real_futures_env(budget=0, venue="binance", sltp=True)
+    trader.get_account_balance.return_value = {
+        "available_balance": float("nan"), "total_margin_balance": float("nan"),
+        "total_wallet_balance": float("nan"), "total_maintenance_margin": 0.0,
+    }
+
+    with pytest.raises(LiveObservationHalt):
+        env.reset()
+
+    assert "balance" not in env._last_confirmed_read
+
+
+def test_an_unusable_balance_is_neither_cached_nor_uncounted():
+    """The two consequences, which the halt above is blind to (#416).
+
+    A fix that halts from the WRONG PLACE -- after `_halting` returns rather than inside
+    its closure -- passes the halt test and fails both of these. That is the whole point
+    of the issue, so they are asserted directly rather than inferred from the raise.
+
+    1. `_halting` stores on the way OUT of a successful read, so a verdict reached after
+       it returns has already been overtaken. `equity == 0.0` is what a venue reports
+       while liquidating you, and `_reset` reads `available_balance` from that same slot.
+    2. Nothing raised means the bar is never flagged, so the outage counter never
+       advances and a permanently broken feed refuses every open forever.
     """
     env, trader = _real_futures_env(budget=0, venue="binance", sltp=True)
     env.config.trade_mode = "fractional"
@@ -4507,25 +4565,6 @@ def test_an_unusable_balance_is_not_stored_as_the_last_confirmed_read():
         env._resolve_bracket_quantity(100.0)
 
     assert "balance" not in env._last_confirmed_read
-
-
-def test_an_unusable_balance_counts_as_an_outage():
-    """#416(2): a read that produces nothing usable is an outage, and must be counted.
-
-    Because the old closure returned successfully, `_status_unknown_this_step` was never
-    set: a permanently broken balance feed failed every SLTP open forever, with no
-    `status_unknown` in the observation and no truncation. The plain path truncates.
-    """
-    env, trader = _real_futures_env(budget=0, venue="binance", sltp=True)
-    env.config.trade_mode = "fractional"
-    trader.get_account_balance.return_value = {
-        "available_balance": 0.0, "total_margin_balance": 0.0,
-        "total_wallet_balance": 0.0, "total_maintenance_margin": 0.0,
-    }
-
-    with pytest.raises(LiveObservationHalt):
-        env._resolve_bracket_quantity(100.0)
-
     assert env._status_unknown_this_step is True
 
 

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -4564,7 +4564,9 @@ def test_reset_cannot_seed_the_balance_cache_with_a_value_sizing_would_refuse(ba
 
 
 @pytest.mark.parametrize("sltp", [False, True], ids=["plain", "sltp"])
-def test_a_grace_budget_does_not_ride_out_an_account_the_venue_says_is_empty(sltp):
+@pytest.mark.parametrize("bad", [0.0, -5.0, float("nan"), float("inf"), "n/a", None],
+                         ids=["zero", "negative", "nan", "inf", "unparseable", "none"])
+def test_a_grace_budget_does_not_ride_out_an_account_the_venue_says_is_empty(sltp, bad):
     """Grace is for a venue that cannot be READ, not for an answer we dislike.
 
     An unusable balance raises inside the `_halting` closure so it is never cached -- but
@@ -4574,6 +4576,13 @@ def test_a_grace_budget_does_not_ride_out_an_account_the_venue_says_is_empty(slt
     produced a 97.96-unit long on the plain path.
 
     Both paths, because the fold made it one line and the plain path had the bug first.
+
+    Every UNUSABLE shape, because the first fix guarded only the invalid-number branch:
+    `float("n/a")` raises before the eviction line is reached, so the stale balance stayed
+    cached and grace sized an order from it anyway. Same bug, one line up, for a value
+    that cannot be parsed rather than one that parses to something impossible. Charlie
+    reproduced it on all four venues and both paths; `None` is here because it fails
+    through TypeError rather than ValueError.
     """
     env, trader = _real_futures_env(budget=2, venue="binance", sltp=sltp)
     env.config.trade_mode = "fractional"
@@ -4583,9 +4592,9 @@ def test_a_grace_budget_does_not_ride_out_an_account_the_venue_says_is_empty(slt
     env.reset()
     assert "balance" in env._last_confirmed_read, "setup: a healthy read must be cached"
 
-    # The venue ANSWERS, and the answer is that the account is gone.
+    # The venue ANSWERS, and the answer is unusable.
     trader.get_account_balance.return_value = dict(
-        healthy, total_margin_balance=0.0, available_balance=0.0
+        healthy, total_margin_balance=bad, available_balance=bad
     )
 
     # Through the method that actually reaches `trader.trade`, not the sizing helper --

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -4662,20 +4662,26 @@ def test_an_unusable_balance_is_not_stored_as_the_last_confirmed_read():
     assert "balance" not in env._last_confirmed_read
 
 
-def test_an_unusable_balance_counts_as_an_outage():
+def test_an_unusable_balance_flags_the_bar_before_it_halts():
     """#416(2). The read produced nothing usable, so the bar is unconfirmed and must say
     so -- the old code returned successfully and left the flag clear.
 
-    Deliberately asserts the FLAG and not truncation, and the reason is measured rather
-    than reasoned: the counter advances in `_finalize_step_flags`, which only runs if
-    `_step` COMPLETES, and on a readable 0.0 balance the halt leaves `_step` first. Driven
-    against a real plain futures env at budget=0, both a hold and an open action raise
-    `LiveObservationHalt` out of `step()`, so nothing reaches the counter either way.
+    The name is deliberately not "counts as an outage", and the docstring is deliberately
+    only what was measured. Three earlier attempts to explain this were wrong:
 
-    Two earlier explanations of this in this docstring were wrong -- the first implied
-    truncation would otherwise happen, the second blamed `_get_portfolio_value` reading
-    outside the halt policy, which it does not (it raises only on a non-finite equity, and
-    0.0 is finite). Hence stating only what was observed.
+    1. Claimed the flag leads to truncation here. It does not: since the eviction, an
+       unusable balance is not grace-eligible, so the halt always leaves `_step` and
+       `_finalize_step_flags` -- which owns the counter -- never runs. Driven at budget=0,
+       both a hold and an open action raise out of `step()`.
+    2. Blamed `_get_portfolio_value` for reading outside the halt policy. It does not, and
+       on a 0.0 balance it does not raise at all -- it guards non-finite equity only.
+    3. Concluded from (2) that the chain was broken. It is not. For a genuine READ
+       FAILURE with a warm cache the chain works end to end -- measured:
+       `bar1 unknown=1 counter=1`, `bar2 unknown=1 truncated=True`. That case is already
+       pinned by `test_a_real_env_flags_the_outage_and_truncates_on_the_budgeted_bar` in
+       tests/envs/test_live_observation_failsafe.py, so it is not re-tested here.
+
+    So: an unusable balance flags the bar and then halts. That is what this asserts.
     """
     env = _refused_sizing_env()
 

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -4541,30 +4541,43 @@ def test_reset_cannot_seed_the_balance_cache_with_a_value_sizing_would_refuse():
     assert "balance" not in env._last_confirmed_read
 
 
-def test_an_unusable_balance_is_neither_cached_nor_uncounted():
-    """The two consequences, which the halt above is blind to (#416).
-
-    A fix that halts from the WRONG PLACE -- after `_halting` returns rather than inside
-    its closure -- passes the halt test and fails both of these. That is the whole point
-    of the issue, so they are asserted directly rather than inferred from the raise.
-
-    1. `_halting` stores on the way OUT of a successful read, so a verdict reached after
-       it returns has already been overtaken. `equity == 0.0` is what a venue reports
-       while liquidating you, and `_reset` reads `available_balance` from that same slot.
-    2. Nothing raised means the bar is never flagged, so the outage counter never
-       advances and a permanently broken feed refuses every open forever.
-    """
+def _refused_sizing_env():
+    """An SLTP env whose balance read produces nothing usable."""
     env, trader = _real_futures_env(budget=0, venue="binance", sltp=True)
     env.config.trade_mode = "fractional"
     trader.get_account_balance.return_value = {
         "available_balance": 0.0, "total_margin_balance": 0.0,
         "total_wallet_balance": 0.0, "total_maintenance_margin": 0.0,
     }
+    return env
+
+
+# Two functions, not one with two asserts. The halt above is blind to both consequences,
+# and #416 broke BOTH at once -- which is exactly the case a merged test hides: the first
+# assert fails, the second never runs, and fixing only the caching half looks green.
+def test_an_unusable_balance_is_not_stored_as_the_last_confirmed_read():
+    """#416(1). `_halting` stores on the way OUT of a read that SUCCEEDED, so a verdict
+    reached after it returns has already been overtaken. `equity == 0.0` is what a venue
+    reports while liquidating you, and `_reset` reads `available_balance` from that slot.
+    """
+    env = _refused_sizing_env()
 
     with pytest.raises(LiveObservationHalt):
         env._resolve_bracket_quantity(100.0)
 
     assert "balance" not in env._last_confirmed_read
+
+
+def test_an_unusable_balance_counts_as_an_outage():
+    """#416(2). Nothing raised means the bar is never flagged, so the outage counter
+    never advances and a permanently broken feed refuses every open forever without
+    truncating. This is the only assertion in the file that pins the flag for this path.
+    """
+    env = _refused_sizing_env()
+
+    with pytest.raises(LiveObservationHalt):
+        env._resolve_bracket_quantity(100.0)
+
     assert env._status_unknown_this_step is True
 
 

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -4666,12 +4666,16 @@ def test_an_unusable_balance_counts_as_an_outage():
     """#416(2). The read produced nothing usable, so the bar is unconfirmed and must say
     so -- the old code returned successfully and left the flag clear.
 
-    Deliberately asserts the FLAG and not truncation. I tried to pin the whole chain and
-    could not: the counter advances in `_finalize_step_flags`, which only runs if `_step`
-    completes, and a balance-feed outage does not get that far because
-    `_get_portfolio_value` reads the balance OUTSIDE the halt policy and dies with a raw
-    RuntimeError first. So the flag is what is true here; claiming truncation would be
-    claiming a chain that is currently broken elsewhere.
+    Deliberately asserts the FLAG and not truncation, and the reason is measured rather
+    than reasoned: the counter advances in `_finalize_step_flags`, which only runs if
+    `_step` COMPLETES, and on a readable 0.0 balance the halt leaves `_step` first. Driven
+    against a real plain futures env at budget=0, both a hold and an open action raise
+    `LiveObservationHalt` out of `step()`, so nothing reaches the counter either way.
+
+    Two earlier explanations of this in this docstring were wrong -- the first implied
+    truncation would otherwise happen, the second blamed `_get_portfolio_value` reading
+    outside the halt policy, which it does not (it raises only on a non-finite equity, and
+    0.0 is finite). Hence stating only what was observed.
     """
     env = _refused_sizing_env()
 

--- a/torchtrade/envs/live/shared/futures_live_base.py
+++ b/torchtrade/envs/live/shared/futures_live_base.py
@@ -188,6 +188,15 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
             # isfinite, not `not (x > 0)`: that catches NaN but passes +inf, and an inf
             # balance sizes an inf target (#277, #347).
             if not math.isfinite(total_balance) or total_balance <= 0:
+                # Evict BEFORE raising, so the grace period has nothing to serve.
+                #
+                # Grace exists for a venue that cannot be READ. This is not that: the
+                # venue answered, and the answer is that the account is empty. Left
+                # cacheable, `_halting` cannot tell the two apart -- it catches this
+                # ValueError, finds a healthy balance from an earlier bar, and sizes a
+                # live order against pre-liquidation equity. Measured on the plain path
+                # before the fold: a venue reporting 0.0 produced a 97.96-unit long.
+                self._last_confirmed_read.pop("balance", None)
                 raise ValueError(
                     f"cannot size against a portfolio value of {total_balance}"
                 )

--- a/torchtrade/envs/live/shared/futures_live_base.py
+++ b/torchtrade/envs/live/shared/futures_live_base.py
@@ -181,21 +181,28 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
         """
         def read_balance():
             info = self.trader.get_account_balance()
-            # Coerce before checking, not for the callers: `math.isfinite("1000.0")` is a
-            # TypeError, so an adapter reporting strings crashed on a good balance. The
-            # dict is returned untouched, so callers still convert.
-            total_balance = float(info["total_margin_balance"])
+            # KeyError deliberately not caught here or in `_halting`: a venue that omits
+            # the field is a config error, not an account state.
+            raw = info["total_margin_balance"]
+            # ONE verdict for every way the balance can be unusable. Coercion failure
+            # belongs inside it: `float()` raising ahead of the eviction left the stale
+            # balance cached, `_halting` caught the ValueError, and grace sized a live
+            # order from it -- this same bug, one line up, for an unparseable value
+            # rather than an invalid number.
+            #
             # isfinite, not `not (x > 0)`: that catches NaN but passes +inf, and an inf
             # balance sizes an inf target (#277, #347).
-            if not math.isfinite(total_balance) or total_balance <= 0:
+            try:
+                usable = math.isfinite(float(raw)) and float(raw) > 0
+            except (TypeError, ValueError):
+                usable = False
+            if not usable:
                 # Drop the cached balance too -- the same invalidation
-                # `_handle_close_action` and `_mark_flat` already do. A venue answering
-                # 0, negative or NaN is not one whose EARLIER equity we may still size
-                # against, on this bar or on a later grace bar (#416).
+                # `_handle_close_action` and `_mark_flat` already do. A venue answering 0,
+                # negative, NaN or gibberish is not one whose EARLIER equity we may still
+                # size against, on this bar or on a later grace bar (#416).
                 self._last_confirmed_read.pop("balance", None)
-                raise ValueError(
-                    f"cannot size against a portfolio value of {total_balance}"
-                )
+                raise ValueError(f"cannot size against a portfolio value of {raw}")
             return info
 
         return self._halting(read_balance, cache_key="balance")

--- a/torchtrade/envs/live/shared/futures_live_base.py
+++ b/torchtrade/envs/live/shared/futures_live_base.py
@@ -167,6 +167,43 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
     # sibling's MRO runs SLTPMixin -> <Venue>Base -> here and never touches the leaf.
     TAKER_FEE: float
 
+    def _read_sizing_balance(self) -> dict:
+        """The account read that money decisions are made from, under the halt policy.
+
+        total_margin_balance, not total_wallet_balance or available_balance: binance's
+        wallet figure excludes unrealized PnL and would under-size, and available_balance
+        omits margin already locked in open positions (#295).
+
+        The VERDICT lives INSIDE the closure. `_halting` catches ValueError precisely so
+        an impossible account becomes a halt, and it stores on the way out of a read that
+        SUCCEEDED -- so a check made one frame above it has already lost: the rejected
+        value is cached as the last CONFIRMED read a grace period will serve, and the bar
+        is never flagged, so the outage counter never advances (#416). `equity == 0.0` is
+        what a venue reports while liquidating you.
+
+        Three callers, one rule. It was written out three times and had already drifted
+        twice: the SLTP path checked after the call, and `_reset` seeded this same cache
+        slot with no check at all -- so a NaN stored at reset was served, unvalidated,
+        into sizing on the next failed read.
+
+        Returns the whole dict, not the float: `_reset` reads `available_balance` from it,
+        and the grace path replays whatever was stored.
+        """
+        def read_balance():
+            info = self.trader.get_account_balance()
+            # float() first: an adapter that returns strings made `math.isfinite` raise
+            # TypeError straight out of `_step`, on a perfectly good balance.
+            total_balance = float(info["total_margin_balance"])
+            # isfinite, not `not (x > 0)`: that catches NaN but passes +inf, and an inf
+            # balance sizes an inf target (#277, #347).
+            if not math.isfinite(total_balance) or total_balance <= 0:
+                raise ValueError(
+                    f"cannot size against a portfolio value of {total_balance}"
+                )
+            return info
+
+        return self._halting(read_balance, cache_key="balance")
+
     def _calculate_fractional_position(
         self, action_value: float, current_price: float
     ) -> tuple[float, float, str]:
@@ -177,28 +214,10 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
         if action_value == 0.0:
             return 0.0, 0.0, "flat"
 
-        # The VERDICT is inside the closure, not just the read. `_halting` catches
-        # ValueError precisely so an impossible account state becomes a halt; raising one
-        # frame above it sent that straight out of `_step`. `equity == 0.0` is what a
-        # venue reports while liquidating you -- the worst moment to crash rather than
-        # halt under policy (#295).
-        def read_balance():
-            info = self.trader.get_account_balance()
-            total_balance = info["total_margin_balance"]
-            # isfinite, not `not (x > 0)`: that catches NaN but passes +inf, and an inf
-            # balance sizes an inf target (#277).
-            if not math.isfinite(total_balance) or total_balance <= 0:
-                raise ValueError(
-                    f"cannot size a trade against a portfolio value of {total_balance}"
-                )
-            return info
-
-        balance_info = self._halting(read_balance, cache_key="balance")
-
-        # total_margin_balance, not available_balance: the target must reflect the whole
-        # portfolio including margin already locked in open positions.
         # The 2% buffer is the venue's maintenance-margin headroom.
-        effective_balance = balance_info["total_margin_balance"] * 0.98
+        effective_balance = float(
+            self._read_sizing_balance()["total_margin_balance"]
+        ) * 0.98
         return calculate_fractional_position(PositionCalculationParams(
             balance=effective_balance,
             action_value=action_value,
@@ -231,30 +250,7 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
         if self.config.trade_mode != "fractional":
             raise ValueError(f"Unsupported trade_mode={self.config.trade_mode!r}")
 
-        # The VERDICT goes INSIDE the closure, as the plain path's does. Validating after
-        # `_halting` returns is the "guard hoisted one frame up" that its own comment
-        # warns about, and here it cost two things (#416): the closure returned
-        # successfully, so the unusable value reached the store and became the last
-        # CONFIRMED read a grace period would go on serving; and nothing raised, so the
-        # bar was never flagged unknown, the outage counter never advanced, and a
-        # permanently broken balance feed refused every open forever without ever
-        # truncating. The plain path, for the same input, did neither.
-        def read_balance():
-            # total_margin_balance, not total_wallet_balance: binance's wallet figure
-            # excludes unrealized PnL and would under-size (#295).
-            info = self.trader.get_account_balance()
-            total_balance = float(info["total_margin_balance"])
-            # isfinite, not just `<= 0`: `nan <= 0` is False, so a NaN balance would size
-            # a NaN bracket (#347). Callers validate current_price before calling.
-            if not math.isfinite(total_balance) or total_balance <= 0:
-                raise ValueError(
-                    f"cannot size a bracket against a portfolio value of {total_balance}"
-                )
-            return info
-
-        balance = float(
-            self._halting(read_balance, cache_key="balance")["total_margin_balance"]
-        )
+        balance = float(self._read_sizing_balance()["total_margin_balance"])
 
         # Reserve what the trader will CHARGE: ReplayOrderExecutor carries its own rate,
         # so reserving the venue constant refused every open for a higher-fee caller (#278).
@@ -937,11 +933,12 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
         # rather than a bare PositionUnknownError, which is what `except
         # LiveObservationHalt` and the FLATTEN policy were always documented to cover and
         # what the reset path actually bypassed until now.
-        # Two `_halting` calls rather than one closure plus a manual cache seed: the
-        # balance goes through the same "balance" slot the sizing path uses, so
-        # `_last_confirmed_read` keeps exactly one writer. `_reset_outage_state` has just
-        # cleared it, so a failure here still raises -- an episode cannot start on cache.
-        balance = self._halting(self.trader.get_account_balance, cache_key="balance")
+        # Through the sizing reader, so the "balance" slot keeps one writer AND one
+        # standard. It used to pass the bare callable: the slot was shared but the verdict
+        # was not, so a NaN stored here was served straight into sizing on the next failed
+        # read (#416). `_reset_outage_state` has just cleared it, so a failure here still
+        # raises -- an episode cannot start on cache.
+        balance = self._read_sizing_balance()
 
         # The CONVERSION is inside the closure, not just the call. No adapter raises from
         # `get_status`: all four RETURN the POSITION_UNKNOWN sentinel, and the error comes

--- a/torchtrade/envs/live/shared/futures_live_base.py
+++ b/torchtrade/envs/live/shared/futures_live_base.py
@@ -210,10 +210,11 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
     def _resolve_bracket_quantity(self, current_price: float) -> float | None:
         """The quantity an SLTP bracket opens with, for all four futures venues (#288).
 
-        None means the account cannot be sized against, and the caller reports a FAILED
-        TRADE rather than halting. The plain path raises inside the `_halting` closure so
-        the same input becomes a halt instead -- a divergence this fold preserves rather
-        than endorses (#416).
+        None means the venue would reject the ORDER -- sizing produced nothing, or the
+        quantity is below a venue minimum -- and the caller reports a failed trade.
+
+        An unusable ACCOUNT is not that case: it raises inside the `_halting` closure, as
+        the plain path does, so the halt policy decides (#416).
         """
         # Every mode goes through the venue-minimum refusal below. The two fixed-size
         # modes returned early and skipped it, which is the same "validated one thing,
@@ -230,19 +231,30 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
         if self.config.trade_mode != "fractional":
             raise ValueError(f"Unsupported trade_mode={self.config.trade_mode!r}")
 
-        # total_margin_balance, not total_wallet_balance: binance's wallet figure excludes
-        # unrealized PnL and would under-size. Under `_halting` -- the read that SIZES a
-        # bracket (#295).
+        # The VERDICT goes INSIDE the closure, as the plain path's does. Validating after
+        # `_halting` returns is the "guard hoisted one frame up" that its own comment
+        # warns about, and here it cost two things (#416): the closure returned
+        # successfully, so the unusable value reached the store and became the last
+        # CONFIRMED read a grace period would go on serving; and nothing raised, so the
+        # bar was never flagged unknown, the outage counter never advanced, and a
+        # permanently broken balance feed refused every open forever without ever
+        # truncating. The plain path, for the same input, did neither.
+        def read_balance():
+            # total_margin_balance, not total_wallet_balance: binance's wallet figure
+            # excludes unrealized PnL and would under-size (#295).
+            info = self.trader.get_account_balance()
+            total_balance = float(info["total_margin_balance"])
+            # isfinite, not just `<= 0`: `nan <= 0` is False, so a NaN balance would size
+            # a NaN bracket (#347). Callers validate current_price before calling.
+            if not math.isfinite(total_balance) or total_balance <= 0:
+                raise ValueError(
+                    f"cannot size a bracket against a portfolio value of {total_balance}"
+                )
+            return info
+
         balance = float(
-            self._halting(self.trader.get_account_balance, cache_key="balance")[
-                "total_margin_balance"
-            ]
+            self._halting(read_balance, cache_key="balance")["total_margin_balance"]
         )
-        # isfinite, not just `<= 0`: `nan <= 0` is False, so a NaN balance would size a
-        # NaN bracket (#347). Callers validate current_price before calling.
-        if not math.isfinite(balance) or balance <= 0:
-            logger.error(f"Cannot size against balance={balance} for {self.config.symbol}")
-            return None
 
         # Reserve what the trader will CHARGE: ReplayOrderExecutor carries its own rate,
         # so reserving the venue constant refused every open for a higher-fee caller (#278).

--- a/torchtrade/envs/live/shared/futures_live_base.py
+++ b/torchtrade/envs/live/shared/futures_live_base.py
@@ -188,14 +188,10 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
             # isfinite, not `not (x > 0)`: that catches NaN but passes +inf, and an inf
             # balance sizes an inf target (#277, #347).
             if not math.isfinite(total_balance) or total_balance <= 0:
-                # Evict BEFORE raising, so the grace period has nothing to serve.
-                #
-                # Grace exists for a venue that cannot be READ. This is not that: the
-                # venue answered, and the answer is that the account is empty. Left
-                # cacheable, `_halting` cannot tell the two apart -- it catches this
-                # ValueError, finds a healthy balance from an earlier bar, and sizes a
-                # live order against pre-liquidation equity. Measured on the plain path
-                # before the fold: a venue reporting 0.0 produced a 97.96-unit long.
+                # Drop the cached balance too -- the same invalidation
+                # `_handle_close_action` and `_mark_flat` already do. A venue answering
+                # 0, negative or NaN is not one whose EARLIER equity we may still size
+                # against, on this bar or on a later grace bar (#416).
                 self._last_confirmed_read.pop("balance", None)
                 raise ValueError(
                     f"cannot size against a portfolio value of {total_balance}"

--- a/torchtrade/envs/live/shared/futures_live_base.py
+++ b/torchtrade/envs/live/shared/futures_live_base.py
@@ -168,31 +168,22 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
     TAKER_FEE: float
 
     def _read_sizing_balance(self) -> dict:
-        """The account read that money decisions are made from, under the halt policy.
+        """The account read that sizing decisions are made from, under the halt policy.
 
-        total_margin_balance, not total_wallet_balance or available_balance: binance's
-        wallet figure excludes unrealized PnL and would under-size, and available_balance
-        omits margin already locked in open positions (#295).
+        The verdict lives INSIDE the closure. `_halting` caches on the way out of a read
+        that SUCCEEDED and flags the bar only on one that raised, so a check made one
+        frame above it gets neither: the rejected value is served as last-confirmed state
+        and the outage counter never advances (#416). `equity == 0.0` is what a venue
+        reports while liquidating you.
 
-        The VERDICT lives INSIDE the closure. `_halting` catches ValueError precisely so
-        an impossible account becomes a halt, and it stores on the way out of a read that
-        SUCCEEDED -- so a check made one frame above it has already lost: the rejected
-        value is cached as the last CONFIRMED read a grace period will serve, and the bar
-        is never flagged, so the outage counter never advances (#416). `equity == 0.0` is
-        what a venue reports while liquidating you.
-
-        Three callers, one rule. It was written out three times and had already drifted
-        twice: the SLTP path checked after the call, and `_reset` seeded this same cache
-        slot with no check at all -- so a NaN stored at reset was served, unvalidated,
-        into sizing on the next failed read.
-
-        Returns the whole dict, not the float: `_reset` reads `available_balance` from it,
-        and the grace path replays whatever was stored.
+        Returns the dict, not the float: `_reset` threads the whole thing into
+        `_get_observation(snapshot=...)` and reads `available_balance` off it.
         """
         def read_balance():
             info = self.trader.get_account_balance()
-            # float() first: an adapter that returns strings made `math.isfinite` raise
-            # TypeError straight out of `_step`, on a perfectly good balance.
+            # Coerce before checking, not for the callers: `math.isfinite("1000.0")` is a
+            # TypeError, so an adapter reporting strings crashed on a good balance. The
+            # dict is returned untouched, so callers still convert.
             total_balance = float(info["total_margin_balance"])
             # isfinite, not `not (x > 0)`: that catches NaN but passes +inf, and an inf
             # balance sizes an inf target (#277, #347).
@@ -207,8 +198,7 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
     def _calculate_fractional_position(
         self, action_value: float, current_price: float
     ) -> tuple[float, float, str]:
-        """Target position size from a fractional action, for all four futures venues.
-        """
+        """Target position size from a fractional action, for all four futures venues."""
         # Above the balance read on purpose: a flat action must not need the exchange.
         # No caller reaches this today -- all four pre-filter zero.
         if action_value == 0.0:
@@ -933,11 +923,9 @@ class TorchTradeFuturesLiveEnv(TorchTradeLiveEnv):
         # rather than a bare PositionUnknownError, which is what `except
         # LiveObservationHalt` and the FLATTEN policy were always documented to cover and
         # what the reset path actually bypassed until now.
-        # Through the sizing reader, so the "balance" slot keeps one writer AND one
-        # standard. It used to pass the bare callable: the slot was shared but the verdict
-        # was not, so a NaN stored here was served straight into sizing on the next failed
-        # read (#416). `_reset_outage_state` has just cleared it, so a failure here still
-        # raises -- an episode cannot start on cache.
+        # Through the sizing reader, so the "balance" slot has one writer AND one
+        # standard (#416). `_reset_outage_state` has just cleared it, so a failure here
+        # still raises -- an episode cannot start on cache.
         balance = self._read_sizing_balance()
 
         # The CONVERSION is inside the closure, not just the call. No adapter raises from


### PR DESCRIPTION
Closes #416.

## The codebase already described this bug

Three functions above the defect, the plain path carries this comment:

```python
# The VERDICT is inside the closure, not just the read. `_halting` catches
# ValueError precisely so an impossible account state becomes a halt; raising one
# frame above it sent that straight out of `_step`.
```

`_resolve_bracket_quantity` **was** that hoisted guard. It read the balance under `_halting` and judged it *after* the call returned — and the read itself never fails, because `0.0` is a perfectly valid dict value. So the closure returned successfully, `_halting` reached its store, and the value the guard was about to reject became the **last confirmed read** — the state a grace period then serves. An equity of `0.0` is what a venue reports *while it is liquidating you*.

Confirmed by execution against `main` before the fix was written, not inferred.

## What the fix turned into

Round 1 showed the real shape: this is one rule written down three times, with two copies drifted. The three writers of the `cache_key="balance"` slot are now one `_read_sizing_balance()`:

| writer | before |
|---|---|
| `_calculate_fractional_position` | verdict inside the closure — correct |
| `_resolve_bracket_quantity` | verdict *after* `_halting` returned — the bug |
| `_reset` | bare callable, **no verdict at all** |

Folding them surfaced two more defects that only became visible with the copies side by side:

- **`_reset` seeded the slot unvalidated.** `_halting`'s grace path returns the cached value without re-running the read, so a value stored at reset was served, unvalidated, into sizing on a later failed read.
- **`float()` before `math.isfinite`.** The plain copy lacked it, and `math.isfinite("1000.0")` is a `TypeError`, not `False` — so any adapter reporting numbers as strings crashed the sizing path. `TypeError` is not in `_halting`'s catch tuple, so it left the halt policy entirely.

## The regression this PR introduced, and then fixed

Making the verdict a `ValueError` *inside* the closure fixed the caching — and made an **empty account indistinguishable from an unreadable venue**. `_halting` caught it, found a healthy balance from an earlier bar, and sized a live order against pre-liquidation equity. Measured, binance, `budget=2`, venue reporting `0.0`:

```
main        plain -> sized 97.96      sltp -> None (refused)
mid-PR      plain -> sized 97.96      sltp -> sized 97.96    <- propagated to a second path
final       plain -> HALT             sltp -> HALT
```

Grace exists for a venue that cannot be **read**. This one answered. The fix is one line — evict the cache slot before raising, so grace has nothing to serve. Verified across **16/16** combinations (4 venues × plain/SLTP × budget 0/2).

**Note the blast radius: the plain futures path had this on `main`**, and is fixed by the same line. Operators running `max_unknown_status_steps > 0` will see episodes halt where they previously continued — that is the point.

## Two claims from an earlier version of this description, withdrawn

Both were wrong and are corrected here rather than quietly dropped:

- **"`_reset` can read the poisoned slot."** It cannot. `_reset_outage_state()` clears `_last_confirmed_read` first, so an episode cannot start on cache. The real exposure was always mid-episode.
- **"This path advances the outage counter toward truncation."** It does not. Since the eviction an unusable balance is not grace-eligible, so the halt always leaves `_step` and `_finalize_step_flags` — which owns the counter — never runs. The bar is flagged and then halts; that is all. For a genuine **read failure** with a warm cache the chain does work end to end (measured: `bar1 unknown=1 counter=1`, `bar2 truncated=True`), and is already pinned by `test_a_real_env_flags_the_outage_and_truncates_on_the_budgeted_bar`.

The test named for that behaviour is `..._flags_the_bar_before_it_halts`, which is what it actually asserts.

## Tests

- `test_a_bracket_that_cannot_be_sized_is_a_failed_trade_on_every_venue` produced its refusal from a `0.0` balance, which is now account-level. It refuses at the **order** level instead, so it still pins the contract it was written for.
- `test_an_unusable_balance_refuses_to_size_a_bracket` asserted the asymmetry as *"pre-existing and deliberate"*. That is no longer true; replaced by a halt test.
- The two consequences are **two functions, not one with two asserts** — #416 broke both at once, which is exactly the case a merged test hides.
- The grace test drives `_execute_trade_if_needed` / `_execute_fractional_action`, not the sizing helpers: `assert not trader.trade.called` against a helper that cannot submit an order asserts nothing.

## Verification

Four review rounds (three plus a verification round on the commits none had seen). Mutants killed: verdict hoisted back out (**10**), `_reset` back to the bare callable, `float()` dropped at three separate sites, and the eviction removed (**2**, one per path).

Suite **4554 passed, 16 skipped**. Production is net **−3** lines.
