### PR TITLE
refactor(288): the venue test fixtures were one shape with four venues' data inlined

### DIFF
--- a/tests/envs/base_exchange_tests.py
+++ b/tests/envs/base_exchange_tests.py
@@ -12,7 +12,102 @@ import torch
 from tensordict import TensorDict
 from unittest.mock import MagicMock, patch
 from abc import ABC, abstractmethod
+from torchtrade.envs.core.common_types import PositionStatus
 from torchtrade.envs.utils.timeframe import TimeFrame, TimeFrameUnit
+
+
+# --- the mocks every venue builds, with the venue's own data at the CALL SITE (#288) -----
+#
+# These were 8 copies of `mock_observer`, 10 of a nested `status`, and a scatter of
+# `mock_observations`/`mock_get_observations`/`mock_obs_zero`. What differed between them
+# was data, not shape: binance and bitget name their timeframes "1m_10" where bybit and okx
+# say "1Minute_10", and a couple of tests need a fixed OHLC bar rather than noise. Passing
+# that in keeps the venue axis these tests exist to cover -- folding it into the helper is
+# how a shared fixture stops testing four venues and starts testing one.
+
+_OBS_FEATURES = {
+    "observation_features": ["feature_close", "feature_open", "feature_high", "feature_low"],
+    "original_features": ["open", "high", "low", "close", "volume"],
+}
+
+
+def some_observations(keys, base=None, timestamps=False):
+    """One window per key. `base` is the OHLC bar `return_base_ohlc=True` should yield --
+    a 4-tuple for a fixed bar, or None for noise."""
+    def observations(return_base_ohlc=False):
+        obs = {k: np.random.randn(10, 4).astype(np.float32) for k in keys}
+        if return_base_ohlc:
+            obs["base_features"] = (
+                np.random.randn(10, 4).astype(np.float32) if base is None
+                else np.array([list(base)] * 10, dtype=np.float32)
+            )
+            if timestamps:
+                obs["base_timestamps"] = np.arange(10)
+        return obs
+    return observations
+
+
+def a_mock_observer(keys, *, base=None, timestamps=False, features=False,
+                    intervals=None, window_sizes=None):
+    """The observer mock, parametrised by what actually differs between the venues."""
+    observer = MagicMock()
+    observer.get_keys = MagicMock(return_value=list(keys))
+    observer.get_observations = MagicMock(
+        side_effect=some_observations(keys, base, timestamps))
+    if features:
+        observer.get_features = MagicMock(return_value=dict(_OBS_FEATURES))
+    else:
+        mirror_features_on(observer)
+    if intervals is not None:
+        observer.intervals = intervals
+    if window_sizes is not None:
+        observer.window_sizes = window_sizes
+    return observer
+
+
+def a_mock_futures_trader():
+    """The flat, healthy trader every futures env test starts from."""
+    trader = MagicMock()
+    trader.cancel_open_orders = MagicMock(return_value=True)
+    trader.close_position = MagicMock(return_value=True)
+    trader.get_account_balance = MagicMock(return_value={
+        "total_wallet_balance": 1000.0, "available_balance": 900.0,
+        "total_unrealized_profit": 0.0, "total_margin_balance": 1000.0,
+    })
+    trader.get_mark_price = MagicMock(return_value=50000.0)
+    trader.get_status = MagicMock(return_value={"position_status": None})
+    trader.trade = MagicMock(return_value=True)
+    trader.get_lot_size = MagicMock(
+        return_value={"min_qty": 0.001, "qty_step": 0.001, "min_notional": 0.0})
+    return trader
+
+
+def add_custom_features(df):
+    """The `feature_*` preprocessing three venues' observation tests each defined."""
+    df = df.copy()
+    df.dropna(inplace=True)
+    df.drop_duplicates(inplace=True)
+    df["feature_close"] = df["close"].pct_change().fillna(0)
+    df["feature_open"] = df["open"] / df["close"]
+    df["feature_high"] = df["high"] / df["close"]
+    df["feature_low"] = df["low"] / df["close"]
+    df["feature_custom"] = df["close"] * 2
+    df.dropna(inplace=True)
+    return df
+
+
+def a_position_status(qty, *, notional=500.0, entry=50000.0, mark=50000.0, leverage=5,
+                      liquidation=45000.0, flat_is_none=False):
+    """What `trader.get_status()` returns. `PositionStatus` is ONE class for all four
+    venues (`core.common_types`), so the per-venue import these copies each carried was
+    itself the duplication."""
+    if flat_is_none and not qty:
+        return {"position_status": None}
+    return {"position_status": PositionStatus(
+        qty=qty, notional_value=notional, entry_price=entry, unrealized_pnl=0.0,
+        unrealized_pnl_pct=0.0, mark_price=mark, leverage=leverage,
+        margin_mode="isolated", liquidation_price=liquidation,
+    )}
 
 
 def mirror_features_on(observer):

--- a/tests/envs/base_exchange_tests.py
+++ b/tests/envs/base_exchange_tests.py
@@ -27,7 +27,8 @@ WINDOW = 10   # every fixture below emits a 10-bar window
 
 def some_observations(keys, *, base=None):
     """One window per key. `base` is the OHLC bar `return_base_ohlc=True` should yield --
-    a 4-tuple for a fixed bar, or None for noise. `base_timestamps` rides along with it,
+    a 4-tuple for a fixed bar, or None for noise. `base=None` is for SHAPE-only tests: the
+    close can come out negative or zero, which an SLTP test pricing off it would flake on. `base_timestamps` rides along with it,
     as the real observer does (`shared/base_obs.py:287-293` emits both or neither)."""
     def observations(return_base_ohlc=False):
         obs = {k: np.random.randn(WINDOW, 4).astype(np.float32) for k in keys}

--- a/tests/envs/base_exchange_tests.py
+++ b/tests/envs/base_exchange_tests.py
@@ -22,33 +22,46 @@ from torchtrade.envs.utils.timeframe import TimeFrame, TimeFrameUnit
 # stops testing four venues and starts testing one.
 
 
+WINDOW = 10   # every fixture below emits a 10-bar window
+
+
 def some_observations(keys, *, base=None):
     """One window per key. `base` is the OHLC bar `return_base_ohlc=True` should yield --
     a 4-tuple for a fixed bar, or None for noise. `base_timestamps` rides along with it,
     as the real observer does (`shared/base_obs.py:287-293` emits both or neither)."""
     def observations(return_base_ohlc=False):
-        obs = {k: np.random.randn(10, 4).astype(np.float32) for k in keys}
+        obs = {k: np.random.randn(WINDOW, 4).astype(np.float32) for k in keys}
         if return_base_ohlc:
+            # Each row is `base` faded 0.1% per bar into the past, so the LAST row is
+            # exactly `base`. Ten identical rows made "the last candle" unobservable:
+            # reading `base_features[0]` instead of `[-1]` passed the whole suite (#288).
+            fade = 1 - 0.001 * np.arange(WINDOW)[::-1]          # [0.991 ... 1.0]
             obs["base_features"] = (
-                np.random.randn(10, 4).astype(np.float32) if base is None
-                # A RAMP into the past, with the last row exactly `base`. Ten identical
-                # rows made "the last candle" unobservable: reading `base_features[0]`
-                # instead of `[-1]` for bracket pricing passed the whole suite (#288).
-                else np.array([[v * (1 - 0.001 * (9 - i)) for v in base]
-                               for i in range(10)], dtype=np.float32)
+                np.random.randn(WINDOW, 4).astype(np.float32) if base is None
+                else np.outer(fade, base).astype(np.float32)
             )
-            obs["base_timestamps"] = np.arange(10)
+            obs["base_timestamps"] = np.arange(WINDOW)
         return obs
     return observations
 
 
 def a_mock_observer(keys, *, base=None):
-    """The observer mock. Features are MIRRORED off the data rather than declared, so the
-    fixture cannot claim a width its own observations contradict (#288)."""
+    """The observer mock, with its feature list MIRRORED off the data it actually emits.
+
+    The envs build observation_spec from get_features() (#288), so a fixture that stubs
+    only get_observations declares width 0 against emitted 4 -- which is exactly what the
+    binance and bitget check_env_specs tests caught when the switch landed. Deriving means
+    a fixture cannot declare a width its own data contradicts.
+    """
+    observations = some_observations(keys, base=base)
+    width = next(iter(observations().values())).shape[1]
     observer = MagicMock()
     observer.get_keys = MagicMock(return_value=list(keys))
-    observer.get_observations = MagicMock(side_effect=some_observations(keys, base=base))
-    mirror_features_on(observer)
+    observer.get_observations = MagicMock(side_effect=observations)
+    observer.get_features = MagicMock(return_value={
+        "observation_features": [f"feature_{i}" for i in range(width)],
+        "original_features": [],
+    })
     return observer
 
 
@@ -95,21 +108,6 @@ def a_position_status(qty, *, notional=500.0, mark=50000.0, liquidation=45000.0)
         unrealized_pnl_pct=0.0, mark_price=mark, leverage=5,
         margin_mode="isolated", liquidation_price=liquidation,
     )}
-
-
-def mirror_features_on(observer):
-    """Derive a mock observer's get_features from the observations it actually emits.
-
-    The envs build observation_spec from get_features() (#288), so a fixture that stubs
-    only get_observations declares width 0 against emitted 4 -- which is exactly what the
-    binance and bitget check_env_specs tests caught when the switch landed. Deriving
-    means a fixture cannot declare a width its own data contradicts.
-    """
-    width = next(iter(observer.get_observations().values())).shape[1]
-    observer.get_features = MagicMock(return_value={
-        "observation_features": [f"feature_{i}" for i in range(width)],
-        "original_features": [],
-    })
 
 
 class BaseObservationClassTests(ABC):

--- a/tests/envs/base_exchange_tests.py
+++ b/tests/envs/base_exchange_tests.py
@@ -22,7 +22,7 @@ from torchtrade.envs.utils.timeframe import TimeFrame, TimeFrameUnit
 # stops testing four venues and starts testing one.
 
 
-def some_observations(keys, base=None):
+def some_observations(keys, *, base=None):
     """One window per key. `base` is the OHLC bar `return_base_ohlc=True` should yield --
     a 4-tuple for a fixed bar, or None for noise. `base_timestamps` rides along with it,
     as the real observer does (`shared/base_obs.py:287-293` emits both or neither)."""
@@ -31,7 +31,11 @@ def some_observations(keys, base=None):
         if return_base_ohlc:
             obs["base_features"] = (
                 np.random.randn(10, 4).astype(np.float32) if base is None
-                else np.array([list(base)] * 10, dtype=np.float32)
+                # A RAMP into the past, with the last row exactly `base`. Ten identical
+                # rows made "the last candle" unobservable: reading `base_features[0]`
+                # instead of `[-1]` for bracket pricing passed the whole suite (#288).
+                else np.array([[v * (1 - 0.001 * (9 - i)) for v in base]
+                               for i in range(10)], dtype=np.float32)
             )
             obs["base_timestamps"] = np.arange(10)
         return obs
@@ -43,7 +47,7 @@ def a_mock_observer(keys, *, base=None):
     fixture cannot claim a width its own observations contradict (#288)."""
     observer = MagicMock()
     observer.get_keys = MagicMock(return_value=list(keys))
-    observer.get_observations = MagicMock(side_effect=some_observations(keys, base))
+    observer.get_observations = MagicMock(side_effect=some_observations(keys, base=base))
     mirror_features_on(observer)
     return observer
 
@@ -82,7 +86,8 @@ def add_custom_features(df):
 def a_position_status(qty, *, notional=500.0, mark=50000.0, liquidation=45000.0):
     """What `trader.get_status()` returns. `PositionStatus` is ONE class for all four
     venues (`core.common_types`), so the per-venue import these copies carried was itself
-    the duplication. `qty=None` is a flat account, which is what the venues report."""
+    the duplication. `qty=None` is a flat account, which is what the venues report --
+    NOT `qty=0`, which is an open position of size zero and reaches the dust rule."""
     if qty is None:
         return {"position_status": None}
     return {"position_status": PositionStatus(

--- a/tests/envs/base_exchange_tests.py
+++ b/tests/envs/base_exchange_tests.py
@@ -17,23 +17,15 @@ from torchtrade.envs.utils.timeframe import TimeFrame, TimeFrameUnit
 
 
 # --- the mocks every venue builds, with the venue's own data at the CALL SITE (#288) -----
-#
-# These were 8 copies of `mock_observer`, 10 of a nested `status`, and a scatter of
-# `mock_observations`/`mock_get_observations`/`mock_obs_zero`. What differed between them
-# was data, not shape: binance and bitget name their timeframes "1m_10" where bybit and okx
-# say "1Minute_10", and a couple of tests need a fixed OHLC bar rather than noise. Passing
-# that in keeps the venue axis these tests exist to cover -- folding it into the helper is
-# how a shared fixture stops testing four venues and starts testing one.
-
-_OBS_FEATURES = {
-    "observation_features": ["feature_close", "feature_open", "feature_high", "feature_low"],
-    "original_features": ["open", "high", "low", "close", "volume"],
-}
+# The keys stay at the call site on purpose: binance and bitget name their timeframes
+# "1m_10" where bybit and okx say "1Minute_10". Folding that in is how a shared fixture
+# stops testing four venues and starts testing one.
 
 
-def some_observations(keys, base=None, timestamps=False):
+def some_observations(keys, base=None):
     """One window per key. `base` is the OHLC bar `return_base_ohlc=True` should yield --
-    a 4-tuple for a fixed bar, or None for noise."""
+    a 4-tuple for a fixed bar, or None for noise. `base_timestamps` rides along with it,
+    as the real observer does (`shared/base_obs.py:287-293` emits both or neither)."""
     def observations(return_base_ohlc=False):
         obs = {k: np.random.randn(10, 4).astype(np.float32) for k in keys}
         if return_base_ohlc:
@@ -41,32 +33,23 @@ def some_observations(keys, base=None, timestamps=False):
                 np.random.randn(10, 4).astype(np.float32) if base is None
                 else np.array([list(base)] * 10, dtype=np.float32)
             )
-            if timestamps:
-                obs["base_timestamps"] = np.arange(10)
+            obs["base_timestamps"] = np.arange(10)
         return obs
     return observations
 
 
-def a_mock_observer(keys, *, base=None, timestamps=False, features=False,
-                    intervals=None, window_sizes=None):
-    """The observer mock, parametrised by what actually differs between the venues."""
+def a_mock_observer(keys, *, base=None):
+    """The observer mock. Features are MIRRORED off the data rather than declared, so the
+    fixture cannot claim a width its own observations contradict (#288)."""
     observer = MagicMock()
     observer.get_keys = MagicMock(return_value=list(keys))
-    observer.get_observations = MagicMock(
-        side_effect=some_observations(keys, base, timestamps))
-    if features:
-        observer.get_features = MagicMock(return_value=dict(_OBS_FEATURES))
-    else:
-        mirror_features_on(observer)
-    if intervals is not None:
-        observer.intervals = intervals
-    if window_sizes is not None:
-        observer.window_sizes = window_sizes
+    observer.get_observations = MagicMock(side_effect=some_observations(keys, base))
+    mirror_features_on(observer)
     return observer
 
 
 def a_mock_futures_trader():
