### PR TITLE
refactor(288): fold the plain configs and the replay cluster (-318 lines)

### DIFF
--- a/tests/envs/base_exchange_tests.py
+++ b/tests/envs/base_exchange_tests.py
@@ -654,7 +654,9 @@ def _replay_env(env_cls, config_cls, replay_df, **config_kw):
         **{"time_frames": ["1m"], "window_sizes": [10], "execute_on": "1m",
            "leverage": 5, **config_kw}   # merged, so a caller may override any of them
     )
-    executor = ReplayOrderExecutor(initial_balance=10000.0, leverage=5)
+    # From the config, not a second literal: overriding `leverage` used to leave the
+    # env and the executor silently disagreeing.
+    executor = ReplayOrderExecutor(initial_balance=10000.0, leverage=config.leverage)
     observer = ReplayObserver(
         df=replay_df,
         time_frames=config.time_frames,

--- a/tests/envs/base_exchange_tests.py
+++ b/tests/envs/base_exchange_tests.py
@@ -640,3 +640,88 @@ def _sole(module, suffix):
         f"({[c.__name__ for c in found]}); the guard would have silently picked the first"
     )
     return found[0]
+
+
+def _replay_env(env_cls, config_cls, replay_df, **config_kw):
+    """A real venue env driven by ReplayObserver + ReplayOrderExecutor (#288).
+
+    Eight venue test classes built this identically, differing only in the two classes
+    and the config values -- which are exactly the two things this takes as arguments.
+    """
+    from unittest.mock import patch
+
+    from torchtrade.envs.replay import ReplayObserver, ReplayOrderExecutor
+
+    config = config_cls(
+        time_frames=["1m"], window_sizes=[10], execute_on="1m", leverage=5, **config_kw
+    )
+    executor = ReplayOrderExecutor(initial_balance=10000.0, leverage=5)
+    observer = ReplayObserver(
+        df=replay_df,
+        time_frames=config.time_frames,
+        window_sizes=config.window_sizes,
+        execute_on=config.execute_on,
+        executor=executor,
+    )
+    with patch("time.sleep"), patch.object(env_cls, "_wait_for_next_timestamp"):
+        env = env_cls(config=config, observer=observer, trader=executor)
+    return env, executor
+
+
+def assert_a_replay_episode_runs(env_cls, config_cls, replay_df, *, actions, steps,
+                                 **config_kw):
+    """Step a real episode over real price data and check the tensordict each bar.
+
+    `actions` is a callable taking the bar index and the env, so the plain envs can cycle
+    action LEVELS and the SLTP ones can cycle bracket indices -- the one thing that
+    genuinely differed between the eight copies.
+    """
+    from unittest.mock import patch
+
+    import torch
+
+    env, executor = _replay_env(env_cls, config_cls, replay_df, **config_kw)
+    with patch.object(env, "_wait_for_next_timestamp"):
+        td = env.reset()
+        for i in range(steps):
+            action_td = td.clone()
+            action_td["action"] = torch.tensor(actions(i, env))
+            td = env.step(action_td)["next"]
+
+            assert "reward" in td.keys()
+            assert "done" in td.keys()
+            assert td["account_state"].shape == (6,)
+            if td["done"].item():
+                break
+
+    assert executor.current_price > 0
+    return env, executor
+
+
+def assert_the_replay_portfolio_tracks_price(env_cls, config_cls, replay_df, **config_kw):
+    """Open a position, hold, and require the portfolio value to MOVE.
+
+    A static value is the failure this catches: an env that never re-reads the mark
+    reports the same equity every bar, which looks like a working episode.
+    """
+    from unittest.mock import patch
+
+    import torch
+
+    env, executor = _replay_env(env_cls, config_cls, replay_df, **config_kw)
+    with patch.object(env, "_wait_for_next_timestamp"):
+        td = env.reset()
+        action_td = td.clone()
+        action_td["action"] = torch.tensor(1)          # open
+        td = env.step(action_td)["next"]
+
+        balances = []
+        for _ in range(10):
+            action_td = td.clone()
+            action_td["action"] = torch.tensor(0)      # hold
+            td = env.step(action_td)["next"]
+            balances.append(executor.get_account_balance()["total_wallet_balance"])
+
+    assert max(balances) != min(balances), (
+        "portfolio value stayed static across ten bars of moving price"
+    )

--- a/tests/envs/base_exchange_tests.py
+++ b/tests/envs/base_exchange_tests.py
@@ -648,12 +648,11 @@ def _replay_env(env_cls, config_cls, replay_df, **config_kw):
     Eight venue test classes built this identically, differing only in the two classes
     and the config values -- which are exactly the two things this takes as arguments.
     """
-    from unittest.mock import patch
-
     from torchtrade.envs.replay import ReplayObserver, ReplayOrderExecutor
 
     config = config_cls(
-        time_frames=["1m"], window_sizes=[10], execute_on="1m", leverage=5, **config_kw
+        **{"time_frames": ["1m"], "window_sizes": [10], "execute_on": "1m",
+           "leverage": 5, **config_kw}   # merged, so a caller may override any of them
     )
     executor = ReplayOrderExecutor(initial_balance=10000.0, leverage=5)
     observer = ReplayObserver(
@@ -676,10 +675,6 @@ def assert_a_replay_episode_runs(env_cls, config_cls, replay_df, *, actions, ste
     action LEVELS and the SLTP ones can cycle bracket indices -- the one thing that
     genuinely differed between the eight copies.
     """
-    from unittest.mock import patch
-
-    import torch
-
     env, executor = _replay_env(env_cls, config_cls, replay_df, **config_kw)
     with patch.object(env, "_wait_for_next_timestamp"):
         td = env.reset()
@@ -695,7 +690,6 @@ def assert_a_replay_episode_runs(env_cls, config_cls, replay_df, *, actions, ste
                 break
 
     assert executor.current_price > 0
-    return env, executor
 
 
 def assert_the_replay_portfolio_tracks_price(env_cls, config_cls, replay_df, **config_kw):
@@ -704,10 +698,6 @@ def assert_the_replay_portfolio_tracks_price(env_cls, config_cls, replay_df, **c
     A static value is the failure this catches: an env that never re-reads the mark
     reports the same equity every bar, which looks like a working episode.
     """
-    from unittest.mock import patch
-
-    import torch
-
     env, executor = _replay_env(env_cls, config_cls, replay_df, **config_kw)
     with patch.object(env, "_wait_for_next_timestamp"):
         td = env.reset()

--- a/tests/envs/base_exchange_tests.py
+++ b/tests/envs/base_exchange_tests.py
@@ -694,23 +694,34 @@ def assert_a_replay_episode_runs(env_cls, config_cls, replay_df, *, actions, ste
     assert executor.current_price > 0
 
 
-def assert_the_replay_portfolio_tracks_price(env_cls, config_cls, replay_df, **config_kw):
+def assert_the_replay_portfolio_tracks_price(env_cls, config_cls, replay_df, *,
+                                             open_action, hold_action, **config_kw):
     """Open a position, hold, and require the portfolio value to MOVE.
 
     A static value is the failure this catches: an env that never re-reads the mark
     reports the same equity every bar, which looks like a working episode.
+
+    The two actions are ARGUMENTS, not literals. Hardcoding 1=open / 0=hold was correct
+    for the four SLTP callers and silently wrong for anything else: driven with a plain
+    env under [-1, 0, 1], action 1 is FLAT (so nothing opens) and action 0 is a full
+    SHORT held ten times -- the balance moves, the assertion passes, and the helper
+    reports success having measured a maximum short it never meant to open (#288).
     """
     env, executor = _replay_env(env_cls, config_cls, replay_df, **config_kw)
     with patch.object(env, "_wait_for_next_timestamp"):
         td = env.reset()
         action_td = td.clone()
-        action_td["action"] = torch.tensor(1)          # open
+        action_td["action"] = torch.tensor(open_action)
         td = env.step(action_td)["next"]
+        assert executor.get_status()["position_status"] is not None, (
+            "the 'open' action opened nothing; the rest of this test would measure a "
+            "position it never took"
+        )
 
         balances = []
         for _ in range(10):
             action_td = td.clone()
-            action_td["action"] = torch.tensor(0)      # hold
+            action_td["action"] = torch.tensor(hold_action)
             td = env.step(action_td)["next"]
             balances.append(executor.get_account_balance()["total_wallet_balance"])
 

--- a/tests/envs/binance/test_torch_env_futures.py
+++ b/tests/envs/binance/test_torch_env_futures.py
@@ -140,40 +140,8 @@ class TestBinanceFuturesTorchTradingEnv:
         assert env.config.demo is True
 
     def test_action_spec(self, env):
-        """Test action spec uses fractional mode with proper ordering."""
-        # Should have fractional action levels (not exact count check)
-        assert env.action_spec.n >= 3, "Should have at least 3 actions"
-
-        # Verify action levels are fractional (floats between -1 and 1)
-        action_levels = env.action_levels
-        assert all(isinstance(level, (int, float)) for level in action_levels), \
-            "Action levels should be numeric"
-        assert all(-1 <= level <= 1 for level in action_levels), \
-            f"Action levels should be in [-1, 1], got {action_levels}"
-
-        # Verify proper ordering: negative values, then 0, then positive values
-        # Should be sorted in ascending order: [-1, -0.5, 0, 0.5, 1] ✓
-        # Should NOT be: [1, 0.5, 0, -0.5, -1] ✗
-        assert action_levels == sorted(action_levels), \
-            f"Action levels should be sorted ascending, got {action_levels}"
-
-        # Verify no improper mixing (e.g., [-1, 0.5, 0, 0.5, 1] would be wrong)
-        negatives = [x for x in action_levels if x < 0]
-        positives = [x for x in action_levels if x > 0]
-        zeros = [x for x in action_levels if x == 0]
-
-        # If we have negatives and positives, zero should be between them
-        if negatives and positives:
-            assert len(zeros) > 0, "Should have 0 between negative and positive values"
-            neg_indices = [i for i, x in enumerate(action_levels) if x < 0]
-            pos_indices = [i for i, x in enumerate(action_levels) if x > 0]
-            zero_indices = [i for i, x in enumerate(action_levels) if x == 0]
-
-            # All negatives should come before zero, zero before positives
-            assert max(neg_indices) < min(zero_indices), \
-                "Negative values should come before zero"
-            assert max(zero_indices) < min(pos_indices), \
-                "Zero should come before positive values"
+        """The unset default, same as its three siblings assert (#288)."""
+        assert env.action_spec.n == 3  # the default: short / flat / long
 
     def test_base_features_declared_in_observation_spec(self, env_config, mock_observer, mock_trader):
         """include_base_features=True must DECLARE base_features in observation_spec, not just
@@ -426,7 +394,7 @@ class TestBinanceFuturesTorchTradingEnv:
 
         with patch.object(env, "_wait_for_next_timestamp"):
             env.reset()
-            long_idx = len(env.action_levels) - 1     # index 1 is FLAT here ([-1, 0, 1])
+            long_idx = len(env.action_levels) - 1
             for _ in range(5):
                 env.step(TensorDict({"action": torch.tensor(long_idx)}, batch_size=()))
             assert env.position.hold_counter > 0      # genuinely aged

--- a/tests/envs/binance/test_torch_env_futures.py
+++ b/tests/envs/binance/test_torch_env_futures.py
@@ -829,78 +829,22 @@ class TestBinanceInitCleanup:
 
 
 class TestWithReplayData:
-    """Integration tests using ReplayObserver + ReplayOrderExecutor with real price data."""
+    """Real price data through ReplayObserver + ReplayOrderExecutor.
 
-    @pytest.fixture
-    def replay_df(self):
-        """Create realistic OHLCV test data."""
-        import pandas as pd
-
-        n = 200
-        rng = np.random.default_rng(42)
-        base = 50000 + np.cumsum(rng.normal(0, 50, n))
-        # Drawn in the original order so the RNG stream is unchanged, then clamped:
-        # a close drawn off base can land outside a high/low drawn off base alone (#326).
-        high_raw = base + np.abs(rng.normal(30, 20, n))
-        low_raw = base - np.abs(rng.normal(30, 20, n))
-        close = base + rng.normal(0, 20, n)
-        high_raw_clamped = np.maximum(high_raw, np.maximum(base, close))
-        low_raw_clamped = np.minimum(low_raw, np.minimum(base, close))
-        return pd.DataFrame({
-            "timestamp": pd.date_range("2024-01-01", periods=n, freq="1min"),
-            "open": base,
-            "high": high_raw_clamped,
-            "low": low_raw_clamped,
-            "close": close,
-            "volume": rng.uniform(100, 1000, n),
-        })
+    The episode body is shared: eight venue copies differed only in the two classes and
+    the config values (#288).
+    """
 
     def test_multi_step_episode_with_replay(self, replay_df):
-        """Run a multi-step episode with realistic price data."""
-        from torchtrade.envs.live.binance.env import BinanceFuturesTorchTradingEnv, BinanceFuturesTradingEnvConfig
-        from torchtrade.envs.replay import ReplayObserver, ReplayOrderExecutor
-
-        config = BinanceFuturesTradingEnvConfig(
-            symbol="BTCUSDT",
-            time_frames=["1m"],
-            window_sizes=[10],
-            execute_on="1m",
-            leverage=5,
-            demo=True,
+        from tests.envs.base_exchange_tests import assert_a_replay_episode_runs
+        from torchtrade.envs.live.binance.env import (
+            BinanceFuturesTorchTradingEnv, BinanceFuturesTradingEnvConfig,
         )
 
-        executor = ReplayOrderExecutor(initial_balance=10000.0, leverage=5)
-        observer = ReplayObserver(
-            df=replay_df,
-            time_frames=config.time_frames,
-            window_sizes=config.window_sizes,
-            execute_on=config.execute_on,
-            executor=executor,
+        assert_a_replay_episode_runs(
+            BinanceFuturesTorchTradingEnv, BinanceFuturesTradingEnvConfig, replay_df,
+            actions=lambda i, env: i % len(env.action_levels), steps=20,
+            symbol="BTCUSDT", demo=True,
         )
 
-        with patch("time.sleep"), \
-             patch.object(BinanceFuturesTorchTradingEnv, "_wait_for_next_timestamp"):
-            env = BinanceFuturesTorchTradingEnv(
-                config=config, observer=observer, trader=executor,
-            )
-
-        with patch.object(env, "_wait_for_next_timestamp"):
-            td = env.reset()
-
-            for i in range(20):
-                # Cycle through action levels (hold, long, hold, short, hold, close...)
-                action_idx = i % len(env.action_levels)
-                action_td = td.clone()
-                action_td["action"] = torch.tensor(action_idx)
-                result = env.step(action_td)
-                td = result["next"]
-
-                assert "reward" in td.keys()
-                assert "done" in td.keys()
-                assert td["account_state"].shape == (6,)
-
-                if td["done"].item():
-                    break
-
-            assert executor.current_price > 0
 

--- a/tests/envs/binance/test_torch_env_futures.py
+++ b/tests/envs/binance/test_torch_env_futures.py
@@ -851,7 +851,6 @@ class TestWithReplayData:
         assert_a_replay_episode_runs(
             BinanceFuturesTorchTradingEnv, BinanceFuturesTradingEnvConfig, replay_df,
             actions=lambda i, env: i % len(env.action_levels), steps=20,
-            symbol="BTCUSDT", demo=True,
         )
 
 

--- a/tests/envs/binance/test_torch_env_futures.py
+++ b/tests/envs/binance/test_torch_env_futures.py
@@ -283,7 +283,10 @@ class TestBinanceFuturesTorchTradingEnv:
         (True, True),    # portfolio collapses below the threshold -> episode terminates
         (False, False),  # same collapse, check disabled -> keep trading
     ], ids=["enabled-terminates", "disabled-keeps-trading"])
-    def test_bankruptcy_termination(self, env, mock_trader, done_on_bankruptcy, expected_done):
+    @pytest.mark.parametrize("level", [0, 1], ids=["flat", "long"])
+    def test_bankruptcy_termination(
+        self, env, mock_trader, done_on_bankruptcy, expected_done, level
+    ):
         """A collapsed portfolio ends the episode through _step iff done_on_bankruptcy.
 
         Threshold arithmetic is covered in tests/envs/test_live_env_base.py; the disabled
@@ -300,7 +303,12 @@ class TestBinanceFuturesTorchTradingEnv:
 
         with patch.object(env, "_wait_for_next_timestamp"):
             env.reset()
-            next_td = env.step(TensorDict({"action": torch.tensor(2)}, batch_size=()))
+            # By VALUE, and BOTH routes. `torch.tensor(2)` used to mean "flat" on
+            # three venues and "full long" on binance, because their default action
+            # levels differed -- the same bytes testing two different behaviours (#288).
+            # Now the defaults agree, so the axis has to be explicit or one route is lost.
+            idx = env.action_levels.index(level)
+            next_td = env.step(TensorDict({"action": torch.tensor(idx)}, batch_size=()))
             assert next_td["next"]["done"].item() is expected_done
 
     def test_close_method(self, env, mock_trader, caplog):

--- a/tests/envs/binance/test_torch_env_futures.py
+++ b/tests/envs/binance/test_torch_env_futures.py
@@ -303,10 +303,8 @@ class TestBinanceFuturesTorchTradingEnv:
 
         with patch.object(env, "_wait_for_next_timestamp"):
             env.reset()
-            # By VALUE, and BOTH routes. `torch.tensor(2)` used to mean "flat" on
-            # three venues and "full long" on binance, because their default action
-            # levels differed -- the same bytes testing two different behaviours (#288).
-            # Now the defaults agree, so the axis has to be explicit or one route is lost.
+            # By VALUE, and both routes: index 2 meant flat on three venues and long on
+            # binance, so the same bytes tested two behaviours (#288).
             idx = env.action_levels.index(level)
             next_td = env.step(TensorDict({"action": torch.tensor(idx)}, batch_size=()))
             assert next_td["next"]["done"].item() is expected_done

--- a/tests/envs/binance/test_torch_env_futures.py
+++ b/tests/envs/binance/test_torch_env_futures.py
@@ -229,13 +229,20 @@ class TestBinanceFuturesTorchTradingEnv:
         with patch.object(env, "_wait_for_next_timestamp"):
             env.reset()
 
-            action_td = TensorDict({"action": torch.tensor(1)}, batch_size=())  # Hold
+            # Flat BY VALUE, like its three siblings. binance was left positional because
+            # its default was the one that WON the unification -- which is exactly why it
+            # should end up identical to the others, not exempt (#288).
+            flat = env.action_levels.index(0)
+            action_td = TensorDict({"action": torch.tensor(flat)}, batch_size=())
             next_td = env.step(action_td)
 
-            # TorchRL step returns results under "next" key
             assert "reward" in next_td["next"].keys()
             assert "done" in next_td["next"].keys()
             assert "account_state" in next_td["next"].keys()
+            # The assertion the name always promised: it only checked keys existed.
+            # Defence in depth, not a discriminating pin -- the flat route has FOUR
+            # independent zero-guards, so no single-branch mutation reaches a trade.
+            mock_trader.trade.assert_not_called()
 
     def test_sizing_delegates_rounding_to_the_executor(self, env, mock_trader):
         """#271: the env carried a SECOND LOT_SIZE parser with the bug this PR fixes.
@@ -517,8 +524,10 @@ class TestBinanceFuturesTorchTradingEnv:
             )} if qty else {"position_status": None}
 
         with patch.object(env, "_wait_for_next_timestamp"):
-            long = TensorDict({"action": torch.tensor(2)}, batch_size=())   # levels [-1, 0, 1]
-            flat = TensorDict({"action": torch.tensor(1)}, batch_size=())
+            long = TensorDict({"action": torch.tensor(env.action_levels.index(1))},
+                              batch_size=())
+            flat = TensorDict({"action": torch.tensor(env.action_levels.index(0))},
+                              batch_size=())
 
             mock_trader.get_status = MagicMock(return_value=status(0.01))
             env.reset()

--- a/tests/envs/binance/test_torch_env_futures_sltp.py
+++ b/tests/envs/binance/test_torch_env_futures_sltp.py
@@ -1280,6 +1280,9 @@ class TestWithReplayData:
 
         assert_the_replay_portfolio_tracks_price(
             BinanceFuturesSLTPTorchTradingEnv, BinanceFuturesSLTPTradingEnvConfig, replay_df, symbol="BTCUSDT",
+            # SLTP action map: 0 is HOLD, 1 the first bracket. Stated, not assumed --
+            # the helper used to hardcode these and was silently wrong off-SLTP.
+            open_action=1, hold_action=0,
             stoploss_levels=(-0.05,), takeprofit_levels=(0.05,),
             trade_mode="quantity", quantity_per_trade=0.01,
         )

--- a/tests/envs/binance/test_torch_env_futures_sltp.py
+++ b/tests/envs/binance/test_torch_env_futures_sltp.py
@@ -1254,129 +1254,33 @@ class TestBinanceSLTPLockPosition:
 
 
 class TestWithReplayData:
-    """Integration tests using ReplayObserver + ReplayOrderExecutor with real price data."""
-
-    @pytest.fixture
-    def replay_df(self):
-        """Create realistic OHLCV test data with price movement."""
-        import pandas as pd
-
-        n = 200
-        timestamps = pd.date_range("2024-01-01", periods=n, freq="1min")
-        base = 50000 + np.cumsum(np.random.default_rng(42).normal(0, 50, n))
-        # close drawn off base can land outside a high/low drawn off base alone (#326).
-        close = base + np.random.default_rng(45).normal(0, 20, n)
-        return pd.DataFrame({
-            "timestamp": timestamps,
-            "open": base,
-            "high": np.maximum(base + np.abs(np.random.default_rng(43).normal(30, 20, n)), np.maximum(base, close)),
-            "low": np.minimum(base - np.abs(np.random.default_rng(44).normal(30, 20, n)), np.minimum(base, close)),
-            "close": close,
-            "volume": np.random.default_rng(46).uniform(100, 1000, n),
-        })
+    """Real price data through ReplayObserver + ReplayOrderExecutor (#288)."""
 
     def test_multi_step_episode_with_replay(self, replay_df):
-        """Run a full multi-step episode with realistic price data."""
+        from tests.envs.base_exchange_tests import assert_a_replay_episode_runs
         from torchtrade.envs.live.binance.env_sltp import (
-            BinanceFuturesSLTPTorchTradingEnv,
-            BinanceFuturesSLTPTradingEnvConfig,
-        )
-        from torchtrade.envs.replay import ReplayObserver, ReplayOrderExecutor
-
-        config = BinanceFuturesSLTPTradingEnvConfig(
-            symbol="BTCUSDT",
-            time_frames=["1m"],
-            window_sizes=[10],
-            execute_on="1m",
-            stoploss_levels=(-0.02,),
-            takeprofit_levels=(0.03,),
-            leverage=5,
-            trade_mode="quantity",
-            quantity_per_trade=0.01,
+            BinanceFuturesSLTPTorchTradingEnv, BinanceFuturesSLTPTradingEnvConfig,
         )
 
-        executor = ReplayOrderExecutor(initial_balance=10000.0, leverage=5)
-        observer = ReplayObserver(
-            df=replay_df,
-            time_frames=config.time_frames,
-            window_sizes=config.window_sizes,
-            execute_on=config.execute_on,
-            executor=executor,
+        assert_a_replay_episode_runs(
+            BinanceFuturesSLTPTorchTradingEnv, BinanceFuturesSLTPTradingEnvConfig, replay_df,
+            actions=lambda i, env: [0, 1, 0, 0, len(env.action_map) - 1, 0][i % 6],
+            steps=50, symbol="BTCUSDT",
+            stoploss_levels=(-0.02,), takeprofit_levels=(0.03,),
+            trade_mode="quantity", quantity_per_trade=0.01,
         )
-
-        with patch("time.sleep"), \
-             patch.object(BinanceFuturesSLTPTorchTradingEnv, "_wait_for_next_timestamp"):
-            env = BinanceFuturesSLTPTorchTradingEnv(
-                config=config, observer=observer, trader=executor,
-            )
-
-        with patch.object(env, "_wait_for_next_timestamp"):
-            td = env.reset()
-
-            for i in range(50):
-                action = [0, 1, 0, 0, len(env.action_map) - 1, 0][i % 6]
-                action_td = td.clone()
-                action_td["action"] = torch.tensor(action)
-                result = env.step(action_td)
-                td = result["next"]
-
-                assert "reward" in td.keys()
-                assert "done" in td.keys()
-                assert td["account_state"].shape == (6,)
-
-                if td["done"].item():
-                    break
 
     def test_replay_portfolio_tracks_price_movement(self, replay_df):
-        """Portfolio value should change with price movement, not stay static."""
+        from tests.envs.base_exchange_tests import (
+            assert_the_replay_portfolio_tracks_price,
+        )
         from torchtrade.envs.live.binance.env_sltp import (
-            BinanceFuturesSLTPTorchTradingEnv,
-            BinanceFuturesSLTPTradingEnvConfig,
-        )
-        from torchtrade.envs.replay import ReplayObserver, ReplayOrderExecutor
-
-        config = BinanceFuturesSLTPTradingEnvConfig(
-            symbol="BTCUSDT",
-            time_frames=["1m"],
-            window_sizes=[10],
-            execute_on="1m",
-            stoploss_levels=(-0.05,),
-            takeprofit_levels=(0.05,),
-            leverage=5,
-            trade_mode="quantity",
-            quantity_per_trade=0.01,
+            BinanceFuturesSLTPTorchTradingEnv, BinanceFuturesSLTPTradingEnvConfig,
         )
 
-        executor = ReplayOrderExecutor(initial_balance=10000.0, leverage=5)
-        observer = ReplayObserver(
-            df=replay_df,
-            time_frames=config.time_frames,
-            window_sizes=config.window_sizes,
-            execute_on=config.execute_on,
-            executor=executor,
+        assert_the_replay_portfolio_tracks_price(
+            BinanceFuturesSLTPTorchTradingEnv, BinanceFuturesSLTPTradingEnvConfig, replay_df, symbol="BTCUSDT",
+            stoploss_levels=(-0.05,), takeprofit_levels=(0.05,),
+            trade_mode="quantity", quantity_per_trade=0.01,
         )
 
-        with patch("time.sleep"), \
-             patch.object(BinanceFuturesSLTPTorchTradingEnv, "_wait_for_next_timestamp"):
-            env = BinanceFuturesSLTPTorchTradingEnv(
-                config=config, observer=observer, trader=executor,
-            )
-
-        with patch.object(env, "_wait_for_next_timestamp"):
-            td = env.reset()
-
-            # Open a long position
-            action_td = td.clone()
-            action_td["action"] = torch.tensor(1)
-            td = env.step(action_td)["next"]
-
-            # Hold for several steps -- price should move, changing portfolio value
-            balances = []
-            for _ in range(10):
-                action_td = td.clone()
-                action_td["action"] = torch.tensor(0)  # HOLD
-                td = env.step(action_td)["next"]
-                balances.append(executor.get_account_balance()["total_wallet_balance"])
-
-            # With real price movement, portfolio value should not stay static
-            assert max(balances) != min(balances), "Portfolio value should vary with price movement"

--- a/tests/envs/binance/test_torch_env_futures_sltp.py
+++ b/tests/envs/binance/test_torch_env_futures_sltp.py
@@ -1265,7 +1265,7 @@ class TestWithReplayData:
         assert_a_replay_episode_runs(
             BinanceFuturesSLTPTorchTradingEnv, BinanceFuturesSLTPTradingEnvConfig, replay_df,
             actions=lambda i, env: [0, 1, 0, 0, len(env.action_map) - 1, 0][i % 6],
-            steps=50, symbol="BTCUSDT",
+            steps=50,
             stoploss_levels=(-0.02,), takeprofit_levels=(0.03,),
             trade_mode="quantity", quantity_per_trade=0.01,
         )
@@ -1279,7 +1279,7 @@ class TestWithReplayData:
         )
 
         assert_the_replay_portfolio_tracks_price(
-            BinanceFuturesSLTPTorchTradingEnv, BinanceFuturesSLTPTradingEnvConfig, replay_df, symbol="BTCUSDT",
+            BinanceFuturesSLTPTorchTradingEnv, BinanceFuturesSLTPTradingEnvConfig, replay_df,
             # SLTP action map: 0 is HOLD, 1 the first bracket. Stated, not assumed --
             # the helper used to hardcode these and was silently wrong off-SLTP.
             open_action=1, hold_action=0,

--- a/tests/envs/bitget/test_torch_env_futures.py
+++ b/tests/envs/bitget/test_torch_env_futures.py
@@ -197,9 +197,7 @@ class TestBitgetFuturesTorchTradingEnv:
         with patch.object(env, "_wait_for_next_timestamp"):
             env.reset()
 
-            # Flat, BY VALUE. Hardcoding index 2 meant 0.0 under the old 5-level
-            # default and means a full LONG under [-1, 0, 1] -- so this stopped
-            # testing a hold the moment the defaults were unified (#288).
+            # Flat BY VALUE: index 2 was 0.0 under the old 5-level default (#288).
             flat = env.action_levels.index(0)
             action_td = TensorDict({"action": torch.tensor(flat)}, batch_size=())
             next_td = env.step(action_td)
@@ -209,9 +207,10 @@ class TestBitgetFuturesTorchTradingEnv:
             assert "done" in next_td["next"].keys()
             assert "account_state" in next_td["next"].keys()
 
-            # The assertion this test's NAME promised and never made: it only checked
-            # that keys existed, so a flat action that TRADED passed it. Disabling
-            # the flat branch in the env used to fail nothing (#288).
+
+            # The assertion the name always promised: it only checked keys existed.
+            # Defence in depth, not a discriminating pin -- the flat route has FOUR
+            # independent zero-guards, so no single-branch mutation reaches a trade.
             mock_trader.trade.assert_not_called()
 
     def test_step_long_action(self, env, mock_trader):
@@ -241,9 +240,7 @@ class TestBitgetFuturesTorchTradingEnv:
         with patch.object(env, "_wait_for_next_timestamp"):
             env.reset()
 
-            # Flat, BY VALUE. Hardcoding index 2 meant 0.0 under the old 5-level
-            # default and means a full LONG under [-1, 0, 1] -- so this stopped
-            # testing a hold the moment the defaults were unified (#288).
+            # Flat BY VALUE: index 2 was 0.0 under the old 5-level default (#288).
             flat = env.action_levels.index(0)
             action_td = TensorDict({"action": torch.tensor(flat)}, batch_size=())
             next_td = env.step(action_td)
@@ -276,10 +273,8 @@ class TestBitgetFuturesTorchTradingEnv:
 
         with patch.object(env, "_wait_for_next_timestamp"):
             env.reset()
-            # By VALUE, and BOTH routes. `torch.tensor(2)` used to mean "flat" on
-            # three venues and "full long" on binance, because their default action
-            # levels differed -- the same bytes testing two different behaviours (#288).
-            # Now the defaults agree, so the axis has to be explicit or one route is lost.
+            # By VALUE, and both routes: index 2 meant flat on three venues and long on
+            # binance, so the same bytes tested two behaviours (#288).
             idx = env.action_levels.index(level)
             next_td = env.step(TensorDict({"action": torch.tensor(idx)}, batch_size=()))
             assert next_td["next"]["done"].item() is expected_done
@@ -703,9 +698,7 @@ class TestBitgetFuturesTorchTradingEnvIntegration:
         td = env.reset()
         assert "account_state" in td.keys()
 
-        # Flat, BY VALUE. Hardcoding index 2 meant 0.0 under the old 5-level
-        # default and means a full LONG under [-1, 0, 1] -- so this stopped
-        # testing a hold the moment the defaults were unified (#288).
+        # Flat BY VALUE: index 2 was 0.0 under the old 5-level default (#288).
         flat = env.action_levels.index(0)
         action_td = TensorDict({"action": torch.tensor(flat)}, batch_size=())
         next_td = env.step(action_td)

--- a/tests/envs/bitget/test_torch_env_futures.py
+++ b/tests/envs/bitget/test_torch_env_futures.py
@@ -486,7 +486,7 @@ class TestBitgetFuturesTorchTradingEnv:
         with patch.object(env, "_wait_for_next_timestamp"):
             mock_trader.get_status = MagicMock(return_value=status(0.01))
             env.reset()
-            long_idx = len(env.action_levels) - 1     # index 1 is FLAT under the [-1, 0, 1] default (#288)
+            long_idx = len(env.action_levels) - 1
             long = TensorDict({"action": torch.tensor(long_idx)}, batch_size=())
 
             for _ in range(5):                       # age a real position
@@ -520,7 +520,7 @@ class TestBitgetFuturesTorchTradingEnv:
 
         with patch.object(env, "_wait_for_next_timestamp"):
             env.reset()
-            long_idx = len(env.action_levels) - 1     # index 1 is FLAT under the [-1, 0, 1] default (#288)
+            long_idx = len(env.action_levels) - 1
             for _ in range(5):
                 env.step(TensorDict({"action": torch.tensor(long_idx)}, batch_size=()))
             assert env.position.hold_counter > 0      # genuinely aged

--- a/tests/envs/bitget/test_torch_env_futures.py
+++ b/tests/envs/bitget/test_torch_env_futures.py
@@ -783,6 +783,5 @@ class TestWithReplayData:
         assert_a_replay_episode_runs(
             BitgetFuturesTorchTradingEnv, BitgetFuturesTradingEnvConfig, replay_df,
             actions=lambda i, env: i % len(env.action_levels), steps=20,
-            symbol="BTCUSDT", demo=True,
         )
 

--- a/tests/envs/bitget/test_torch_env_futures.py
+++ b/tests/envs/bitget/test_torch_env_futures.py
@@ -758,77 +758,21 @@ class TestBitgetInitCleanup:
 
 
 class TestWithReplayData:
-    """Integration tests using ReplayObserver + ReplayOrderExecutor with real price data."""
+    """Real price data through ReplayObserver + ReplayOrderExecutor.
 
-    @pytest.fixture
-    def replay_df(self):
-        """Create realistic OHLCV test data."""
-        import pandas as pd
-
-        n = 200
-        rng = np.random.default_rng(42)
-        base = 50000 + np.cumsum(rng.normal(0, 50, n))
-        # Drawn in the original order so the RNG stream is unchanged, then clamped:
-        # a close drawn off base can land outside a high/low drawn off base alone (#326).
-        high_raw = base + np.abs(rng.normal(30, 20, n))
-        low_raw = base - np.abs(rng.normal(30, 20, n))
-        close = base + rng.normal(0, 20, n)
-        high_raw_clamped = np.maximum(high_raw, np.maximum(base, close))
-        low_raw_clamped = np.minimum(low_raw, np.minimum(base, close))
-        return pd.DataFrame({
-            "timestamp": pd.date_range("2024-01-01", periods=n, freq="1min"),
-            "open": base,
-            "high": high_raw_clamped,
-            "low": low_raw_clamped,
-            "close": close,
-            "volume": rng.uniform(100, 1000, n),
-        })
+    The episode body is shared: eight venue copies differed only in the two classes and
+    the config values (#288).
+    """
 
     def test_multi_step_episode_with_replay(self, replay_df):
-        """Run a multi-step episode with realistic price data."""
-        from torchtrade.envs.live.bitget.env import BitgetFuturesTorchTradingEnv, BitgetFuturesTradingEnvConfig
-        from torchtrade.envs.replay import ReplayObserver, ReplayOrderExecutor
-
-        config = BitgetFuturesTradingEnvConfig(
-            symbol="BTC/USDT:USDT",
-            time_frames=["1m"],
-            window_sizes=[10],
-            execute_on="1m",
-            leverage=5,
-            demo=True,
+        from tests.envs.base_exchange_tests import assert_a_replay_episode_runs
+        from torchtrade.envs.live.bitget.env import (
+            BitgetFuturesTorchTradingEnv, BitgetFuturesTradingEnvConfig,
         )
 
-        executor = ReplayOrderExecutor(initial_balance=10000.0, leverage=5)
-        observer = ReplayObserver(
-            df=replay_df,
-            time_frames=config.time_frames,
-            window_sizes=config.window_sizes,
-            execute_on=config.execute_on,
-            executor=executor,
+        assert_a_replay_episode_runs(
+            BitgetFuturesTorchTradingEnv, BitgetFuturesTradingEnvConfig, replay_df,
+            actions=lambda i, env: i % len(env.action_levels), steps=20,
+            symbol="BTCUSDT", demo=True,
         )
 
-        with patch("time.sleep"), \
-             patch.object(BitgetFuturesTorchTradingEnv, "_wait_for_next_timestamp"):
-            env = BitgetFuturesTorchTradingEnv(
-                config=config, observer=observer, trader=executor,
-            )
-
-        with patch.object(env, "_wait_for_next_timestamp"):
-            td = env.reset()
-
-            for i in range(20):
-                # Cycle through action levels (hold, long, hold, short, hold, close...)
-                action_idx = i % len(env.action_levels)
-                action_td = td.clone()
-                action_td["action"] = torch.tensor(action_idx)
-                result = env.step(action_td)
-                td = result["next"]
-
-                assert "reward" in td.keys()
-                assert "done" in td.keys()
-                assert td["account_state"].shape == (6,)
-
-                if td["done"].item():
-                    break
-
-            assert executor.current_price > 0

--- a/tests/envs/bitget/test_torch_env_futures.py
+++ b/tests/envs/bitget/test_torch_env_futures.py
@@ -197,13 +197,22 @@ class TestBitgetFuturesTorchTradingEnv:
         with patch.object(env, "_wait_for_next_timestamp"):
             env.reset()
 
-            action_td = TensorDict({"action": torch.tensor(2)}, batch_size=())  # Hold/Close (0.0)
+            # Flat, BY VALUE. Hardcoding index 2 meant 0.0 under the old 5-level
+            # default and means a full LONG under [-1, 0, 1] -- so this stopped
+            # testing a hold the moment the defaults were unified (#288).
+            flat = env.action_levels.index(0)
+            action_td = TensorDict({"action": torch.tensor(flat)}, batch_size=())
             next_td = env.step(action_td)
 
             # TorchRL step returns results under "next" key
             assert "reward" in next_td["next"].keys()
             assert "done" in next_td["next"].keys()
             assert "account_state" in next_td["next"].keys()
+
+            # The assertion this test's NAME promised and never made: it only checked
+            # that keys existed, so a flat action that TRADED passed it. Disabling
+            # the flat branch in the env used to fail nothing (#288).
+            mock_trader.trade.assert_not_called()
 
     def test_step_long_action(self, env, mock_trader):
         """Test step with long action."""
@@ -232,7 +241,11 @@ class TestBitgetFuturesTorchTradingEnv:
         with patch.object(env, "_wait_for_next_timestamp"):
             env.reset()
 
-            action_td = TensorDict({"action": torch.tensor(2)}, batch_size=())  # 0.0
+            # Flat, BY VALUE. Hardcoding index 2 meant 0.0 under the old 5-level
+            # default and means a full LONG under [-1, 0, 1] -- so this stopped
+            # testing a hold the moment the defaults were unified (#288).
+            flat = env.action_levels.index(0)
+            action_td = TensorDict({"action": torch.tensor(flat)}, batch_size=())
             next_td = env.step(action_td)
 
             reward = next_td["next"]["reward"]
@@ -690,7 +703,11 @@ class TestBitgetFuturesTorchTradingEnvIntegration:
         td = env.reset()
         assert "account_state" in td.keys()
 
-        action_td = TensorDict({"action": torch.tensor(2)}, batch_size=())  # 0.0
+        # Flat, BY VALUE. Hardcoding index 2 meant 0.0 under the old 5-level
+        # default and means a full LONG under [-1, 0, 1] -- so this stopped
+        # testing a hold the moment the defaults were unified (#288).
+        flat = env.action_levels.index(0)
+        action_td = TensorDict({"action": torch.tensor(flat)}, batch_size=())
         next_td = env.step(action_td)
         assert "reward" in next_td["next"].keys()
 

--- a/tests/envs/bitget/test_torch_env_futures.py
+++ b/tests/envs/bitget/test_torch_env_futures.py
@@ -308,7 +308,7 @@ class TestBitgetFuturesTorchTradingEnv:
             # so assert_called_once() counts only what _step does.
             mock_trader.close_position.reset_mock()
 
-            # Fractional action levels: [0=-1.0, 1=-0.5, 2=0.0, 3=0.5, 4=1.0]
+            # Action levels default to [-1, 0, 1]; index by value, not position.
             # Level 0.0 -> close the open position.
             flat_idx = env.action_levels.index(0)
             action_td = TensorDict({"action": torch.tensor(flat_idx)}, batch_size=())
@@ -486,7 +486,7 @@ class TestBitgetFuturesTorchTradingEnv:
         with patch.object(env, "_wait_for_next_timestamp"):
             mock_trader.get_status = MagicMock(return_value=status(0.01))
             env.reset()
-            long_idx = len(env.action_levels) - 1     # index 1 is a half SHORT in these fixtures
+            long_idx = len(env.action_levels) - 1     # index 1 is FLAT under the [-1, 0, 1] default (#288)
             long = TensorDict({"action": torch.tensor(long_idx)}, batch_size=())
 
             for _ in range(5):                       # age a real position
@@ -520,7 +520,7 @@ class TestBitgetFuturesTorchTradingEnv:
 
         with patch.object(env, "_wait_for_next_timestamp"):
             env.reset()
-            long_idx = len(env.action_levels) - 1     # index 1 is a half SHORT in these fixtures
+            long_idx = len(env.action_levels) - 1     # index 1 is FLAT under the [-1, 0, 1] default (#288)
             for _ in range(5):
                 env.step(TensorDict({"action": torch.tensor(long_idx)}, batch_size=()))
             assert env.position.hold_counter > 0      # genuinely aged

--- a/tests/envs/bitget/test_torch_env_futures.py
+++ b/tests/envs/bitget/test_torch_env_futures.py
@@ -243,7 +243,10 @@ class TestBitgetFuturesTorchTradingEnv:
         (True, True),    # portfolio collapses below the threshold -> episode terminates
         (False, False),  # same collapse, check disabled -> keep trading
     ], ids=["enabled-terminates", "disabled-keeps-trading"])
-    def test_bankruptcy_termination(self, env, mock_trader, done_on_bankruptcy, expected_done):
+    @pytest.mark.parametrize("level", [0, 1], ids=["flat", "long"])
+    def test_bankruptcy_termination(
+        self, env, mock_trader, done_on_bankruptcy, expected_done, level
+    ):
         """A collapsed portfolio ends the episode through _step iff done_on_bankruptcy.
 
         Threshold arithmetic is covered in tests/envs/test_live_env_base.py; the disabled
@@ -260,7 +263,12 @@ class TestBitgetFuturesTorchTradingEnv:
 
         with patch.object(env, "_wait_for_next_timestamp"):
             env.reset()
-            next_td = env.step(TensorDict({"action": torch.tensor(2)}, batch_size=()))
+            # By VALUE, and BOTH routes. `torch.tensor(2)` used to mean "flat" on
+            # three venues and "full long" on binance, because their default action
+            # levels differed -- the same bytes testing two different behaviours (#288).
+            # Now the defaults agree, so the axis has to be explicit or one route is lost.
+            idx = env.action_levels.index(level)
+            next_td = env.step(TensorDict({"action": torch.tensor(idx)}, batch_size=()))
             assert next_td["next"]["done"].item() is expected_done
 
     def test_close_position_action(self, env, mock_trader):

--- a/tests/envs/bitget/test_torch_env_futures.py
+++ b/tests/envs/bitget/test_torch_env_futures.py
@@ -135,11 +135,13 @@ class TestBitgetFuturesTorchTradingEnv:
 
     def test_action_spec(self, env):
         """Test action spec is correctly defined."""
-        assert env.action_spec.n == 5  # fractional: -1.0, -0.5, 0.0, 0.5, 1.0
+        assert env.action_spec.n == 3  # the default: short / flat / long
 
     def test_action_levels(self, env):
         """Test action levels are correctly set."""
-        assert env.action_levels == [-1.0, -0.5, 0.0, 0.5, 1.0]
+        # The DEFAULT, shared by all four venues since #288. Any monotonic list in
+        # [-1, 1] is valid -- see BaseFuturesTradingConfig.action_levels.
+        assert env.action_levels == [-1, 0, 1]
 
     def test_base_features_declared_in_observation_spec(self, env_config, mock_observer, mock_trader):
         """include_base_features=True must DECLARE base_features in observation_spec, not just
@@ -208,7 +210,8 @@ class TestBitgetFuturesTorchTradingEnv:
         with patch.object(env, "_wait_for_next_timestamp"):
             env.reset()
 
-            action_td = TensorDict({"action": torch.tensor(4)}, batch_size=())  # Long (1.0)
+            long_idx = env.action_levels.index(1)  # by VALUE: the list length may change
+            action_td = TensorDict({"action": torch.tensor(long_idx)}, batch_size=())
             next_td = env.step(action_td)
 
             # Trade should have been attempted
@@ -290,8 +293,9 @@ class TestBitgetFuturesTorchTradingEnv:
             mock_trader.close_position.reset_mock()
 
             # Fractional action levels: [0=-1.0, 1=-0.5, 2=0.0, 3=0.5, 4=1.0]
-            # Action index 2 -> level 0.0 -> close the open position.
-            action_td = TensorDict({"action": torch.tensor(2)}, batch_size=())
+            # Level 0.0 -> close the open position.
+            flat_idx = env.action_levels.index(0)
+            action_td = TensorDict({"action": torch.tensor(flat_idx)}, batch_size=())
             env._step(action_td)
 
         mock_trader.close_position.assert_called_once()
@@ -319,7 +323,8 @@ class TestBitgetFuturesTorchTradingEnv:
             env.reset()
 
             # Go long (should buy to flip from short to long)
-            action_td = TensorDict({"action": torch.tensor(4)}, batch_size=())  # Long (1.0)
+            long_idx = env.action_levels.index(1)  # by VALUE: the list length may change
+            action_td = TensorDict({"action": torch.tensor(long_idx)}, batch_size=())
             env._step(action_td)
 
             # With fractional sizing, it should call trade() with the delta amount to flip position

--- a/tests/envs/bitget/test_torch_env_futures_sltp.py
+++ b/tests/envs/bitget/test_torch_env_futures_sltp.py
@@ -989,6 +989,9 @@ class TestWithReplayData:
 
         assert_the_replay_portfolio_tracks_price(
             BitgetFuturesSLTPTorchTradingEnv, BitgetFuturesSLTPTradingEnvConfig, replay_df, symbol="BTCUSDT",
+            # SLTP action map: 0 is HOLD, 1 the first bracket. Stated, not assumed --
+            # the helper used to hardcode these and was silently wrong off-SLTP.
+            open_action=1, hold_action=0,
             stoploss_levels=(-0.05,), takeprofit_levels=(0.05,),
             trade_mode="quantity", quantity_per_trade=0.01,
         )

--- a/tests/envs/bitget/test_torch_env_futures_sltp.py
+++ b/tests/envs/bitget/test_torch_env_futures_sltp.py
@@ -974,7 +974,7 @@ class TestWithReplayData:
         assert_a_replay_episode_runs(
             BitgetFuturesSLTPTorchTradingEnv, BitgetFuturesSLTPTradingEnvConfig, replay_df,
             actions=lambda i, env: [0, 1, 0, 0, len(env.action_map) - 1, 0][i % 6],
-            steps=50, symbol="BTCUSDT",
+            steps=50,
             stoploss_levels=(-0.02,), takeprofit_levels=(0.03,),
             trade_mode="quantity", quantity_per_trade=0.01,
         )
@@ -988,7 +988,7 @@ class TestWithReplayData:
         )
 
         assert_the_replay_portfolio_tracks_price(
-            BitgetFuturesSLTPTorchTradingEnv, BitgetFuturesSLTPTradingEnvConfig, replay_df, symbol="BTCUSDT",
+            BitgetFuturesSLTPTorchTradingEnv, BitgetFuturesSLTPTradingEnvConfig, replay_df,
             # SLTP action map: 0 is HOLD, 1 the first bracket. Stated, not assumed --
             # the helper used to hardcode these and was silently wrong off-SLTP.
             open_action=1, hold_action=0,

--- a/tests/envs/bitget/test_torch_env_futures_sltp.py
+++ b/tests/envs/bitget/test_torch_env_futures_sltp.py
@@ -963,129 +963,33 @@ class TestBitgetSLTPLockPosition:
 
 
 class TestWithReplayData:
-    """Integration tests using ReplayObserver + ReplayOrderExecutor with real price data."""
-
-    @pytest.fixture
-    def replay_df(self):
-        """Create realistic OHLCV test data with price movement."""
-        import pandas as pd
-
-        n = 200
-        timestamps = pd.date_range("2024-01-01", periods=n, freq="1min")
-        base = 50000 + np.cumsum(np.random.default_rng(42).normal(0, 50, n))
-        # close drawn off base can land outside a high/low drawn off base alone (#326).
-        close = base + np.random.default_rng(45).normal(0, 20, n)
-        return pd.DataFrame({
-            "timestamp": timestamps,
-            "open": base,
-            "high": np.maximum(base + np.abs(np.random.default_rng(43).normal(30, 20, n)), np.maximum(base, close)),
-            "low": np.minimum(base - np.abs(np.random.default_rng(44).normal(30, 20, n)), np.minimum(base, close)),
-            "close": close,
-            "volume": np.random.default_rng(46).uniform(100, 1000, n),
-        })
+    """Real price data through ReplayObserver + ReplayOrderExecutor (#288)."""
 
     def test_multi_step_episode_with_replay(self, replay_df):
-        """Run a full multi-step episode with realistic price data."""
+        from tests.envs.base_exchange_tests import assert_a_replay_episode_runs
         from torchtrade.envs.live.bitget.env_sltp import (
-            BitgetFuturesSLTPTorchTradingEnv,
-            BitgetFuturesSLTPTradingEnvConfig,
-        )
-        from torchtrade.envs.replay import ReplayObserver, ReplayOrderExecutor
-
-        config = BitgetFuturesSLTPTradingEnvConfig(
-            symbol="BTC/USDT:USDT",
-            time_frames=["1m"],
-            window_sizes=[10],
-            execute_on="1m",
-            stoploss_levels=(-0.02,),
-            takeprofit_levels=(0.03,),
-            leverage=5,
-            trade_mode="quantity",
-            quantity_per_trade=0.01,
+            BitgetFuturesSLTPTorchTradingEnv, BitgetFuturesSLTPTradingEnvConfig,
         )
 
-        executor = ReplayOrderExecutor(initial_balance=10000.0, leverage=5)
-        observer = ReplayObserver(
-            df=replay_df,
-            time_frames=config.time_frames,
-            window_sizes=config.window_sizes,
-            execute_on=config.execute_on,
-            executor=executor,
+        assert_a_replay_episode_runs(
+            BitgetFuturesSLTPTorchTradingEnv, BitgetFuturesSLTPTradingEnvConfig, replay_df,
+            actions=lambda i, env: [0, 1, 0, 0, len(env.action_map) - 1, 0][i % 6],
+            steps=50, symbol="BTCUSDT",
+            stoploss_levels=(-0.02,), takeprofit_levels=(0.03,),
+            trade_mode="quantity", quantity_per_trade=0.01,
         )
-
-        with patch("time.sleep"), \
-             patch.object(BitgetFuturesSLTPTorchTradingEnv, "_wait_for_next_timestamp"):
-            env = BitgetFuturesSLTPTorchTradingEnv(
-                config=config, observer=observer, trader=executor,
-            )
-
-        with patch.object(env, "_wait_for_next_timestamp"):
-            td = env.reset()
-
-            for i in range(50):
-                action = [0, 1, 0, 0, len(env.action_map) - 1, 0][i % 6]
-                action_td = td.clone()
-                action_td["action"] = torch.tensor(action)
-                result = env.step(action_td)
-                td = result["next"]
-
-                assert "reward" in td.keys()
-                assert "done" in td.keys()
-                assert td["account_state"].shape == (6,)
-
-                if td["done"].item():
-                    break
 
     def test_replay_portfolio_tracks_price_movement(self, replay_df):
-        """Portfolio value should change with price movement, not stay static."""
+        from tests.envs.base_exchange_tests import (
+            assert_the_replay_portfolio_tracks_price,
+        )
         from torchtrade.envs.live.bitget.env_sltp import (
-            BitgetFuturesSLTPTorchTradingEnv,
-            BitgetFuturesSLTPTradingEnvConfig,
-        )
-        from torchtrade.envs.replay import ReplayObserver, ReplayOrderExecutor
-
-        config = BitgetFuturesSLTPTradingEnvConfig(
-            symbol="BTC/USDT:USDT",
-            time_frames=["1m"],
-            window_sizes=[10],
-            execute_on="1m",
-            stoploss_levels=(-0.05,),
-            takeprofit_levels=(0.05,),
-            leverage=5,
-            trade_mode="quantity",
-            quantity_per_trade=0.01,
+            BitgetFuturesSLTPTorchTradingEnv, BitgetFuturesSLTPTradingEnvConfig,
         )
 
-        executor = ReplayOrderExecutor(initial_balance=10000.0, leverage=5)
-        observer = ReplayObserver(
-            df=replay_df,
-            time_frames=config.time_frames,
-            window_sizes=config.window_sizes,
-            execute_on=config.execute_on,
-            executor=executor,
+        assert_the_replay_portfolio_tracks_price(
+            BitgetFuturesSLTPTorchTradingEnv, BitgetFuturesSLTPTradingEnvConfig, replay_df, symbol="BTCUSDT",
+            stoploss_levels=(-0.05,), takeprofit_levels=(0.05,),
+            trade_mode="quantity", quantity_per_trade=0.01,
         )
 
-        with patch("time.sleep"), \
-             patch.object(BitgetFuturesSLTPTorchTradingEnv, "_wait_for_next_timestamp"):
-            env = BitgetFuturesSLTPTorchTradingEnv(
-                config=config, observer=observer, trader=executor,
-            )
-
-        with patch.object(env, "_wait_for_next_timestamp"):
-            td = env.reset()
-
-            # Open a long position
-            action_td = td.clone()
-            action_td["action"] = torch.tensor(1)
-            td = env.step(action_td)["next"]
-
-            # Hold for several steps -- price should move, changing portfolio value
-            balances = []
-            for _ in range(10):
-                action_td = td.clone()
-                action_td["action"] = torch.tensor(0)  # HOLD
-                td = env.step(action_td)["next"]
-                balances.append(executor.get_account_balance()["total_wallet_balance"])
-
-            # With real price movement, portfolio value should not stay static
-            assert max(balances) != min(balances), "Portfolio value should vary with price movement"

--- a/tests/envs/bybit/test_torch_env_futures.py
+++ b/tests/envs/bybit/test_torch_env_futures.py
@@ -104,8 +104,9 @@ class TestBybitFuturesTorchTradingEnv:
 
     def test_action_spec(self, env):
         """Test action spec and levels are correctly defined."""
-        assert env.action_spec.n == 5  # [-1.0, -0.5, 0.0, 0.5, 1.0]
-        assert env.action_levels == [-1.0, -0.5, 0.0, 0.5, 1.0]
+        assert env.action_spec.n == 3  # the default: short / flat / long
+        # Any monotonic list in [-1, 1] is valid; see BaseFuturesTradingConfig.action_levels.
+        assert env.action_levels == [-1, 0, 1]
 
     def test_include_base_features_flows_through_shared_get_observation(self, mock_observer, mock_trader):
         """The shared TorchTradeFuturesLiveEnv._get_observation passes base_features through.
@@ -176,15 +177,16 @@ class TestBybitFuturesTorchTradingEnv:
             assert "done" in next_td["next"].keys()
             assert "account_state" in next_td["next"].keys()
 
-    @pytest.mark.parametrize("action_idx,label", [
-        (4, "long"),   # action_levels[4] = 1.0
-        (0, "short"),  # action_levels[0] = -1.0
+    @pytest.mark.parametrize("level,label", [
+        (1, "long"), (-1, "short"),
     ], ids=["long", "short"])
-    def test_step_trade_action(self, env, mock_trader, action_idx, label):
+    def test_step_trade_action(self, env, mock_trader, level, label):
         """Test step with long/short action calls trade."""
         with patch.object(env, "_wait_for_next_timestamp"):
             env.reset()
-            action_td = TensorDict({"action": torch.tensor(action_idx)}, batch_size=())
+            # By VALUE, so the test does not encode the length of action_levels.
+            idx = env.action_levels.index(level)
+            action_td = TensorDict({"action": torch.tensor(idx)}, batch_size=())
             env.step(action_td)
             mock_trader.trade.assert_called()
 

--- a/tests/envs/bybit/test_torch_env_futures.py
+++ b/tests/envs/bybit/test_torch_env_futures.py
@@ -170,9 +170,7 @@ class TestBybitFuturesTorchTradingEnv:
         """Test step with hold action."""
         with patch.object(env, "_wait_for_next_timestamp"):
             env.reset()
-            # Flat, BY VALUE. Hardcoding index 2 meant 0.0 under the old 5-level
-            # default and means a full LONG under [-1, 0, 1] -- so this stopped
-            # testing a hold the moment the defaults were unified (#288).
+            # Flat BY VALUE: index 2 was 0.0 under the old 5-level default (#288).
             flat = env.action_levels.index(0)
             action_td = TensorDict({"action": torch.tensor(flat)}, batch_size=())
             next_td = env.step(action_td)
@@ -181,9 +179,10 @@ class TestBybitFuturesTorchTradingEnv:
             assert "done" in next_td["next"].keys()
             assert "account_state" in next_td["next"].keys()
 
-            # The assertion this test's NAME promised and never made: it only checked
-            # that keys existed, so a flat action that TRADED passed it. Disabling
-            # the flat branch in the env used to fail nothing (#288).
+
+            # The assertion the name always promised: it only checked keys existed.
+            # Defence in depth, not a discriminating pin -- the flat route has FOUR
+            # independent zero-guards, so no single-branch mutation reaches a trade.
             mock_trader.trade.assert_not_called()
 
     @pytest.mark.parametrize("level,label", [
@@ -203,9 +202,7 @@ class TestBybitFuturesTorchTradingEnv:
         """The done family is asserted by assert_the_step_emits_the_whole_done_family."""
         with patch.object(env, "_wait_for_next_timestamp"):
             env.reset()
-            # Flat, BY VALUE. Hardcoding index 2 meant 0.0 under the old 5-level
-            # default and means a full LONG under [-1, 0, 1] -- so this stopped
-            # testing a hold the moment the defaults were unified (#288).
+            # Flat BY VALUE: index 2 was 0.0 under the old 5-level default (#288).
             flat = env.action_levels.index(0)
             action_td = TensorDict({"action": torch.tensor(flat)}, batch_size=())
             next_td = env.step(action_td)
@@ -236,10 +233,8 @@ class TestBybitFuturesTorchTradingEnv:
 
         with patch.object(env, "_wait_for_next_timestamp"):
             env.reset()
-            # By VALUE, and BOTH routes. `torch.tensor(2)` used to mean "flat" on
-            # three venues and "full long" on binance, because their default action
-            # levels differed -- the same bytes testing two different behaviours (#288).
-            # Now the defaults agree, so the axis has to be explicit or one route is lost.
+            # By VALUE, and both routes: index 2 meant flat on three venues and long on
+            # binance, so the same bytes tested two behaviours (#288).
             idx = env.action_levels.index(level)
             next_td = env.step(TensorDict({"action": torch.tensor(idx)}, batch_size=()))
             assert next_td["next"]["done"].item() is expected_done

--- a/tests/envs/bybit/test_torch_env_futures.py
+++ b/tests/envs/bybit/test_torch_env_futures.py
@@ -299,7 +299,7 @@ class TestBybitFuturesTorchTradingEnv:
         with patch.object(env, "_wait_for_next_timestamp"):
             mock_trader.get_status = MagicMock(return_value=status(0.01))
             env.reset()
-            long_idx = len(env.action_levels) - 1     # index 1 is FLAT under the [-1, 0, 1] default (#288)
+            long_idx = len(env.action_levels) - 1
             long = TensorDict({"action": torch.tensor(long_idx)}, batch_size=())
 
             for _ in range(5):                       # age a real position
@@ -341,7 +341,7 @@ class TestBybitFuturesTorchTradingEnv:
 
         with patch.object(env, "_wait_for_next_timestamp"):
             env.reset()
-            long_idx = len(env.action_levels) - 1     # index 1 is FLAT under the [-1, 0, 1] default (#288)
+            long_idx = len(env.action_levels) - 1
             for _ in range(5):
                 env.step(TensorDict({"action": torch.tensor(long_idx)}, batch_size=()))
             assert env.position.hold_counter > 0      # genuinely aged

--- a/tests/envs/bybit/test_torch_env_futures.py
+++ b/tests/envs/bybit/test_torch_env_futures.py
@@ -170,12 +170,21 @@ class TestBybitFuturesTorchTradingEnv:
         """Test step with hold action."""
         with patch.object(env, "_wait_for_next_timestamp"):
             env.reset()
-            action_td = TensorDict({"action": torch.tensor(2)}, batch_size=())  # 0.0
+            # Flat, BY VALUE. Hardcoding index 2 meant 0.0 under the old 5-level
+            # default and means a full LONG under [-1, 0, 1] -- so this stopped
+            # testing a hold the moment the defaults were unified (#288).
+            flat = env.action_levels.index(0)
+            action_td = TensorDict({"action": torch.tensor(flat)}, batch_size=())
             next_td = env.step(action_td)
 
             assert "reward" in next_td["next"].keys()
             assert "done" in next_td["next"].keys()
             assert "account_state" in next_td["next"].keys()
+
+            # The assertion this test's NAME promised and never made: it only checked
+            # that keys existed, so a flat action that TRADED passed it. Disabling
+            # the flat branch in the env used to fail nothing (#288).
+            mock_trader.trade.assert_not_called()
 
     @pytest.mark.parametrize("level,label", [
         (1, "long"), (-1, "short"),
@@ -194,7 +203,11 @@ class TestBybitFuturesTorchTradingEnv:
         """The done family is asserted by assert_the_step_emits_the_whole_done_family."""
         with patch.object(env, "_wait_for_next_timestamp"):
             env.reset()
-            action_td = TensorDict({"action": torch.tensor(2)}, batch_size=())
+            # Flat, BY VALUE. Hardcoding index 2 meant 0.0 under the old 5-level
+            # default and means a full LONG under [-1, 0, 1] -- so this stopped
+            # testing a hold the moment the defaults were unified (#288).
+            flat = env.action_levels.index(0)
+            action_td = TensorDict({"action": torch.tensor(flat)}, batch_size=())
             next_td = env.step(action_td)
 
             assert next_td["next"]["reward"].shape == (1,)

--- a/tests/envs/bybit/test_torch_env_futures.py
+++ b/tests/envs/bybit/test_torch_env_futures.py
@@ -203,7 +203,10 @@ class TestBybitFuturesTorchTradingEnv:
         (True, True),    # portfolio collapses below the threshold -> episode terminates
         (False, False),  # same collapse, check disabled -> keep trading
     ], ids=["enabled-terminates", "disabled-keeps-trading"])
-    def test_bankruptcy_termination(self, env, mock_trader, done_on_bankruptcy, expected_done):
+    @pytest.mark.parametrize("level", [0, 1], ids=["flat", "long"])
+    def test_bankruptcy_termination(
+        self, env, mock_trader, done_on_bankruptcy, expected_done, level
+    ):
         """A collapsed portfolio ends the episode through _step iff done_on_bankruptcy.
 
         Threshold arithmetic is covered in tests/envs/test_live_env_base.py; the disabled
@@ -220,7 +223,12 @@ class TestBybitFuturesTorchTradingEnv:
 
         with patch.object(env, "_wait_for_next_timestamp"):
             env.reset()
-            next_td = env.step(TensorDict({"action": torch.tensor(2)}, batch_size=()))
+            # By VALUE, and BOTH routes. `torch.tensor(2)` used to mean "flat" on
+            # three venues and "full long" on binance, because their default action
+            # levels differed -- the same bytes testing two different behaviours (#288).
+            # Now the defaults agree, so the axis has to be explicit or one route is lost.
+            idx = env.action_levels.index(level)
+            next_td = env.step(TensorDict({"action": torch.tensor(idx)}, batch_size=()))
             assert next_td["next"]["done"].item() is expected_done
 
     def test_config_post_init(self):

--- a/tests/envs/bybit/test_torch_env_futures.py
+++ b/tests/envs/bybit/test_torch_env_futures.py
@@ -688,77 +688,21 @@ class TestBybitFractionalPositionResizing:
 
 
 class TestWithReplayData:
-    """Integration tests using ReplayObserver + ReplayOrderExecutor with real price data."""
+    """Real price data through ReplayObserver + ReplayOrderExecutor.
 
-    @pytest.fixture
-    def replay_df(self):
-        """Create realistic OHLCV test data."""
-        import pandas as pd
-
-        n = 200
-        rng = np.random.default_rng(42)
-        base = 50000 + np.cumsum(rng.normal(0, 50, n))
-        # Drawn in the original order so the RNG stream is unchanged, then clamped:
-        # a close drawn off base can land outside a high/low drawn off base alone (#326).
-        high_raw = base + np.abs(rng.normal(30, 20, n))
-        low_raw = base - np.abs(rng.normal(30, 20, n))
-        close = base + rng.normal(0, 20, n)
-        high_raw_clamped = np.maximum(high_raw, np.maximum(base, close))
-        low_raw_clamped = np.minimum(low_raw, np.minimum(base, close))
-        return pd.DataFrame({
-            "timestamp": pd.date_range("2024-01-01", periods=n, freq="1min"),
-            "open": base,
-            "high": high_raw_clamped,
-            "low": low_raw_clamped,
-            "close": close,
-            "volume": rng.uniform(100, 1000, n),
-        })
+    The episode body is shared: eight venue copies differed only in the two classes and
+    the config values (#288).
+    """
 
     def test_multi_step_episode_with_replay(self, replay_df):
-        """Run a multi-step episode with realistic price data."""
-        from torchtrade.envs.live.bybit.env import BybitFuturesTorchTradingEnv, BybitFuturesTradingEnvConfig
-        from torchtrade.envs.replay import ReplayObserver, ReplayOrderExecutor
-
-        config = BybitFuturesTradingEnvConfig(
-            symbol="BTCUSDT",
-            time_frames=["1m"],
-            window_sizes=[10],
-            execute_on="1m",
-            leverage=5,
-            demo=True,
+        from tests.envs.base_exchange_tests import assert_a_replay_episode_runs
+        from torchtrade.envs.live.bybit.env import (
+            BybitFuturesTorchTradingEnv, BybitFuturesTradingEnvConfig,
         )
 
-        executor = ReplayOrderExecutor(initial_balance=10000.0, leverage=5)
-        observer = ReplayObserver(
-            df=replay_df,
-            time_frames=config.time_frames,
-            window_sizes=config.window_sizes,
-            execute_on=config.execute_on,
-            executor=executor,
+        assert_a_replay_episode_runs(
+            BybitFuturesTorchTradingEnv, BybitFuturesTradingEnvConfig, replay_df,
+            actions=lambda i, env: i % len(env.action_levels), steps=20,
+            symbol="BTCUSDT", demo=True,
         )
 
-        with patch("time.sleep"), \
-             patch.object(BybitFuturesTorchTradingEnv, "_wait_for_next_timestamp"):
-            env = BybitFuturesTorchTradingEnv(
-                config=config, observer=observer, trader=executor,
-            )
-
-        with patch.object(env, "_wait_for_next_timestamp"):
-            td = env.reset()
-
-            for i in range(20):
-                # Cycle through action levels (hold, long, hold, short, hold, close...)
-                action_idx = i % len(env.action_levels)
-                action_td = td.clone()
-                action_td["action"] = torch.tensor(action_idx)
-                result = env.step(action_td)
-                td = result["next"]
-
-                assert "reward" in td.keys()
-                assert "done" in td.keys()
-                assert td["account_state"].shape == (6,)
-
-                if td["done"].item():
-                    break
-
-            assert executor.current_price > 0

--- a/tests/envs/bybit/test_torch_env_futures.py
+++ b/tests/envs/bybit/test_torch_env_futures.py
@@ -299,7 +299,7 @@ class TestBybitFuturesTorchTradingEnv:
         with patch.object(env, "_wait_for_next_timestamp"):
             mock_trader.get_status = MagicMock(return_value=status(0.01))
             env.reset()
-            long_idx = len(env.action_levels) - 1     # index 1 is a half SHORT in these fixtures
+            long_idx = len(env.action_levels) - 1     # index 1 is FLAT under the [-1, 0, 1] default (#288)
             long = TensorDict({"action": torch.tensor(long_idx)}, batch_size=())
 
             for _ in range(5):                       # age a real position
@@ -341,7 +341,7 @@ class TestBybitFuturesTorchTradingEnv:
 
         with patch.object(env, "_wait_for_next_timestamp"):
             env.reset()
-            long_idx = len(env.action_levels) - 1     # index 1 is a half SHORT in these fixtures
+            long_idx = len(env.action_levels) - 1     # index 1 is FLAT under the [-1, 0, 1] default (#288)
             for _ in range(5):
                 env.step(TensorDict({"action": torch.tensor(long_idx)}, batch_size=()))
             assert env.position.hold_counter > 0      # genuinely aged

--- a/tests/envs/bybit/test_torch_env_futures.py
+++ b/tests/envs/bybit/test_torch_env_futures.py
@@ -711,6 +711,5 @@ class TestWithReplayData:
         assert_a_replay_episode_runs(
             BybitFuturesTorchTradingEnv, BybitFuturesTradingEnvConfig, replay_df,
             actions=lambda i, env: i % len(env.action_levels), steps=20,
-            symbol="BTCUSDT", demo=True,
         )
 

--- a/tests/envs/bybit/test_torch_env_futures_sltp.py
+++ b/tests/envs/bybit/test_torch_env_futures_sltp.py
@@ -723,130 +723,33 @@ class TestBybitSLTPLockPosition:
 
 
 class TestWithReplayData:
-    """Integration tests using ReplayObserver + ReplayOrderExecutor with real price data."""
-
-    @pytest.fixture
-    def replay_df(self):
-        """Create realistic OHLCV test data with price movement."""
-        import numpy as np
-        import pandas as pd
-
-        n = 200
-        timestamps = pd.date_range("2024-01-01", periods=n, freq="1min")
-        base = 50000 + np.cumsum(np.random.default_rng(42).normal(0, 50, n))
-        # close drawn off base can land outside a high/low drawn off base alone (#326).
-        close = base + np.random.default_rng(45).normal(0, 20, n)
-        return pd.DataFrame({
-            "timestamp": timestamps,
-            "open": base,
-            "high": np.maximum(base + np.abs(np.random.default_rng(43).normal(30, 20, n)), np.maximum(base, close)),
-            "low": np.minimum(base - np.abs(np.random.default_rng(44).normal(30, 20, n)), np.minimum(base, close)),
-            "close": close,
-            "volume": np.random.default_rng(46).uniform(100, 1000, n),
-        })
+    """Real price data through ReplayObserver + ReplayOrderExecutor (#288)."""
 
     def test_multi_step_episode_with_replay(self, replay_df):
-        """Run a full multi-step episode with realistic price data."""
+        from tests.envs.base_exchange_tests import assert_a_replay_episode_runs
         from torchtrade.envs.live.bybit.env_sltp import (
-            BybitFuturesSLTPTorchTradingEnv,
-            BybitFuturesSLTPTradingEnvConfig,
-        )
-        from torchtrade.envs.replay import ReplayObserver, ReplayOrderExecutor
-
-        config = BybitFuturesSLTPTradingEnvConfig(
-            symbol="BTCUSDT",
-            time_frames=["1m"],
-            window_sizes=[10],
-            execute_on="1m",
-            stoploss_levels=(-0.02,),
-            takeprofit_levels=(0.03,),
-            leverage=5,
-            trade_mode="quantity",
-            quantity_per_trade=0.01,
+            BybitFuturesSLTPTorchTradingEnv, BybitFuturesSLTPTradingEnvConfig,
         )
 
-        executor = ReplayOrderExecutor(initial_balance=10000.0, leverage=5)
-        observer = ReplayObserver(
-            df=replay_df,
-            time_frames=config.time_frames,
-            window_sizes=config.window_sizes,
-            execute_on=config.execute_on,
-            executor=executor,
+        assert_a_replay_episode_runs(
+            BybitFuturesSLTPTorchTradingEnv, BybitFuturesSLTPTradingEnvConfig, replay_df,
+            actions=lambda i, env: [0, 1, 0, 0, len(env.action_map) - 1, 0][i % 6],
+            steps=50, symbol="BTCUSDT",
+            stoploss_levels=(-0.02,), takeprofit_levels=(0.03,),
+            trade_mode="quantity", quantity_per_trade=0.01,
         )
-
-        with patch("time.sleep"), \
-             patch.object(BybitFuturesSLTPTorchTradingEnv, "_wait_for_next_timestamp"):
-            env = BybitFuturesSLTPTorchTradingEnv(
-                config=config, observer=observer, trader=executor,
-            )
-
-        with patch.object(env, "_wait_for_next_timestamp"):
-            td = env.reset()
-
-            for i in range(50):
-                action = [0, 1, 0, 0, len(env.action_map) - 1, 0][i % 6]
-                action_td = td.clone()
-                action_td["action"] = torch.tensor(action)
-                result = env.step(action_td)
-                td = result["next"]
-
-                assert "reward" in td.keys()
-                assert "done" in td.keys()
-                assert td["account_state"].shape == (6,)
-
-                if td["done"].item():
-                    break
 
     def test_replay_portfolio_tracks_price_movement(self, replay_df):
-        """Portfolio value should change with price movement, not stay static."""
+        from tests.envs.base_exchange_tests import (
+            assert_the_replay_portfolio_tracks_price,
+        )
         from torchtrade.envs.live.bybit.env_sltp import (
-            BybitFuturesSLTPTorchTradingEnv,
-            BybitFuturesSLTPTradingEnvConfig,
-        )
-        from torchtrade.envs.replay import ReplayObserver, ReplayOrderExecutor
-
-        config = BybitFuturesSLTPTradingEnvConfig(
-            symbol="BTCUSDT",
-            time_frames=["1m"],
-            window_sizes=[10],
-            execute_on="1m",
-            stoploss_levels=(-0.05,),
-            takeprofit_levels=(0.05,),
-            leverage=5,
-            trade_mode="quantity",
-            quantity_per_trade=0.01,
+            BybitFuturesSLTPTorchTradingEnv, BybitFuturesSLTPTradingEnvConfig,
         )
 
-        executor = ReplayOrderExecutor(initial_balance=10000.0, leverage=5)
-        observer = ReplayObserver(
-            df=replay_df,
-            time_frames=config.time_frames,
-            window_sizes=config.window_sizes,
-            execute_on=config.execute_on,
-            executor=executor,
+        assert_the_replay_portfolio_tracks_price(
+            BybitFuturesSLTPTorchTradingEnv, BybitFuturesSLTPTradingEnvConfig, replay_df, symbol="BTCUSDT",
+            stoploss_levels=(-0.05,), takeprofit_levels=(0.05,),
+            trade_mode="quantity", quantity_per_trade=0.01,
         )
 
-        with patch("time.sleep"), \
-             patch.object(BybitFuturesSLTPTorchTradingEnv, "_wait_for_next_timestamp"):
-            env = BybitFuturesSLTPTorchTradingEnv(
-                config=config, observer=observer, trader=executor,
-            )
-
-        with patch.object(env, "_wait_for_next_timestamp"):
-            td = env.reset()
-
-            # Open a long position
-            action_td = td.clone()
-            action_td["action"] = torch.tensor(1)
-            td = env.step(action_td)["next"]
-
-            # Hold for several steps -- price should move, changing portfolio value
-            balances = []
-            for _ in range(10):
-                action_td = td.clone()
-                action_td["action"] = torch.tensor(0)  # HOLD
-                td = env.step(action_td)["next"]
-                balances.append(executor.get_account_balance()["total_wallet_balance"])
-
-            # With real price movement, portfolio value should not stay static
-            assert max(balances) != min(balances), "Portfolio value should vary with price movement"

--- a/tests/envs/bybit/test_torch_env_futures_sltp.py
+++ b/tests/envs/bybit/test_torch_env_futures_sltp.py
@@ -749,6 +749,9 @@ class TestWithReplayData:
 
         assert_the_replay_portfolio_tracks_price(
             BybitFuturesSLTPTorchTradingEnv, BybitFuturesSLTPTradingEnvConfig, replay_df, symbol="BTCUSDT",
+            # SLTP action map: 0 is HOLD, 1 the first bracket. Stated, not assumed --
+            # the helper used to hardcode these and was silently wrong off-SLTP.
+            open_action=1, hold_action=0,
             stoploss_levels=(-0.05,), takeprofit_levels=(0.05,),
             trade_mode="quantity", quantity_per_trade=0.01,
         )

--- a/tests/envs/bybit/test_torch_env_futures_sltp.py
+++ b/tests/envs/bybit/test_torch_env_futures_sltp.py
@@ -734,7 +734,7 @@ class TestWithReplayData:
         assert_a_replay_episode_runs(
             BybitFuturesSLTPTorchTradingEnv, BybitFuturesSLTPTradingEnvConfig, replay_df,
             actions=lambda i, env: [0, 1, 0, 0, len(env.action_map) - 1, 0][i % 6],
-            steps=50, symbol="BTCUSDT",
+            steps=50,
             stoploss_levels=(-0.02,), takeprofit_levels=(0.03,),
             trade_mode="quantity", quantity_per_trade=0.01,
         )
@@ -748,7 +748,7 @@ class TestWithReplayData:
         )
 
         assert_the_replay_portfolio_tracks_price(
-            BybitFuturesSLTPTorchTradingEnv, BybitFuturesSLTPTradingEnvConfig, replay_df, symbol="BTCUSDT",
+            BybitFuturesSLTPTorchTradingEnv, BybitFuturesSLTPTradingEnvConfig, replay_df,
             # SLTP action map: 0 is HOLD, 1 the first bracket. Stated, not assumed --
             # the helper used to hardcode these and was silently wrong off-SLTP.
             open_action=1, hold_action=0,

--- a/tests/envs/conftest.py
+++ b/tests/envs/conftest.py
@@ -1,0 +1,34 @@
+"""Fixtures shared by every venue's test directory (#288).
+
+`replay_df` lived in seven places: six venue test classes defined it inline and okx's
+conftest held a seventh copy. They were the same 20 lines, and the two that had drifted
+had drifted in the RNG stream rather than in anything a reader would notice.
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+
+@pytest.fixture
+def replay_df():
+    """Realistic OHLCV for the replay integration tests.
+
+    Drawn in this order so the RNG stream is what the original fixtures produced, then
+    clamped: a close drawn off `base` can land outside a high/low drawn off `base` alone,
+    which is a bar the venue would never print (#326).
+    """
+    n = 200
+    rng = np.random.default_rng(42)
+    base = 50000 + np.cumsum(rng.normal(0, 50, n))
+    high_raw = base + np.abs(rng.normal(30, 20, n))
+    low_raw = base - np.abs(rng.normal(30, 20, n))
+    close = base + rng.normal(0, 20, n)
+    return pd.DataFrame({
+        "timestamp": pd.date_range("2024-01-01", periods=n, freq="1min"),
+        "open": base,
+        "high": np.maximum(high_raw, np.maximum(base, close)),
+        "low": np.minimum(low_raw, np.minimum(base, close)),
+        "close": close,
+        "volume": rng.uniform(100, 1000, n),
+    })

--- a/tests/envs/okx/conftest.py
+++ b/tests/envs/okx/conftest.py
@@ -178,26 +178,3 @@ def mock_env_trader():
     trader.trade = MagicMock(return_value=True)
     trader.get_lot_size = MagicMock(return_value={"min_qty": 0.001, "qty_step": 0.001, "min_notional": 0.0})
     return trader
-
-
-@pytest.fixture
-def replay_df():
-    """Create realistic OHLCV test data for replay integration tests."""
-    n = 200
-    rng = np.random.default_rng(42)
-    base = 50000 + np.cumsum(rng.normal(0, 50, n))
-    # Drawn in the original order so the RNG stream is unchanged, then clamped:
-    # a close drawn off base can land outside a high/low drawn off base alone (#326).
-    high_raw = base + np.abs(rng.normal(30, 20, n))
-    low_raw = base - np.abs(rng.normal(30, 20, n))
-    close = base + rng.normal(0, 20, n)
-    high_raw_clamped = np.maximum(high_raw, np.maximum(base, close))
-    low_raw_clamped = np.minimum(low_raw, np.minimum(base, close))
-    return pd.DataFrame({
-        "timestamp": pd.date_range("2024-01-01", periods=n, freq="1min"),
-        "open": base,
-        "high": high_raw_clamped,
-        "low": low_raw_clamped,
-        "close": close,
-        "volume": rng.uniform(100, 1000, n),
-    })

--- a/tests/envs/okx/conftest.py
+++ b/tests/envs/okx/conftest.py
@@ -1,7 +1,6 @@
 """Shared test fixtures for OKX tests."""
 
 import numpy as np
-import pandas as pd
 import pytest
 from unittest.mock import MagicMock
 

--- a/tests/envs/okx/test_torch_env_futures.py
+++ b/tests/envs/okx/test_torch_env_futures.py
@@ -233,7 +233,7 @@ class TestOKXFuturesTorchTradingEnv:
         with patch.object(env, "_wait_for_next_timestamp"):
             mock_env_trader.get_status = MagicMock(return_value=status(0.01))
             env.reset()
-            long_idx = len(env.action_levels) - 1     # index 1 is FLAT under the [-1, 0, 1] default (#288)
+            long_idx = len(env.action_levels) - 1
             long = TensorDict({"action": torch.tensor(long_idx)}, batch_size=())
 
             for _ in range(5):                       # age a real position
@@ -267,7 +267,7 @@ class TestOKXFuturesTorchTradingEnv:
 
         with patch.object(env, "_wait_for_next_timestamp"):
             env.reset()
-            long_idx = len(env.action_levels) - 1     # index 1 is FLAT under the [-1, 0, 1] default (#288)
+            long_idx = len(env.action_levels) - 1
             for _ in range(5):
                 env.step(TensorDict({"action": torch.tensor(long_idx)}, batch_size=()))
             assert env.position.hold_counter > 0      # genuinely aged

--- a/tests/envs/okx/test_torch_env_futures.py
+++ b/tests/envs/okx/test_torch_env_futures.py
@@ -111,14 +111,23 @@ class TestOKXFuturesTorchTradingEnv:
         assert td["market_data_1Minute_10"].shape == (10, 4)
         mock_env_trader.cancel_open_orders.assert_called()
 
-    def test_step_hold_action(self, env):
+    def test_step_hold_action(self, env, mock_env_trader):
         """Test step with hold action produces valid output."""
         with patch.object(env, "_wait_for_next_timestamp"):
             env.reset()
-            action_td = TensorDict({"action": torch.tensor(2)}, batch_size=())
+            # Flat, BY VALUE. Hardcoding index 2 meant 0.0 under the old 5-level
+            # default and means a full LONG under [-1, 0, 1] -- so this stopped
+            # testing a hold the moment the defaults were unified (#288).
+            flat = env.action_levels.index(0)
+            action_td = TensorDict({"action": torch.tensor(flat)}, batch_size=())
             next_td = env.step(action_td)
             assert "reward" in next_td["next"].keys()
             assert "done" in next_td["next"].keys()
+
+            # The assertion this test's NAME promised and never made: it only checked
+            # that keys existed, so a flat action that TRADED passed it. Disabling
+            # the flat branch in the env used to fail nothing (#288).
+            mock_env_trader.trade.assert_not_called()
 
     @pytest.mark.parametrize("level,label", [
         (1, "long"), (-1, "short"),
@@ -136,7 +145,11 @@ class TestOKXFuturesTorchTradingEnv:
         """The done family is asserted by assert_the_step_emits_the_whole_done_family."""
         with patch.object(env, "_wait_for_next_timestamp"):
             env.reset()
-            next_td = env.step(TensorDict({"action": torch.tensor(2)}, batch_size=()))
+            # Flat, BY VALUE. Hardcoding index 2 meant 0.0 under the old 5-level
+            # default and means a full LONG under [-1, 0, 1] -- so this stopped
+            # testing a hold the moment the defaults were unified (#288).
+            flat = env.action_levels.index(0)
+            next_td = env.step(TensorDict({"action": torch.tensor(flat)}, batch_size=()))
             assert next_td["next"]["reward"].shape == (1,)
 
     @pytest.mark.parametrize("done_on_bankruptcy,expected_done", [

--- a/tests/envs/okx/test_torch_env_futures.py
+++ b/tests/envs/okx/test_torch_env_futures.py
@@ -514,36 +514,21 @@ class TestOKXInitCleanup:
 
 
 class TestWithReplayData:
-    """Integration tests using ReplayObserver + ReplayOrderExecutor."""
+    """Real price data through ReplayObserver + ReplayOrderExecutor.
+
+    The episode body is shared: eight venue copies differed only in the two classes and
+    the config values (#288).
+    """
 
     def test_multi_step_episode_with_replay(self, replay_df):
-        """Run a multi-step episode with realistic price data."""
-        from torchtrade.envs.live.okx.env import OKXFuturesTorchTradingEnv, OKXFuturesTradingEnvConfig
-        from torchtrade.envs.replay import ReplayObserver, ReplayOrderExecutor
-
-        config = OKXFuturesTradingEnvConfig(
-            symbol="BTC-USDT-SWAP", time_frames=["1m"], window_sizes=[10],
-            execute_on="1m", leverage=5, demo=True,
-        )
-        executor = ReplayOrderExecutor(initial_balance=10000.0, leverage=5)
-        observer = ReplayObserver(
-            df=replay_df, time_frames=config.time_frames,
-            window_sizes=config.window_sizes, execute_on=config.execute_on, executor=executor,
+        from tests.envs.base_exchange_tests import assert_a_replay_episode_runs
+        from torchtrade.envs.live.okx.env import (
+            OKXFuturesTorchTradingEnv, OKXFuturesTradingEnvConfig,
         )
 
-        with patch("time.sleep"), \
-             patch.object(OKXFuturesTorchTradingEnv, "_wait_for_next_timestamp"):
-            env = OKXFuturesTorchTradingEnv(config=config, observer=observer, trader=executor)
+        assert_a_replay_episode_runs(
+            OKXFuturesTorchTradingEnv, OKXFuturesTradingEnvConfig, replay_df,
+            actions=lambda i, env: i % len(env.action_levels), steps=20,
+            symbol="BTC-USDT-SWAP", demo=True,
+        )
 
-        with patch.object(env, "_wait_for_next_timestamp"):
-            td = env.reset()
-            for i in range(20):
-                action_idx = i % len(env.action_levels)
-                action_td = td.clone()
-                action_td["action"] = torch.tensor(action_idx)
-                result = env.step(action_td)
-                td = result["next"]
-                assert td["account_state"].shape == (6,)
-                if td["done"].item():
-                    break
-            assert executor.current_price > 0

--- a/tests/envs/okx/test_torch_env_futures.py
+++ b/tests/envs/okx/test_torch_env_futures.py
@@ -143,7 +143,10 @@ class TestOKXFuturesTorchTradingEnv:
         (True, True),    # portfolio collapses below the threshold -> episode terminates
         (False, False),  # same collapse, check disabled -> keep trading
     ], ids=["enabled-terminates", "disabled-keeps-trading"])
-    def test_bankruptcy_termination(self, env, mock_env_trader, done_on_bankruptcy, expected_done):
+    @pytest.mark.parametrize("level", [0, 1], ids=["flat", "long"])
+    def test_bankruptcy_termination(
+        self, env, mock_env_trader, done_on_bankruptcy, expected_done, level
+    ):
         """A collapsed portfolio ends the episode through _step iff done_on_bankruptcy.
 
         Threshold arithmetic is covered in tests/envs/test_live_env_base.py; the disabled
@@ -160,7 +163,12 @@ class TestOKXFuturesTorchTradingEnv:
 
         with patch.object(env, "_wait_for_next_timestamp"):
             env.reset()
-            next_td = env.step(TensorDict({"action": torch.tensor(2)}, batch_size=()))
+            # By VALUE, and BOTH routes. `torch.tensor(2)` used to mean "flat" on
+            # three venues and "full long" on binance, because their default action
+            # levels differed -- the same bytes testing two different behaviours
+            # (#288). Now the defaults agree, so the axis has to be explicit.
+            idx = env.action_levels.index(level)
+            next_td = env.step(TensorDict({"action": torch.tensor(idx)}, batch_size=()))
             assert next_td["next"]["done"].item() is expected_done
 
     def test_reset_reads_dust_as_flat(self, env, mock_env_trader):

--- a/tests/envs/okx/test_torch_env_futures.py
+++ b/tests/envs/okx/test_torch_env_futures.py
@@ -537,6 +537,5 @@ class TestWithReplayData:
         assert_a_replay_episode_runs(
             OKXFuturesTorchTradingEnv, OKXFuturesTradingEnvConfig, replay_df,
             actions=lambda i, env: i % len(env.action_levels), steps=20,
-            symbol="BTC-USDT-SWAP", demo=True,
         )
 

--- a/tests/envs/okx/test_torch_env_futures.py
+++ b/tests/envs/okx/test_torch_env_futures.py
@@ -115,18 +115,17 @@ class TestOKXFuturesTorchTradingEnv:
         """Test step with hold action produces valid output."""
         with patch.object(env, "_wait_for_next_timestamp"):
             env.reset()
-            # Flat, BY VALUE. Hardcoding index 2 meant 0.0 under the old 5-level
-            # default and means a full LONG under [-1, 0, 1] -- so this stopped
-            # testing a hold the moment the defaults were unified (#288).
+            # Flat BY VALUE: index 2 was 0.0 under the old 5-level default (#288).
             flat = env.action_levels.index(0)
             action_td = TensorDict({"action": torch.tensor(flat)}, batch_size=())
             next_td = env.step(action_td)
             assert "reward" in next_td["next"].keys()
             assert "done" in next_td["next"].keys()
 
-            # The assertion this test's NAME promised and never made: it only checked
-            # that keys existed, so a flat action that TRADED passed it. Disabling
-            # the flat branch in the env used to fail nothing (#288).
+
+            # The assertion the name always promised: it only checked keys existed.
+            # Defence in depth, not a discriminating pin -- the flat route has FOUR
+            # independent zero-guards, so no single-branch mutation reaches a trade.
             mock_env_trader.trade.assert_not_called()
 
     @pytest.mark.parametrize("level,label", [
@@ -145,9 +144,7 @@ class TestOKXFuturesTorchTradingEnv:
         """The done family is asserted by assert_the_step_emits_the_whole_done_family."""
         with patch.object(env, "_wait_for_next_timestamp"):
             env.reset()
-            # Flat, BY VALUE. Hardcoding index 2 meant 0.0 under the old 5-level
-            # default and means a full LONG under [-1, 0, 1] -- so this stopped
-            # testing a hold the moment the defaults were unified (#288).
+            # Flat BY VALUE: index 2 was 0.0 under the old 5-level default (#288).
             flat = env.action_levels.index(0)
             next_td = env.step(TensorDict({"action": torch.tensor(flat)}, batch_size=()))
             assert next_td["next"]["reward"].shape == (1,)
@@ -176,10 +173,8 @@ class TestOKXFuturesTorchTradingEnv:
 
         with patch.object(env, "_wait_for_next_timestamp"):
             env.reset()
-            # By VALUE, and BOTH routes. `torch.tensor(2)` used to mean "flat" on
-            # three venues and "full long" on binance, because their default action
-            # levels differed -- the same bytes testing two different behaviours
-            # (#288). Now the defaults agree, so the axis has to be explicit.
+            # By VALUE, and both routes: index 2 meant flat on three venues and long on
+            # binance, so the same bytes tested two behaviours (#288).
             idx = env.action_levels.index(level)
             next_td = env.step(TensorDict({"action": torch.tensor(idx)}, batch_size=()))
             assert next_td["next"]["done"].item() is expected_done

--- a/tests/envs/okx/test_torch_env_futures.py
+++ b/tests/envs/okx/test_torch_env_futures.py
@@ -73,8 +73,9 @@ class TestOKXFuturesTorchTradingEnv:
 
     def test_action_spec(self, env):
         """Test action spec and levels are correctly defined."""
-        assert env.action_spec.n == 5
-        assert env.action_levels == [-1.0, -0.5, 0.0, 0.5, 1.0]
+        assert env.action_spec.n == 3  # the default: short / flat / long
+        # Any monotonic list in [-1, 1] is valid; see BaseFuturesTradingConfig.action_levels.
+        assert env.action_levels == [-1, 0, 1]
 
     def test_base_features_declared_in_observation_spec(self, env_config, mock_observer, mock_env_trader):
         """include_base_features=True must DECLARE base_features in observation_spec, not just
@@ -119,14 +120,16 @@ class TestOKXFuturesTorchTradingEnv:
             assert "reward" in next_td["next"].keys()
             assert "done" in next_td["next"].keys()
 
-    @pytest.mark.parametrize("action_idx,label", [
-        (4, "long"), (0, "short"),
+    @pytest.mark.parametrize("level,label", [
+        (1, "long"), (-1, "short"),
     ], ids=["long", "short"])
-    def test_step_trade_action(self, env, mock_env_trader, action_idx, label):
+    def test_step_trade_action(self, env, mock_env_trader, level, label):
         """Test step with long/short action calls trade."""
         with patch.object(env, "_wait_for_next_timestamp"):
             env.reset()
-            env.step(TensorDict({"action": torch.tensor(action_idx)}, batch_size=()))
+            # By VALUE, so the test does not encode the length of action_levels.
+            idx = env.action_levels.index(level)
+            env.step(TensorDict({"action": torch.tensor(idx)}, batch_size=()))
             mock_env_trader.trade.assert_called()
 
     def test_reward_tensor_shape(self, env):
@@ -309,7 +312,9 @@ class TestOKXFuturesTorchTradingEnv:
             f"a position opened after a liquidation inherited the dead position's age ({aged})"
         )
 
-    def test_a_partial_reduction_does_not_age_or_flip_the_position(self, env, mock_env_trader):
+    def test_a_partial_reduction_does_not_age_or_flip_the_position(
+        self, env_config, mock_observer, mock_env_trader
+    ):
         """#276 end to end: the harm was never the direction field, it was the chain.
 
         Trimming a long 1.0 -> 0.5 sends a SELL, which was recorded as current_position
@@ -317,8 +322,25 @@ class TestOKXFuturesTorchTradingEnv:
         a mismatch the env had inflicted on itself, discarded hold_counter and NaN'd
         current_action_level -- so a 20-bar-old position reported holding_time=1 and the
         duplicate-action guard never fired again.
+
+        Builds its own env with a five-level action space: a PARTIAL reduction needs
+        a fractional level, and the default is short/flat/long, where the only
+        "reduction" available is a full close. Asking for the levels is the point --
+        `action_levels` is a default, not a constraint (#288).
         """
         from torchtrade.envs.live.okx.order_executor import PositionStatus
+
+        import dataclasses
+
+        from torchtrade.envs.live.okx.env import OKXFuturesTorchTradingEnv
+
+        cfg = dataclasses.replace(env_config,
+                                  action_levels=[-1.0, -0.5, 0.0, 0.5, 1.0])
+        with patch("time.sleep"), \
+             patch.object(OKXFuturesTorchTradingEnv, "_wait_for_next_timestamp"):
+            env = OKXFuturesTorchTradingEnv(
+                config=cfg, observer=mock_observer, trader=mock_env_trader,
+            )
 
         def status(qty):
             return {"position_status": PositionStatus(

--- a/tests/envs/okx/test_torch_env_futures.py
+++ b/tests/envs/okx/test_torch_env_futures.py
@@ -233,7 +233,7 @@ class TestOKXFuturesTorchTradingEnv:
         with patch.object(env, "_wait_for_next_timestamp"):
             mock_env_trader.get_status = MagicMock(return_value=status(0.01))
             env.reset()
-            long_idx = len(env.action_levels) - 1     # index 1 is a half SHORT in these fixtures
+            long_idx = len(env.action_levels) - 1     # index 1 is FLAT under the [-1, 0, 1] default (#288)
             long = TensorDict({"action": torch.tensor(long_idx)}, batch_size=())
 
             for _ in range(5):                       # age a real position
@@ -267,7 +267,7 @@ class TestOKXFuturesTorchTradingEnv:
 
         with patch.object(env, "_wait_for_next_timestamp"):
             env.reset()
-            long_idx = len(env.action_levels) - 1     # index 1 is a half SHORT in these fixtures
+            long_idx = len(env.action_levels) - 1     # index 1 is FLAT under the [-1, 0, 1] default (#288)
             for _ in range(5):
                 env.step(TensorDict({"action": torch.tensor(long_idx)}, batch_size=()))
             assert env.position.hold_counter > 0      # genuinely aged

--- a/tests/envs/okx/test_torch_env_futures_sltp.py
+++ b/tests/envs/okx/test_torch_env_futures_sltp.py
@@ -483,6 +483,9 @@ class TestWithReplayData:
 
         assert_the_replay_portfolio_tracks_price(
             OKXFuturesSLTPTorchTradingEnv, OKXFuturesSLTPTradingEnvConfig, replay_df, symbol="BTC-USDT-SWAP",
+            # SLTP action map: 0 is HOLD, 1 the first bracket. Stated, not assumed --
+            # the helper used to hardcode these and was silently wrong off-SLTP.
+            open_action=1, hold_action=0,
             stoploss_levels=(-0.05,), takeprofit_levels=(0.05,),
             trade_mode="quantity", quantity_per_trade=0.01,
         )

--- a/tests/envs/okx/test_torch_env_futures_sltp.py
+++ b/tests/envs/okx/test_torch_env_futures_sltp.py
@@ -457,36 +457,33 @@ class TestOKXSLTPInvalidAction:
 
 
 class TestWithReplayData:
-    """Integration tests using ReplayObserver + ReplayOrderExecutor."""
+    """Real price data through ReplayObserver + ReplayOrderExecutor (#288)."""
 
     def test_multi_step_episode_with_replay(self, replay_df):
-        """Run a full multi-step episode with realistic price data."""
-        from torchtrade.envs.live.okx.env_sltp import OKXFuturesSLTPTorchTradingEnv, OKXFuturesSLTPTradingEnvConfig
-        from torchtrade.envs.replay import ReplayObserver, ReplayOrderExecutor
-
-        config = OKXFuturesSLTPTradingEnvConfig(
-            symbol="BTC-USDT-SWAP", time_frames=["1m"], window_sizes=[10],
-            execute_on="1m", stoploss_levels=(-0.02,), takeprofit_levels=(0.03,),
-            leverage=5, trade_mode="quantity", quantity_per_trade=0.01,
-        )
-        executor = ReplayOrderExecutor(initial_balance=10000.0, leverage=5)
-        observer = ReplayObserver(
-            df=replay_df, time_frames=config.time_frames,
-            window_sizes=config.window_sizes, execute_on=config.execute_on, executor=executor,
+        from tests.envs.base_exchange_tests import assert_a_replay_episode_runs
+        from torchtrade.envs.live.okx.env_sltp import (
+            OKXFuturesSLTPTorchTradingEnv, OKXFuturesSLTPTradingEnvConfig,
         )
 
-        with patch("time.sleep"), \
-             patch.object(OKXFuturesSLTPTorchTradingEnv, "_wait_for_next_timestamp"):
-            env = OKXFuturesSLTPTorchTradingEnv(config=config, observer=observer, trader=executor)
+        assert_a_replay_episode_runs(
+            OKXFuturesSLTPTorchTradingEnv, OKXFuturesSLTPTradingEnvConfig, replay_df,
+            actions=lambda i, env: [0, 1, 0, 0, len(env.action_map) - 1, 0][i % 6],
+            steps=50, symbol="BTC-USDT-SWAP",
+            stoploss_levels=(-0.02,), takeprofit_levels=(0.03,),
+            trade_mode="quantity", quantity_per_trade=0.01,
+        )
 
-        with patch.object(env, "_wait_for_next_timestamp"):
-            td = env.reset()
-            for i in range(50):
-                action = [0, 1, 0, 0, len(env.action_map) - 1, 0][i % 6]
-                action_td = td.clone()
-                action_td["action"] = torch.tensor(action)
-                result = env.step(action_td)
-                td = result["next"]
-                assert td["account_state"].shape == (6,)
-                if td["done"].item():
-                    break
+    def test_replay_portfolio_tracks_price_movement(self, replay_df):
+        from tests.envs.base_exchange_tests import (
+            assert_the_replay_portfolio_tracks_price,
+        )
+        from torchtrade.envs.live.okx.env_sltp import (
+            OKXFuturesSLTPTorchTradingEnv, OKXFuturesSLTPTradingEnvConfig,
+        )
+
+        assert_the_replay_portfolio_tracks_price(
+            OKXFuturesSLTPTorchTradingEnv, OKXFuturesSLTPTradingEnvConfig, replay_df, symbol="BTC-USDT-SWAP",
+            stoploss_levels=(-0.05,), takeprofit_levels=(0.05,),
+            trade_mode="quantity", quantity_per_trade=0.01,
+        )
+

--- a/tests/envs/okx/test_torch_env_futures_sltp.py
+++ b/tests/envs/okx/test_torch_env_futures_sltp.py
@@ -468,7 +468,7 @@ class TestWithReplayData:
         assert_a_replay_episode_runs(
             OKXFuturesSLTPTorchTradingEnv, OKXFuturesSLTPTradingEnvConfig, replay_df,
             actions=lambda i, env: [0, 1, 0, 0, len(env.action_map) - 1, 0][i % 6],
-            steps=50, symbol="BTC-USDT-SWAP",
+            steps=50,
             stoploss_levels=(-0.02,), takeprofit_levels=(0.03,),
             trade_mode="quantity", quantity_per_trade=0.01,
         )
@@ -482,7 +482,7 @@ class TestWithReplayData:
         )
 
         assert_the_replay_portfolio_tracks_price(
-            OKXFuturesSLTPTorchTradingEnv, OKXFuturesSLTPTradingEnvConfig, replay_df, symbol="BTC-USDT-SWAP",
+            OKXFuturesSLTPTorchTradingEnv, OKXFuturesSLTPTradingEnvConfig, replay_df,
             # SLTP action map: 0 is HOLD, 1 the first bracket. Stated, not assumed --
             # the helper used to hardcode these and was silently wrong off-SLTP.
             open_action=1, hold_action=0,

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -3852,7 +3852,9 @@ def test_every_plain_config_defaults_to_the_same_action_space():
     """
     levels = {c.values[0].__name__: c.values[0]().action_levels for c in PLAIN_CONFIGS}
     assert len(set(map(tuple, levels.values()))) == 1, levels
-    assert next(iter(levels.values())) == build_default_action_levels(allow_short=True)
+    # A LITERAL, not `build_default_action_levels(...)`: comparing the helper's output
+    # against itself is true by construction and cannot see the default change.
+    assert next(iter(levels.values())) == [-1, 0, 1]
 
 
 @pytest.mark.parametrize("config_cls", SLTP_CONFIGS)
@@ -4414,17 +4416,17 @@ def test_a_recovered_venue_does_not_truncate_the_next_episode():
         ), observer=observer, trader=trader)
 
         td = env.reset()
-        td = env.step(td.set("action", torch.tensor(1)))["next"]
+        td = env.step(td.set("action", torch.tensor(env.action_levels.index(0))))["next"]
         trader.get_status.side_effect = PositionUnknownError("down")
         for _ in range(2):
             td = env.step(td.exclude("done", "terminated", "truncated", "reward")
-                          .set("action", torch.tensor(1)))["next"]
+                          .set("action", torch.tensor(env.action_levels.index(0))))["next"]
         assert bool(td["truncated"]), "setup: the outage should have truncated"
 
         trader.get_status.side_effect = None          # venue recovers
         fresh = env.reset()
         assert env.consecutive_unknown_status == 0
-        nxt = env.step(fresh.set("action", torch.tensor(1)))["next"]
+        nxt = env.step(fresh.set("action", torch.tensor(env.action_levels.index(0))))["next"]
 
     assert not bool(nxt["truncated"]), (
         "the new episode truncated on its first step: the outage counter survived reset"

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -3780,9 +3780,7 @@ from torchtrade.envs.utils.fractional_sizing import build_default_action_levels
 # The PLAIN configs, discovered from the env classes so a fifth venue cannot opt out.
 PLAIN_CONFIGS = [
     pytest.param(
-        next(o for o in vars(importlib.import_module(c.__module__)).values()
-             if dataclasses.is_dataclass(o)
-             and getattr(o, "__name__", "").endswith("TradingEnvConfig")),
+        _sole(importlib.import_module(c.__module__), "TradingEnvConfig"),
         id=c.__module__.split(".")[-2],
     )
     for c in PLAIN_FUTURES_ENVS
@@ -3817,7 +3815,9 @@ def test_every_plain_config_runs_the_shared_post_init(config_cls):
     )
 
 
-def test_no_venue_defaults_to_cross_margin():
+@pytest.mark.parametrize("config_cls", [p.values[0] for p in PLAIN_CONFIGS + SLTP_CONFIGS],
+                         ids=lambda c: c.__name__)
+def test_no_venue_defaults_to_cross_margin(config_cls):
     """The default margin mode is a MONEY decision, and nothing pinned its VALUE.
 
     Folding the four configs, I changed okx's default from ISOLATED to CROSS by mistake
@@ -3827,19 +3827,17 @@ def test_no_venue_defaults_to_cross_margin():
     rather than the position's own margin, so it is not a default anything should acquire
     silently -- least of all from a deduplication (#288).
 
-    Both config families, because okx's plain and SLTP twins had already disagreed for
-    the length of one commit.
+    Parametrized, not looped: a loop stops at the first venue and a second regression of
+    the same shape would stay hidden behind it. Both families, because okx's plain and
+    SLTP twins had already disagreed for the length of one commit.
     """
     from torchtrade.envs.core.common_types import MarginMode as SharedMarginMode
 
-    for family in (PLAIN_CONFIGS, SLTP_CONFIGS):
-        for param in family:
-            cfg = param.values[0]
-            mode = cfg().margin_mode
-            assert mode.name == SharedMarginMode.ISOLATED.name, (
-                f"{cfg.__name__} defaults to {mode.name}; isolated margin is the default "
-                f"every venue ships, and cross exposes the whole balance"
-            )
+    mode = config_cls().margin_mode
+    assert mode.name == SharedMarginMode.ISOLATED.name, (
+        f"{config_cls.__name__} defaults to {mode.name}; isolated margin is the default "
+        f"every venue ships, and cross exposes the whole balance"
+    )
 
 
 def test_every_plain_config_defaults_to_the_same_action_space():
@@ -3870,11 +3868,33 @@ def test_every_sltp_config_inherits_the_shared_fields(config_cls):
     )
 
 
-@pytest.mark.parametrize("config_cls", SLTP_CONFIGS)
-def test_hoisting_a_default_did_not_change_it(config_cls):
-    """Values the four venues agreed on before the hoist, and must still agree on."""
+# The plain base carries 12 of the same keys. Deriving the set rather than retyping it
+# means a field leaving either base is a loud failure here, not a silently smaller pin.
+_PLAIN_SHARED_DEFAULTS = {
+    f.name: SHARED_DEFAULTS[f.name]
+    for f in dataclasses.fields(BaseFuturesTradingConfig) if f.name in SHARED_DEFAULTS
+}
+assert len(_PLAIN_SHARED_DEFAULTS) == 12, sorted(_PLAIN_SHARED_DEFAULTS)
+
+
+@pytest.mark.parametrize("config_cls,pinned", (
+    [pytest.param(c.values[0], SHARED_DEFAULTS, id=f"sltp-{c.id or c.values[0].__name__}")
+     for c in SLTP_CONFIGS]
+    + [pytest.param(c.values[0], _PLAIN_SHARED_DEFAULTS,
+                    id=f"plain-{c.id or c.values[0].__name__}")
+       for c in PLAIN_CONFIGS]
+))
+def test_hoisting_a_default_did_not_change_it(config_cls, pinned):
+    """Values the four venues agreed on before the hoist, and must still agree on.
+
+    BOTH families. The plain fold put twelve money-bearing defaults behind a single
+    literal and pinned none of them: flipping `demo` to False -- every venue then
+    defaulting to the LIVE exchange rather than testnet -- passed 2044 tests, and so did
+    moving `bankrupt_threshold` 0.1 -> 0.5, a 5x change in every venue's force-close
+    point. That is the hoisted-but-unpinned state this test was written for (#288).
+    """
     config = config_cls()
-    assert {f: getattr(config, f) for f in SHARED_DEFAULTS} == SHARED_DEFAULTS
+    assert {f: getattr(config, f) for f in pinned} == pinned
 
 
 # Both variants per venue: the SLTP-only list let a base config drift unseen. Imported

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -3775,7 +3775,6 @@ SHARED_DEFAULTS = {
 
 
 from torchtrade.envs.live.shared.futures_config import BaseFuturesTradingConfig
-from torchtrade.envs.utils.fractional_sizing import build_default_action_levels
 
 # The PLAIN configs, discovered from the env classes so a fifth venue cannot opt out.
 PLAIN_CONFIGS = [

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -3774,6 +3774,64 @@ SHARED_DEFAULTS = {
 }
 
 
+from torchtrade.envs.live.shared.futures_config import BaseFuturesTradingConfig
+from torchtrade.envs.utils.fractional_sizing import build_default_action_levels
+
+# The PLAIN configs, discovered from the env classes so a fifth venue cannot opt out.
+PLAIN_CONFIGS = [
+    pytest.param(
+        next(o for o in vars(importlib.import_module(c.__module__)).values()
+             if dataclasses.is_dataclass(o)
+             and getattr(o, "__name__", "").endswith("TradingEnvConfig")),
+        id=c.__module__.split(".")[-2],
+    )
+    for c in PLAIN_FUTURES_ENVS
+]
+
+# Venue surface: what a plain config is still allowed to declare for itself. `margin_mode`
+# is a DIFFERENT enum per venue (okx spells its member CROSS where the others say
+# CROSSED), so hoisting it would flatten a real vocabulary difference into Any.
+_PLAIN_VENUE_FIELDS = {"symbol", "margin_mode", "position_mode", "product_type"}
+
+
+@pytest.mark.parametrize("config_cls", PLAIN_CONFIGS)
+def test_every_plain_config_inherits_the_shared_fields(config_cls):
+    """The plain twin of the SLTP guard below. A subclass re-declaring a shared field
+    silently shadows the base default -- same value today, stops tracking tomorrow (#288).
+    """
+    assert issubclass(config_cls, BaseFuturesTradingConfig)
+    own = set(vars(config_cls).get("__annotations__", {}))
+    assert not (own - _PLAIN_VENUE_FIELDS), (
+        f"{config_cls.__name__} re-declares {sorted(own - _PLAIN_VENUE_FIELDS)}; only the "
+        f"venue surface belongs in a subclass"
+    )
+
+
+@pytest.mark.parametrize("config_cls", PLAIN_CONFIGS)
+def test_every_plain_config_runs_the_shared_post_init(config_cls):
+    """A subclass growing its own `__post_init__` and dropping the super() call stops
+    validating every field the shared one checks, silently.
+    """
+    assert config_cls.__post_init__ is BaseFuturesTradingConfig.__post_init__, (
+        f"{config_cls.__name__} defines its own __post_init__"
+    )
+
+
+def test_every_plain_config_defaults_to_the_same_action_space():
+    """One unset config, one `action_spec.n`, on every venue.
+
+    binance derived its default from `build_default_action_levels` while the other three
+    hard-coded a five-level list, so the SAME config produced a 3-action space on one
+    venue and a 5-action space on the other three. `action_spec.n` is what a checkpoint is
+    bound to, so a policy could not move between venues it was meant to be portable
+    across (#288). The VALUE is a default, not a constraint -- a config that sets
+    `action_levels` explicitly is the supported way to trade half sizes.
+    """
+    levels = {c.values[0].__name__: c.values[0]().action_levels for c in PLAIN_CONFIGS}
+    assert len(set(map(tuple, levels.values()))) == 1, levels
+    assert next(iter(levels.values())) == build_default_action_levels(allow_short=True)
+
+
 @pytest.mark.parametrize("config_cls", SLTP_CONFIGS)
 def test_every_sltp_config_inherits_the_shared_fields(config_cls):
     """A subclass re-declaring a shared field silently shadows the base default (#288)."""
@@ -5620,18 +5678,22 @@ def test_the_history_row_is_the_one_the_reward_function_scores(sltp):
     )
 
 
-# binance ships [-1, 0, 1]; the other three ship [-1, -0.5, 0, 0.5, 1]. The venue axis is
-# NOT theatre here, unlike elsewhere in this file: venues differ in DATA,
-# not only in code, and on binance a mutation flattening the level to its sign is a no-op.
-#
-@pytest.mark.parametrize("venue,want", [
-    ("binance", 1), ("binance", -1), ("bitget", 0.5), ("bitget", -0.5),
+# The half rows set `action_levels` EXPLICITLY. They used to lean on bitget defaulting to
+# five levels while binance defaulted to three -- a divergence #288 removed, since the same
+# unset config produced a different `action_spec.n` per venue. A fractional level is still
+# the case that matters here (a mutation flattening the level to its sign is a no-op on
+# +-1), so the test now asks for it rather than relying on a venue's default.
+@pytest.mark.parametrize("venue,want,levels", [
+    ("binance", 1, None), ("binance", -1, None),
+    ("bitget", 0.5, [-1.0, -0.5, 0.0, 0.5, 1.0]),
+    ("bitget", -0.5, [-1.0, -0.5, 0.0, 0.5, 1.0]),
 ], ids=["full-long", "full-short", "half-long", "half-short"])
-def test_the_plain_history_row_records_the_action_actually_traded(venue, want):
+def test_the_plain_history_row_records_the_action_actually_traded(venue, want, levels):
     """`action` in the history row is what the reward function scores -- the LEVEL, not
     its sign.
     """
-    env, _ = _real_futures_env(budget=0, venue=venue)
+    kw = {"action_levels": levels} if levels else {}
+    env, _ = _real_futures_env(budget=0, venue=venue, **kw)
     # Index by value, not position: the action_levels lists differ in length.
     action = env.action_levels.index(want)
     td = env.reset()

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -3785,9 +3785,13 @@ PLAIN_CONFIGS = [
     for c in PLAIN_FUTURES_ENVS
 ]
 
+# Both families, for the guards that apply to a futures config regardless of brackets.
+_ALL_FUTURES_CONFIGS = [p.values[0] for p in PLAIN_CONFIGS + SLTP_CONFIGS]
+assert len(_ALL_FUTURES_CONFIGS) == 8, [c.__name__ for c in _ALL_FUTURES_CONFIGS]
+
 # Venue surface: what a plain config is still allowed to declare for itself. `margin_mode`
-# is a DIFFERENT enum per venue (okx spells its member CROSS where the others say
-# CROSSED), so hoisting it would flatten a real vocabulary difference into Any.
+# is a DIFFERENT enum CLASS per venue, so there is no one type to hoist -- hoisting it
+# would need `Any`, which is how the okx default slipped from ISOLATED to CROSS.
 _PLAIN_VENUE_FIELDS = {"symbol", "margin_mode", "position_mode", "product_type"}
 
 
@@ -3814,8 +3818,27 @@ def test_every_plain_config_runs_the_shared_post_init(config_cls):
     )
 
 
-@pytest.mark.parametrize("config_cls", [p.values[0] for p in PLAIN_CONFIGS + SLTP_CONFIGS],
-                         ids=lambda c: c.__name__)
+@pytest.mark.parametrize("config_cls", _ALL_FUTURES_CONFIGS, ids=lambda c: c.__name__)
+def test_every_config_normalizes_with_its_own_venue_parser(config_cls):
+    """The one token the fold left unguarded.
+
+    Hoisting `__post_init__` turned four inline `normalize_<venue>_timeframe_config`
+    calls into one class attribute per subclass, and nothing checked where it points.
+    Cross-wiring bybit's config to binance's normalizer passes all 3678 env tests -- but
+    the parsers are genuinely different vocabularies, so bybit's native `"60"`/`"D"`/
+    `"240"` all become construction-time ValueErrors. It fails loud rather than trading
+    wrong, which is why it is a pin and not a bug; the guards above check the fields and
+    the `__post_init__` identity and stop one line short of what it calls (#288).
+    """
+    venue = config_cls.__module__.split(".")[-2]
+    expected = getattr(importlib.import_module(f"torchtrade.envs.live.{venue}.utils"),
+                       f"normalize_{venue}_timeframe_config")
+    assert config_cls._normalize_timeframes is expected, (
+        f"{config_cls.__name__} normalizes timeframes with a parser that is not {venue}'s"
+    )
+
+
+@pytest.mark.parametrize("config_cls", _ALL_FUTURES_CONFIGS, ids=lambda c: c.__name__)
 def test_no_venue_defaults_to_cross_margin(config_cls):
     """The default margin mode is a MONEY decision, and nothing pinned its VALUE.
 
@@ -3829,13 +3852,15 @@ def test_no_venue_defaults_to_cross_margin(config_cls):
     Parametrized, not looped: a loop stops at the first venue and a second regression of
     the same shape would stay hidden behind it. Both families, because okx's plain and
     SLTP twins had already disagreed for the length of one commit.
-    """
-    from torchtrade.envs.core.common_types import MarginMode as SharedMarginMode
 
+    On the VALUE, not the member name: the value is what reaches the venue. Case-folded
+    because binance's shared enum spells it upper-case where the other three send the
+    lower-case wire string.
+    """
     mode = config_cls().margin_mode
-    assert mode.name == SharedMarginMode.ISOLATED.name, (
-        f"{config_cls.__name__} defaults to {mode.name}; isolated margin is the default "
-        f"every venue ships, and cross exposes the whole balance"
+    assert mode.value.lower() == "isolated", (
+        f"{config_cls.__name__} defaults to {mode.name}={mode.value!r}; isolated margin "
+        f"is the default every venue ships, and cross exposes the whole balance"
     )
 
 

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -3817,6 +3817,31 @@ def test_every_plain_config_runs_the_shared_post_init(config_cls):
     )
 
 
+def test_no_venue_defaults_to_cross_margin():
+    """The default margin mode is a MONEY decision, and nothing pinned its VALUE.
+
+    Folding the four configs, I changed okx's default from ISOLATED to CROSS by mistake
+    and the whole suite stayed green: the existing guard asserts the field's NAME is
+    spelled the same everywhere, and `_PLAIN_VENUE_FIELDS` deliberately treats the value
+    as venue business. Cross margin backs the position with the entire account balance
+    rather than the position's own margin, so it is not a default anything should acquire
+    silently -- least of all from a deduplication (#288).
+
+    Both config families, because okx's plain and SLTP twins had already disagreed for
+    the length of one commit.
+    """
+    from torchtrade.envs.core.common_types import MarginMode as SharedMarginMode
+
+    for family in (PLAIN_CONFIGS, SLTP_CONFIGS):
+        for param in family:
+            cfg = param.values[0]
+            mode = cfg().margin_mode
+            assert mode.name == SharedMarginMode.ISOLATED.name, (
+                f"{cfg.__name__} defaults to {mode.name}; isolated margin is the default "
+                f"every venue ships, and cross exposes the whole balance"
+            )
+
+
 def test_every_plain_config_defaults_to_the_same_action_space():
     """One unset config, one `action_spec.n`, on every venue.
 

--- a/tests/envs/test_live_observation_failsafe.py
+++ b/tests/envs/test_live_observation_failsafe.py
@@ -516,10 +516,9 @@ def test_a_grace_bar_can_still_SIZE_a_trade_with_the_venue_down(venue):
     import torch
 
     env, trader = _real_futures_env(budget=3, venue=venue)
-    # Index-by-VALUE, not by position: binance ships [-1, 0, 1] and the others
-    # [-1, -0.5, 0, 0.5, 1], so a hardcoded index 2 is "flat" on three of the four and
-    # takes the close path instead of the sizing path. That is exactly how this fix went
-    # untested on three venues in the first place.
+    # Index-by-VALUE, not by position: the four venues now share [-1, 0, 1], but they
+    # did not when this fix landed, and a hardcoded index took the close path instead of
+    # the sizing path on three of them. By value it cannot go stale again (#288).
     flat = env.action_levels.index(0.0)
     full_long = len(env.action_levels) - 1
 
@@ -631,7 +630,10 @@ def test_grace_covers_the_exception_the_adapters_actually_raise(venue, sltp):
                                     **({"trade_mode": "fractional",
                                         "position_fraction": 0.5} if sltp else {}))
     td = env.reset()
-    td = env.step(td.set("action", torch.tensor(0 if sltp else 1)))["next"]
+    # Setup step, flat: plain index 1 was a half-short on three venues before the shared
+    # default, so say what it means rather than where it sits.
+    flat = 0 if sltp else env.action_levels.index(0.0)
+    td = env.step(td.set("action", torch.tensor(flat)))["next"]
 
     trader.get_account_balance.side_effect = RuntimeError(
         "Failed to get account balance: connection reset"

--- a/torchtrade/envs/live/binance/env.py
+++ b/torchtrade/envs/live/binance/env.py
@@ -59,9 +59,7 @@ class BinanceFuturesTorchTradingEnv(BinanceBaseTorchTradingEnv):
         position_size = (balance × |action| × leverage) / price
         (rounded to exchange step size)
 
-    Default action_levels: [-1, 0, 1] (short / flat / long). It is a DEFAULT, not a
-    constraint -- pass any monotonic list in [-1.0, 1.0] and its length becomes the
-    Categorical's n, e.g. [-1.0, -0.5, 0.0, 0.5, 1.0] for half-size steps.
+    Default action_levels: [-1, 0, 1]; see BaseFuturesTradingConfig.action_levels.
     Custom levels supported: e.g., [-1, -0.3, -0.1, 0, 0.1, 0.3, 1]
 
     Leverage Design:

--- a/torchtrade/envs/live/binance/env.py
+++ b/torchtrade/envs/live/binance/env.py
@@ -52,16 +52,16 @@ class BinanceFuturesTorchTradingEnv(BinanceBaseTorchTradingEnv):
     Action values in range [-1.0, 1.0]:
 
     - action = -1.0: 100% short (all-in short)
-    - action = -0.5: 50% short
     - action = 0.0: Market neutral (close all positions, stay in cash)
-    - action = 0.5: 50% long
     - action = 1.0: 100% long (all-in long)
 
     Position sizing formula:
         position_size = (balance × |action| × leverage) / price
         (rounded to exchange step size)
 
-    Default action_levels: [-1, 0, 1] (short / flat / long)
+    Default action_levels: [-1, 0, 1] (short / flat / long). It is a DEFAULT, not a
+    constraint -- pass any monotonic list in [-1.0, 1.0] and its length becomes the
+    Categorical's n, e.g. [-1.0, -0.5, 0.0, 0.5, 1.0] for half-size steps.
     Custom levels supported: e.g., [-1, -0.3, -0.1, 0, 0.1, 0.3, 1]
 
     Leverage Design:

--- a/torchtrade/envs/live/binance/env.py
+++ b/torchtrade/envs/live/binance/env.py
@@ -1,26 +1,17 @@
 from dataclasses import dataclass
-from typing import Dict, List, Optional, Union, Callable
+from typing import Dict, Optional, Callable
 import logging
 
 
 logger = logging.getLogger(__name__)
 from torchrl.data import Categorical
 
-from torchtrade.envs.utils.timeframe import TimeFrame
-from torchtrade.envs.core.common import validate_unknown_status_budget
-from torchtrade.envs.core.live import (
-    ObservationFailurePolicy,
-)
 from torchtrade.envs.live.binance.observation import BinanceObservationClass
 from torchtrade.envs.live.binance.order_executor import (
     BinanceFuturesOrderClass,
     MarginMode,
 )
 from torchtrade.envs.live.binance.base import BinanceBaseTorchTradingEnv
-from torchtrade.envs.utils.fractional_sizing import (
-    validate_action_levels,
-    build_default_action_levels,
-)
 from torchtrade.envs.live.shared.futures_config import BaseFuturesTradingConfig
 from torchtrade.envs.live.binance.utils import normalize_binance_timeframe_config
 
@@ -32,7 +23,6 @@ class BinanceFuturesTradingEnvConfig(BaseFuturesTradingConfig):
     margin_mode: MarginMode = MarginMode.ISOLATED
 
     _normalize_timeframes = staticmethod(normalize_binance_timeframe_config)
-
 
 
 class BinanceFuturesTorchTradingEnv(BinanceBaseTorchTradingEnv):

--- a/torchtrade/envs/live/binance/env.py
+++ b/torchtrade/envs/live/binance/env.py
@@ -21,58 +21,18 @@ from torchtrade.envs.utils.fractional_sizing import (
     validate_action_levels,
     build_default_action_levels,
 )
+from torchtrade.envs.live.shared.futures_config import BaseFuturesTradingConfig
+from torchtrade.envs.live.binance.utils import normalize_binance_timeframe_config
 
 
 @dataclass
-class BinanceFuturesTradingEnvConfig:
+class BinanceFuturesTradingEnvConfig(BaseFuturesTradingConfig):
     """Configuration for Binance Futures Trading Environment."""
 
-    symbol: str = "BTCUSDT"
-
-    # Timeframes and windows
-    time_frames: Union[List[Union[str, TimeFrame]], Union[str, TimeFrame]] = "1Hour"
-    window_sizes: Union[List[int], int] = 10
-    execute_on: Union[str, TimeFrame] = "1Hour"  # Timeframe for trade execution timing
-
-    # Trading parameters
-    leverage: int = 1  # Leverage (1-125)
     margin_mode: MarginMode = MarginMode.ISOLATED
 
-    # Action space configuration (fractional mode only)
-    action_levels: List[float] = None  # Custom action levels, or None for defaults
+    _normalize_timeframes = staticmethod(normalize_binance_timeframe_config)
 
-    # Termination settings
-    done_on_bankruptcy: bool = True
-    bankrupt_threshold: float = 0.1  # 10% of initial balance
-
-    # Environment settings
-    demo: bool = True  # Use demo/testnet for paper trading
-    seed: Optional[int] = 42
-    include_base_features: bool = False
-    close_position_on_init: bool = True
-    close_position_on_reset: bool = False
-    observation_failure_policy: ObservationFailurePolicy | str = ObservationFailurePolicy.HALT
-    # Bars to ride out an unreadable venue before truncating; 0 disables (#295).
-    max_unknown_status_steps: int = 0
-
-    def __post_init__(self):
-        """Normalize timeframe configuration and build action levels."""
-        from torchtrade.envs.live.binance.utils import normalize_binance_timeframe_config
-
-        self.observation_failure_policy = ObservationFailurePolicy(self.observation_failure_policy)
-        validate_unknown_status_budget(self.max_unknown_status_steps)
-
-        self.execute_on, self.time_frames, self.window_sizes = normalize_binance_timeframe_config(
-            self.execute_on, self.time_frames, self.window_sizes
-        )
-
-        # Build default action levels
-        if self.action_levels is None:
-            self.action_levels = build_default_action_levels(
-                allow_short=True  # Futures allow short positions
-            )
-
-        validate_action_levels(self.action_levels)
 
 
 class BinanceFuturesTorchTradingEnv(BinanceBaseTorchTradingEnv):

--- a/torchtrade/envs/live/bitget/README.md
+++ b/torchtrade/envs/live/bitget/README.md
@@ -157,10 +157,11 @@ env = BitgetFuturesTorchTradingEnv(
 td = env.reset()
 
 # Actions are CATEGORICAL indices into action_levels, which on Bitget
-# defaults to [-1.0, -0.5, 0.0, 0.5, 1.0]:
-# 0 = full short, 2 = flat, 4 = full long. Leverage and size come from the config,
-# not from the action.
-td["action"] = torch.tensor(4)  # go full long
+# defaults to [-1, 0, 1]:
+# 0 = full short, 1 = flat, 2 = full long. Leverage and size come from the config,
+# not from the action. Pass `action_levels` for a finer space, e.g.
+# [-1.0, -0.5, 0.0, 0.5, 1.0], and the index meanings shift with it.
+td["action"] = torch.tensor(2)  # go full long
 td = env.step(td)
 ```
 

--- a/torchtrade/envs/live/bitget/env.py
+++ b/torchtrade/envs/live/bitget/env.py
@@ -17,56 +17,20 @@ from torchtrade.envs.core.live import (
 from torchtrade.envs.utils.fractional_sizing import (
     validate_action_levels,
 )
+from torchtrade.envs.live.shared.futures_config import BaseFuturesTradingConfig
+from torchtrade.envs.live.bitget.utils import normalize_bitget_timeframe_config
 
 
 @dataclass
-class BitgetFuturesTradingEnvConfig:
+class BitgetFuturesTradingEnvConfig(BaseFuturesTradingConfig):
     """Configuration for Bitget Futures Trading Environment."""
 
-    symbol: str = "BTCUSDT"
-
-    # Timeframes and windows
-    time_frames: Union[List[Union[str, "TimeFrame"]], Union[str, "TimeFrame"]] = "1Hour"
-    window_sizes: Union[List[int], int] = 10
-    execute_on: Union[str, "TimeFrame"] = "1Hour"  # Timeframe for trade execution timing
-
-    # Trading parameters
-    product_type: str = "USDT-FUTURES"  # V2 API: USDT-FUTURES, COIN-FUTURES, USDC-FUTURES
-    leverage: int = 1  # Leverage (1-125)
     margin_mode: MarginMode = MarginMode.ISOLATED
-    position_mode: PositionMode = PositionMode.ONE_WAY  # ONE_WAY or HEDGE
+    position_mode: PositionMode = PositionMode.ONE_WAY
+    product_type: str = "USDT-FUTURES"
 
-    # Action space configuration
-    action_levels: List[float] = None  # Custom action levels, or None for defaults
+    _normalize_timeframes = staticmethod(normalize_bitget_timeframe_config)
 
-    # Termination settings
-    done_on_bankruptcy: bool = True
-    bankrupt_threshold: float = 0.1  # 10% of initial balance
-
-    # Environment settings
-    demo: bool = True  # Use testnet for demo
-    seed: Optional[int] = 42
-    include_base_features: bool = False
-    close_position_on_init: bool = True
-    close_position_on_reset: bool = False
-    observation_failure_policy: ObservationFailurePolicy | str = ObservationFailurePolicy.HALT
-    # Bars to ride out an unreadable venue before truncating; 0 disables (#295).
-    max_unknown_status_steps: int = 0
-
-    def __post_init__(self):
-        self.observation_failure_policy = ObservationFailurePolicy(self.observation_failure_policy)
-        validate_unknown_status_budget(self.max_unknown_status_steps)
-        # Normalize timeframes using utility function
-        from torchtrade.envs.live.bitget.utils import normalize_bitget_timeframe_config
-        self.execute_on, self.time_frames, self.window_sizes = normalize_bitget_timeframe_config(
-            self.execute_on, self.time_frames, self.window_sizes
-        )
-
-        # Build default action levels for fractional mode
-        if self.action_levels is None:
-            self.action_levels = [-1.0, -0.5, 0.0, 0.5, 1.0]  # Standard fractional with long/short
-
-        validate_action_levels(self.action_levels)
 
 
 class BitgetFuturesTorchTradingEnv(BitgetBaseTorchTradingEnv):

--- a/torchtrade/envs/live/bitget/env.py
+++ b/torchtrade/envs/live/bitget/env.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import List, Optional, Union, Callable, Dict
+from typing import Optional, Callable, Dict
 
 from torchrl.data import Categorical
 
@@ -10,13 +10,6 @@ from torchtrade.envs.live.bitget.order_executor import (
     PositionMode,
 )
 from torchtrade.envs.live.bitget.base import BitgetBaseTorchTradingEnv
-from torchtrade.envs.core.common import validate_unknown_status_budget
-from torchtrade.envs.core.live import (
-    ObservationFailurePolicy,
-)
-from torchtrade.envs.utils.fractional_sizing import (
-    validate_action_levels,
-)
 from torchtrade.envs.live.shared.futures_config import BaseFuturesTradingConfig
 from torchtrade.envs.live.bitget.utils import normalize_bitget_timeframe_config
 
@@ -32,7 +25,6 @@ class BitgetFuturesTradingEnvConfig(BaseFuturesTradingConfig):
     product_type: str = "USDT-FUTURES"
 
     _normalize_timeframes = staticmethod(normalize_bitget_timeframe_config)
-
 
 
 class BitgetFuturesTorchTradingEnv(BitgetBaseTorchTradingEnv):

--- a/torchtrade/envs/live/bitget/env.py
+++ b/torchtrade/envs/live/bitget/env.py
@@ -58,9 +58,7 @@ class BitgetFuturesTorchTradingEnv(BitgetBaseTorchTradingEnv):
     Position sizing formula:
         position_size = (balance × |action| × leverage) / price
 
-    Default action_levels: [-1, 0, 1] (short / flat / long). It is a DEFAULT, not a
-    constraint -- pass any monotonic list in [-1.0, 1.0] and its length becomes the
-    Categorical's n, e.g. [-1.0, -0.5, 0.0, 0.5, 1.0] for half-size steps.
+    Default action_levels: [-1, 0, 1]; see BaseFuturesTradingConfig.action_levels.
     Custom levels supported: e.g., [-1, -0.3, -0.1, 0, 0.1, 0.3, 1]
 
     Leverage Design:

--- a/torchtrade/envs/live/bitget/env.py
+++ b/torchtrade/envs/live/bitget/env.py
@@ -27,6 +27,8 @@ class BitgetFuturesTradingEnvConfig(BaseFuturesTradingConfig):
 
     margin_mode: MarginMode = MarginMode.ISOLATED
     position_mode: PositionMode = PositionMode.ONE_WAY
+    # V2 API: USDT-FUTURES, COIN-FUTURES, USDC-FUTURES. A bare str with no
+    # validator, so this comment is where the legal values live.
     product_type: str = "USDT-FUTURES"
 
     _normalize_timeframes = staticmethod(normalize_bitget_timeframe_config)
@@ -50,15 +52,15 @@ class BitgetFuturesTorchTradingEnv(BitgetBaseTorchTradingEnv):
     Action values in range [-1.0, 1.0]:
 
     - action = -1.0: 100% short (all-in short)
-    - action = -0.5: 50% short
     - action = 0.0: Market neutral (close all positions, stay in cash)
-    - action = 0.5: 50% long
     - action = 1.0: 100% long (all-in long)
 
     Position sizing formula:
         position_size = (balance × |action| × leverage) / price
 
-    Default action_levels: [-1.0, -0.5, 0.0, 0.5, 1.0]
+    Default action_levels: [-1, 0, 1] (short / flat / long). It is a DEFAULT, not a
+    constraint -- pass any monotonic list in [-1.0, 1.0] and its length becomes the
+    Categorical's n, e.g. [-1.0, -0.5, 0.0, 0.5, 1.0] for half-size steps.
     Custom levels supported: e.g., [-1, -0.3, -0.1, 0, 0.1, 0.3, 1]
 
     Leverage Design:

--- a/torchtrade/envs/live/bybit/env.py
+++ b/torchtrade/envs/live/bybit/env.py
@@ -2,7 +2,7 @@
 
 from torchtrade.envs.utils.precision import decimals_for_step
 from dataclasses import dataclass
-from typing import List, Optional, Union, Callable, Dict
+from typing import Optional, Callable, Dict
 
 from torchrl.data import Categorical
 
@@ -13,13 +13,6 @@ from torchtrade.envs.live.bybit.order_executor import (
     PositionMode,
 )
 from torchtrade.envs.live.bybit.base import BybitBaseTorchTradingEnv
-from torchtrade.envs.core.common import validate_unknown_status_budget
-from torchtrade.envs.core.live import (
-    ObservationFailurePolicy,
-)
-from torchtrade.envs.utils.fractional_sizing import (
-    validate_action_levels,
-)
 from torchtrade.envs.live.shared.futures_config import BaseFuturesTradingConfig
 from torchtrade.envs.live.bybit.utils import normalize_bybit_timeframe_config
 
@@ -32,7 +25,6 @@ class BybitFuturesTradingEnvConfig(BaseFuturesTradingConfig):
     position_mode: PositionMode = PositionMode.ONE_WAY
 
     _normalize_timeframes = staticmethod(normalize_bybit_timeframe_config)
-
 
 
 class BybitFuturesTorchTradingEnv(BybitBaseTorchTradingEnv):

--- a/torchtrade/envs/live/bybit/env.py
+++ b/torchtrade/envs/live/bybit/env.py
@@ -48,12 +48,12 @@ class BybitFuturesTorchTradingEnv(BybitBaseTorchTradingEnv):
 
     Action Space (Fractional Mode - Default):
     - action = -1.0: 100% short (all-in short)
-    - action = -0.5: 50% short
     - action = 0.0: Market neutral (close all positions)
-    - action = 0.5: 50% long
     - action = 1.0: 100% long (all-in long)
 
-    Default action_levels: [-1.0, -0.5, 0.0, 0.5, 1.0]
+    Default action_levels: [-1, 0, 1] (short / flat / long). It is a DEFAULT, not a
+    constraint -- pass any monotonic list in [-1.0, 1.0] and its length becomes the
+    Categorical's n, e.g. [-1.0, -0.5, 0.0, 0.5, 1.0] for half-size steps.
     """
 
     def __init__(

--- a/torchtrade/envs/live/bybit/env.py
+++ b/torchtrade/envs/live/bybit/env.py
@@ -20,53 +20,19 @@ from torchtrade.envs.core.live import (
 from torchtrade.envs.utils.fractional_sizing import (
     validate_action_levels,
 )
+from torchtrade.envs.live.shared.futures_config import BaseFuturesTradingConfig
+from torchtrade.envs.live.bybit.utils import normalize_bybit_timeframe_config
 
 
 @dataclass
-class BybitFuturesTradingEnvConfig:
+class BybitFuturesTradingEnvConfig(BaseFuturesTradingConfig):
     """Configuration for Bybit Futures Trading Environment."""
 
-    symbol: str = "BTCUSDT"
-
-    # Timeframes and windows
-    time_frames: Union[List[Union[str, "TimeFrame"]], Union[str, "TimeFrame"]] = "1Hour"
-    window_sizes: Union[List[int], int] = 10
-    execute_on: Union[str, "TimeFrame"] = "1Hour"
-
-    # Trading parameters
-    leverage: int = 1
     margin_mode: MarginMode = MarginMode.ISOLATED
     position_mode: PositionMode = PositionMode.ONE_WAY
 
-    # Action space configuration
-    action_levels: List[float] = None
+    _normalize_timeframes = staticmethod(normalize_bybit_timeframe_config)
 
-    # Termination settings
-    done_on_bankruptcy: bool = True
-    bankrupt_threshold: float = 0.1
-
-    # Environment settings
-    demo: bool = True
-    seed: Optional[int] = 42
-    include_base_features: bool = False
-    close_position_on_init: bool = True
-    close_position_on_reset: bool = False
-    observation_failure_policy: ObservationFailurePolicy | str = ObservationFailurePolicy.HALT
-    # Bars to ride out an unreadable venue before truncating; 0 disables (#295).
-    max_unknown_status_steps: int = 0
-
-    def __post_init__(self):
-        self.observation_failure_policy = ObservationFailurePolicy(self.observation_failure_policy)
-        validate_unknown_status_budget(self.max_unknown_status_steps)
-        from torchtrade.envs.live.bybit.utils import normalize_bybit_timeframe_config
-        self.execute_on, self.time_frames, self.window_sizes = normalize_bybit_timeframe_config(
-            self.execute_on, self.time_frames, self.window_sizes
-        )
-
-        if self.action_levels is None:
-            self.action_levels = [-1.0, -0.5, 0.0, 0.5, 1.0]
-
-        validate_action_levels(self.action_levels)
 
 
 class BybitFuturesTorchTradingEnv(BybitBaseTorchTradingEnv):

--- a/torchtrade/envs/live/bybit/env.py
+++ b/torchtrade/envs/live/bybit/env.py
@@ -51,9 +51,7 @@ class BybitFuturesTorchTradingEnv(BybitBaseTorchTradingEnv):
     - action = 0.0: Market neutral (close all positions)
     - action = 1.0: 100% long (all-in long)
 
-    Default action_levels: [-1, 0, 1] (short / flat / long). It is a DEFAULT, not a
-    constraint -- pass any monotonic list in [-1.0, 1.0] and its length becomes the
-    Categorical's n, e.g. [-1.0, -0.5, 0.0, 0.5, 1.0] for half-size steps.
+    Default action_levels: [-1, 0, 1]; see BaseFuturesTradingConfig.action_levels.
     """
 
     def __init__(

--- a/torchtrade/envs/live/okx/env.py
+++ b/torchtrade/envs/live/okx/env.py
@@ -50,9 +50,7 @@ class OKXFuturesTorchTradingEnv(OKXBaseTorchTradingEnv):
     - action = 0.0: Market neutral (close all positions)
     - action = 1.0: 100% long (all-in long)
 
-    Default action_levels: [-1, 0, 1] (short / flat / long). It is a DEFAULT, not a
-    constraint -- pass any monotonic list in [-1.0, 1.0] and its length becomes the
-    Categorical's n, e.g. [-1.0, -0.5, 0.0, 0.5, 1.0] for half-size steps.
+    Default action_levels: [-1, 0, 1]; see BaseFuturesTradingConfig.action_levels.
     """
 
     def __init__(

--- a/torchtrade/envs/live/okx/env.py
+++ b/torchtrade/envs/live/okx/env.py
@@ -18,53 +18,20 @@ from torchtrade.envs.core.live import (
 from torchtrade.envs.utils.fractional_sizing import (
     validate_action_levels,
 )
+from torchtrade.envs.live.shared.futures_config import BaseFuturesTradingConfig
+from torchtrade.envs.live.okx.utils import normalize_okx_timeframe_config
 
 
 @dataclass
-class OKXFuturesTradingEnvConfig:
+class OKXFuturesTradingEnvConfig(BaseFuturesTradingConfig):
     """Configuration for OKX Futures Trading Environment."""
 
     symbol: str = "BTC-USDT-SWAP"
-
-    # Timeframes and windows
-    time_frames: Union[List[Union[str, "TimeFrame"]], Union[str, "TimeFrame"]] = "1Hour"
-    window_sizes: Union[List[int], int] = 10
-    execute_on: Union[str, "TimeFrame"] = "1Hour"
-
-    # Trading parameters
-    leverage: int = 1
-    margin_mode: MarginMode = MarginMode.ISOLATED
+    margin_mode: MarginMode = MarginMode.CROSS
     position_mode: PositionMode = PositionMode.NET
 
-    # Action space configuration
-    action_levels: List[float] = None
+    _normalize_timeframes = staticmethod(normalize_okx_timeframe_config)
 
-    # Termination settings
-    done_on_bankruptcy: bool = True
-    bankrupt_threshold: float = 0.1
-
-    # Environment settings
-    demo: bool = True
-    seed: Optional[int] = 42
-    include_base_features: bool = False
-    close_position_on_init: bool = True
-    close_position_on_reset: bool = False
-    observation_failure_policy: ObservationFailurePolicy | str = ObservationFailurePolicy.HALT
-    # Bars to ride out an unreadable venue before truncating; 0 disables (#295).
-    max_unknown_status_steps: int = 0
-
-    def __post_init__(self):
-        self.observation_failure_policy = ObservationFailurePolicy(self.observation_failure_policy)
-        validate_unknown_status_budget(self.max_unknown_status_steps)
-        from torchtrade.envs.live.okx.utils import normalize_okx_timeframe_config
-        self.execute_on, self.time_frames, self.window_sizes = normalize_okx_timeframe_config(
-            self.execute_on, self.time_frames, self.window_sizes
-        )
-
-        if self.action_levels is None:
-            self.action_levels = [-1.0, -0.5, 0.0, 0.5, 1.0]
-
-        validate_action_levels(self.action_levels)
 
 
 class OKXFuturesTorchTradingEnv(OKXBaseTorchTradingEnv):

--- a/torchtrade/envs/live/okx/env.py
+++ b/torchtrade/envs/live/okx/env.py
@@ -1,6 +1,6 @@
 """OKX Futures TorchRL trading environment with fractional position sizing."""
 from dataclasses import dataclass
-from typing import List, Optional, Union, Callable, Dict
+from typing import Optional, Callable, Dict
 
 from torchrl.data import Categorical
 
@@ -11,13 +11,6 @@ from torchtrade.envs.live.okx.order_executor import (
     PositionMode,
 )
 from torchtrade.envs.live.okx.base import OKXBaseTorchTradingEnv
-from torchtrade.envs.core.common import validate_unknown_status_budget
-from torchtrade.envs.core.live import (
-    ObservationFailurePolicy,
-)
-from torchtrade.envs.utils.fractional_sizing import (
-    validate_action_levels,
-)
 from torchtrade.envs.live.shared.futures_config import BaseFuturesTradingConfig
 from torchtrade.envs.live.okx.utils import normalize_okx_timeframe_config
 
@@ -31,7 +24,6 @@ class OKXFuturesTradingEnvConfig(BaseFuturesTradingConfig):
     position_mode: PositionMode = PositionMode.NET
 
     _normalize_timeframes = staticmethod(normalize_okx_timeframe_config)
-
 
 
 class OKXFuturesTorchTradingEnv(OKXBaseTorchTradingEnv):

--- a/torchtrade/envs/live/okx/env.py
+++ b/torchtrade/envs/live/okx/env.py
@@ -27,7 +27,7 @@ class OKXFuturesTradingEnvConfig(BaseFuturesTradingConfig):
     """Configuration for OKX Futures Trading Environment."""
 
     symbol: str = "BTC-USDT-SWAP"
-    margin_mode: MarginMode = MarginMode.CROSS
+    margin_mode: MarginMode = MarginMode.ISOLATED
     position_mode: PositionMode = PositionMode.NET
 
     _normalize_timeframes = staticmethod(normalize_okx_timeframe_config)
@@ -47,12 +47,12 @@ class OKXFuturesTorchTradingEnv(OKXBaseTorchTradingEnv):
 
     Action Space (Fractional Mode - Default):
     - action = -1.0: 100% short (all-in short)
-    - action = -0.5: 50% short
     - action = 0.0: Market neutral (close all positions)
-    - action = 0.5: 50% long
     - action = 1.0: 100% long (all-in long)
 
-    Default action_levels: [-1.0, -0.5, 0.0, 0.5, 1.0]
+    Default action_levels: [-1, 0, 1] (short / flat / long). It is a DEFAULT, not a
+    constraint -- pass any monotonic list in [-1.0, 1.0] and its length becomes the
+    Categorical's n, e.g. [-1.0, -0.5, 0.0, 0.5, 1.0] for half-size steps.
     """
 
     def __init__(

--- a/torchtrade/envs/live/shared/futures_config.py
+++ b/torchtrade/envs/live/shared/futures_config.py
@@ -20,9 +20,10 @@ from torchtrade.envs.utils.timeframe import TimeFrame
 class BaseFuturesTradingConfig:
     """Fields the four venue configs declared identically, name, type and default.
 
-    Each venue keeps only its margin surface -- `margin_mode` is a DIFFERENT enum per
-    venue (okx spells its member `CROSS` where the others say `CROSSED`), so it cannot
-    live here without flattening a real vocabulary difference into `Any`. `symbol` does
+    Each venue keeps only its margin surface -- `margin_mode` is a different Enum
+    class per venue -- binance uses the shared `core.common_types.MarginMode`, the other
+    three declare their own carrying the venue's wire value -- so there is no single type
+    to hoist. `symbol` does
     live here so it stays parameter #1; okx overrides its default.
     """
 
@@ -32,15 +33,10 @@ class BaseFuturesTradingConfig:
     execute_on: Union[str, TimeFrame] = "1Hour"  # timeframe that gates trade execution
     leverage: int = 1  # 1-125
 
-    # The action space. `None` means "use the default below" -- it is a DEFAULT, not a
-    # constraint, and it is the first thing to change for a different trading style.
-    # Any monotonic list in [-1.0, 1.0] works, and its length is the Categorical's n:
-    #
-    #     action_levels=[-1, 0, 1]                    short / flat / long   (the default)
-    #     action_levels=[-1.0, -0.5, 0.0, 0.5, 1.0]   half-size steps too
-    #     action_levels=[0, 0.25, 0.5, 0.75, 1.0]     long-only, four sizes
-    #
-    # A checkpoint is tied to the length it trained on, so changing this needs a retrain.
+    # `None` means the default below. The list's LENGTH is the Categorical's n, and a
+    # checkpoint is bound to the length it trained on, so changing this needs a retrain.
+    # `validate_action_levels` checks range [-1, 1], distinctness and len >= 2 -- NOT
+    # ordering. e.g. [-1.0, -0.5, 0.0, 0.5, 1.0] for half-size steps.
     action_levels: Optional[List[float]] = None
 
     done_on_bankruptcy: bool = True

--- a/torchtrade/envs/live/shared/futures_config.py
+++ b/torchtrade/envs/live/shared/futures_config.py
@@ -1,0 +1,81 @@
+"""The plain-futures config fields every exchange declares identically (#288).
+
+The SLTP twin of this file is `sltp_config.py`, and it landed first. This one is the same
+extraction for the non-SLTP configs, which the four venues had still been repeating.
+"""
+
+from dataclasses import dataclass
+from typing import List, Optional, Union
+
+from torchtrade.envs.core.common import validate_unknown_status_budget
+from torchtrade.envs.core.live import ObservationFailurePolicy
+from torchtrade.envs.utils.fractional_sizing import (
+    build_default_action_levels,
+    validate_action_levels,
+)
+from torchtrade.envs.utils.timeframe import TimeFrame
+
+
+@dataclass
+class BaseFuturesTradingConfig:
+    """Fields the four venue configs declared identically, name, type and default.
+
+    Each venue keeps only its margin surface -- `margin_mode` is a DIFFERENT enum per
+    venue (okx spells its member `CROSS` where the others say `CROSSED`), so it cannot
+    live here without flattening a real vocabulary difference into `Any`. `symbol` does
+    live here so it stays parameter #1; okx overrides its default.
+    """
+
+    symbol: str = "BTCUSDT"
+    time_frames: Union[List[Union[str, TimeFrame]], Union[str, TimeFrame]] = "1Hour"
+    window_sizes: Union[List[int], int] = 10
+    execute_on: Union[str, TimeFrame] = "1Hour"  # timeframe that gates trade execution
+    leverage: int = 1  # 1-125
+
+    # The action space. `None` means "use the default below" -- it is a DEFAULT, not a
+    # constraint, and it is the first thing to change for a different trading style.
+    # Any monotonic list in [-1.0, 1.0] works, and its length is the Categorical's n:
+    #
+    #     action_levels=[-1, 0, 1]                    short / flat / long   (the default)
+    #     action_levels=[-1.0, -0.5, 0.0, 0.5, 1.0]   half-size steps too
+    #     action_levels=[0, 0.25, 0.5, 0.75, 1.0]     long-only, four sizes
+    #
+    # A checkpoint is tied to the length it trained on, so changing this needs a retrain.
+    action_levels: Optional[List[float]] = None
+
+    done_on_bankruptcy: bool = True
+    bankrupt_threshold: float = 0.1  # fraction of INITIAL balance, not current
+    demo: bool = True
+    seed: Optional[int] = 42
+    include_base_features: bool = False
+    close_position_on_init: bool = True
+    close_position_on_reset: bool = False
+    observation_failure_policy: Union[ObservationFailurePolicy, str] = (
+        ObservationFailurePolicy.HALT
+    )
+    # Bars to ride out an unreadable venue before truncating; 0 disables (#295).
+    max_unknown_status_steps: int = 0
+
+    # Each subclass sets this to its venue normalizer -- all four are a partial of the
+    # same normalize_timeframe_config, differing only in parse_fn.
+    _normalize_timeframes = None
+
+    def __post_init__(self):
+        """Validate at the boundary, so nothing downstream has to guard."""
+        self.observation_failure_policy = ObservationFailurePolicy(
+            self.observation_failure_policy
+        )
+        validate_unknown_status_budget(self.max_unknown_status_steps)
+        self.execute_on, self.time_frames, self.window_sizes = self._normalize_timeframes(
+            self.execute_on, self.time_frames, self.window_sizes
+        )
+
+        # One default for all four. binance derived it from this helper while the other
+        # three hard-coded a five-level list, so the SAME unset config produced a
+        # 3-action space on one venue and a 5-action space on the other three -- and
+        # `action_spec.n` is what a checkpoint is bound to, so a policy could not move
+        # between venues it was meant to be portable across (#288).
+        if self.action_levels is None:
+            self.action_levels = build_default_action_levels(allow_short=True)
+
+        validate_action_levels(self.action_levels)


### PR DESCRIPTION
Part of #288. **Net −318 lines** (production −62, tests −256).

Two slices the [scope re-measurement](https://github.com/TorchTrade/torchtrade/issues/288#issuecomment-) named as remaining, plus one defect the first slice surfaced.

## 1. The plain configs fold — and a default that was not the same

`BaseFuturesSLTPConfig` folded the SLTP configs earlier; the four **plain** ones were still repeating the same 15 fields and `__post_init__`. Each venue now declares only its genuine surface:

| kept per venue | why |
|---|---|
| `margin_mode` | a **different enum** per venue — okx spells its member `CROSS` where the others say `CROSSED`. Hoisting it would flatten a real vocabulary difference into `Any`. |
| `position_mode` | bitget/bybit/okx only |
| `product_type` | bitget only |
| `symbol` | okx alone overrides the default |

Production **−143 lines** in that slice.

### ⚠️ Breaking: the default action space is now the same on all four venues

The fold is what exposed this. The **same unset config** produced a different action space per venue:

```
binance   [-1, 0, 1]                 -> Categorical(n=3)
bitget    [-1.0,-0.5,0.0,0.5,1.0]    -> Categorical(n=5)
bybit     [-1.0,-0.5,0.0,0.5,1.0]    -> Categorical(n=5)
okx       [-1.0,-0.5,0.0,0.5,1.0]    -> Categorical(n=5)
```

Nothing documented it — all four carried the *identical* field comment, and `build_default_action_levels()`, which returns `[-1, 0, 1]`, had exactly **one** production caller. `action_spec.n` is what a checkpoint binds to, so a policy could not move between venues the framework advertises as interchangeable.

**All four now default to `[-1, 0, 1]`. bitget/bybit/okx checkpoints trained against the unset default must be retrained.**

The value is a **default, not a constraint**. The field now documents that with worked examples, and the tests that need half sizes ask for them explicitly rather than leaning on a venue's default — which demonstrates the feature better than the accident did.

## 2. A trap the issue thread had already recorded

The thread warns:

> `test_bankruptcy_termination` is byte-identical across all four venues and steps `torch.tensor(2)`. binance builds `[-1, 0, 1]`, so index 2 is a **full long**. bitget/bybit/okx hardcode `[-1,-0.5,0,0.5,1]`, where index 2 is **flat**. The same bytes test two different behaviours. Fold it naively and one disappears silently.

Unifying the defaults triggered it **from the other side**: index 2 became a full long everywhere, the flat route stopped being exercised on three venues, and the suite stayed green. The test now picks its action **by value** and runs both routes on all four venues (26 → 28 cases).

## 3. The replay cluster — the thread's "best single cluster"

675 lines across eight `TestWithReplayData` classes → **200**.

```
binance/bitget/bybit  75 -> 19      binance/bitget/bybit sltp  127/128 -> 31
okx                   34 -> 19      okx sltp                    34 -> 31
```

They differed in exactly two things — the env/config classes and the config values — which is what the two shared helpers take as arguments. The one genuine difference between plain and SLTP is *which action each bar picks*, so that is a **callable**, not a flag: plain cycles action levels, SLTP cycles bracket indices.

`replay_df` existed **seven** times (six inline + okx's conftest) and the copies had already drifted, though only in the RNG stream. One fixture now, in the first shared `tests/envs/conftest.py`.

## Deliberately not in this PR

Per the thread's own record, so they are not re-proposed on a line count:

- **`_execute_fractional_action`** — 4 copies, 180 lines, but **18–49%** pairwise. Four genuinely different exchange APIs; folding would mean inventing parameters to paper over real differences.
- **`order_executor.py`** — 47% at best, already excluded.
- **plain `_execute_trade_if_needed`** — still 4 copies, but the bybit/okx split is *documented as deliberate* in `futures_live_base.py`: the duplicate-action guard is load-bearing for binance/bitget and inert for bybit/okx, which take the threaded qty. Folding it is a design decision, not a dedup.

## Verification

Three structural guards on the config fold, each mutation-verified: re-declaring a shared field fails 1, growing a private `__post_init__` fails 10, the shared default drifting off the helper fails 7.

Suite **4680 passed, 16 skipped**.


## Second compatibility note: positional construction

Folding fields into a base dataclass **reorders the generated positional constructor**. @CharlieHelps was right that "only `symbol` keeps its position" was wrong: measured against `main`, the first **four** parameters are unchanged on all four venues (`symbol, time_frames, window_sizes, execute_on`), and `leverage` holds position 5 on binance/bybit/okx too — bitget diverges one earlier because `product_type` sat there. Every consumer in this repo uses keyword arguments (verified across `torchtrade/`, `tests/` and `examples/`), so nothing here breaks, but any external caller constructing a venue config positionally would. Raised by @CharlieHelps; worth a line in the release notes alongside the `action_levels` change.

## Also fixed after review

- **okx's `margin_mode` default had flipped ISOLATED → CROSS** during the fold — my transcription error, caught by three reviewers. Cross margin backs the position with the whole account balance. Reverted, and now pinned **by value** across both config families; re-introducing it fails a test. The previous guard only asserted the field's *name* was spelled the same everywhere.
- **Ten** hardcoded action indices (I reported seven, then found three more — including binance's `test_step_hold_action`, the fourth of the "three" hold tests) meant the opposite of their name under the new default, not the one the issue thread documented. `torch.tensor(2)` was `0.0` before and is a full **long** now, so all four `test_step_hold_action` tests — the only per-venue coverage of the flat route — were sending a long. The worst was a credentials-skipped bitget integration test that would have sent a real market order against the testnet. All resolve by value now.
- The hold tests gained `trade.assert_not_called()`, which they never had: they only asserted keys existed, so a flat action that *traded* passed them.



## Round 3 + review response (`c44c6c08`, and the commit above this line)

- **"Verified with pyflakes: 0 unused imports remain" ran a tool that is not installed.** The command printed `No module named pyflakes`; `grep -c "imported but unused"` of that output is `0`, which I reported as a clean result — and the same empty output had driven the removal script, so it deleted nothing. Redone with `ruff 0.14.10`: **`Found 23 errors` → `All checks passed!`**. One `F401` remains in a file this PR touches (bybit SLTP's `PositionStatus`); it is pre-existing on `main` and out of scope.
- **The eight replay call sites passed a `symbol=` that silently rewrote bitget SLTP's default** from `BTC/USDT:USDT` to `BTCUSDT`. Dropping the redundant kwargs restores each venue's own default instead of encoding a wrong one.
- **`_normalize_timeframes` was the one token the fold left unpinned.** Hoisting `__post_init__` turned four inline `normalize_<venue>_timeframe_config` calls into one class attribute per subclass, and nothing checked where it pointed — cross-wiring bybit's config to binance's normalizer passes all 3678 env tests, while making bybit's native `"60"`/`"D"`/`"240"` construction-time errors. Now pinned across **all eight** futures configs (this PR took the seam from 4 unpinned wirings to 8), and the cross-wire fails.
- **The margin guard compared `.name`, not the wire value** — @CharlieHelps' point. It now asserts the case-folded `.value`, which is what actually reaches the venue; re-introducing the okx `ISOLATED → CROSS` flip still fails it.
- **The `margin_mode` gloss was wrong in the direction that matters.** The load-bearing claim survives — a distinct enum *class* per venue, so hoisting needs `Any` — but "a real vocabulary difference" was not: bitget and bybit keep the uniform `CROSSED` and convert at the edge, okx has no converter so its wire value named its member, binance declares none. That accident is what produced this PR's one real bug, so enshrining it as a principle was backwards.
- Charlie's seven `# index 1 is FLAT` comments sat on the line that derives the *last* index — true, irrelevant, and the seed of comment rot. Dropped.
- binance's `test_action_spec` was `>= 3` where its three siblings are `== 3`, and spent 36 lines re-asserting range/distinctness that `validate_action_levels` enforces at the boundary and the contract file pins once. Collapsed to the sibling one-liner (**−32**) — the last place binance was exempt from the uniformity this PR is about.
- One item of Charlie's does not reproduce: `tests/envs/test_live_env_main.py` does not exist, and `ruff --select F401` is clean on all four contract/test files at this head, so there is no stale `build_default_action_levels` import to remove.