-    """The flat, healthy trader every futures env test starts from."""
+    """The flat, healthy trader a futures env test starts from."""
     trader = MagicMock()
     trader.cancel_open_orders = MagicMock(return_value=True)
     trader.close_position = MagicMock(return_value=True)
@@ -96,16 +79,15 @@ def add_custom_features(df):
     return df
 
 
-def a_position_status(qty, *, notional=500.0, entry=50000.0, mark=50000.0, leverage=5,
-                      liquidation=45000.0, flat_is_none=False):
+def a_position_status(qty, *, notional=500.0, mark=50000.0, liquidation=45000.0):
     """What `trader.get_status()` returns. `PositionStatus` is ONE class for all four
-    venues (`core.common_types`), so the per-venue import these copies each carried was
-    itself the duplication."""
-    if flat_is_none and not qty:
+    venues (`core.common_types`), so the per-venue import these copies carried was itself
+    the duplication. `qty=None` is a flat account, which is what the venues report."""
+    if qty is None:
         return {"position_status": None}
     return {"position_status": PositionStatus(
-        qty=qty, notional_value=notional, entry_price=entry, unrealized_pnl=0.0,
-        unrealized_pnl_pct=0.0, mark_price=mark, leverage=leverage,
+        qty=qty, notional_value=notional, entry_price=50000.0, unrealized_pnl=0.0,
+        unrealized_pnl_pct=0.0, mark_price=mark, leverage=5,
         margin_mode="isolated", liquidation_price=liquidation,
     )}
 

--- a/tests/envs/binance/test_torch_env_futures.py
+++ b/tests/envs/binance/test_torch_env_futures.py
@@ -6,7 +6,6 @@ import pytest
 from tests.envs.base_exchange_tests import (
     a_mock_observer,
     a_position_status,
-    a_mock_observer,
     INVALID_ACTIONS,
     assert_an_invalid_action_cannot_move_an_open_position,
     assert_an_invalid_action_raises_before_trading,

--- a/tests/envs/binance/test_torch_env_futures.py
+++ b/tests/envs/binance/test_torch_env_futures.py
@@ -24,12 +24,7 @@ class TestBinanceFuturesTorchTradingEnv:
 
     @pytest.fixture
     def mock_observer(self):
-        return a_mock_observer(
-            ["1m_10", "5m_10"],
-            timestamps=True,
-            intervals=["1m", "5m"],
-            window_sizes=[10, 10],
-        )
+        return a_mock_observer(["1m_10", "5m_10"])
 
     @pytest.fixture
     def mock_trader(self):
@@ -430,7 +425,7 @@ class TestBinanceFuturesTorchTradingEnv:
         """
 
         def status(qty):
-            return a_position_status(qty, flat_is_none=True)
+            return a_position_status(qty)
 
         with patch.object(env, "_wait_for_next_timestamp"):
             long = TensorDict({"action": torch.tensor(env.action_levels.index(1))},
@@ -460,7 +455,7 @@ class TestBinanceFuturesTorchTradingEnv:
         """
 
         def status(qty):
-            return a_position_status(qty, flat_is_none=True)
+            return a_position_status(qty)
 
         with patch.object(env, "_wait_for_next_timestamp"):
             long_idx = len(env.action_levels) - 1

--- a/tests/envs/binance/test_torch_env_futures.py
+++ b/tests/envs/binance/test_torch_env_futures.py
@@ -4,6 +4,7 @@ import logging
 import pytest
 
 from tests.envs.base_exchange_tests import (
+    a_mock_futures_trader,
     a_mock_observer,
     a_position_status,
     INVALID_ACTIONS,
@@ -26,35 +27,14 @@ class TestBinanceFuturesTorchTradingEnv:
 
     @pytest.fixture
     def mock_trader(self):
-        """Create a mock trader."""
-        trader = MagicMock()
-
-        # Mock methods
+        trader = a_mock_futures_trader()
         # Models the executor's lot-size rounding, which the env now delegates to rather
         # than re-querying futures_exchange_info() per sizing decision (#271). A bare
         # MagicMock returns a MagicMock and every comparison downstream raises.
         trader.round_quantity = MagicMock(
             side_effect=lambda q, symbol=None: math.floor(q / 0.001 + 1e-9) * 0.001
         )
-        trader.cancel_open_orders = MagicMock(return_value=True)
-        trader.close_position = MagicMock(return_value=True)
         trader.close_all_positions = MagicMock(return_value={})
-
-        trader.get_account_balance = MagicMock(return_value={
-            "total_wallet_balance": 1000.0,
-            "available_balance": 900.0,
-            "total_unrealized_profit": 0.0,
-            "total_margin_balance": 1000.0,
-        })
-
-        trader.get_mark_price = MagicMock(return_value=50000.0)
-
-        trader.get_status = MagicMock(return_value={
-            "position_status": None,
-        })
-
-        trader.trade = MagicMock(return_value=True)
-
         return trader
 
     @pytest.fixture
@@ -422,25 +402,23 @@ class TestBinanceFuturesTorchTradingEnv:
         disagreement every step, so it could never age.
         """
 
-        status = a_position_status
-
         with patch.object(env, "_wait_for_next_timestamp"):
             long = TensorDict({"action": torch.tensor(env.action_levels.index(1))},
                               batch_size=())
             flat = TensorDict({"action": torch.tensor(env.action_levels.index(0))},
                               batch_size=())
 
-            mock_trader.get_status = MagicMock(return_value=status(0.01))
+            mock_trader.get_status = MagicMock(return_value=a_position_status(0.01))
             env.reset()
             for _ in range(5):
                 env._step(long)
             assert env.position.hold_counter == 5           # genuinely aged
 
-            mock_trader.get_status = MagicMock(return_value=status(None))   # closed
+            mock_trader.get_status = MagicMock(return_value=a_position_status(None))   # closed
             env._step(flat)
             assert env.position.hold_counter == 0           # the age goes with it
 
-            mock_trader.get_status = MagicMock(return_value=status(0.01))   # a BRAND NEW one
+            mock_trader.get_status = MagicMock(return_value=a_position_status(0.01))   # a BRAND NEW one
             env._step(long)
 
         assert env.position.hold_counter == 1, "a new position starts older than 1 bar"
@@ -451,20 +429,18 @@ class TestBinanceFuturesTorchTradingEnv:
         hold_counter, the policy is handed a brand-new position as N+1 bars old.
         """
 
-        status = a_position_status
-
         with patch.object(env, "_wait_for_next_timestamp"):
             long_idx = len(env.action_levels) - 1
             long = TensorDict({"action": torch.tensor(long_idx)}, batch_size=())
 
-            mock_trader.get_status = MagicMock(return_value=status(0.01))
+            mock_trader.get_status = MagicMock(return_value=a_position_status(0.01))
             env.reset()
             for _ in range(5):
                 env.step(long)
             aged = env.position.hold_counter
             assert aged > 1
 
-            mock_trader.get_status = MagicMock(return_value=status(None))   # liquidated
+            mock_trader.get_status = MagicMock(return_value=a_position_status(None))   # liquidated
             td = env.step(long)                                          # same-step re-entry
 
         assert td["next"]["account_state"][3].item() <= 1.0, (

--- a/tests/envs/binance/test_torch_env_futures.py
+++ b/tests/envs/binance/test_torch_env_futures.py
@@ -4,16 +4,15 @@ import logging
 import pytest
 
 from tests.envs.base_exchange_tests import (
+    a_mock_observer,
     a_position_status,
     a_mock_observer,
     INVALID_ACTIONS,
     assert_an_invalid_action_cannot_move_an_open_position,
     assert_an_invalid_action_raises_before_trading,
-    mirror_features_on,
 )
 import torch
 from torchrl.envs.utils import check_env_specs
-import numpy as np
 import math
 from unittest.mock import MagicMock, patch
 from tensordict import TensorDict
@@ -508,14 +507,7 @@ class TestMultipleSteps:
             BinanceFuturesTradingEnvConfig,
         )
 
-        mock_observer = MagicMock()
-        mock_observer.get_keys = MagicMock(return_value=["1m_10"])
-        mock_observer.get_observations = MagicMock(return_value={
-            "1m_10": np.random.randn(10, 4).astype(np.float32),
-        })
-        mirror_features_on(mock_observer)
-        mock_observer.intervals = ["1m"]
-        mock_observer.window_sizes = [10]
+        mock_observer = a_mock_observer(["1m_10"])
 
         mock_trader = MagicMock()
         # Models the executor's lot-size rounding (#271); a bare MagicMock

--- a/tests/envs/binance/test_torch_env_futures.py
+++ b/tests/envs/binance/test_torch_env_futures.py
@@ -4,6 +4,8 @@ import logging
 import pytest
 
 from tests.envs.base_exchange_tests import (
+    a_position_status,
+    a_mock_observer,
     INVALID_ACTIONS,
     assert_an_invalid_action_cannot_move_an_open_position,
     assert_an_invalid_action_raises_before_trading,
@@ -22,29 +24,12 @@ class TestBinanceFuturesTorchTradingEnv:
 
     @pytest.fixture
     def mock_observer(self):
-        """Create a mock observer."""
-        observer = MagicMock()
-
-        # Mock get_keys
-        observer.get_keys = MagicMock(return_value=["1m_10", "5m_10"])
-
-        # Mock get_observations
-        def mock_observations(return_base_ohlc=False):
-            obs = {
-                "1m_10": np.random.randn(10, 4).astype(np.float32),
-                "5m_10": np.random.randn(10, 4).astype(np.float32),
-            }
-            if return_base_ohlc:
-                obs["base_features"] = np.random.randn(10, 4).astype(np.float32)
-                obs["base_timestamps"] = np.arange(10)
-            return obs
-
-        observer.get_observations = MagicMock(side_effect=mock_observations)
-        mirror_features_on(observer)
-        observer.intervals = ["1m", "5m"]
-        observer.window_sizes = [10, 10]
-
-        return observer
+        return a_mock_observer(
+            ["1m_10", "5m_10"],
+            timestamps=True,
+            intervals=["1m", "5m"],
+            window_sizes=[10, 10],
+        )
 
     @pytest.fixture
     def mock_trader(self):
@@ -443,14 +428,9 @@ class TestBinanceFuturesTorchTradingEnv:
         while the env believes it is long, and the sync (correctly) resets the counter on that
         disagreement every step, so it could never age.
         """
-        from torchtrade.envs.live.binance.order_executor import PositionStatus
 
         def status(qty):
-            return {"position_status": PositionStatus(
-                qty=qty, notional_value=500.0, entry_price=50000.0, unrealized_pnl=0.0,
-                unrealized_pnl_pct=0.0, mark_price=50000.0, leverage=5,
-                margin_mode="isolated", liquidation_price=45000.0,
-            )} if qty else {"position_status": None}
+            return a_position_status(qty, flat_is_none=True)
 
         with patch.object(env, "_wait_for_next_timestamp"):
             long = TensorDict({"action": torch.tensor(env.action_levels.index(1))},
@@ -478,14 +458,9 @@ class TestBinanceFuturesTorchTradingEnv:
         The sync detects the close and lets the guard re-enter -- but if it does not discard
         hold_counter, the policy is handed a brand-new position as N+1 bars old.
         """
-        from torchtrade.envs.live.binance.order_executor import PositionStatus
 
         def status(qty):
-            return {"position_status": PositionStatus(
-                qty=qty, notional_value=500.0, entry_price=50000.0, unrealized_pnl=0.0,
-                unrealized_pnl_pct=0.0, mark_price=50000.0, leverage=5,
-                margin_mode="isolated", liquidation_price=45000.0,
-            )} if qty else {"position_status": None}
+            return a_position_status(qty, flat_is_none=True)
 
         with patch.object(env, "_wait_for_next_timestamp"):
             long_idx = len(env.action_levels) - 1
@@ -613,13 +588,7 @@ class TestBinanceInitCleanup:
 
     @pytest.fixture
     def mock_observer(self):
-        observer = MagicMock()
-        observer.get_keys = MagicMock(return_value=["1m_10"])
-        observer.get_observations = MagicMock(return_value={
-            "1m_10": np.random.randn(10, 4).astype(np.float32),
-        })
-        mirror_features_on(observer)
-        return observer
+        return a_mock_observer(["1m_10"])
 
     @pytest.fixture
     def mock_trader(self):

--- a/tests/envs/binance/test_torch_env_futures.py
+++ b/tests/envs/binance/test_torch_env_futures.py
@@ -422,8 +422,7 @@ class TestBinanceFuturesTorchTradingEnv:
         disagreement every step, so it could never age.
         """
 
-        def status(qty):
-            return a_position_status(qty)
+        status = a_position_status
 
         with patch.object(env, "_wait_for_next_timestamp"):
             long = TensorDict({"action": torch.tensor(env.action_levels.index(1))},
@@ -452,8 +451,7 @@ class TestBinanceFuturesTorchTradingEnv:
         hold_counter, the policy is handed a brand-new position as N+1 bars old.
         """
 
-        def status(qty):
-            return a_position_status(qty)
+        status = a_position_status
 
         with patch.object(env, "_wait_for_next_timestamp"):
             long_idx = len(env.action_levels) - 1

--- a/tests/envs/binance/test_torch_env_futures_sltp.py
+++ b/tests/envs/binance/test_torch_env_futures_sltp.py
@@ -23,12 +23,7 @@ class TestBinanceFuturesSLTPTorchTradingEnv:
 
     @pytest.fixture
     def mock_observer(self):
-        return a_mock_observer(
-            ["1m_10"],
-            base=(50000, 50100, 49900, 50050),
-            intervals=["1m"],
-            window_sizes=[10],
-        )
+        return a_mock_observer(["1m_10"], base=(50000, 50100, 49900, 50050))
 
     @pytest.fixture
     def mock_trader(self):

--- a/tests/envs/binance/test_torch_env_futures_sltp.py
+++ b/tests/envs/binance/test_torch_env_futures_sltp.py
@@ -2,16 +2,15 @@
 
 import pytest
 
-from tests.envs.base_exchange_tests import a_mock_observer, mirror_features_on
 import torch
 from torchrl.envs.utils import check_env_specs
-import numpy as np
 from unittest.mock import MagicMock, patch
 from tensordict import TensorDict
 
 from torchtrade.envs.core.live import LiveObservationHalt
 from tests.envs.base_exchange_tests import (
     a_mock_futures_trader,
+    a_mock_observer,
     some_observations,
     INVALID_ACTIONS,
     assert_an_invalid_action_cannot_move_an_open_position,
@@ -28,10 +27,7 @@ class TestBinanceFuturesSLTPTorchTradingEnv:
 
     @pytest.fixture
     def mock_trader(self):
-        """Create a mock trader."""
-        trader = a_mock_futures_trader()
-
-        return trader
+        return a_mock_futures_trader()
 
     @pytest.fixture
     def env_config(self):
@@ -511,10 +507,6 @@ class TestCriticalEdgeCases:
             BinanceFuturesSLTPTorchTradingEnv,
             BinanceFuturesSLTPTradingEnvConfig,
         )
-        from torchtrade.envs.live.binance.observation import BinanceObservationClass
-        from torchtrade.envs.live.binance.order_executor import (
-            BinanceFuturesOrderClass,
-        )
 
         config = BinanceFuturesSLTPTradingEnvConfig(
             symbol="BTCUSDT",
@@ -524,29 +516,8 @@ class TestCriticalEdgeCases:
             demo=True,
         )
 
-        mock_observer = MagicMock(spec=BinanceObservationClass)
-        mock_trader = MagicMock(spec=BinanceFuturesOrderClass)
-        # Realistic lot step (float(MagicMock()) is 1.0 -- see the note above).
-        mock_trader.get_lot_size = MagicMock(
-            return_value={"min_qty": 0.001, "qty_step": 0.001, "min_notional": 0.0})
-
-        mock_get_observations = some_observations(['1m_10'], base=(50000, 50100, 49900, 50050))
-
-        mock_observer.get_observations = MagicMock(side_effect=mock_get_observations)
-        mirror_features_on(mock_observer)
-        mock_observer.get_keys = MagicMock(return_value=["1m_10"])
-
-        mock_trader.get_account_balance = MagicMock(
-            return_value={
-                "total_wallet_balance": 1000.0,
-                "available_balance": 1000.0,
-                "total_margin_balance": 1000.0,
-            }
-        )
-        mock_trader.get_status = MagicMock(return_value={"position_status": None})
-        mock_trader.get_mark_price = MagicMock(return_value=50000.0)
-        mock_trader.cancel_open_orders = MagicMock()
-        mock_trader.close_position = MagicMock()
+        mock_observer = a_mock_observer(["1m_10"], base=(50000, 50100, 49900, 50050))
+        mock_trader = a_mock_futures_trader()
 
         env = BinanceFuturesSLTPTorchTradingEnv(
             config, observer=mock_observer, trader=mock_trader
@@ -645,17 +616,8 @@ class TestCriticalEdgeCases:
         """Test bracket order calculation when current price is zero (Critical: 5/10)."""
         env, mock_trader, mock_observer = env_with_mocks
 
-        def mock_obs_zero_price(return_base_ohlc=False):
-            obs = {"1m_10": np.random.randn(10, 4).astype(np.float32)}
-            if return_base_ohlc:
-                # Zero price edge case
-                obs["base_features"] = np.array(
-                    [[0, 0, 0, 0]] * 10, dtype=np.float32
-                )
-            return obs
-
-        mock_observer.get_observations = MagicMock(side_effect=mock_obs_zero_price)
-        mirror_features_on(mock_observer)
+        mock_observer.get_observations = MagicMock(
+            side_effect=some_observations(["1m_10"], base=(0, 0, 0, 0)))
 
         env.reset()
         action_tuple = ("long", -0.02, 0.03)

--- a/tests/envs/binance/test_torch_env_futures_sltp.py
+++ b/tests/envs/binance/test_torch_env_futures_sltp.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from tests.envs.base_exchange_tests import mirror_features_on
+from tests.envs.base_exchange_tests import a_mock_observer, mirror_features_on
 import torch
 from torchrl.envs.utils import check_env_specs
 import numpy as np
@@ -11,6 +11,7 @@ from tensordict import TensorDict
 
 from torchtrade.envs.core.live import LiveObservationHalt
 from tests.envs.base_exchange_tests import (
+    some_observations,
     INVALID_ACTIONS,
     assert_an_invalid_action_cannot_move_an_open_position,
     assert_an_invalid_action_raises_before_trading,
@@ -22,30 +23,12 @@ class TestBinanceFuturesSLTPTorchTradingEnv:
 
     @pytest.fixture
     def mock_observer(self):
-        """Create a mock observer."""
-        observer = MagicMock()
-
-        # Mock get_keys
-        observer.get_keys = MagicMock(return_value=["1m_10"])
-
-        # Mock get_observations
-        def mock_observations(return_base_ohlc=False):
-            obs = {
-                "1m_10": np.random.randn(10, 4).astype(np.float32),
-            }
-            if return_base_ohlc:
-                # OHLC features: [open, high, low, close]
-                obs["base_features"] = np.array([
-                    [50000, 50100, 49900, 50050]  # Current price ~50050
-                ] * 10, dtype=np.float32)
-            return obs
-
-        observer.get_observations = MagicMock(side_effect=mock_observations)
-        mirror_features_on(observer)
-        observer.intervals = ["1m"]
-        observer.window_sizes = [10]
-
-        return observer
+        return a_mock_observer(
+            ["1m_10"],
+            base=(50000, 50100, 49900, 50050),
+            intervals=["1m"],
+            window_sizes=[10],
+        )
 
     @pytest.fixture
     def mock_trader(self):
@@ -595,13 +578,7 @@ class TestCriticalEdgeCases:
         mock_trader.get_lot_size = MagicMock(
             return_value={"min_qty": 0.001, "qty_step": 0.001, "min_notional": 0.0})
 
-        def mock_get_observations(return_base_ohlc=False):
-            obs = {"1m_10": np.random.randn(10, 4).astype(np.float32)}
-            if return_base_ohlc:
-                obs["base_features"] = np.array(
-                    [[50000, 50100, 49900, 50050]] * 10, dtype=np.float32
-                )
-            return obs
+        mock_get_observations = some_observations(['1m_10'], base=(50000, 50100, 49900, 50050))
 
         mock_observer.get_observations = MagicMock(side_effect=mock_get_observations)
         mirror_features_on(mock_observer)
@@ -790,13 +767,7 @@ class TestDuplicateActionPrevention:
         mock_observer = MagicMock()
         mock_observer.get_keys = MagicMock(return_value=["1m_10"])
 
-        def mock_get_observations(return_base_ohlc=False):
-            obs = {"1m_10": np.random.randn(10, 4).astype(np.float32)}
-            if return_base_ohlc:
-                obs["base_features"] = np.array(
-                    [[50000, 50100, 49900, 50050]] * 10, dtype=np.float32
-                )
-            return obs
+        mock_get_observations = some_observations(['1m_10'], base=(50000, 50100, 49900, 50050))
 
         mock_observer.get_observations = MagicMock(side_effect=mock_get_observations)
         mirror_features_on(mock_observer)
@@ -966,13 +937,7 @@ class TestBinanceSLTPNotionalTradeMode:
         mock_observer = MagicMock()
         mock_observer.get_keys = MagicMock(return_value=["1m_10"])
 
-        def mock_observations(return_base_ohlc=False):
-            obs = {"1m_10": np.random.randn(10, 4).astype(np.float32)}
-            if return_base_ohlc:
-                obs["base_features"] = np.array(
-                    [[50000, 50100, 49900, 50050]] * 10, dtype=np.float32
-                )
-            return obs
+        mock_observations = some_observations(['1m_10'], base=(50000, 50100, 49900, 50050))
 
         mock_observer.get_observations = MagicMock(side_effect=mock_observations)
         mirror_features_on(mock_observer)
@@ -1035,11 +1000,7 @@ class TestBinanceSLTPNotionalTradeMode:
         env, mock_trader = notional_env
 
         # Override observer to return zero-price candles
-        def mock_obs_zero(return_base_ohlc=False):
-            obs = {"1m_10": np.random.randn(10, 4).astype(np.float32)}
-            if return_base_ohlc:
-                obs["base_features"] = np.array([[0, 0, 0, 0]] * 10, dtype=np.float32)
-            return obs
+        mock_obs_zero = some_observations(['1m_10'], base=(0, 0, 0, 0))
 
         env.observer.get_observations = MagicMock(side_effect=mock_obs_zero)
         env.reset()
@@ -1126,13 +1087,7 @@ class TestBinanceSLTPNotionalTradeMode:
         mock_observer = MagicMock()
         mock_observer.get_keys = MagicMock(return_value=["1m_10"])
 
-        def mock_observations(return_base_ohlc=False):
-            obs = {"1m_10": np.random.randn(10, 4).astype(np.float32)}
-            if return_base_ohlc:
-                obs["base_features"] = np.array(
-                    [[50000, 50100, 49900, 50050]] * 10, dtype=np.float32
-                )
-            return obs
+        mock_observations = some_observations(['1m_10'], base=(50000, 50100, 49900, 50050))
 
         mock_observer.get_observations = MagicMock(side_effect=mock_observations)
         mirror_features_on(mock_observer)

--- a/tests/envs/binance/test_torch_env_futures_sltp.py
+++ b/tests/envs/binance/test_torch_env_futures_sltp.py
@@ -11,6 +11,7 @@ from tensordict import TensorDict
 
 from torchtrade.envs.core.live import LiveObservationHalt
 from tests.envs.base_exchange_tests import (
+    a_mock_futures_trader,
     some_observations,
     INVALID_ACTIONS,
     assert_an_invalid_action_cannot_move_an_open_position,
@@ -28,30 +29,7 @@ class TestBinanceFuturesSLTPTorchTradingEnv:
     @pytest.fixture
     def mock_trader(self):
         """Create a mock trader."""
-        trader = MagicMock()
-        # A realistic lot step: `float(MagicMock())` is 1.0, which reads as a 1.0-BTC
-        # lot and floors every real quantity to zero in the shared sizing guard.
-        trader.get_lot_size = MagicMock(
-            return_value={"min_qty": 0.001, "qty_step": 0.001, "min_notional": 0.0})
-
-        # Mock methods
-        trader.cancel_open_orders = MagicMock(return_value=True)
-        trader.close_position = MagicMock(return_value=True)
-
-        trader.get_account_balance = MagicMock(return_value={
-            "total_wallet_balance": 1000.0,
-            "available_balance": 900.0,
-            "total_unrealized_profit": 0.0,
-            "total_margin_balance": 1000.0,
-        })
-
-        trader.get_mark_price = MagicMock(return_value=50000.0)
-
-        trader.get_status = MagicMock(return_value={
-            "position_status": None,
-        })
-
-        trader.trade = MagicMock(return_value=True)
+        trader = a_mock_futures_trader()
 
         return trader
 
@@ -474,30 +452,9 @@ class TestMultipleSteps:
             BinanceFuturesSLTPTradingEnvConfig,
         )
 
-        mock_observer = MagicMock()
-        mock_observer.get_keys = MagicMock(return_value=["1m_10"])
-        mock_observer.get_observations = MagicMock(return_value={
-            "1m_10": np.random.randn(10, 4).astype(np.float32),
-            "base_features": np.array([[50000, 50100, 49900, 50050]] * 10, dtype=np.float32),
-        })
-        mirror_features_on(mock_observer)
-        mock_observer.intervals = ["1m"]
-        mock_observer.window_sizes = [10]
+        mock_observer = a_mock_observer(["1m_10"], base=(50000, 50100, 49900, 50050))
 
-        mock_trader = MagicMock()
-        # Realistic lot step (float(MagicMock()) is 1.0 -- see the note above).
-        mock_trader.get_lot_size = MagicMock(
-            return_value={"min_qty": 0.001, "qty_step": 0.001, "min_notional": 0.0})
-        mock_trader.cancel_open_orders = MagicMock(return_value=True)
-        mock_trader.close_position = MagicMock(return_value=True)
-        mock_trader.get_account_balance = MagicMock(return_value={
-            "total_wallet_balance": 1000.0,
-            "available_balance": 900.0,
-            "total_margin_balance": 1000.0,
-        })
-        mock_trader.get_mark_price = MagicMock(return_value=50000.0)
-        mock_trader.get_status = MagicMock(return_value={"position_status": None})
-        mock_trader.trade = MagicMock(return_value=True)
+        mock_trader = a_mock_futures_trader()
 
         config = BinanceFuturesSLTPTradingEnvConfig(
             symbol="BTCUSDT",
@@ -759,8 +716,7 @@ class TestDuplicateActionPrevention:
             BinanceFuturesSLTPTradingEnvConfig,
         )
 
-        mock_observer = MagicMock()
-        mock_observer.get_keys = MagicMock(return_value=["1m_10"])
+        mock_observer = a_mock_observer(["1m_10"])
 
         mock_get_observations = some_observations(['1m_10'], base=(50000, 50100, 49900, 50050))
 
@@ -769,20 +725,7 @@ class TestDuplicateActionPrevention:
         mock_observer.intervals = ["1m"]
         mock_observer.window_sizes = [10]
 
-        mock_trader = MagicMock()
-        # Realistic lot step (float(MagicMock()) is 1.0 -- see the note above).
-        mock_trader.get_lot_size = MagicMock(
-            return_value={"min_qty": 0.001, "qty_step": 0.001, "min_notional": 0.0})
-        mock_trader.cancel_open_orders = MagicMock(return_value=True)
-        mock_trader.close_position = MagicMock(return_value=True)
-        mock_trader.get_account_balance = MagicMock(return_value={
-            "total_wallet_balance": 1000.0,
-            "available_balance": 900.0,
-            "total_margin_balance": 1000.0,
-        })
-        mock_trader.get_mark_price = MagicMock(return_value=50000.0)
-        mock_trader.get_status = MagicMock(return_value={"position_status": None})
-        mock_trader.trade = MagicMock(return_value=True)
+        mock_trader = a_mock_futures_trader()
 
         config = BinanceFuturesSLTPTradingEnvConfig(
             symbol="BTCUSDT",
@@ -929,8 +872,7 @@ class TestBinanceSLTPNotionalTradeMode:
             BinanceFuturesSLTPTradingEnvConfig,
         )
 
-        mock_observer = MagicMock()
-        mock_observer.get_keys = MagicMock(return_value=["1m_10"])
+        mock_observer = a_mock_observer(["1m_10"])
 
         mock_observations = some_observations(['1m_10'], base=(50000, 50100, 49900, 50050))
 
@@ -939,20 +881,7 @@ class TestBinanceSLTPNotionalTradeMode:
         mock_observer.intervals = ["1m"]
         mock_observer.window_sizes = [10]
 
-        mock_trader = MagicMock()
-        # Realistic lot step (float(MagicMock()) is 1.0 -- see the note above).
-        mock_trader.get_lot_size = MagicMock(
-            return_value={"min_qty": 0.001, "qty_step": 0.001, "min_notional": 0.0})
-        mock_trader.cancel_open_orders = MagicMock(return_value=True)
-        mock_trader.close_position = MagicMock(return_value=True)
-        mock_trader.get_account_balance = MagicMock(return_value={
-            "total_wallet_balance": 1000.0,
-            "available_balance": 900.0,
-            "total_margin_balance": 1000.0,
-        })
-        mock_trader.get_mark_price = MagicMock(return_value=50000.0)
-        mock_trader.get_status = MagicMock(return_value={"position_status": None})
-        mock_trader.trade = MagicMock(return_value=True)
+        mock_trader = a_mock_futures_trader()
 
         config = BinanceFuturesSLTPTradingEnvConfig(
             symbol="BTCUSDT",
@@ -1017,31 +946,9 @@ class TestBinanceSLTPNotionalTradeMode:
             BinanceFuturesSLTPTradingEnvConfig,
         )
 
-        mock_observer = MagicMock()
-        mock_observer.get_keys = MagicMock(return_value=["1m_10"])
-        mock_observer.get_observations = MagicMock(return_value={
-            "1m_10": np.random.randn(10, 4).astype(np.float32),
-            "base_features": np.array(
-                [[50000, 50100, 49900, 50050]] * 10, dtype=np.float32
-            ),
-        })
-        mirror_features_on(mock_observer)
-        mock_observer.intervals = ["1m"]
-        mock_observer.window_sizes = [10]
+        mock_observer = a_mock_observer(["1m_10"], base=(50000, 50100, 49900, 50050))
 
-        mock_trader = MagicMock()
-        # Realistic lot step (float(MagicMock()) is 1.0 -- see the note above).
-        mock_trader.get_lot_size = MagicMock(
-            return_value={"min_qty": 0.001, "qty_step": 0.001, "min_notional": 0.0})
-        mock_trader.get_mark_price = MagicMock(return_value=50000.0)
-        mock_trader.cancel_open_orders = MagicMock(return_value=True)
-        mock_trader.close_position = MagicMock(return_value=True)
-        mock_trader.get_account_balance = MagicMock(return_value={
-            "total_wallet_balance": 1000.0, "available_balance": 900.0,
-            "total_margin_balance": 1000.0,
-        })
-        mock_trader.get_status = MagicMock(return_value={"position_status": None})
-        mock_trader.trade = MagicMock(return_value=True)
+        mock_trader = a_mock_futures_trader()
 
         config = BinanceFuturesSLTPTradingEnvConfig(
             symbol="BTCUSDT",
@@ -1079,8 +986,7 @@ class TestBinanceSLTPNotionalTradeMode:
             BinanceFuturesSLTPTradingEnvConfig,
         )
 
-        mock_observer = MagicMock()
-        mock_observer.get_keys = MagicMock(return_value=["1m_10"])
+        mock_observer = a_mock_observer(["1m_10"])
 
         mock_observations = some_observations(['1m_10'], base=(50000, 50100, 49900, 50050))
 
@@ -1089,13 +995,7 @@ class TestBinanceSLTPNotionalTradeMode:
         mock_observer.intervals = ["1m"]
         mock_observer.window_sizes = [10]
 
-        mock_trader = MagicMock()
-        # Realistic lot step (float(MagicMock()) is 1.0 -- see the note above).
-        mock_trader.get_lot_size = MagicMock(
-            return_value={"min_qty": 0.001, "qty_step": 0.001, "min_notional": 0.0})
-        mock_trader.get_mark_price = MagicMock(return_value=50000.0)
-        mock_trader.cancel_open_orders = MagicMock(return_value=True)
-        mock_trader.close_position = MagicMock(return_value=True)
+        mock_trader = a_mock_futures_trader()
         mock_trader.get_account_balance = MagicMock(return_value={
             # wallet != margin: sizing must use total_margin_balance (equity, incl.
             # unrealized PnL), matching offline's portfolio_value basis (#65).
@@ -1104,8 +1004,6 @@ class TestBinanceSLTPNotionalTradeMode:
             "total_unrealized_profit": 100.0,
             "total_margin_balance": 1100.0,
         })
-        mock_trader.get_status = MagicMock(return_value={"position_status": None})
-        mock_trader.trade = MagicMock(return_value=True)
 
         config = BinanceFuturesSLTPTradingEnvConfig(
             symbol="BTCUSDT",
@@ -1146,31 +1044,9 @@ class TestBinanceSLTPLockPosition:
             BinanceFuturesSLTPTradingEnvConfig,
         )
 
-        mock_observer = MagicMock()
-        mock_observer.get_keys = MagicMock(return_value=["1m_10"])
-        mock_observer.get_observations = MagicMock(return_value={
-            "1m_10": np.random.randn(10, 4).astype(np.float32),
-            "base_features": np.array(
-                [[50000, 50100, 49900, 50050]] * 10, dtype=np.float32
-            ),
-        })
-        mirror_features_on(mock_observer)
-        mock_observer.intervals = ["1m"]
-        mock_observer.window_sizes = [10]
+        mock_observer = a_mock_observer(["1m_10"], base=(50000, 50100, 49900, 50050))
 
-        mock_trader = MagicMock()
-        # Realistic lot step (float(MagicMock()) is 1.0 -- see the note above).
-        mock_trader.get_lot_size = MagicMock(
-            return_value={"min_qty": 0.001, "qty_step": 0.001, "min_notional": 0.0})
-        mock_trader.get_mark_price = MagicMock(return_value=50000.0)
-        mock_trader.cancel_open_orders = MagicMock(return_value=True)
-        mock_trader.close_position = MagicMock(return_value=True)
-        mock_trader.get_account_balance = MagicMock(return_value={
-            "total_wallet_balance": 1000.0, "available_balance": 900.0,
-            "total_margin_balance": 1000.0,
-        })
-        mock_trader.get_status = MagicMock(return_value={"position_status": None})
-        mock_trader.trade = MagicMock(return_value=True)
+        mock_trader = a_mock_futures_trader()
 
         config = BinanceFuturesSLTPTradingEnvConfig(
             symbol="BTCUSDT",

--- a/tests/envs/binance/test_torch_env_futures_sltp.py
+++ b/tests/envs/binance/test_torch_env_futures_sltp.py
@@ -716,14 +716,7 @@ class TestDuplicateActionPrevention:
             BinanceFuturesSLTPTradingEnvConfig,
         )
 
-        mock_observer = a_mock_observer(["1m_10"])
-
-        mock_get_observations = some_observations(['1m_10'], base=(50000, 50100, 49900, 50050))
-
-        mock_observer.get_observations = MagicMock(side_effect=mock_get_observations)
-        mirror_features_on(mock_observer)
-        mock_observer.intervals = ["1m"]
-        mock_observer.window_sizes = [10]
+        mock_observer = a_mock_observer(["1m_10"], base=(50000, 50100, 49900, 50050))
 
         mock_trader = a_mock_futures_trader()
 
@@ -872,14 +865,7 @@ class TestBinanceSLTPNotionalTradeMode:
             BinanceFuturesSLTPTradingEnvConfig,
         )
 
-        mock_observer = a_mock_observer(["1m_10"])
-
-        mock_observations = some_observations(['1m_10'], base=(50000, 50100, 49900, 50050))
-
-        mock_observer.get_observations = MagicMock(side_effect=mock_observations)
-        mirror_features_on(mock_observer)
-        mock_observer.intervals = ["1m"]
-        mock_observer.window_sizes = [10]
+        mock_observer = a_mock_observer(["1m_10"], base=(50000, 50100, 49900, 50050))
 
         mock_trader = a_mock_futures_trader()
 
@@ -986,14 +972,7 @@ class TestBinanceSLTPNotionalTradeMode:
             BinanceFuturesSLTPTradingEnvConfig,
         )
 
-        mock_observer = a_mock_observer(["1m_10"])
-
-        mock_observations = some_observations(['1m_10'], base=(50000, 50100, 49900, 50050))
-
-        mock_observer.get_observations = MagicMock(side_effect=mock_observations)
-        mirror_features_on(mock_observer)
-        mock_observer.intervals = ["1m"]
-        mock_observer.window_sizes = [10]
+        mock_observer = a_mock_observer(["1m_10"], base=(50000, 50100, 49900, 50050))
 
         mock_trader = a_mock_futures_trader()
         mock_trader.get_account_balance = MagicMock(return_value={

--- a/tests/envs/bitget/test_obs_class.py
+++ b/tests/envs/bitget/test_obs_class.py
@@ -10,7 +10,7 @@ import numpy as np
 from unittest.mock import MagicMock
 from torchtrade.envs.utils.timeframe import TimeFrame, TimeFrameUnit
 from torchtrade.envs.live.bitget.observation import BitgetObservationClass
-from tests.envs.base_exchange_tests import BaseObservationClassTests
+from tests.envs.base_exchange_tests import BaseObservationClassTests, add_custom_features
 
 
 def _make_bitget_client():
@@ -98,17 +98,7 @@ class TestBitgetObservationClass(BaseObservationClassTests):
 
     def test_custom_preprocessing_five_features(self, mock_ccxt_client):
         """Custom preprocessing adding OHLC-derived + custom feature -> 5 cols."""
-        def custom_preprocess(df):
-            df = df.copy()
-            df.dropna(inplace=True)
-            df.drop_duplicates(inplace=True)
-            df["feature_close"] = df["close"].pct_change().fillna(0)
-            df["feature_open"] = df["open"] / df["close"]
-            df["feature_high"] = df["high"] / df["close"]
-            df["feature_low"] = df["low"] / df["close"]
-            df["feature_custom"] = df["close"] * 2
-            df.dropna(inplace=True)
-            return df
+        custom_preprocess = add_custom_features
 
         observer = BitgetObservationClass(
             symbol="BTC/USDT:USDT", time_frames=TimeFrame(1, TimeFrameUnit.Minute),

--- a/tests/envs/bitget/test_obs_class.py
+++ b/tests/envs/bitget/test_obs_class.py
@@ -98,11 +98,10 @@ class TestBitgetObservationClass(BaseObservationClassTests):
 
     def test_custom_preprocessing_five_features(self, mock_ccxt_client):
         """Custom preprocessing adding OHLC-derived + custom feature -> 5 cols."""
-        custom_preprocess = add_custom_features
 
         observer = BitgetObservationClass(
             symbol="BTC/USDT:USDT", time_frames=TimeFrame(1, TimeFrameUnit.Minute),
-            window_sizes=10, feature_preprocessing_fn=custom_preprocess, client=mock_ccxt_client)
+            window_sizes=10, feature_preprocessing_fn=add_custom_features, client=mock_ccxt_client)
         assert observer.get_observations()["1Minute_10"].shape[1] == 5
 
     def test_get_features_names(self, observer_single):

--- a/tests/envs/bitget/test_torch_env_futures.py
+++ b/tests/envs/bitget/test_torch_env_futures.py
@@ -27,10 +27,8 @@ class TestBitgetFuturesTorchTradingEnv:
 
     @pytest.fixture
     def mock_trader(self):
-        """Create a mock trader."""
         trader = a_mock_futures_trader()
         trader._round_amount = MagicMock(side_effect=lambda amount: amount)
-
         return trader
 
     @pytest.fixture
@@ -395,10 +393,8 @@ class TestBitgetFuturesTorchTradingEnv:
         """A residual left between two positions must not carry the old age into the new one.
         """
 
-        status = a_position_status
-
         with patch.object(env, "_wait_for_next_timestamp"):
-            mock_trader.get_status = MagicMock(return_value=status(0.01))
+            mock_trader.get_status = MagicMock(return_value=a_position_status(0.01))
             env.reset()
             long_idx = len(env.action_levels) - 1
             long = TensorDict({"action": torch.tensor(long_idx)}, batch_size=())
@@ -406,10 +402,10 @@ class TestBitgetFuturesTorchTradingEnv:
             for _ in range(5):                       # age a real position
                 env.step(long)
 
-            mock_trader.get_status = MagicMock(return_value=status(1e-12))   # closed -> dust
+            mock_trader.get_status = MagicMock(return_value=a_position_status(1e-12))   # closed -> dust
             env.step(long)
 
-            mock_trader.get_status = MagicMock(return_value=status(0.01))    # a NEW position
+            mock_trader.get_status = MagicMock(return_value=a_position_status(0.01))    # a NEW position
             td = env.step(long)
 
         holding_time = td["next"]["account_state"][3].item()
@@ -469,20 +465,18 @@ class TestBitgetFuturesTorchTradingEnv:
         hold_counter, the policy is handed a brand-new position as N+1 bars old.
         """
 
-        status = a_position_status
-
         with patch.object(env, "_wait_for_next_timestamp"):
             long_idx = len(env.action_levels) - 1
             long = TensorDict({"action": torch.tensor(long_idx)}, batch_size=())
 
-            mock_trader.get_status = MagicMock(return_value=status(0.01))
+            mock_trader.get_status = MagicMock(return_value=a_position_status(0.01))
             env.reset()
             for _ in range(5):
                 env.step(long)
             aged = env.position.hold_counter
             assert aged > 1
 
-            mock_trader.get_status = MagicMock(return_value=status(None))   # liquidated
+            mock_trader.get_status = MagicMock(return_value=a_position_status(None))   # liquidated
             td = env.step(long)                                          # same-step re-entry
 
         assert td["next"]["account_state"][3].item() <= 1.0, (

--- a/tests/envs/bitget/test_torch_env_futures.py
+++ b/tests/envs/bitget/test_torch_env_futures.py
@@ -22,12 +22,7 @@ class TestBitgetFuturesTorchTradingEnv:
 
     @pytest.fixture
     def mock_observer(self):
-        return a_mock_observer(
-            ["1m_10", "5m_10"],
-            timestamps=True,
-            intervals=["1m", "5m"],
-            window_sizes=[10, 10],
-        )
+        return a_mock_observer(["1m_10", "5m_10"])
 
     @pytest.fixture
     def mock_trader(self):
@@ -495,7 +490,7 @@ class TestBitgetFuturesTorchTradingEnv:
         """
 
         def status(qty):
-            return a_position_status(qty, flat_is_none=True)
+            return a_position_status(qty)
 
         with patch.object(env, "_wait_for_next_timestamp"):
             long_idx = len(env.action_levels) - 1

--- a/tests/envs/bitget/test_torch_env_futures.py
+++ b/tests/envs/bitget/test_torch_env_futures.py
@@ -3,14 +3,14 @@
 import pytest
 
 from tests.envs.base_exchange_tests import (
+    a_position_status,
+    a_mock_observer,
     INVALID_ACTIONS,
     assert_an_invalid_action_cannot_move_an_open_position,
     assert_an_invalid_action_raises_before_trading,
-    mirror_features_on,
 )
 import torch
 from torchrl.envs.utils import check_env_specs
-import numpy as np
 from unittest.mock import MagicMock, patch
 from tensordict import TensorDict
 
@@ -22,29 +22,12 @@ class TestBitgetFuturesTorchTradingEnv:
 
     @pytest.fixture
     def mock_observer(self):
-        """Create a mock observer."""
-        observer = MagicMock()
-
-        # Mock get_keys
-        observer.get_keys = MagicMock(return_value=["1m_10", "5m_10"])
-
-        # Mock get_observations
-        def mock_observations(return_base_ohlc=False):
-            obs = {
-                "1m_10": np.random.randn(10, 4).astype(np.float32),
-                "5m_10": np.random.randn(10, 4).astype(np.float32),
-            }
-            if return_base_ohlc:
-                obs["base_features"] = np.random.randn(10, 4).astype(np.float32)
-                obs["base_timestamps"] = np.arange(10)
-            return obs
-
-        observer.get_observations = MagicMock(side_effect=mock_observations)
-        mirror_features_on(observer)
-        observer.intervals = ["1m", "5m"]
-        observer.window_sizes = [10, 10]
-
-        return observer
+        return a_mock_observer(
+            ["1m_10", "5m_10"],
+            timestamps=True,
+            intervals=["1m", "5m"],
+            window_sizes=[10, 10],
+        )
 
     @pytest.fixture
     def mock_trader(self):
@@ -435,14 +418,9 @@ class TestBitgetFuturesTorchTradingEnv:
     def test_dust_between_positions_does_not_age_the_next_one(self, env, mock_trader):
         """A residual left between two positions must not carry the old age into the new one.
         """
-        from torchtrade.envs.live.bitget.order_executor import PositionStatus
 
         def status(qty):
-            return {"position_status": PositionStatus(
-                qty=qty, notional_value=500.0, entry_price=50000.0, unrealized_pnl=0.0,
-                unrealized_pnl_pct=0.0, mark_price=50000.0, leverage=5,
-                margin_mode="isolated", liquidation_price=45000.0,
-            )}
+            return a_position_status(qty)
 
         with patch.object(env, "_wait_for_next_timestamp"):
             mock_trader.get_status = MagicMock(return_value=status(0.01))
@@ -515,14 +493,9 @@ class TestBitgetFuturesTorchTradingEnv:
         The sync detects the close and lets the guard re-enter -- but if it does not discard
         hold_counter, the policy is handed a brand-new position as N+1 bars old.
         """
-        from torchtrade.envs.live.bitget.order_executor import PositionStatus
 
         def status(qty):
-            return {"position_status": PositionStatus(
-                qty=qty, notional_value=500.0, entry_price=50000.0, unrealized_pnl=0.0,
-                unrealized_pnl_pct=0.0, mark_price=50000.0, leverage=5,
-                margin_mode="isolated", liquidation_price=45000.0,
-            )} if qty else {"position_status": None}
+            return a_position_status(qty, flat_is_none=True)
 
         with patch.object(env, "_wait_for_next_timestamp"):
             long_idx = len(env.action_levels) - 1
@@ -586,13 +559,7 @@ class TestBitgetInitCleanup:
 
     @pytest.fixture
     def mock_observer(self):
-        observer = MagicMock()
-        observer.get_keys = MagicMock(return_value=["1m_10"])
-        observer.get_observations = MagicMock(return_value={
-            "1m_10": np.random.randn(10, 4).astype(np.float32),
-        })
-        mirror_features_on(observer)
-        return observer
+        return a_mock_observer(["1m_10"])
 
     @pytest.fixture
     def mock_trader(self):

--- a/tests/envs/bitget/test_torch_env_futures.py
+++ b/tests/envs/bitget/test_torch_env_futures.py
@@ -3,9 +3,9 @@
 import pytest
 
 from tests.envs.base_exchange_tests import (
+    a_mock_futures_trader,
     a_mock_observer,
     a_position_status,
-    a_mock_observer,
     INVALID_ACTIONS,
     assert_an_invalid_action_cannot_move_an_open_position,
     assert_an_invalid_action_raises_before_trading,
@@ -28,28 +28,8 @@ class TestBitgetFuturesTorchTradingEnv:
     @pytest.fixture
     def mock_trader(self):
         """Create a mock trader."""
-        trader = MagicMock()
-
-        # Mock methods
-        trader.cancel_open_orders = MagicMock(return_value=True)
-        trader.close_position = MagicMock(return_value=True)
-
-        trader.get_account_balance = MagicMock(return_value={
-            "total_wallet_balance": 1000.0,
-            "available_balance": 900.0,
-            "total_unrealized_profit": 0.0,
-            "total_margin_balance": 1000.0,
-        })
-
-        trader.get_mark_price = MagicMock(return_value=50000.0)
-        trader.get_lot_size = MagicMock(return_value={"min_qty": 0.001, "qty_step": 0.001, "min_notional": 0.0})
+        trader = a_mock_futures_trader()
         trader._round_amount = MagicMock(side_effect=lambda amount: amount)
-
-        trader.get_status = MagicMock(return_value={
-            "position_status": None,
-        })
-
-        trader.trade = MagicMock(return_value=True)
 
         return trader
 

--- a/tests/envs/bitget/test_torch_env_futures.py
+++ b/tests/envs/bitget/test_torch_env_futures.py
@@ -3,6 +3,7 @@
 import pytest
 
 from tests.envs.base_exchange_tests import (
+    a_mock_observer,
     a_position_status,
     a_mock_observer,
     INVALID_ACTIONS,

--- a/tests/envs/bitget/test_torch_env_futures.py
+++ b/tests/envs/bitget/test_torch_env_futures.py
@@ -395,8 +395,7 @@ class TestBitgetFuturesTorchTradingEnv:
         """A residual left between two positions must not carry the old age into the new one.
         """
 
-        def status(qty):
-            return a_position_status(qty)
+        status = a_position_status
 
         with patch.object(env, "_wait_for_next_timestamp"):
             mock_trader.get_status = MagicMock(return_value=status(0.01))
@@ -470,8 +469,7 @@ class TestBitgetFuturesTorchTradingEnv:
         hold_counter, the policy is handed a brand-new position as N+1 bars old.
         """
 
-        def status(qty):
-            return a_position_status(qty)
+        status = a_position_status
 
         with patch.object(env, "_wait_for_next_timestamp"):
             long_idx = len(env.action_levels) - 1

--- a/tests/envs/bitget/test_torch_env_futures_sltp.py
+++ b/tests/envs/bitget/test_torch_env_futures_sltp.py
@@ -2,7 +2,6 @@
 
 import pytest
 
-from tests.envs.base_exchange_tests import a_mock_observer
 import torch
 from torchrl.envs.utils import check_env_specs
 from unittest.mock import MagicMock, patch
@@ -10,6 +9,7 @@ from tensordict import TensorDict
 
 from tests.envs.base_exchange_tests import (
     a_mock_futures_trader,
+    a_mock_observer,
     some_observations,
     INVALID_ACTIONS,
     assert_an_invalid_action_cannot_move_an_open_position,
@@ -29,10 +29,8 @@ class TestBitgetFuturesSLTPTorchTradingEnv:
 
     @pytest.fixture
     def mock_trader(self):
-        """Create a mock trader."""
         trader = a_mock_futures_trader()
         trader._round_amount = MagicMock(side_effect=lambda amount: amount)
-
         return trader
 
     @pytest.fixture

--- a/tests/envs/bitget/test_torch_env_futures_sltp.py
+++ b/tests/envs/bitget/test_torch_env_futures_sltp.py
@@ -25,12 +25,7 @@ class TestBitgetFuturesSLTPTorchTradingEnv:
 
     @pytest.fixture
     def mock_observer(self):
-        return a_mock_observer(
-            ["1m_10"],
-            base=(50000, 50100, 49900, 50050),
-            intervals=["1m"],
-            window_sizes=[10],
-        )
+        return a_mock_observer(["1m_10"], base=(50000, 50100, 49900, 50050))
 
     @pytest.fixture
     def mock_trader(self):

--- a/tests/envs/bitget/test_torch_env_futures_sltp.py
+++ b/tests/envs/bitget/test_torch_env_futures_sltp.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from tests.envs.base_exchange_tests import a_mock_observer, mirror_features_on
+from tests.envs.base_exchange_tests import a_mock_observer
 import torch
 from torchrl.envs.utils import check_env_specs
 from unittest.mock import MagicMock, patch
@@ -30,28 +30,8 @@ class TestBitgetFuturesSLTPTorchTradingEnv:
     @pytest.fixture
     def mock_trader(self):
         """Create a mock trader."""
-        trader = MagicMock()
-
-        # Mock methods
-        trader.cancel_open_orders = MagicMock(return_value=True)
-        trader.close_position = MagicMock(return_value=True)
-
-        trader.get_account_balance = MagicMock(return_value={
-            "total_wallet_balance": 1000.0,
-            "available_balance": 900.0,
-            "total_unrealized_profit": 0.0,
-            "total_margin_balance": 1000.0,
-        })
-
-        trader.get_mark_price = MagicMock(return_value=50000.0)
-        trader.get_lot_size = MagicMock(return_value={"min_qty": 0.001, "qty_step": 0.001, "min_notional": 0.0})
+        trader = a_mock_futures_trader()
         trader._round_amount = MagicMock(side_effect=lambda amount: amount)
-
-        trader.get_status = MagicMock(return_value={
-            "position_status": None,
-        })
-
-        trader.trade = MagicMock(return_value=True)
 
         return trader
 
@@ -477,28 +457,10 @@ class TestDuplicateActionPrevention:
             BitgetFuturesSLTPTradingEnvConfig,
         )
 
-        mock_observer = a_mock_observer(["1m_10"])
+        mock_observer = a_mock_observer(["1m_10"], base=(50000, 50100, 49900, 50050))
 
-        mock_get_observations = some_observations(['1m_10'], base=(50000, 50100, 49900, 50050))
-
-        mock_observer.get_observations = MagicMock(side_effect=mock_get_observations)
-        mirror_features_on(mock_observer)
-        mock_observer.intervals = ["1m"]
-        mock_observer.window_sizes = [10]
-
-        mock_trader = MagicMock()
-        mock_trader.cancel_open_orders = MagicMock(return_value=True)
-        mock_trader.close_position = MagicMock(return_value=True)
-        mock_trader.get_account_balance = MagicMock(return_value={
-            "total_wallet_balance": 1000.0,
-            "available_balance": 900.0,
-            "total_margin_balance": 1000.0,
-        })
-        mock_trader.get_mark_price = MagicMock(return_value=50000.0)
-        mock_trader.get_lot_size = MagicMock(return_value={"min_qty": 0.001, "qty_step": 0.001, "min_notional": 0.0})
+        mock_trader = a_mock_futures_trader()
         mock_trader._round_amount = MagicMock(side_effect=lambda amount: amount)
-        mock_trader.get_status = MagicMock(return_value={"position_status": None})
-        mock_trader.trade = MagicMock(return_value=True)
 
         config = BitgetFuturesSLTPTradingEnvConfig(
             symbol="BTCUSDT",
@@ -643,28 +605,10 @@ class TestBitgetSLTPNotionalTradeMode:
             BitgetFuturesSLTPTradingEnvConfig,
         )
 
-        mock_observer = a_mock_observer(["1m_10"])
+        mock_observer = a_mock_observer(["1m_10"], base=(50000, 50100, 49900, 50050))
 
-        mock_observations = some_observations(['1m_10'], base=(50000, 50100, 49900, 50050))
-
-        mock_observer.get_observations = MagicMock(side_effect=mock_observations)
-        mirror_features_on(mock_observer)
-        mock_observer.intervals = ["1m"]
-        mock_observer.window_sizes = [10]
-
-        mock_trader = MagicMock()
-        mock_trader.cancel_open_orders = MagicMock(return_value=True)
-        mock_trader.close_position = MagicMock(return_value=True)
-        mock_trader.get_account_balance = MagicMock(return_value={
-            "total_wallet_balance": 1000.0,
-            "available_balance": 900.0,
-            "total_margin_balance": 1000.0,
-        })
-        mock_trader.get_mark_price = MagicMock(return_value=50000.0)
-        mock_trader.get_lot_size = MagicMock(return_value={"min_qty": 0.001, "qty_step": 0.001, "min_notional": 0.0})
+        mock_trader = a_mock_futures_trader()
         mock_trader._round_amount = MagicMock(side_effect=lambda amount: amount)
-        mock_trader.get_status = MagicMock(return_value={"position_status": None})
-        mock_trader.trade = MagicMock(return_value=True)
 
         config = BitgetFuturesSLTPTradingEnvConfig(
             symbol="BTC/USDT:USDT",
@@ -769,14 +713,7 @@ class TestBitgetSLTPNotionalTradeMode:
             BitgetFuturesSLTPTradingEnvConfig,
         )
 
-        mock_observer = a_mock_observer(["1m_10"])
-
-        mock_observations = some_observations(['1m_10'], base=(50000, 50100, 49900, 50050))
-
-        mock_observer.get_observations = MagicMock(side_effect=mock_observations)
-        mirror_features_on(mock_observer)
-        mock_observer.intervals = ["1m"]
-        mock_observer.window_sizes = [10]
+        mock_observer = a_mock_observer(["1m_10"], base=(50000, 50100, 49900, 50050))
 
         mock_trader = a_mock_futures_trader()
         mock_trader.get_account_balance = MagicMock(return_value={

--- a/tests/envs/bitget/test_torch_env_futures_sltp.py
+++ b/tests/envs/bitget/test_torch_env_futures_sltp.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from tests.envs.base_exchange_tests import mirror_features_on
+from tests.envs.base_exchange_tests import a_mock_observer, mirror_features_on
 import torch
 from torchrl.envs.utils import check_env_specs
 import numpy as np
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock, patch
 from tensordict import TensorDict
 
 from tests.envs.base_exchange_tests import (
+    some_observations,
     INVALID_ACTIONS,
     assert_an_invalid_action_cannot_move_an_open_position,
     assert_an_invalid_action_raises_before_trading,
@@ -24,30 +25,12 @@ class TestBitgetFuturesSLTPTorchTradingEnv:
 
     @pytest.fixture
     def mock_observer(self):
-        """Create a mock observer."""
-        observer = MagicMock()
-
-        # Mock get_keys
-        observer.get_keys = MagicMock(return_value=["1m_10"])
-
-        # Mock get_observations
-        def mock_observations(return_base_ohlc=False):
-            obs = {
-                "1m_10": np.random.randn(10, 4).astype(np.float32),
-            }
-            if return_base_ohlc:
-                # OHLC features: [open, high, low, close]
-                obs["base_features"] = np.array([
-                    [50000, 50100, 49900, 50050]  # Current price ~50050
-                ] * 10, dtype=np.float32)
-            return obs
-
-        observer.get_observations = MagicMock(side_effect=mock_observations)
-        mirror_features_on(observer)
-        observer.intervals = ["1m"]
-        observer.window_sizes = [10]
-
-        return observer
+        return a_mock_observer(
+            ["1m_10"],
+            base=(50000, 50100, 49900, 50050),
+            intervals=["1m"],
+            window_sizes=[10],
+        )
 
     @pytest.fixture
     def mock_trader(self):
@@ -502,13 +485,7 @@ class TestDuplicateActionPrevention:
         mock_observer = MagicMock()
         mock_observer.get_keys = MagicMock(return_value=["1m_10"])
 
-        def mock_get_observations(return_base_ohlc=False):
-            obs = {"1m_10": np.random.randn(10, 4).astype(np.float32)}
-            if return_base_ohlc:
-                obs["base_features"] = np.array(
-                    [[50000, 50100, 49900, 50050]] * 10, dtype=np.float32
-                )
-            return obs
+        mock_get_observations = some_observations(['1m_10'], base=(50000, 50100, 49900, 50050))
 
         mock_observer.get_observations = MagicMock(side_effect=mock_get_observations)
         mirror_features_on(mock_observer)
@@ -675,13 +652,7 @@ class TestBitgetSLTPNotionalTradeMode:
         mock_observer = MagicMock()
         mock_observer.get_keys = MagicMock(return_value=["1m_10"])
 
-        def mock_observations(return_base_ohlc=False):
-            obs = {"1m_10": np.random.randn(10, 4).astype(np.float32)}
-            if return_base_ohlc:
-                obs["base_features"] = np.array(
-                    [[50000, 50100, 49900, 50050]] * 10, dtype=np.float32
-                )
-            return obs
+        mock_observations = some_observations(['1m_10'], base=(50000, 50100, 49900, 50050))
 
         mock_observer.get_observations = MagicMock(side_effect=mock_observations)
         mirror_features_on(mock_observer)
@@ -743,11 +714,7 @@ class TestBitgetSLTPNotionalTradeMode:
         env, mock_trader = notional_env
 
         # Override observer to return zero-price candles
-        def mock_obs_zero(return_base_ohlc=False):
-            obs = {"1m_10": np.random.randn(10, 4).astype(np.float32)}
-            if return_base_ohlc:
-                obs["base_features"] = np.array([[0, 0, 0, 0]] * 10, dtype=np.float32)
-            return obs
+        mock_obs_zero = some_observations(['1m_10'], base=(0, 0, 0, 0))
 
         env.observer.get_observations = MagicMock(side_effect=mock_obs_zero)
         env.reset()
@@ -835,13 +802,7 @@ class TestBitgetSLTPNotionalTradeMode:
         mock_observer = MagicMock()
         mock_observer.get_keys = MagicMock(return_value=["1m_10"])
 
-        def mock_observations(return_base_ohlc=False):
-            obs = {"1m_10": np.random.randn(10, 4).astype(np.float32)}
-            if return_base_ohlc:
-                obs["base_features"] = np.array(
-                    [[50000, 50100, 49900, 50050]] * 10, dtype=np.float32
-                )
-            return obs
+        mock_observations = some_observations(['1m_10'], base=(50000, 50100, 49900, 50050))
 
         mock_observer.get_observations = MagicMock(side_effect=mock_observations)
         mirror_features_on(mock_observer)

--- a/tests/envs/bitget/test_torch_env_futures_sltp.py
+++ b/tests/envs/bitget/test_torch_env_futures_sltp.py
@@ -5,11 +5,11 @@ import pytest
 from tests.envs.base_exchange_tests import a_mock_observer, mirror_features_on
 import torch
 from torchrl.envs.utils import check_env_specs
-import numpy as np
 from unittest.mock import MagicMock, patch
 from tensordict import TensorDict
 
 from tests.envs.base_exchange_tests import (
+    a_mock_futures_trader,
     some_observations,
     INVALID_ACTIONS,
     assert_an_invalid_action_cannot_move_an_open_position,
@@ -477,8 +477,7 @@ class TestDuplicateActionPrevention:
             BitgetFuturesSLTPTradingEnvConfig,
         )
 
-        mock_observer = MagicMock()
-        mock_observer.get_keys = MagicMock(return_value=["1m_10"])
+        mock_observer = a_mock_observer(["1m_10"])
 
         mock_get_observations = some_observations(['1m_10'], base=(50000, 50100, 49900, 50050))
 
@@ -644,8 +643,7 @@ class TestBitgetSLTPNotionalTradeMode:
             BitgetFuturesSLTPTradingEnvConfig,
         )
 
-        mock_observer = MagicMock()
-        mock_observer.get_keys = MagicMock(return_value=["1m_10"])
+        mock_observer = a_mock_observer(["1m_10"])
 
         mock_observations = some_observations(['1m_10'], base=(50000, 50100, 49900, 50050))
 
@@ -731,32 +729,9 @@ class TestBitgetSLTPNotionalTradeMode:
             BitgetFuturesSLTPTradingEnvConfig,
         )
 
-        mock_observer = MagicMock()
-        mock_observer.get_keys = MagicMock(return_value=["1m_10"])
-        mock_observer.get_observations = MagicMock(return_value={
-            "1m_10": np.random.randn(10, 4).astype(np.float32),
-            "base_features": np.array(
-                [[50000, 50100, 49900, 50050]] * 10, dtype=np.float32
-            ),
-        })
-        mirror_features_on(mock_observer)
-        mock_observer.intervals = ["1m"]
-        mock_observer.window_sizes = [10]
+        mock_observer = a_mock_observer(["1m_10"], base=(50000, 50100, 49900, 50050))
 
-        mock_trader = MagicMock()
-        # A realistic lot step: `float(MagicMock())` is 1.0, which reads as a 1.0-BTC
-        # lot and floors every real quantity to zero in the shared sizing guard.
-        mock_trader.get_lot_size = MagicMock(
-            return_value={"min_qty": 0.001, "qty_step": 0.001, "min_notional": 0.0})
-        mock_trader.get_mark_price = MagicMock(return_value=50000.0)
-        mock_trader.cancel_open_orders = MagicMock(return_value=True)
-        mock_trader.close_position = MagicMock(return_value=True)
-        mock_trader.get_account_balance = MagicMock(return_value={
-            "total_wallet_balance": 1000.0, "available_balance": 900.0,
-            "total_margin_balance": 1000.0,
-        })
-        mock_trader.get_status = MagicMock(return_value={"position_status": None})
-        mock_trader.trade = MagicMock(return_value=True)
+        mock_trader = a_mock_futures_trader()
 
         config = BitgetFuturesSLTPTradingEnvConfig(
             symbol="BTC/USDT:USDT",
@@ -794,8 +769,7 @@ class TestBitgetSLTPNotionalTradeMode:
             BitgetFuturesSLTPTradingEnvConfig,
         )
 
-        mock_observer = MagicMock()
-        mock_observer.get_keys = MagicMock(return_value=["1m_10"])
+        mock_observer = a_mock_observer(["1m_10"])
 
         mock_observations = some_observations(['1m_10'], base=(50000, 50100, 49900, 50050))
 
@@ -804,13 +778,7 @@ class TestBitgetSLTPNotionalTradeMode:
         mock_observer.intervals = ["1m"]
         mock_observer.window_sizes = [10]
 
-        mock_trader = MagicMock()
-        # Realistic lot step (float(MagicMock()) is 1.0 -- see the note above).
-        mock_trader.get_lot_size = MagicMock(
-            return_value={"min_qty": 0.001, "qty_step": 0.001, "min_notional": 0.0})
-        mock_trader.get_mark_price = MagicMock(return_value=50000.0)
-        mock_trader.cancel_open_orders = MagicMock(return_value=True)
-        mock_trader.close_position = MagicMock(return_value=True)
+        mock_trader = a_mock_futures_trader()
         mock_trader.get_account_balance = MagicMock(return_value={
             # wallet != margin: sizing must use total_margin_balance (equity, incl.
             # unrealized PnL), matching offline's portfolio_value basis (#65).
@@ -819,8 +787,6 @@ class TestBitgetSLTPNotionalTradeMode:
             "total_unrealized_profit": 100.0,
             "total_margin_balance": 1100.0,
         })
-        mock_trader.get_status = MagicMock(return_value={"position_status": None})
-        mock_trader.trade = MagicMock(return_value=True)
 
         config = BitgetFuturesSLTPTradingEnvConfig(
             symbol="BTC/USDT:USDT",
@@ -861,31 +827,9 @@ class TestBitgetSLTPLockPosition:
             BitgetFuturesSLTPTradingEnvConfig,
         )
 
-        mock_observer = MagicMock()
-        mock_observer.get_keys = MagicMock(return_value=["1m_10"])
-        mock_observer.get_observations = MagicMock(return_value={
-            "1m_10": np.random.randn(10, 4).astype(np.float32),
-            "base_features": np.array(
-                [[50000, 50100, 49900, 50050]] * 10, dtype=np.float32
-            ),
-        })
-        mirror_features_on(mock_observer)
-        mock_observer.intervals = ["1m"]
-        mock_observer.window_sizes = [10]
+        mock_observer = a_mock_observer(["1m_10"], base=(50000, 50100, 49900, 50050))
 
-        mock_trader = MagicMock()
-        # Realistic lot step (float(MagicMock()) is 1.0 -- see the note above).
-        mock_trader.get_lot_size = MagicMock(
-            return_value={"min_qty": 0.001, "qty_step": 0.001, "min_notional": 0.0})
-        mock_trader.get_mark_price = MagicMock(return_value=50000.0)
-        mock_trader.cancel_open_orders = MagicMock(return_value=True)
-        mock_trader.close_position = MagicMock(return_value=True)
-        mock_trader.get_account_balance = MagicMock(return_value={
-            "total_wallet_balance": 1000.0, "available_balance": 900.0,
-            "total_margin_balance": 1000.0,
-        })
-        mock_trader.get_status = MagicMock(return_value={"position_status": None})
-        mock_trader.trade = MagicMock(return_value=True)
+        mock_trader = a_mock_futures_trader()
 
         config = BitgetFuturesSLTPTradingEnvConfig(
             symbol="BTC/USDT:USDT",

--- a/tests/envs/bybit/conftest.py
+++ b/tests/envs/bybit/conftest.py
@@ -126,7 +126,7 @@ def mock_pybit_client():
 
 @pytest.fixture
 def mock_env_observer():
-    return a_mock_observer(["1Minute_10"], base=(50000, 50100, 49900, 50050), features=True)
+    return a_mock_observer(["1Minute_10"], base=(50000, 50100, 49900, 50050))
 
 
 @pytest.fixture

--- a/tests/envs/bybit/conftest.py
+++ b/tests/envs/bybit/conftest.py
@@ -1,6 +1,6 @@
 """Shared test fixtures for Bybit tests."""
 
-import numpy as np
+from tests.envs.base_exchange_tests import a_mock_futures_trader, a_mock_observer
 import pytest
 from unittest.mock import MagicMock
 
@@ -126,43 +126,12 @@ def mock_pybit_client():
 
 @pytest.fixture
 def mock_env_observer():
-    """Create a mock observer for env tests (single timeframe)."""
-    observer = MagicMock()
-    observer.get_keys = MagicMock(return_value=["1Minute_10"])
-
-    def mock_observations(return_base_ohlc=False):
-        obs = {"1Minute_10": np.random.randn(10, 4).astype(np.float32)}
-        if return_base_ohlc:
-            obs["base_features"] = np.array(
-                [[50000, 50100, 49900, 50050]] * 10, dtype=np.float32
-            )
-        return obs
-
-    observer.get_observations = MagicMock(side_effect=mock_observations)
-    observer.get_features = MagicMock(return_value={
-        "observation_features": ["feature_close", "feature_open", "feature_high", "feature_low"],
-        "original_features": ["open", "high", "low", "close", "volume"],
-    })
-    return observer
+    return a_mock_observer(["1Minute_10"], base=(50000, 50100, 49900, 50050), features=True)
 
 
 @pytest.fixture
 def mock_env_trader():
-    """Create a mock trader for env tests."""
-    trader = MagicMock()
-    trader.cancel_open_orders = MagicMock(return_value=True)
-    trader.close_position = MagicMock(return_value=True)
-    trader.get_account_balance = MagicMock(return_value={
-        "total_wallet_balance": 1000.0,
-        "available_balance": 900.0,
-        "total_unrealized_profit": 0.0,
-        "total_margin_balance": 1000.0,
-    })
-    trader.get_mark_price = MagicMock(return_value=50000.0)
-    trader.get_status = MagicMock(return_value={"position_status": None})
-    trader.trade = MagicMock(return_value=True)
-    trader.get_lot_size = MagicMock(return_value={"min_qty": 0.001, "qty_step": 0.001, "min_notional": 0.0})
-    return trader
+    return a_mock_futures_trader()
 
 
 @pytest.fixture

--- a/tests/envs/bybit/test_obs_class.py
+++ b/tests/envs/bybit/test_obs_class.py
@@ -88,11 +88,10 @@ class TestBybitObservationClass(BaseObservationClassTests):
         """Custom preprocessing adding OHLC-derived + custom feature -> 5 cols."""
         from torchtrade.envs.live.bybit.observation import BybitObservationClass
 
-        custom_preprocess = add_custom_features
 
         observer = BybitObservationClass(
             symbol="BTCUSDT", time_frames=TimeFrame(1, TimeFrameUnit.Minute),
-            window_sizes=10, feature_preprocessing_fn=custom_preprocess,
+            window_sizes=10, feature_preprocessing_fn=add_custom_features,
             client=_make_pybit_client())
         assert observer.get_observations()["1Minute_10"].shape[1] == 5
 

--- a/tests/envs/bybit/test_obs_class.py
+++ b/tests/envs/bybit/test_obs_class.py
@@ -6,10 +6,9 @@ chronological parsing, utils) and stricter exact-shape assertions live here.
 """
 
 import pytest
-import numpy as np
 from unittest.mock import MagicMock
 from torchtrade.envs.utils.timeframe import TimeFrame, TimeFrameUnit
-from tests.envs.base_exchange_tests import BaseObservationClassTests
+from tests.envs.base_exchange_tests import BaseObservationClassTests, add_custom_features
 
 
 def _make_pybit_client():
@@ -89,17 +88,7 @@ class TestBybitObservationClass(BaseObservationClassTests):
         """Custom preprocessing adding OHLC-derived + custom feature -> 5 cols."""
         from torchtrade.envs.live.bybit.observation import BybitObservationClass
 
-        def custom_preprocess(df):
-            df = df.copy()
-            df.dropna(inplace=True)
-            df.drop_duplicates(inplace=True)
-            df["feature_close"] = df["close"].pct_change().fillna(0)
-            df["feature_open"] = df["open"] / df["close"]
-            df["feature_high"] = df["high"] / df["close"]
-            df["feature_low"] = df["low"] / df["close"]
-            df["feature_custom"] = df["close"] * 2
-            df.dropna(inplace=True)
-            return df
+        custom_preprocess = add_custom_features
 
         observer = BybitObservationClass(
             symbol="BTCUSDT", time_frames=TimeFrame(1, TimeFrameUnit.Minute),

--- a/tests/envs/bybit/test_torch_env_futures.py
+++ b/tests/envs/bybit/test_torch_env_futures.py
@@ -24,11 +24,7 @@ class TestBybitFuturesTorchTradingEnv:
 
     @pytest.fixture
     def mock_observer(self):
-        return a_mock_observer(
-            ["1Minute_10", "5Minute_10"],
-            timestamps=True,
-            features=True,
-        )
+        return a_mock_observer(["1Minute_10", "5Minute_10"])
 
     @pytest.fixture
     def mock_trader(self):
@@ -358,7 +354,7 @@ class TestBybitFuturesTorchTradingEnv:
         """
 
         def status(qty):
-            return a_position_status(qty, flat_is_none=True)
+            return a_position_status(qty)
 
         with patch.object(env, "_wait_for_next_timestamp"):
             long_idx = len(env.action_levels) - 1

--- a/tests/envs/bybit/test_torch_env_futures.py
+++ b/tests/envs/bybit/test_torch_env_futures.py
@@ -8,6 +8,8 @@ from unittest.mock import MagicMock, patch
 from tensordict import TensorDict
 
 from tests.envs.base_exchange_tests import (
+    a_mock_futures_trader,
+    a_mock_observer,
     a_position_status,
     a_mock_observer,
     INVALID_ACTIONS,
@@ -29,19 +31,7 @@ class TestBybitFuturesTorchTradingEnv:
     @pytest.fixture
     def mock_trader(self):
         """Create a mock trader."""
-        trader = MagicMock()
-        trader.cancel_open_orders = MagicMock(return_value=True)
-        trader.close_position = MagicMock(return_value=True)
-        trader.get_account_balance = MagicMock(return_value={
-            "total_wallet_balance": 1000.0,
-            "available_balance": 900.0,
-            "total_unrealized_profit": 0.0,
-            "total_margin_balance": 1000.0,
-        })
-        trader.get_mark_price = MagicMock(return_value=50000.0)
-        trader.get_status = MagicMock(return_value={"position_status": None})
-        trader.trade = MagicMock(return_value=True)
-        trader.get_lot_size = MagicMock(return_value={"min_qty": 0.001, "qty_step": 0.001, "min_notional": 0.0})
+        trader = a_mock_futures_trader()
         return trader
 
     @pytest.fixture

--- a/tests/envs/bybit/test_torch_env_futures.py
+++ b/tests/envs/bybit/test_torch_env_futures.py
@@ -11,7 +11,6 @@ from tests.envs.base_exchange_tests import (
     a_mock_futures_trader,
     a_mock_observer,
     a_position_status,
-    a_mock_observer,
     INVALID_ACTIONS,
     assert_an_invalid_action_cannot_move_an_open_position,
     assert_an_invalid_action_raises_before_trading,
@@ -617,13 +616,6 @@ class TestBybitFractionalPositionResizing:
                 liquidation_price=0,
             )
         })
-        mock_env_trader.get_mark_price = MagicMock(return_value=50000.0)
-        mock_env_trader.get_lot_size = MagicMock(return_value={"min_qty": 0.001, "qty_step": 0.001, "min_notional": 0.0})
-        mock_env_trader.get_account_balance = MagicMock(return_value={
-            "total_wallet_balance": 1000.0, "available_balance": 900.0,
-            "total_unrealized_profit": 0.0, "total_margin_balance": 1000.0,
-        })
-
         env.reset()
         result = env._execute_fractional_action(1.0, current_qty=position_qty_from_status(
                 env.trader.get_status().get("position_status")),

--- a/tests/envs/bybit/test_torch_env_futures.py
+++ b/tests/envs/bybit/test_torch_env_futures.py
@@ -4,11 +4,12 @@ import logging
 import pytest
 import torch
 from torchrl.envs.utils import check_env_specs
-import numpy as np
 from unittest.mock import MagicMock, patch
 from tensordict import TensorDict
 
 from tests.envs.base_exchange_tests import (
+    a_position_status,
+    a_mock_observer,
     INVALID_ACTIONS,
     assert_an_invalid_action_cannot_move_an_open_position,
     assert_an_invalid_action_raises_before_trading,
@@ -23,26 +24,11 @@ class TestBybitFuturesTorchTradingEnv:
 
     @pytest.fixture
     def mock_observer(self):
-        """Create a mock observer with two timeframes."""
-        observer = MagicMock()
-        observer.get_keys = MagicMock(return_value=["1Minute_10", "5Minute_10"])
-
-        def mock_observations(return_base_ohlc=False):
-            obs = {
-                "1Minute_10": np.random.randn(10, 4).astype(np.float32),
-                "5Minute_10": np.random.randn(10, 4).astype(np.float32),
-            }
-            if return_base_ohlc:
-                obs["base_features"] = np.random.randn(10, 4).astype(np.float32)
-                obs["base_timestamps"] = np.arange(10)
-            return obs
-
-        observer.get_observations = MagicMock(side_effect=mock_observations)
-        observer.get_features = MagicMock(return_value={
-            "observation_features": ["feature_close", "feature_open", "feature_high", "feature_low"],
-            "original_features": ["open", "high", "low", "close", "volume"],
-        })
-        return observer
+        return a_mock_observer(
+            ["1Minute_10", "5Minute_10"],
+            timestamps=True,
+            features=True,
+        )
 
     @pytest.fixture
     def mock_trader(self):
@@ -287,14 +273,9 @@ class TestBybitFuturesTorchTradingEnv:
     def test_dust_between_positions_does_not_age_the_next_one(self, env, mock_trader):
         """A residual left between two positions must not carry the old age into the new one.
         """
-        from torchtrade.envs.live.bybit.order_executor import PositionStatus
 
         def status(qty):
-            return {"position_status": PositionStatus(
-                qty=qty, notional_value=500.0, entry_price=50000.0, unrealized_pnl=0.0,
-                unrealized_pnl_pct=0.0, mark_price=50000.0, leverage=5,
-                margin_mode="isolated", liquidation_price=45000.0,
-            )}
+            return a_position_status(qty)
 
         with patch.object(env, "_wait_for_next_timestamp"):
             mock_trader.get_status = MagicMock(return_value=status(0.01))
@@ -375,14 +356,9 @@ class TestBybitFuturesTorchTradingEnv:
         The sync detects the close and lets the guard re-enter -- but if it does not discard
         hold_counter, the policy is handed a brand-new position as N+1 bars old.
         """
-        from torchtrade.envs.live.bybit.order_executor import PositionStatus
 
         def status(qty):
-            return {"position_status": PositionStatus(
-                qty=qty, notional_value=500.0, entry_price=50000.0, unrealized_pnl=0.0,
-                unrealized_pnl_pct=0.0, mark_price=50000.0, leverage=5,
-                margin_mode="isolated", liquidation_price=45000.0,
-            )} if qty else {"position_status": None}
+            return a_position_status(qty, flat_is_none=True)
 
         with patch.object(env, "_wait_for_next_timestamp"):
             long_idx = len(env.action_levels) - 1

--- a/tests/envs/bybit/test_torch_env_futures.py
+++ b/tests/envs/bybit/test_torch_env_futures.py
@@ -259,8 +259,7 @@ class TestBybitFuturesTorchTradingEnv:
         """A residual left between two positions must not carry the old age into the new one.
         """
 
-        def status(qty):
-            return a_position_status(qty)
+        status = a_position_status
 
         with patch.object(env, "_wait_for_next_timestamp"):
             mock_trader.get_status = MagicMock(return_value=status(0.01))
@@ -342,8 +341,7 @@ class TestBybitFuturesTorchTradingEnv:
         hold_counter, the policy is handed a brand-new position as N+1 bars old.
         """
 
-        def status(qty):
-            return a_position_status(qty)
+        status = a_position_status
 
         with patch.object(env, "_wait_for_next_timestamp"):
             long_idx = len(env.action_levels) - 1

--- a/tests/envs/bybit/test_torch_env_futures.py
+++ b/tests/envs/bybit/test_torch_env_futures.py
@@ -29,9 +29,7 @@ class TestBybitFuturesTorchTradingEnv:
 
     @pytest.fixture
     def mock_trader(self):
-        """Create a mock trader."""
-        trader = a_mock_futures_trader()
-        return trader
+        return a_mock_futures_trader()
 
     @pytest.fixture
     def env_config(self):
@@ -259,10 +257,8 @@ class TestBybitFuturesTorchTradingEnv:
         """A residual left between two positions must not carry the old age into the new one.
         """
 
-        status = a_position_status
-
         with patch.object(env, "_wait_for_next_timestamp"):
-            mock_trader.get_status = MagicMock(return_value=status(0.01))
+            mock_trader.get_status = MagicMock(return_value=a_position_status(0.01))
             env.reset()
             long_idx = len(env.action_levels) - 1
             long = TensorDict({"action": torch.tensor(long_idx)}, batch_size=())
@@ -270,10 +266,10 @@ class TestBybitFuturesTorchTradingEnv:
             for _ in range(5):                       # age a real position
                 env.step(long)
 
-            mock_trader.get_status = MagicMock(return_value=status(1e-12))   # closed -> dust
+            mock_trader.get_status = MagicMock(return_value=a_position_status(1e-12))   # closed -> dust
             env.step(long)
 
-            mock_trader.get_status = MagicMock(return_value=status(0.01))    # a NEW position
+            mock_trader.get_status = MagicMock(return_value=a_position_status(0.01))    # a NEW position
             td = env.step(long)
 
         holding_time = td["next"]["account_state"][3].item()
@@ -341,20 +337,18 @@ class TestBybitFuturesTorchTradingEnv:
         hold_counter, the policy is handed a brand-new position as N+1 bars old.
         """
 
-        status = a_position_status
-
         with patch.object(env, "_wait_for_next_timestamp"):
             long_idx = len(env.action_levels) - 1
             long = TensorDict({"action": torch.tensor(long_idx)}, batch_size=())
 
-            mock_trader.get_status = MagicMock(return_value=status(0.01))
+            mock_trader.get_status = MagicMock(return_value=a_position_status(0.01))
             env.reset()
             for _ in range(5):
                 env.step(long)
             aged = env.position.hold_counter
             assert aged > 1
 
-            mock_trader.get_status = MagicMock(return_value=status(None))   # liquidated
+            mock_trader.get_status = MagicMock(return_value=a_position_status(None))   # liquidated
             td = env.step(long)                                          # same-step re-entry
 
         assert td["next"]["account_state"][3].item() <= 1.0, (

--- a/tests/envs/okx/conftest.py
+++ b/tests/envs/okx/conftest.py
@@ -140,7 +140,7 @@ def mock_okx_market_client():
 
 @pytest.fixture
 def mock_env_observer():
-    return a_mock_observer(["1Minute_10"], base=(50000, 50100, 49900, 50050), features=True)
+    return a_mock_observer(["1Minute_10"], base=(50000, 50100, 49900, 50050))
 
 
 @pytest.fixture

--- a/tests/envs/okx/conftest.py
+++ b/tests/envs/okx/conftest.py
@@ -1,6 +1,6 @@
 """Shared test fixtures for OKX tests."""
 
-import numpy as np
+from tests.envs.base_exchange_tests import a_mock_futures_trader, a_mock_observer
 import pytest
 from unittest.mock import MagicMock
 
@@ -140,40 +140,9 @@ def mock_okx_market_client():
 
 @pytest.fixture
 def mock_env_observer():
-    """Create a mock observer for env tests (single timeframe)."""
-    observer = MagicMock()
-    observer.get_keys = MagicMock(return_value=["1Minute_10"])
-
-    def mock_observations(return_base_ohlc=False):
-        obs = {"1Minute_10": np.random.randn(10, 4).astype(np.float32)}
-        if return_base_ohlc:
-            obs["base_features"] = np.array(
-                [[50000, 50100, 49900, 50050]] * 10, dtype=np.float32
-            )
-        return obs
-
-    observer.get_observations = MagicMock(side_effect=mock_observations)
-    observer.get_features = MagicMock(return_value={
-        "observation_features": ["feature_close", "feature_open", "feature_high", "feature_low"],
-        "original_features": ["open", "high", "low", "close", "volume"],
-    })
-    return observer
+    return a_mock_observer(["1Minute_10"], base=(50000, 50100, 49900, 50050), features=True)
 
 
 @pytest.fixture
 def mock_env_trader():
-    """Create a mock trader for env tests."""
-    trader = MagicMock()
-    trader.cancel_open_orders = MagicMock(return_value=True)
-    trader.close_position = MagicMock(return_value=True)
-    trader.get_account_balance = MagicMock(return_value={
-        "total_wallet_balance": 1000.0,
-        "available_balance": 900.0,
-        "total_unrealized_profit": 0.0,
-        "total_margin_balance": 1000.0,
-    })
-    trader.get_mark_price = MagicMock(return_value=50000.0)
-    trader.get_status = MagicMock(return_value={"position_status": None})
-    trader.trade = MagicMock(return_value=True)
-    trader.get_lot_size = MagicMock(return_value={"min_qty": 0.001, "qty_step": 0.001, "min_notional": 0.0})
-    return trader
+    return a_mock_futures_trader()

--- a/tests/envs/okx/test_obs_class.py
+++ b/tests/envs/okx/test_obs_class.py
@@ -93,13 +93,12 @@ class TestOKXObservationClass(BaseObservationClassTests):
         """Custom preprocessing that adds OHLC-derived + a custom feature -> 5 cols."""
         from torchtrade.envs.live.okx.observation import OKXObservationClass
 
-        custom_preprocess = add_custom_features
 
         observer = OKXObservationClass(
             symbol="BTC-USDT-SWAP",
             time_frames=TimeFrame(1, TimeFrameUnit.Minute),
             window_sizes=10,
-            feature_preprocessing_fn=custom_preprocess,
+            feature_preprocessing_fn=add_custom_features,
             client=_make_okx_market_client(),
         )
         observations = observer.get_observations()

--- a/tests/envs/okx/test_obs_class.py
+++ b/tests/envs/okx/test_obs_class.py
@@ -7,10 +7,9 @@ here.
 """
 
 import pytest
-import numpy as np
 from unittest.mock import MagicMock
 from torchtrade.envs.utils.timeframe import TimeFrame, TimeFrameUnit
-from tests.envs.base_exchange_tests import BaseObservationClassTests
+from tests.envs.base_exchange_tests import BaseObservationClassTests, add_custom_features
 
 
 def _make_okx_market_client():
@@ -94,17 +93,7 @@ class TestOKXObservationClass(BaseObservationClassTests):
         """Custom preprocessing that adds OHLC-derived + a custom feature -> 5 cols."""
         from torchtrade.envs.live.okx.observation import OKXObservationClass
 
-        def custom_preprocess(df):
-            df = df.copy()
-            df.dropna(inplace=True)
-            df.drop_duplicates(inplace=True)
-            df["feature_close"] = df["close"].pct_change().fillna(0)
-            df["feature_open"] = df["open"] / df["close"]
-            df["feature_high"] = df["high"] / df["close"]
-            df["feature_low"] = df["low"] / df["close"]
-            df["feature_custom"] = df["close"] * 2
-            df.dropna(inplace=True)
-            return df
+        custom_preprocess = add_custom_features
 
         observer = OKXObservationClass(
             symbol="BTC-USDT-SWAP",

--- a/tests/envs/okx/test_torch_env_futures.py
+++ b/tests/envs/okx/test_torch_env_futures.py
@@ -9,7 +9,6 @@ from tensordict import TensorDict
 from tests.envs.base_exchange_tests import (
     a_mock_observer,
     a_position_status,
-    a_mock_observer,
     INVALID_ACTIONS,
     assert_an_invalid_action_cannot_move_an_open_position,
     assert_an_invalid_action_raises_before_trading,

--- a/tests/envs/okx/test_torch_env_futures.py
+++ b/tests/envs/okx/test_torch_env_futures.py
@@ -3,11 +3,12 @@
 import pytest
 import torch
 from torchrl.envs.utils import check_env_specs
-import numpy as np
 from unittest.mock import MagicMock, patch
 from tensordict import TensorDict
 
 from tests.envs.base_exchange_tests import (
+    a_position_status,
+    a_mock_observer,
     INVALID_ACTIONS,
     assert_an_invalid_action_cannot_move_an_open_position,
     assert_an_invalid_action_raises_before_trading,
@@ -19,26 +20,11 @@ class TestOKXFuturesTorchTradingEnv:
 
     @pytest.fixture
     def mock_observer(self):
-        """Create a mock observer with two timeframes."""
-        observer = MagicMock()
-        observer.get_keys = MagicMock(return_value=["1Minute_10", "5Minute_10"])
-
-        def mock_observations(return_base_ohlc=False):
-            obs = {
-                "1Minute_10": np.random.randn(10, 4).astype(np.float32),
-                "5Minute_10": np.random.randn(10, 4).astype(np.float32),
-            }
-            if return_base_ohlc:
-                obs["base_features"] = np.random.randn(10, 4).astype(np.float32)
-                obs["base_timestamps"] = np.arange(10)
-            return obs
-
-        observer.get_observations = MagicMock(side_effect=mock_observations)
-        observer.get_features = MagicMock(return_value={
-            "observation_features": ["feature_close", "feature_open", "feature_high", "feature_low"],
-            "original_features": ["open", "high", "low", "close", "volume"],
-        })
-        return observer
+        return a_mock_observer(
+            ["1Minute_10", "5Minute_10"],
+            timestamps=True,
+            features=True,
+        )
 
     @pytest.fixture
     def env_config(self):
@@ -221,14 +207,9 @@ class TestOKXFuturesTorchTradingEnv:
     def test_dust_between_positions_does_not_age_the_next_one(self, env, mock_env_trader):
         """A residual left between two positions must not carry the old age into the new one.
         """
-        from torchtrade.envs.live.okx.order_executor import PositionStatus
 
         def status(qty):
-            return {"position_status": PositionStatus(
-                qty=qty, notional_value=500.0, entry_price=50000.0, unrealized_pnl=0.0,
-                unrealized_pnl_pct=0.0, mark_price=50000.0, leverage=5,
-                margin_mode="isolated", liquidation_price=45000.0,
-            )}
+            return a_position_status(qty)
 
         with patch.object(env, "_wait_for_next_timestamp"):
             mock_env_trader.get_status = MagicMock(return_value=status(0.01))
@@ -301,14 +282,9 @@ class TestOKXFuturesTorchTradingEnv:
         The sync detects the close and lets the guard re-enter -- but if it does not discard
         hold_counter, the policy is handed a brand-new position as N+1 bars old.
         """
-        from torchtrade.envs.live.okx.order_executor import PositionStatus
 
         def status(qty):
-            return {"position_status": PositionStatus(
-                qty=qty, notional_value=500.0, entry_price=50000.0, unrealized_pnl=0.0,
-                unrealized_pnl_pct=0.0, mark_price=50000.0, leverage=5,
-                margin_mode="isolated", liquidation_price=45000.0,
-            )} if qty else {"position_status": None}
+            return a_position_status(qty, flat_is_none=True)
 
         with patch.object(env, "_wait_for_next_timestamp"):
             long_idx = len(env.action_levels) - 1
@@ -344,7 +320,6 @@ class TestOKXFuturesTorchTradingEnv:
         "reduction" available is a full close. Asking for the levels is the point --
         `action_levels` is a default, not a constraint (#288).
         """
-        from torchtrade.envs.live.okx.order_executor import PositionStatus
 
         import dataclasses
 
@@ -359,11 +334,7 @@ class TestOKXFuturesTorchTradingEnv:
             )
 
         def status(qty):
-            return {"position_status": PositionStatus(
-                qty=qty, notional_value=qty * 50000.0, entry_price=50000.0,
-                unrealized_pnl=0.0, unrealized_pnl_pct=0.0, mark_price=50000.0,
-                leverage=5, margin_mode="isolated", liquidation_price=40000.0,
-            )}
+            return a_position_status(qty, notional=qty * 50000.0, liquidation=40000.0)
 
         long_idx = len(env.action_levels) - 1
         half_idx = env.action_levels.index(0.5)
@@ -406,14 +377,10 @@ class TestOKXFuturesTorchTradingEnv:
         Both okx fields feeding mark_price fall back to 0.0 when empty, so this arrives
         from two blank venue fields, not only a wire fault -- and {harm}.
         """
-        from torchtrade.envs.live.okx.order_executor import PositionStatus
 
         def status(price):
-            return {"position_status": PositionStatus(
-                qty=0.1, notional_value=5000.0, entry_price=50000.0, unrealized_pnl=0.0,
-                unrealized_pnl_pct=0.0, mark_price=price, leverage=5,
-                margin_mode="isolated", liquidation_price=40000.0,
-            )}
+            return a_position_status(
+                0.1, notional=5000.0, mark=price, liquidation=40000.0)
 
         # Reset on a healthy price, then poison: the venue tick that goes bad mid-episode
         # is the one that reaches sizing, and it isolates _step from the reset-time guard.

--- a/tests/envs/okx/test_torch_env_futures.py
+++ b/tests/envs/okx/test_torch_env_futures.py
@@ -204,10 +204,8 @@ class TestOKXFuturesTorchTradingEnv:
         """A residual left between two positions must not carry the old age into the new one.
         """
 
-        status = a_position_status
-
         with patch.object(env, "_wait_for_next_timestamp"):
-            mock_env_trader.get_status = MagicMock(return_value=status(0.01))
+            mock_env_trader.get_status = MagicMock(return_value=a_position_status(0.01))
             env.reset()
             long_idx = len(env.action_levels) - 1
             long = TensorDict({"action": torch.tensor(long_idx)}, batch_size=())
@@ -215,10 +213,10 @@ class TestOKXFuturesTorchTradingEnv:
             for _ in range(5):                       # age a real position
                 env.step(long)
 
-            mock_env_trader.get_status = MagicMock(return_value=status(1e-12))   # closed -> dust
+            mock_env_trader.get_status = MagicMock(return_value=a_position_status(1e-12))   # closed -> dust
             env.step(long)
 
-            mock_env_trader.get_status = MagicMock(return_value=status(0.01))    # a NEW position
+            mock_env_trader.get_status = MagicMock(return_value=a_position_status(0.01))    # a NEW position
             td = env.step(long)
 
         holding_time = td["next"]["account_state"][3].item()
@@ -278,20 +276,18 @@ class TestOKXFuturesTorchTradingEnv:
         hold_counter, the policy is handed a brand-new position as N+1 bars old.
         """
 
-        status = a_position_status
-
         with patch.object(env, "_wait_for_next_timestamp"):
             long_idx = len(env.action_levels) - 1
             long = TensorDict({"action": torch.tensor(long_idx)}, batch_size=())
 
-            mock_env_trader.get_status = MagicMock(return_value=status(0.01))
+            mock_env_trader.get_status = MagicMock(return_value=a_position_status(0.01))
             env.reset()
             for _ in range(5):
                 env.step(long)
             aged = env.position.hold_counter
             assert aged > 1
 
-            mock_env_trader.get_status = MagicMock(return_value=status(None))   # liquidated
+            mock_env_trader.get_status = MagicMock(return_value=a_position_status(None))   # liquidated
             td = env.step(long)                                          # same-step re-entry
 
         assert td["next"]["account_state"][3].item() <= 1.0, (
@@ -327,21 +323,21 @@ class TestOKXFuturesTorchTradingEnv:
                 config=cfg, observer=mock_observer, trader=mock_env_trader,
             )
 
-        def status(qty):
+        def a_long_of(qty):
             return a_position_status(qty, notional=qty * 50000.0, liquidation=40000.0)
 
         long_idx = len(env.action_levels) - 1
         half_idx = env.action_levels.index(0.5)
 
         with patch.object(env, "_wait_for_next_timestamp"):
-            mock_env_trader.get_status = MagicMock(return_value=status(1.0))
+            mock_env_trader.get_status = MagicMock(return_value=a_long_of(1.0))
             env.reset()
             env.step(TensorDict({"action": torch.tensor(long_idx)}, []))
             aged = 20
             env.position.hold_counter = aged
 
             # the venue reports the RESULTING half-size long, as it would after the trim
-            mock_env_trader.get_status = MagicMock(return_value=status(0.5))
+            mock_env_trader.get_status = MagicMock(return_value=a_long_of(0.5))
             env.step(TensorDict({"action": torch.tensor(half_idx)}, []))
 
             assert env.position.current_position == 1, "a trimmed long is still a long"
@@ -372,16 +368,16 @@ class TestOKXFuturesTorchTradingEnv:
         from two blank venue fields, not only a wire fault -- and {harm}.
         """
 
-        def status(price):
+        def a_position_marked_at(price):
             return a_position_status(
                 0.1, notional=5000.0, mark=price, liquidation=40000.0)
 
         # Reset on a healthy price, then poison: the venue tick that goes bad mid-episode
         # is the one that reaches sizing, and it isolates _step from the reset-time guard.
-        mock_env_trader.get_status = MagicMock(return_value=status(50000.0))
+        mock_env_trader.get_status = MagicMock(return_value=a_position_marked_at(50000.0))
         with patch.object(env, "_wait_for_next_timestamp"):
             env.reset()
-            mock_env_trader.get_status = MagicMock(return_value=status(mark_price))
+            mock_env_trader.get_status = MagicMock(return_value=a_position_marked_at(mark_price))
             td = TensorDict({"action": torch.tensor(len(env.action_levels) - 1)}, [])
             # LiveObservationHalt now, not a bare ValueError: the pre-trade read runs
             # under the halt policy (#355), so an unusable mark surfaces the same way an

--- a/tests/envs/okx/test_torch_env_futures.py
+++ b/tests/envs/okx/test_torch_env_futures.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 from tensordict import TensorDict
 
 from tests.envs.base_exchange_tests import (
+    a_mock_observer,
     a_position_status,
     a_mock_observer,
     INVALID_ACTIONS,

--- a/tests/envs/okx/test_torch_env_futures.py
+++ b/tests/envs/okx/test_torch_env_futures.py
@@ -20,11 +20,7 @@ class TestOKXFuturesTorchTradingEnv:
 
     @pytest.fixture
     def mock_observer(self):
-        return a_mock_observer(
-            ["1Minute_10", "5Minute_10"],
-            timestamps=True,
-            features=True,
-        )
+        return a_mock_observer(["1Minute_10", "5Minute_10"])
 
     @pytest.fixture
     def env_config(self):
@@ -284,7 +280,7 @@ class TestOKXFuturesTorchTradingEnv:
         """
 
         def status(qty):
-            return a_position_status(qty, flat_is_none=True)
+            return a_position_status(qty)
 
         with patch.object(env, "_wait_for_next_timestamp"):
             long_idx = len(env.action_levels) - 1

--- a/tests/envs/okx/test_torch_env_futures.py
+++ b/tests/envs/okx/test_torch_env_futures.py
@@ -204,8 +204,7 @@ class TestOKXFuturesTorchTradingEnv:
         """A residual left between two positions must not carry the old age into the new one.
         """
 
-        def status(qty):
-            return a_position_status(qty)
+        status = a_position_status
 
         with patch.object(env, "_wait_for_next_timestamp"):
             mock_env_trader.get_status = MagicMock(return_value=status(0.01))
@@ -279,8 +278,7 @@ class TestOKXFuturesTorchTradingEnv:
         hold_counter, the policy is handed a brand-new position as N+1 bars old.
         """
 
-        def status(qty):
-            return a_position_status(qty)
+        status = a_position_status
 
         with patch.object(env, "_wait_for_next_timestamp"):
             long_idx = len(env.action_levels) - 1

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -44,7 +44,7 @@ from torchtrade.envs.utils.liquidation import (
     cross_liquidation_price,
     isolated_liquidation_price,
 )
-from tests.envs.base_exchange_tests import _sole, wire_outage_state
+from tests.envs.base_exchange_tests import _sole, a_position_status, some_observations, wire_outage_state
 from tests.envs.test_live_observation_failsafe import _real_futures_env
 from torchtrade.envs.core.common_types import PositionStatus
 from torchtrade.envs.core.state import (
@@ -249,6 +249,39 @@ def test_no_futures_env_reforks_the_shared_observation(env_cls, method):
         f"{env_cls.__name__} re-forks {method} instead of sharing TorchTradeFuturesLiveEnv's. "
         f"Drop the override, or the unification no longer covers it."
     )
+
+
+# --- the shared fixture factories, guarded (#288) ----------------------------------------
+
+
+def test_the_mocked_base_window_can_tell_its_last_bar_from_its_first():
+    """The guard on a guard.
+
+    The window used to be ten identical rows, which made "price off the most recent
+    candle" unobservable: reading `base_features[0]` instead of `[-1]` for bracket pricing
+    passed the whole suite. A ramp fixed it -- but nothing stops the ramp being flattened
+    again by widening the window or shrinking the factor until float32 rounds the rows
+    together, and every existing assertion reads the LAST row, which stays right either way.
+    """
+    bar = (50000.0, 50100.0, 49900.0, 50050.0)
+    window = some_observations(["1m_10"], base=bar)(return_base_ohlc=True)["base_features"]
+
+    assert list(window[-1]) == list(bar), "the last row must be the bar the caller asked for"
+    assert not np.array_equal(window[0], window[-1]), (
+        "first and last rows are identical, so nothing can tell which one the code read"
+    )
+
+
+def test_a_flat_account_is_none_not_a_zero_quantity():
+    """`a_position_status` unified two spellings, and only one of them means flat.
+
+    Six of the folded sites treated `0.0` as flat and six treated it as an open position
+    of size zero. The shared rule is `qty is None`; a `0.0` is a real (dust) position that
+    reaches `position_direction_from_status`. No caller passes 0 today, which is exactly
+    why the next one to try it needs this to be stated somewhere executable.
+    """
+    assert a_position_status(None)["position_status"] is None
+    assert a_position_status(0.0)["position_status"].qty == 0.0
 
 
 # --- the trade gate: one implementation, and the behaviour it exists for (#288) ----------


### PR DESCRIPTION
The #288 thread flagged ~2,400 lines of non-test defs across the four venue test directories as *"the biggest remaining win and nobody has been looking at it"*, worth about −600. This is that slice, measured rather than estimated.

## What is foldable, and what is not

22 fixture names recur across ≥2 venues (1,754 lines). But foldability is governed by the **worst** pair, not the best — the thread's own lesson — and the three largest fail that test:

| fixture | lines | min-pair | verdict |
|---|---|---|---|
| `env_with_mocks` | 291 | **20%** | genuine venue differences — left alone |
| `env` | 247 | **17%** | left alone |
| `mock_trader` | 157 | **11%** | left alone |
| `mock_observer` + `mock_env_observer` | 194 | — | **folded** |
| nested `status` ×10 | 60 | 94% | **folded** |
| nested observation builders ×9 | ~50 | 54–100% | **folded** |
| `mock_env_trader` (bybit≡okx) | 32 | 100% | **folded** |
| `custom_preprocess` (3 venues ≡) | 33 | 100% | **folded** |

## The design: the venue's data stays at the call site

Every `mock_observer` builds the same MagicMock. What differs is **data** — binance and bitget name their timeframes `"1m_10"` where bybit and okx say `"1Minute_10"`, some tests need a fixed OHLC bar rather than noise, some set `intervals`/`window_sizes`, some `get_features` and others `mirror_features_on`. So the shape is shared and the data is passed in:

```python
    @pytest.fixture
    def mock_observer(self):
        return a_mock_observer(
            ["1Minute_10", "5Minute_10"], timestamps=True, features=True,
        )
```

That is the whole point. Folding the keys *into* the helper is how a shared fixture stops testing four venues and starts testing one — the trap this issue's thread documents. **Verified rather than asserted: giving bybit binance's timeframe naming fails 2 tests.**

The 10 nested `status(qty)` helpers each rebuilt the same `PositionStatus` dict, and the per-venue `from <venue>.order_executor import PositionStatus` they carried was itself duplication — it is **one class** from `core.common_types`, re-exported four times (verified: `is` the same object for all four).

## Numbers

**Tests −204** (175 insertions, 379 deletions). **Production untouched.** Suite **4722 passed, 16 skipped**.

Also removed 18 imports whose only users were the deleted bodies — 16 introduced here, 2 pre-existing in the same files (`main` reports 2 for this file set; HEAD reported 18).

## Recorded, not fixed

okx's conftest observer hardcodes an OHLC bar that nothing asserts: replacing it with noise passes all 175 okx tests. Pre-existing — `main`'s copy has the same bar and the same absence of a test — so it is noted rather than folded into this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LBfyCu9QGCFbqP4urG8co5