### PR TITLE
docs: the structure docs named directories and files that do not exist

### DIFF
--- a/docs/environments/offline-rl.md
+++ b/docs/environments/offline-rl.md
@@ -110,10 +110,10 @@ TorchTrade's offline RL support is compatible with any offline RL algorithm from
 
 ## Next Steps
 
-- **[IQL Example](../examples.md#offline-training)** - Complete offline RL implementation
+- **[IQL Example](../examples/index.md#offline-rl)** - Complete offline RL implementation
 - **[Offline Environments](offline.md)** - Environments for dataset collection
 - **[Online Environments](online.md)** - Live trading for data collection
-- **[Examples](../examples.md)** - Browse all training examples
+- **[Examples](../examples/index.md)** - Browse all training examples
 
 ## References
 

--- a/docs/environments/offline-rl.md
+++ b/docs/environments/offline-rl.md
@@ -19,7 +19,7 @@ This approach is particularly valuable for:
 
 ## Example: IQL (Implicit Q-Learning)
 
-TorchTrade provides an example implementation of offline RL using **Implicit Q-Learning (IQL)** in `examples/offline/iql/`.
+TorchTrade provides an example implementation of offline RL using **Implicit Q-Learning (IQL)** in `examples/offline_rl/iql/`.
 
 ```python
 # Example: Training IQL on pre-collected dataset
@@ -43,7 +43,7 @@ for batch in replay_buffer:
     optimizer.step()
 ```
 
-For a complete implementation, see [examples/offline/iql/](https://github.com/TorchTrade/torchtrade/tree/main/examples/offline/iql).
+For a complete implementation, see [examples/offline_rl/iql/](https://github.com/TorchTrade/torchtrade/tree/main/examples/offline_rl/iql).
 
 ## Dataset Collection
 

--- a/docs/environments/visualization.md
+++ b/docs/environments/visualization.md
@@ -36,7 +36,7 @@ fig.savefig("episode_history.png")
 
 ## Visualization Types
 
-All environments render **3 subplots**:
+All three listed environments render **3 subplots**:
 
 1. **Price History with Actions**: Shows the asset price over time with long/short actions marked as green upward triangles (long/buy) and red downward triangles (short/sell). Position closes are shown as orange (long close) and cyan (short close) markers.
 2. **Portfolio Value vs Buy-and-Hold**: Compares your agent's portfolio value against a simple buy-and-hold baseline strategy.

--- a/docs/environments/visualization.md
+++ b/docs/environments/visualization.md
@@ -1,6 +1,6 @@
 # Visualizing Episode History
 
-All offline environments support **`render_history()`** to visualize episode performance after training or evaluation. The method automatically detects the environment type and renders appropriate plots.
+The three sequential offline environments support **`render_history()`** to visualize episode performance after training or evaluation. The method automatically detects the environment type and renders appropriate plots. The vectorized environments do not have it.
 
 ## Overview
 

--- a/docs/environments/visualization.md
+++ b/docs/environments/visualization.md
@@ -51,4 +51,4 @@ All environments render **3 subplots**:
 | `return_fig` | bool | `False` | Return matplotlib figure instead of displaying |
 | `plot_bh_baseline` | bool | `True` | Show buy-and-hold baseline comparison |
 
-Implemented in `torchtrade/envs/offline/base.py`. Requires `matplotlib`.
+Implemented in `torchtrade/envs/core/offline_base.py`. Requires `matplotlib`.

--- a/docs/environments/visualization.md
+++ b/docs/environments/visualization.md
@@ -4,7 +4,7 @@ The three sequential offline environments support **`render_history()`** to visu
 
 ## Overview
 
-The `render_history()` method is inherited from the `TorchTradeOfflineEnv` base class and provides consistent visualization across all 3 offline environments:
+The `render_history()` method is inherited from the `TorchTradeOfflineEnv` base class and provides consistent visualization across the three:
 
 - **SequentialTradingEnv**
 - **SequentialTradingEnvSLTP**

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -116,7 +116,7 @@ uv run python examples/online_rl/ppo/train.py \
     loss.gamma=0.95
 ```
 
-See the **[Examples](examples.md)** page for all available algorithms (PPO, DQN, IQL, DSAC, GRPO) and usage guides.
+See the **[Examples](examples/index.md)** page for all available algorithms (PPO, DQN, IQL, DSAC, GRPO) and usage guides.
 
 ## Common Use Cases
 
@@ -240,7 +240,7 @@ env = BinanceFuturesTorchTradingEnv(config)
 
 - **[Offline Environments](environments/offline.md)** - Deep dive into backtesting environments
 - **[Online Environments](environments/online.md)** - Live trading with exchange APIs
-- **[Examples](examples.md)** - Training scripts for all algorithms
+- **[Examples](examples/index.md)** - Training scripts for all algorithms
 
 ??? tip "Troubleshooting"
     - **"No module named 'torchtrade'"** → Activate the venv: `source .venv/bin/activate`

--- a/docs/guides/sampler.md
+++ b/docs/guides/sampler.md
@@ -341,7 +341,7 @@ Choose window sizes based on the information needed:
 
 ## Technical Reference
 
-- **Source**: [`torchtrade/envs/offline/infrastructure/sampler.py`](https://github.com/TorchTrade/TorchTrade/blob/main/torchtrade/envs/offline/infrastructure/sampler.py)
+- **Source**: [`torchtrade/envs/offline/infrastructure/sampler.py`](https://github.com/TorchTrade/torchtrade/blob/main/torchtrade/envs/offline/infrastructure/sampler.py)
 - **Resampling Logic**: Uses pandas `resample().agg()` with OHLCV aggregation rules (auxiliary columns use `"last"`)
 - **Column Order**: OHLCV always occupies positions 0-4 regardless of input column order
 - **Indexing**: Execution times mapped to 1-minute bar indices, then resampled timeframes aligned

--- a/docs/guides/sampler.md
+++ b/docs/guides/sampler.md
@@ -1,6 +1,6 @@
 # Understanding the Sampler
 
-The `MarketDataObservationSampler` (found in `torchtrade/envs/offline/sampler.py`) handles multi-timeframe data sampling in TorchTrade's offline environments. It resamples high-frequency data (1-minute bars) to multiple timeframes and creates synchronized observation windows while preventing lookahead bias. This allows RL agents to observe market patterns across different time scales simultaneously, from short-term momentum to long-term trends.
+The `MarketDataObservationSampler` (found in `torchtrade/envs/offline/infrastructure/sampler.py`) handles multi-timeframe data sampling in TorchTrade's offline environments. It resamples high-frequency data (1-minute bars) to multiple timeframes and creates synchronized observation windows while preventing lookahead bias. This allows RL agents to observe market patterns across different time scales simultaneously, from short-term momentum to long-term trends.
 
 ## What Is the Sampler?
 

--- a/examples/online_rl/ppo_chronos/README.md
+++ b/examples/online_rl/ppo_chronos/README.md
@@ -53,7 +53,7 @@ model:
 ### Train the agent
 
 ```bash
-cd examples/online/ppo_chronos
+cd examples/online_rl/ppo_chronos
 python train.py
 ```
 

--- a/examples/online_rl/ppo_vectorized/README.md
+++ b/examples/online_rl/ppo_vectorized/README.md
@@ -24,12 +24,6 @@ python train.py
 python train.py env.train_envs=128 model.hidden_size=256 optim.lr=1e-4
 ```
 
-### Test Performance
-```bash
-# Compare vectorized vs standard
-python ../../benchmarks/bench_sequential.py --benchmark vectorized
-```
-
 ## Configuration
 
 ### Environment (`env/vectorized_sequential.yaml`)

--- a/tests/test_documented_imports.py
+++ b/tests/test_documented_imports.py
@@ -367,3 +367,67 @@ def test_a_documented_block_calls_nothing_that_does_not_exist(earlier_blocks, bl
     assert not unknown, (
         f"calls names that exist nowhere in torchtrade: {sorted(unknown)}"
     )
+
+
+# A repo path in a doc, in either of the two forms one appears in: backticked
+# (`torchtrade/envs/offline/sampler.py`), anchored to the four real top-level directories
+# so ordinary prose in backticks cannot match; or inside a github tree/blob URL. Both
+# forms are needed: offline-rl.md named the same phantom twice, once each way.
+DOC_PATH = re.compile(r"`((?:torchtrade|examples|tests|benchmarks)/[\w./-]+)`")
+DOC_URL = re.compile(
+    r"https://github\.com/TorchTrade/torchtrade/(?:tree|blob)/main/([\w./-]+)"
+)
+
+
+def _documented_paths():
+    for path in _doc_sources():
+        text = path.read_text()
+        for pattern in (DOC_PATH, DOC_URL):
+            for match in pattern.finditer(text):
+                raw = match.group(1)
+                if "*" in raw:  # a glob is a pattern, not a path
+                    continue
+                yield pytest.param(raw, id=f"{path.relative_to(REPO)}::{raw}")
+
+
+DOC_PATHS = list(_documented_paths())
+
+
+def _tracked_paths():
+    """Every tracked file, plus every directory on the way to one. Checked against the
+    index and not the filesystem for the same reason `_doc_sources` is: an empty local
+    directory left over from a rename is not something a reader can clone. That is the
+    exact shape of the `examples/offline/iql` phantom, which still existed on the machine
+    that documented it.
+    """
+    listing = subprocess.run(["git", "ls-files"], cwd=REPO,
+                             capture_output=True, text=True, check=True)
+    known = set()
+    for line in listing.stdout.split("\n"):
+        if line.strip():
+            parts = pathlib.PurePosixPath(line.strip()).parts
+            known.update("/".join(parts[:i]) for i in range(1, len(parts) + 1))
+    return known
+
+
+TRACKED = _tracked_paths()
+
+
+@pytest.mark.parametrize("raw", DOC_PATHS)
+def test_a_documented_repo_path_is_tracked(raw):
+    """Kills the mutation that moves a file and leaves the docs naming the old location.
+    Three phantoms shipped this way: offline/base.py, offline/sampler.py and
+    examples/offline/iql. The import sweep above cannot see them, because a path in
+    backticks is not an import.
+
+    It does not cover the tree diagrams in the READMEs, which write bare names like
+    `longonly/` with no prefix to anchor on. Two phantom directories shipped there.
+    """
+    assert raw.rstrip("/") in TRACKED, f"documented path is not in the repo: {raw}"
+
+
+def test_the_path_sweep_found_paths_to_check():
+    """An empty parametrize passes silently, so a regex that stops matching would turn
+    the guard above into a no-op rather than a failure.
+    """
+    assert len(DOC_PATHS) > 25, f"only {len(DOC_PATHS)} documented paths found"

--- a/tests/test_documented_imports.py
+++ b/tests/test_documented_imports.py
@@ -23,15 +23,19 @@ IMPORT_LINE = re.compile(r"^from (torchtrade[\w.]*) import (?:\(([^)]*)\)|([^\n(
 PY_BLOCK = re.compile(r"```python\n(.*?)```", re.S)
 
 
+@functools.lru_cache(maxsize=None)
+def _git_ls_files(pattern=None):
+    """Tracked paths from the index, not the filesystem. Anyone's untracked local notes
+    must not fail the suite, and an empty directory left behind by a rename is not
+    something a reader can clone."""
+    argv = ["git", "ls-files"] + ([pattern] if pattern else [])
+    listing = subprocess.run(argv, cwd=REPO, capture_output=True, text=True, check=True)
+    return tuple(line for line in listing.stdout.splitlines() if line.strip())
+
+
+@functools.lru_cache(maxsize=None)
 def _doc_sources():
-    """Tracked markdown only. Sourcing from the index rather than the filesystem keeps
-    anyone's untracked local notes from failing the suite, without hardcoding a
-    directory name that only exists on one machine."""
-    listing = subprocess.run(["git", "ls-files", "*.md"], cwd=REPO,
-                             capture_output=True, text=True, check=True)
-    for line in listing.stdout.split("\n"):
-        if line.strip():
-            yield REPO / line.strip()
+    return tuple(REPO / line for line in _git_ls_files("*.md"))
 
 
 def _documented_imports():
@@ -369,65 +373,179 @@ def test_a_documented_block_calls_nothing_that_does_not_exist(earlier_blocks, bl
     )
 
 
-# A repo path in a doc, in either of the two forms one appears in: backticked
-# (`torchtrade/envs/offline/sampler.py`), anchored to the four real top-level directories
-# so ordinary prose in backticks cannot match; or inside a github tree/blob URL. Both
-# forms are needed: offline-rl.md named the same phantom twice, once each way.
-DOC_PATH = re.compile(r"`((?:torchtrade|examples|tests|benchmarks)/[\w./-]+)`")
-DOC_URL = re.compile(
-    r"https://github\.com/TorchTrade/torchtrade/(?:tree|blob)/main/([\w./-]+)"
+# The three ways a doc names a repo file: backticked (`torchtrade/envs/core/live.py`),
+# inside a github tree/blob URL, and as a markdown link target. All three have shipped a
+# phantom. The prefix alternation is built from git rather than hardcoded, so it cannot
+# claim a directory the repo does not have.
+_TOP_LEVEL = "|".join(sorted({p.split("/")[0] for p in _git_ls_files() if "/" in p}))
+BACKTICKED_PATH = re.compile(rf"`((?:{_TOP_LEVEL})/[\w./-]+)`")
+GITHUB_URL = re.compile(
+    r"https://github\.com/TorchTrade/torchtrade/(?:tree|blob)/main/([\w./-]+)",
+    re.IGNORECASE,
 )
+RELATIVE_LINK = re.compile(r"\]\((?!https?:|#|mailto:)([^)\s#]+)(?:#[^)\s]*)?\)")
 
 
 def _documented_paths():
+    """Every repo path the docs name, as (source, repo-relative path) pairs.
+
+    Link targets are relative to their own file, so they are resolved against it and then
+    made repo-relative. The other two forms are already repo-relative.
+    """
+    seen = set()
     for path in _doc_sources():
         text = path.read_text()
-        for pattern in (DOC_PATH, DOC_URL):
+        for pattern in (BACKTICKED_PATH, GITHUB_URL):
             for match in pattern.finditer(text):
-                raw = match.group(1)
-                if "*" in raw:  # a glob is a pattern, not a path
-                    continue
-                yield pytest.param(raw, id=f"{path.relative_to(REPO)}::{raw}")
+                yield from _one(seen, path, match.group(1))
+        for match in RELATIVE_LINK.finditer(text):
+            target = (path.parent / match.group(1)).resolve()
+            if target.is_relative_to(REPO):
+                yield from _one(seen, path, str(target.relative_to(REPO)))
+
+
+def _one(seen, source, raw):
+    """One param per (source, path). A doc that names the same phantom twice is one fix,
+    and CONFIG_KWARGS already dedupes for the same reason."""
+    raw = raw.rstrip("/")
+    key = (source, raw)
+    if key not in seen:
+        seen.add(key)
+        yield pytest.param(raw, id=f"{source.relative_to(REPO)}::{raw}")
 
 
 DOC_PATHS = list(_documented_paths())
 
 
+@functools.lru_cache(maxsize=None)
 def _tracked_paths():
-    """Every tracked file, plus every directory on the way to one. Checked against the
-    index and not the filesystem for the same reason `_doc_sources` is: an empty local
-    directory left over from a rename is not something a reader can clone. That is the
-    exact shape of the `examples/offline/iql` phantom, which still existed on the machine
-    that documented it.
-    """
-    listing = subprocess.run(["git", "ls-files"], cwd=REPO,
-                             capture_output=True, text=True, check=True)
+    """Tracked files plus every directory on the way to one."""
     known = set()
-    for line in listing.stdout.split("\n"):
-        if line.strip():
-            parts = pathlib.PurePosixPath(line.strip()).parts
-            known.update("/".join(parts[:i]) for i in range(1, len(parts) + 1))
-    return known
+    for line in _git_ls_files():
+        path = pathlib.PurePosixPath(line)
+        known.update(str(p) for p in (path, *path.parents))
+    return known - {"."}
 
 
-TRACKED = _tracked_paths()
-
-
-@pytest.mark.parametrize("raw", DOC_PATHS)
-def test_a_documented_repo_path_is_tracked(raw):
+@pytest.mark.parametrize("documented_path", DOC_PATHS)
+def test_a_documented_repo_path_is_tracked(documented_path):
     """Kills the mutation that moves a file and leaves the docs naming the old location.
-    Three phantoms shipped this way: offline/base.py, offline/sampler.py and
-    examples/offline/iql. The import sweep above cannot see them, because a path in
-    backticks is not an import.
+    Nine phantoms shipped this way: offline/base.py, offline/sampler.py,
+    examples/offline/iql (twice), a nonexistent offline/README.md linked from three
+    READMEs, and a nonexistent docs/examples.md linked from two guides.
 
-    It does not cover the tree diagrams in the READMEs, which write bare names like
-    `longonly/` with no prefix to anchor on. Two phantom directories shipped there.
+    Checked against the index, not the filesystem: the examples/offline/iql phantom still
+    existed as an empty directory on the machine that documented it.
+
+    Three forms are still unchecked, all of which have carried a phantom: the ASCII trees
+    in the READMEs, bare filenames in backticks, and paths inside shell fences.
     """
-    assert raw.rstrip("/") in TRACKED, f"documented path is not in the repo: {raw}"
+    assert documented_path in _tracked_paths(), (
+        f"documented path is not in the repo: {documented_path}"
+    )
 
 
-def test_the_path_sweep_found_paths_to_check():
-    """An empty parametrize passes silently, so a regex that stops matching would turn
-    the guard above into a no-op rather than a failure.
+def test_each_path_form_still_finds_paths():
+    """Floors just under the real counts. A single floor over the total does not work
+    here: dropping the github-URL form entirely still left 31 of 65, which cleared a
+    `> 25` guard while half the sweep was dead.
+
+    A fully empty parametrize ERRORS on this pytest rather than passing, so partial
+    shrinkage, not silence, is what this catches.
     """
-    assert len(DOC_PATHS) > 25, f"only {len(DOC_PATHS)} documented paths found"
+    counts = {}
+    for source in _doc_sources():
+        text = source.read_text()
+        for name, pattern in (("backtick", BACKTICKED_PATH), ("url", GITHUB_URL),
+                              ("link", RELATIVE_LINK)):
+            counts[name] = counts.get(name, 0) + len(pattern.findall(text))
+    assert counts["backtick"] > 28, counts
+    assert counts["url"] > 30, counts
+    assert counts["link"] > 80, counts
+
+
+# The class-hierarchy diagram in core/README.md, parsed by indentation: a class's parent
+# is the nearest line above it that starts further left.
+HIERARCHY_DOC = REPO / "torchtrade" / "envs" / "core" / "README.md"
+TREE_BLOCK = re.compile(r"```\n(TorchTradeBaseEnv.*?)```", re.S)
+TREE_LINE = re.compile(r"^([\s│├└─]*)([A-Z]\w+)")
+
+
+def _documented_edges():
+    block = TREE_BLOCK.search(HIERARCHY_DOC.read_text()).group(1)
+    edges, open_at = [], {}
+    for line in block.split("\n"):
+        match = TREE_LINE.match(line)
+        if not match:
+            continue
+        column, name = len(match.group(1)), match.group(2)
+        outer = [c for c in open_at if c < column]
+        if outer:
+            edges.append(pytest.param(open_at[max(outer)], name,
+                                      id=f"{open_at[max(outer)]}->{name}"))
+        open_at = {c: n for c, n in open_at.items() if c < column}
+        open_at[column] = name
+    return edges
+
+
+DOCUMENTED_EDGES = _documented_edges()
+
+
+def _env_classes():
+    """Name -> class, over the whole walked package. `_package_names` does the walking;
+    without it `__subclasses__` sees only what other tests happened to import."""
+    _package_names()
+    found, stack = {}, [importlib.import_module("torchtrade.envs.core.base").TorchTradeBaseEnv]
+    while stack:
+        cls = stack.pop()
+        if cls.__name__ not in found:
+            found[cls.__name__] = cls
+            stack.extend(cls.__subclasses__())
+    return found
+
+
+@pytest.mark.parametrize("parent,child", DOCUMENTED_EDGES)
+def test_a_documented_hierarchy_edge_is_a_real_base(parent, child):
+    """The diagram drew the offline envs as four siblings when they are a chain, and hung
+    the four futures venues off TorchTradeLiveEnv when they route through
+    TorchTradeFuturesLiveEnv.
+
+    Direct bases, not issubclass: issubclass(OneStepTradingEnv, TorchTradeOfflineEnv) is
+    True, so an issubclass check passes the sibling version unchanged and tests nothing.
+    """
+    classes = _env_classes()
+    assert child in classes, f"diagram names a class that does not exist: {child}"
+    bases = [b.__name__ for b in classes[child].__bases__]
+    assert parent in bases, f"{child} is drawn under {parent}, real bases are {bases}"
+
+
+def test_every_intermediate_env_class_is_in_the_diagram():
+    """A venue added without updating the diagram is how it drifted the first time. Only
+    intermediates are required: the concrete leaves are elided deliberately, which the
+    diagram says in words.
+    """
+    classes = _env_classes()
+    drawn = {n for e in DOCUMENTED_EDGES for n in e.values} | {"TorchTradeBaseEnv"}
+    intermediate = {n for n, c in classes.items() if c.__subclasses__()}
+    assert not intermediate - drawn, f"missing from the diagram: {sorted(intermediate - drawn)}"
+
+
+@pytest.mark.parametrize("name", ["VectorizedSequentialTradingEnv",
+                                  "VectorizedSequentialTradingEnvSLTP",
+                                  "PolymarketBetEnv"])
+def test_the_envs_documented_as_outside_the_hierarchy_really_are(name):
+    """core/README.md tells the reader these do not inherit the shared bases, so a change
+    to those bases must be applied by hand. If someone reparents one, that warning turns
+    into a lie about money-moving code and nothing else would notice.
+    """
+    _package_names()
+    base = importlib.import_module("torchtrade.envs.core.base").TorchTradeBaseEnv
+    cls = _env_classes().get(name) or getattr(
+        importlib.import_module("torchtrade.envs"), name, None)
+    if cls is None:
+        for mod in ["torchtrade.envs.offline.vectorized_sequential",
+                    "torchtrade.envs.offline.vectorized_sequential_sltp",
+                    "torchtrade.envs.live.polymarket.env"]:
+            cls = cls or getattr(importlib.import_module(mod), name, None)
+    assert cls is not None, f"{name} does not exist"
+    assert not issubclass(cls, base), f"{name} now inherits TorchTradeBaseEnv"

--- a/tests/test_documented_imports.py
+++ b/tests/test_documented_imports.py
@@ -1,7 +1,8 @@
 """The docs are executed here, because prose cannot be verified by review.
 
-Scope: `from torchtrade... import X` (flat AND parenthesized), plus a syntax check on the
-python blocks in the in-package READMEs. Config kwargs are covered below; observation keys still are not.
+Scope: `from torchtrade... import X` (flat AND parenthesized), a syntax check on the
+python blocks in the in-package READMEs, config kwargs, every repo path a doc names, and
+the class hierarchy drawn in core/README.md. Observation keys still are not covered.
 """
 
 import ast
@@ -372,12 +373,14 @@ def test_a_documented_block_calls_nothing_that_does_not_exist(earlier_blocks, bl
         f"calls names that exist nowhere in torchtrade: {sorted(unknown)}"
     )
 
-
 # The three ways a doc names a repo file: backticked (`torchtrade/envs/core/live.py`),
 # inside a github tree/blob URL, and as a markdown link target. All three have shipped a
 # phantom. The prefix alternation is built from git rather than hardcoded, so it cannot
-# claim a directory the repo does not have.
-_TOP_LEVEL = "|".join(sorted({p.split("/")[0] for p in _git_ls_files() if "/" in p}))
+# claim a directory the repo does not have. re.escape, because `.github` unescaped is a
+# regex whose dot matches anything.
+_TOP_LEVEL = "|".join(sorted(
+    {re.escape(p.split("/")[0]) for p in _git_ls_files() if "/" in p}
+))
 BACKTICKED_PATH = re.compile(rf"`((?:{_TOP_LEVEL})/[\w./-]+)`")
 GITHUB_URL = re.compile(
     r"https://github\.com/TorchTrade/torchtrade/(?:tree|blob)/main/([\w./-]+)",
@@ -387,34 +390,26 @@ RELATIVE_LINK = re.compile(r"\]\((?!https?:|#|mailto:)([^)\s#]+)(?:#[^)\s]*)?\)"
 
 
 def _documented_paths():
-    """Every repo path the docs name, as (source, repo-relative path) pairs.
+    """One param per (source, path). A doc that names the same phantom twice is one fix,
+    which is why CONFIG_KWARGS dedupes too.
 
     Link targets are relative to their own file, so they are resolved against it and then
     made repo-relative. The other two forms are already repo-relative.
     """
-    seen = set()
-    for path in _doc_sources():
-        text = path.read_text()
+    found = []
+    for source in _doc_sources():
+        text = source.read_text()
         for pattern in (BACKTICKED_PATH, GITHUB_URL):
-            for match in pattern.finditer(text):
-                yield from _one(seen, path, match.group(1))
+            found += [(source, match.group(1)) for match in pattern.finditer(text)]
         for match in RELATIVE_LINK.finditer(text):
-            target = (path.parent / match.group(1)).resolve()
+            target = (source.parent / match.group(1)).resolve()
             if target.is_relative_to(REPO):
-                yield from _one(seen, path, str(target.relative_to(REPO)))
+                found.append((source, str(target.relative_to(REPO))))
+    return [pytest.param(raw, id=f"{source.relative_to(REPO)}::{raw}")
+            for source, raw in dict.fromkeys((s, r.rstrip("/")) for s, r in found)]
 
 
-def _one(seen, source, raw):
-    """One param per (source, path). A doc that names the same phantom twice is one fix,
-    and CONFIG_KWARGS already dedupes for the same reason."""
-    raw = raw.rstrip("/")
-    key = (source, raw)
-    if key not in seen:
-        seen.add(key)
-        yield pytest.param(raw, id=f"{source.relative_to(REPO)}::{raw}")
-
-
-DOC_PATHS = list(_documented_paths())
+DOCUMENTED_PATHS = _documented_paths()
 
 
 @functools.lru_cache(maxsize=None)
@@ -427,18 +422,19 @@ def _tracked_paths():
     return known - {"."}
 
 
-@pytest.mark.parametrize("documented_path", DOC_PATHS)
+@pytest.mark.parametrize("documented_path", DOCUMENTED_PATHS)
 def test_a_documented_repo_path_is_tracked(documented_path):
     """Kills the mutation that moves a file and leaves the docs naming the old location.
-    Nine phantoms shipped this way: offline/base.py, offline/sampler.py,
-    examples/offline/iql (twice), a nonexistent offline/README.md linked from three
-    READMEs, and a nonexistent docs/examples.md linked from two guides.
+    Twelve phantom references shipped this way: offline/base.py, offline/sampler.py,
+    examples/offline/iql named twice, a nonexistent offline/README.md linked four times,
+    and a nonexistent docs/examples.md linked four times.
 
     Checked against the index, not the filesystem: the examples/offline/iql phantom still
-    existed as an empty directory on the machine that documented it.
+    existed as an empty directory on the machine that documented it, and an untracked
+    directory is one a reader who clones does not get.
 
-    Three forms are still unchecked, all of which have carried a phantom: the ASCII trees
-    in the READMEs, bare filenames in backticks, and paths inside shell fences.
+    Uncovered forms, each of which has carried a phantom: the ASCII trees in the READMEs,
+    bare filenames in backticks, paths inside shell fences, and link anchors.
     """
     assert documented_path in _tracked_paths(), (
         f"documented path is not in the repo: {documented_path}"
@@ -446,12 +442,12 @@ def test_a_documented_repo_path_is_tracked(documented_path):
 
 
 def test_each_path_form_still_finds_paths():
-    """Floors just under the real counts. A single floor over the total does not work
-    here: dropping the github-URL form entirely still left 31 of 65, which cleared a
-    `> 25` guard while half the sweep was dead.
+    """Floors just under the real counts, per form. One floor over the total does not
+    work: with the github-URL form dead, the other two still cleared it while a third of
+    the sweep was gone.
 
     A fully empty parametrize ERRORS on this pytest rather than passing, so partial
-    shrinkage, not silence, is what this catches.
+    shrinkage, not silence, is what these catch.
     """
     counts = {}
     for source in _doc_sources():
@@ -472,35 +468,50 @@ TREE_LINE = re.compile(r"^([\s│├└─]*)([A-Z]\w+)")
 
 
 def _documented_edges():
-    block = TREE_BLOCK.search(HIERARCHY_DOC.read_text()).group(1)
-    edges, open_at = [], {}
-    for line in block.split("\n"):
+    found = TREE_BLOCK.search(HIERARCHY_DOC.read_text())
+    # Without this the whole module dies at import on `NoneType has no attribute group`,
+    # naming neither the file nor the reason, and every other sweep here dies with it.
+    assert found, f"no TorchTradeBaseEnv tree block in {HIERARCHY_DOC.relative_to(REPO)}"
+    edges, open_parents = [], []          # (column, name), columns strictly increasing
+    for line in found.group(1).split("\n"):
         match = TREE_LINE.match(line)
         if not match:
             continue
         column, name = len(match.group(1)), match.group(2)
-        outer = [c for c in open_at if c < column]
-        if outer:
-            edges.append(pytest.param(open_at[max(outer)], name,
-                                      id=f"{open_at[max(outer)]}->{name}"))
-        open_at = {c: n for c, n in open_at.items() if c < column}
-        open_at[column] = name
+        while open_parents and open_parents[-1][0] >= column:
+            open_parents.pop()
+        if open_parents:
+            parent = open_parents[-1][1]
+            edges.append(pytest.param(parent, name, id=f"{parent}->{name}"))
+        open_parents.append((column, name))
     return edges
 
 
 DOCUMENTED_EDGES = _documented_edges()
 
 
+def _package_subclasses(cls):
+    """Direct subclasses defined in the package, never in a test.
+
+    A harness a test file defines is a real subclass: `tests/envs/test_live_env_base.py`
+    declares `_CloseHarness(TorchTradeFuturesLiveEnv)` at module scope. Counting it makes
+    whatever it extends look like an intermediate class, so this file fails naming a
+    production env, and only when that test module was imported first.
+    """
+    return [c for c in cls.__subclasses__() if c.__module__.startswith("torchtrade.")]
+
+
 def _env_classes():
-    """Name -> class, over the whole walked package. `_package_names` does the walking;
-    without it `__subclasses__` sees only what other tests happened to import."""
+    """Name -> class for the env hierarchy. `_package_names` does the walking; without it
+    `__subclasses__` sees only what other tests happened to import.
+    """
     _package_names()
     found, stack = {}, [importlib.import_module("torchtrade.envs.core.base").TorchTradeBaseEnv]
     while stack:
         cls = stack.pop()
         if cls.__name__ not in found:
             found[cls.__name__] = cls
-            stack.extend(cls.__subclasses__())
+            stack.extend(_package_subclasses(cls))
     return found
 
 
@@ -514,7 +525,7 @@ def test_a_documented_hierarchy_edge_is_a_real_base(parent, child):
     True, so an issubclass check passes the sibling version unchanged and tests nothing.
     """
     classes = _env_classes()
-    assert child in classes, f"diagram names a class that does not exist: {child}"
+    assert child in classes, f"diagram names a class that is not in the hierarchy: {child}"
     bases = [b.__name__ for b in classes[child].__bases__]
     assert parent in bases, f"{child} is drawn under {parent}, real bases are {bases}"
 
@@ -524,28 +535,29 @@ def test_every_intermediate_env_class_is_in_the_diagram():
     intermediates are required: the concrete leaves are elided deliberately, which the
     diagram says in words.
     """
-    classes = _env_classes()
     drawn = {n for e in DOCUMENTED_EDGES for n in e.values} | {"TorchTradeBaseEnv"}
-    intermediate = {n for n, c in classes.items() if c.__subclasses__()}
+    intermediate = {n for n, c in _env_classes().items() if _package_subclasses(c)}
     assert not intermediate - drawn, f"missing from the diagram: {sorted(intermediate - drawn)}"
 
 
-@pytest.mark.parametrize("name", ["VectorizedSequentialTradingEnv",
-                                  "VectorizedSequentialTradingEnvSLTP",
-                                  "PolymarketBetEnv"])
-def test_the_envs_documented_as_outside_the_hierarchy_really_are(name):
+@pytest.mark.parametrize("module,name,base", [
+    ("torchtrade.envs.offline.vectorized_sequential",
+     "VectorizedSequentialTradingEnv", "EnvBase"),
+    ("torchtrade.envs.offline.vectorized_sequential_sltp",
+     "VectorizedSequentialTradingEnvSLTP", "VectorizedSequentialTradingEnv"),
+    ("torchtrade.envs.live.polymarket.env", "PolymarketBetEnv", "EnvBase"),
+], ids=lambda v: v.rsplit(".", 1)[-1])
+def test_the_envs_documented_as_outside_the_hierarchy_really_are(module, name, base):
     """core/README.md tells the reader these do not inherit the shared bases, so a change
     to those bases must be applied by hand. If someone reparents one, that warning turns
     into a lie about money-moving code and nothing else would notice.
+
+    The direct base is pinned too, because the diagram's `(+SLTP)` shorthand once put the
+    SLTP variant one level too high and an issubclass check would not have seen it.
     """
-    _package_names()
-    base = importlib.import_module("torchtrade.envs.core.base").TorchTradeBaseEnv
-    cls = _env_classes().get(name) or getattr(
-        importlib.import_module("torchtrade.envs"), name, None)
-    if cls is None:
-        for mod in ["torchtrade.envs.offline.vectorized_sequential",
-                    "torchtrade.envs.offline.vectorized_sequential_sltp",
-                    "torchtrade.envs.live.polymarket.env"]:
-            cls = cls or getattr(importlib.import_module(mod), name, None)
-    assert cls is not None, f"{name} does not exist"
-    assert not issubclass(cls, base), f"{name} now inherits TorchTradeBaseEnv"
+    cls = getattr(importlib.import_module(module), name)
+    root = importlib.import_module("torchtrade.envs.core.base").TorchTradeBaseEnv
+    assert not issubclass(cls, root), f"{name} now inherits TorchTradeBaseEnv"
+    assert [b.__name__ for b in cls.__bases__] == [base], (
+        f"{name} bases are {[b.__name__ for b in cls.__bases__]}, documented as {base}"
+    )

--- a/tests/test_documented_imports.py
+++ b/tests/test_documented_imports.py
@@ -387,6 +387,8 @@ GITHUB_URL = re.compile(
     re.IGNORECASE,
 )
 RELATIVE_LINK = re.compile(r"\]\((?!https?:|#|mailto:)([^)\s#]+)(?:#[^)\s]*)?\)")
+SHELL_FENCE = re.compile(r"```(?:bash|sh|shell|console)\n(.*?)```", re.S)
+FENCE_PATH = re.compile(rf"(?<![\w/.-])((?:{_TOP_LEVEL})/[\w./-]+)")
 
 
 def _documented_paths():
@@ -394,19 +396,22 @@ def _documented_paths():
     which is why CONFIG_KWARGS dedupes too.
 
     Link targets are relative to their own file, so they are resolved against it and then
-    made repo-relative. The other two forms are already repo-relative.
+    made repo-relative. The other three forms are already repo-relative.
     """
     found = []
     for source in _doc_sources():
         text = source.read_text()
         for pattern in (BACKTICKED_PATH, GITHUB_URL):
             found += [(source, match.group(1)) for match in pattern.finditer(text)]
+        for fence in SHELL_FENCE.findall(text):
+            found += [(source, path) for path in FENCE_PATH.findall(fence)]
         for match in RELATIVE_LINK.finditer(text):
             target = (source.parent / match.group(1)).resolve()
             if target.is_relative_to(REPO):
                 found.append((source, str(target.relative_to(REPO))))
-    return [pytest.param(raw, id=f"{source.relative_to(REPO)}::{raw}")
-            for source, raw in dict.fromkeys((s, r.rstrip("/")) for s, r in found)]
+    deduped = dict.fromkeys((source, path.rstrip("/")) for source, path in found)
+    return [pytest.param(path, id=f"{source.relative_to(REPO)}::{path}")
+            for source, path in deduped]
 
 
 DOCUMENTED_PATHS = _documented_paths()
@@ -425,16 +430,14 @@ def _tracked_paths():
 @pytest.mark.parametrize("documented_path", DOCUMENTED_PATHS)
 def test_a_documented_repo_path_is_tracked(documented_path):
     """Kills the mutation that moves a file and leaves the docs naming the old location.
-    Twelve phantom references shipped this way: offline/base.py, offline/sampler.py,
-    examples/offline/iql named twice, a nonexistent offline/README.md linked four times,
-    and a nonexistent docs/examples.md linked four times.
-
     Checked against the index, not the filesystem: the examples/offline/iql phantom still
     existed as an empty directory on the machine that documented it, and an untracked
     directory is one a reader who clones does not get.
 
-    Uncovered forms, each of which has carried a phantom: the ASCII trees in the READMEs,
-    bare filenames in backticks, paths inside shell fences, and link anchors.
+    Still uncovered: the ASCII trees in the READMEs, bare filenames in backticks, and
+    link anchors. The trees are the gap that matters, and a correct checker for them is
+    not cheap: they are display-rooted at the README's own directory, and some entries are
+    placeholders or generated output.
     """
     assert documented_path in _tracked_paths(), (
         f"documented path is not in the repo: {documented_path}"
@@ -442,22 +445,24 @@ def test_a_documented_repo_path_is_tracked(documented_path):
 
 
 def test_each_path_form_still_finds_paths():
-    """Floors just under the real counts, per form. One floor over the total does not
-    work: with the github-URL form dead, the other two still cleared it while a third of
-    the sweep was gone.
+    """Floors just under the real counts, one per form. A single floor over the total
+    does not work: killing the github-URL form leaves the other forms clearing it while a
+    fifth of the sweep is dead.
 
     A fully empty parametrize ERRORS on this pytest rather than passing, so partial
     shrinkage, not silence, is what these catch.
     """
-    counts = {}
-    for source in _doc_sources():
-        text = source.read_text()
-        for name, pattern in (("backtick", BACKTICKED_PATH), ("url", GITHUB_URL),
-                              ("link", RELATIVE_LINK)):
-            counts[name] = counts.get(name, 0) + len(pattern.findall(text))
+    texts = [source.read_text() for source in _doc_sources()]
+    fences = ["\n".join(SHELL_FENCE.findall(text)) for text in texts]
+    counts = {name: sum(len(pattern.findall(text)) for text in bodies)
+              for name, pattern, bodies in (("backtick", BACKTICKED_PATH, texts),
+                                            ("url", GITHUB_URL, texts),
+                                            ("link", RELATIVE_LINK, texts),
+                                            ("fence", FENCE_PATH, fences))}
     assert counts["backtick"] > 28, counts
     assert counts["url"] > 30, counts
     assert counts["link"] > 80, counts
+    assert counts["fence"] > 30, counts
 
 
 # The class-hierarchy diagram in core/README.md, parsed by indentation: a class's parent
@@ -468,12 +473,14 @@ TREE_LINE = re.compile(r"^([\s│├└─]*)([A-Z]\w+)")
 
 
 def _documented_edges():
-    found = TREE_BLOCK.search(HIERARCHY_DOC.read_text())
+    tree_block = TREE_BLOCK.search(HIERARCHY_DOC.read_text())
     # Without this the whole module dies at import on `NoneType has no attribute group`,
     # naming neither the file nor the reason, and every other sweep here dies with it.
-    assert found, f"no TorchTradeBaseEnv tree block in {HIERARCHY_DOC.relative_to(REPO)}"
+    assert tree_block, (
+        f"no TorchTradeBaseEnv tree block in {HIERARCHY_DOC.relative_to(REPO)}"
+    )
     edges, open_parents = [], []          # (column, name), columns strictly increasing
-    for line in found.group(1).split("\n"):
+    for line in tree_block.group(1).split("\n"):
         match = TREE_LINE.match(line)
         if not match:
             continue
@@ -482,7 +489,7 @@ def _documented_edges():
             open_parents.pop()
         if open_parents:
             parent = open_parents[-1][1]
-            edges.append(pytest.param(parent, name, id=f"{parent}->{name}"))
+            edges.append((parent, name))
         open_parents.append((column, name))
     return edges
 
@@ -515,7 +522,8 @@ def _env_classes():
     return found
 
 
-@pytest.mark.parametrize("parent,child", DOCUMENTED_EDGES)
+@pytest.mark.parametrize("parent,child", DOCUMENTED_EDGES,
+                         ids=[f"{p}->{c}" for p, c in DOCUMENTED_EDGES])
 def test_a_documented_hierarchy_edge_is_a_real_base(parent, child):
     """The diagram drew the offline envs as four siblings when they are a chain, and hung
     the four futures venues off TorchTradeLiveEnv when they route through
@@ -535,9 +543,10 @@ def test_every_intermediate_env_class_is_in_the_diagram():
     intermediates are required: the concrete leaves are elided deliberately, which the
     diagram says in words.
     """
-    drawn = {n for e in DOCUMENTED_EDGES for n in e.values} | {"TorchTradeBaseEnv"}
+    drawn = {n for edge in DOCUMENTED_EDGES for n in edge} | {"TorchTradeBaseEnv"}
     intermediate = {n for n, c in _env_classes().items() if _package_subclasses(c)}
-    assert not intermediate - drawn, f"missing from the diagram: {sorted(intermediate - drawn)}"
+    missing = intermediate - drawn
+    assert not missing, f"missing from the diagram: {sorted(missing)}"
 
 
 @pytest.mark.parametrize("module,name,base", [

--- a/torchtrade/envs/README.md
+++ b/torchtrade/envs/README.md
@@ -9,12 +9,7 @@ torchtrade/envs/
 ├── core/              # Base classes and fundamental abstractions
 ├── utils/             # Shared utility functions and helpers
 ├── offline/           # Backtesting environments
-│   ├── infrastructure/    # Internal sampler and utilities
-│   ├── sequential.py
-│   ├── sequential_sltp.py
-│   ├── onestep.py
-│   ├── vectorized_sequential.py
-│   └── vectorized_sequential_sltp.py
+│   └── infrastructure/    # Internal sampler and utilities
 ├── live/              # Live trading environments
 │   ├── shared/            # Shared components across providers
 │   ├── alpaca/            # Alpaca integration
@@ -99,7 +94,7 @@ Backtesting environments for strategy development and evaluation:
 - **Futures**: Leveraged long/short futures environments
 - **Infrastructure**: Internal sampling and utilities (not user-facing)
 
-See [offline/README.md](offline/README.md) for details.
+See [the offline environments guide](../../docs/environments/offline.md) for details.
 
 ### Live Environments (`live/`)
 
@@ -149,9 +144,9 @@ Multi-step environments where agents make decisions at each timestep:
 
 - `SequentialTradingEnv`: Unified sequential trading (spot or futures via `leverage` and `action_levels`)
 - `SequentialTradingEnvSLTP`: Sequential with stop-loss/take-profit bracket orders
-- `VectorizedSequentialTradingEnv`, `VectorizedSequentialTradingEnvSLTP`: batched variants.
-  They subclass `EnvBase` directly, not `TorchTradeOfflineEnv`, so a change to the shared
-  offline base does not reach them.
+- `VectorizedSequentialTradingEnv`, `VectorizedSequentialTradingEnvSLTP`: batched
+  variants. They sit outside the `TorchTradeOfflineEnv` hierarchy; see
+  [core/README.md](core/README.md).
 
 ### One-Step Environments
 
@@ -173,13 +168,13 @@ Real-time trading environments with API integration:
 - `BybitFuturesSLTPTorchTradingEnv`: Bybit with SL/TP
 - `OKXFuturesTorchTradingEnv`: OKX Futures
 - `OKXFuturesSLTPTorchTradingEnv`: OKX with SL/TP
-- `PolymarketBetEnv`: prediction markets, with a `dry_run` paper path
+- `PolymarketBetEnv`: prediction markets, paper only. `dry_run=False` raises
 
 ## Design Principles
 
 1. **Clear Separation**: Core classes, utilities, and implementations are clearly separated
 2. **Consistent Naming**: All provider files follow the same naming conventions
-3. **Parallel Structure**: each live provider directory has the same layout
+3. **Parallel Structure**: the five exchange directories share one file layout
 4. **Import Flexibility**: Support both top-level and direct imports
 5. **Maintainability**: READMEs at each level explain purpose and usage
 
@@ -214,5 +209,5 @@ When adding new environments or utilities:
 
 - [Core Base Classes](core/README.md)
 - [Utilities Documentation](utils/README.md)
-- [Offline Environments Guide](offline/README.md)
+- [Offline Environments Guide](../../docs/environments/offline.md)
 - [Live Environments Guide](live/README.md)

--- a/torchtrade/envs/README.md
+++ b/torchtrade/envs/README.md
@@ -90,8 +90,9 @@ See [utils/README.md](utils/README.md) for details.
 
 Backtesting environments for strategy development and evaluation:
 
-- **Long-Only**: Traditional buy-and-hold style environments
-- **Futures**: Leveraged long/short futures environments
+- **Sequential**: `SequentialTradingEnv` and its SLTP and one-step variants. Spot or
+  futures is a config choice (`leverage`, `action_levels`), not a separate class.
+- **Vectorized**: batched variants of the sequential envs
 - **Infrastructure**: Internal sampling and utilities (not user-facing)
 
 See [the offline environments guide](../../docs/environments/offline.md) for details.
@@ -104,6 +105,8 @@ Production-ready environments for live trading:
 - **Binance**: Crypto futures trading
 - **Bitget**: Crypto futures trading
 - **Bybit**: Crypto futures trading
+- **OKX**: Crypto futures trading
+- **Polymarket**: Prediction markets, paper only
 - **Shared**: Common components (futures base observation)
 
 See [live/README.md](live/README.md) for details.

--- a/torchtrade/envs/README.md
+++ b/torchtrade/envs/README.md
@@ -10,14 +10,20 @@ torchtrade/envs/
 ├── utils/             # Shared utility functions and helpers
 ├── offline/           # Backtesting environments
 │   ├── infrastructure/    # Internal sampler and utilities
-│   ├── longonly/          # Long-only trading environments
-│   └── futures/           # Futures trading environments
+│   ├── sequential.py
+│   ├── sequential_sltp.py
+│   ├── onestep.py
+│   ├── vectorized_sequential.py
+│   └── vectorized_sequential_sltp.py
 ├── live/              # Live trading environments
 │   ├── shared/            # Shared components across providers
 │   ├── alpaca/            # Alpaca integration
 │   ├── binance/           # Binance Futures integration
 │   ├── bitget/            # Bitget Futures integration
-│   └── bybit/             # Bybit Futures integration
+│   ├── bybit/             # Bybit Futures integration
+│   ├── okx/               # OKX Futures integration
+│   └── polymarket/        # Polymarket prediction markets
+├── replay/            # Historical playback through the live pipeline
 └── transforms/        # TorchRL environment transforms
 ```
 
@@ -143,6 +149,9 @@ Multi-step environments where agents make decisions at each timestep:
 
 - `SequentialTradingEnv`: Unified sequential trading (spot or futures via `leverage` and `action_levels`)
 - `SequentialTradingEnvSLTP`: Sequential with stop-loss/take-profit bracket orders
+- `VectorizedSequentialTradingEnv`, `VectorizedSequentialTradingEnvSLTP`: batched variants.
+  They subclass `EnvBase` directly, not `TorchTradeOfflineEnv`, so a change to the shared
+  offline base does not reach them.
 
 ### One-Step Environments
 
@@ -162,12 +171,15 @@ Real-time trading environments with API integration:
 - `BitgetFuturesSLTPTorchTradingEnv`: Bitget with SL/TP
 - `BybitFuturesTorchTradingEnv`: Bybit Futures
 - `BybitFuturesSLTPTorchTradingEnv`: Bybit with SL/TP
+- `OKXFuturesTorchTradingEnv`: OKX Futures
+- `OKXFuturesSLTPTorchTradingEnv`: OKX with SL/TP
+- `PolymarketBetEnv`: prediction markets, with a `dry_run` paper path
 
 ## Design Principles
 
 1. **Clear Separation**: Core classes, utilities, and implementations are clearly separated
 2. **Consistent Naming**: All provider files follow the same naming conventions
-3. **Parallel Structure**: Offline longonly and futures mirror each other
+3. **Parallel Structure**: each live provider directory has the same layout
 4. **Import Flexibility**: Support both top-level and direct imports
 5. **Maintainability**: READMEs at each level explain purpose and usage
 

--- a/torchtrade/envs/README.md
+++ b/torchtrade/envs/README.md
@@ -99,15 +99,7 @@ See [the offline environments guide](../../docs/environments/offline.md) for det
 
 ### Live Environments (`live/`)
 
-Production-ready environments for live trading:
-
-- **Alpaca**: US equities and crypto spot trading
-- **Binance**: Crypto futures trading
-- **Bitget**: Crypto futures trading
-- **Bybit**: Crypto futures trading
-- **OKX**: Crypto futures trading
-- **Polymarket**: Prediction markets, paper only
-- **Shared**: Common components (futures base observation)
+Production-ready environments for live trading. The tree above lists the venues.
 
 See [live/README.md](live/README.md) for details.
 

--- a/torchtrade/envs/README.md
+++ b/torchtrade/envs/README.md
@@ -63,13 +63,14 @@ env = AlpacaTorchTradingEnv(config, api_key="your_key", api_secret="your_secret"
 
 ### Core (`core/`)
 
-Contains the fundamental base classes that all environments inherit from:
+Contains the base classes of the shared environment hierarchy:
 
-- **TorchTradeBaseEnv**: Root base class for all environments
-- **TorchTradeOfflineEnv**: Base for backtesting environments
-- **TorchTradeLiveEnv**: Base for live trading environments
+- **TorchTradeBaseEnv**: Root of the shared hierarchy
+- **TorchTradeOfflineEnv**: Base for the sequential backtesting environments
+- **TorchTradeLiveEnv**: Base for the live exchange environments
 - **PositionState**: State management for positions
-- **HistoryTracker**: Episode history used by every environment
+- **HistoryTracker**: Episode history. Built by `offline_base.py`, `futures_live_base.py`
+  and `alpaca/base.py`, so the vectorized envs and polymarket do not have one
 - **default_rewards**: the built-in reward functions
 
 See [core/README.md](core/README.md) for details.

--- a/torchtrade/envs/core/README.md
+++ b/torchtrade/envs/core/README.md
@@ -74,15 +74,29 @@ Common types and enums.
 ```
 TorchTradeBaseEnv (base.py)
 ├── TorchTradeOfflineEnv (offline_base.py)
-│   ├── SequentialTradingEnv
-│   ├── SequentialTradingEnvSLTP
-│   ├── OneStepTradingEnv
-│   └── VectorizedSequentialTradingEnv(+SLTP)
+│   └── SequentialTradingEnv
+│       └── SequentialTradingEnvSLTP
+│           └── OneStepTradingEnv
 └── TorchTradeLiveEnv (live.py)
     ├── AlpacaBaseTorchTradingEnv
-    ├── BinanceBaseTorchTradingEnv
-    └── ...
+    │   ├── AlpacaTorchTradingEnv
+    │   └── AlpacaSLTPTorchTradingEnv
+    └── TorchTradeFuturesLiveEnv (futures_live_base.py)
+        ├── BinanceBaseTorchTradingEnv
+        ├── BitgetBaseTorchTradingEnv
+        ├── BybitBaseTorchTradingEnv
+        └── OKXBaseTorchTradingEnv
+            (each with a plain and an SLTP leaf)
 ```
+
+The offline side is a chain, not four siblings: `OneStepTradingEnv` inherits
+`SequentialTradingEnvSLTP`, which inherits `SequentialTradingEnv`. A change to
+`SequentialTradingEnv` reaches all three.
+
+Two families sit outside this tree and subclass TorchRL's `EnvBase` directly:
+`VectorizedSequentialTradingEnv(+SLTP)` and `PolymarketBetEnv`. They do not inherit
+`TorchTradeOfflineEnv` or `TorchTradeLiveEnv`, so shared changes must be applied to them
+by hand.
 
 ## Usage Examples
 

--- a/torchtrade/envs/core/README.md
+++ b/torchtrade/envs/core/README.md
@@ -86,8 +86,9 @@ TorchTradeBaseEnv (base.py)
         ├── BitgetBaseTorchTradingEnv
         ├── BybitBaseTorchTradingEnv
         └── OKXBaseTorchTradingEnv
-            (each with a plain and an SLTP leaf)
 ```
+
+Each of the four futures bases has a plain and an SLTP leaf, elided here.
 
 The offline side is a chain: `OneStepTradingEnv` inherits `SequentialTradingEnvSLTP`,
 which inherits `SequentialTradingEnv`. A change to `SequentialTradingEnv` reaches all
@@ -97,8 +98,8 @@ Two families sit outside this tree. `VectorizedSequentialTradingEnv` and
 `PolymarketBetEnv` subclass TorchRL's `EnvBase` directly, and
 `VectorizedSequentialTradingEnvSLTP` extends the plain vectorized env. None of them
 inherit `TorchTradeOfflineEnv` or `TorchTradeLiveEnv`, so a change to those bases must be
-applied to them by hand. They do still share the `utils/` modules and the reward
-functions in `core/default_rewards.py`.
+applied to them by hand. The vectorized pair still shares `utils/` and the batched reward
+in `core/default_rewards.py`; polymarket shares only `utils/termination.py`.
 
 ## Usage Examples
 

--- a/torchtrade/envs/core/README.md
+++ b/torchtrade/envs/core/README.md
@@ -1,11 +1,12 @@
 # Core Base Classes
 
-This directory contains the fundamental base classes that all TorchTrade environments inherit from.
+This directory contains the base classes of the shared TorchTrade environment hierarchy.
+Two families sit outside it; see Class Hierarchy below.
 
 ## Module Overview
 
 ### `base.py`
-Root base class for all environments.
+Root of the shared environment hierarchy.
 
 **Key Classes:**
 - `TorchTradeBaseEnv`: Abstract base class defining the core environment interface
@@ -17,7 +18,7 @@ Root base class for all environments.
 - Render and logging interfaces
 
 ### `offline_base.py`
-Base class for all backtesting environments.
+Base class for the sequential backtesting environments.
 
 **Key Classes:**
 - `TorchTradeOfflineEnv`: Extends `TorchTradeBaseEnv` for offline simulations
@@ -29,7 +30,7 @@ Base class for all backtesting environments.
 - Fast-forward execution
 
 ### `live.py`
-Base class for all live trading environments.
+Base class for the live exchange environments.
 
 **Key Classes:**
 - `TorchTradeLiveEnv`: Extends `TorchTradeBaseEnv` for live trading

--- a/torchtrade/envs/core/README.md
+++ b/torchtrade/envs/core/README.md
@@ -81,7 +81,7 @@ TorchTradeBaseEnv (base.py)
     ├── AlpacaBaseTorchTradingEnv
     │   ├── AlpacaTorchTradingEnv
     │   └── AlpacaSLTPTorchTradingEnv
-    └── TorchTradeFuturesLiveEnv (futures_live_base.py)
+    └── TorchTradeFuturesLiveEnv (live/shared/futures_live_base.py)
         ├── BinanceBaseTorchTradingEnv
         ├── BitgetBaseTorchTradingEnv
         ├── BybitBaseTorchTradingEnv
@@ -89,14 +89,16 @@ TorchTradeBaseEnv (base.py)
             (each with a plain and an SLTP leaf)
 ```
 
-The offline side is a chain, not four siblings: `OneStepTradingEnv` inherits
-`SequentialTradingEnvSLTP`, which inherits `SequentialTradingEnv`. A change to
-`SequentialTradingEnv` reaches all three.
+The offline side is a chain: `OneStepTradingEnv` inherits `SequentialTradingEnvSLTP`,
+which inherits `SequentialTradingEnv`. A change to `SequentialTradingEnv` reaches all
+three.
 
-Two families sit outside this tree and subclass TorchRL's `EnvBase` directly:
-`VectorizedSequentialTradingEnv(+SLTP)` and `PolymarketBetEnv`. They do not inherit
-`TorchTradeOfflineEnv` or `TorchTradeLiveEnv`, so shared changes must be applied to them
-by hand.
+Two families sit outside this tree. `VectorizedSequentialTradingEnv` and
+`PolymarketBetEnv` subclass TorchRL's `EnvBase` directly, and
+`VectorizedSequentialTradingEnvSLTP` extends the plain vectorized env. None of them
+inherit `TorchTradeOfflineEnv` or `TorchTradeLiveEnv`, so a change to those bases must be
+applied to them by hand. They do still share the `utils/` modules and the reward
+functions in `core/default_rewards.py`.
 
 ## Usage Examples
 
@@ -280,6 +282,6 @@ def test_env():
 ## See Also
 
 - [Utilities Documentation](../utils/README.md)
-- [Offline Environments](../offline/README.md)
+- [Offline Environments](../../../docs/environments/offline.md)
 - [Live Environments](../live/README.md)
 - [Main README](../README.md)

--- a/torchtrade/envs/live/README.md
+++ b/torchtrade/envs/live/README.md
@@ -12,7 +12,7 @@ live/
 ├── bitget/      # Bitget Futures (crypto)
 ├── bybit/       # Bybit Futures (crypto, cross/isolated margin)
 ├── okx/         # OKX Futures (crypto, bybit-derived)
-└── polymarket/  # Polymarket prediction markets (has a dry_run paper path)
+└── polymarket/  # Polymarket prediction markets (paper only)
 ```
 
 ## Supported Providers
@@ -45,7 +45,7 @@ live/
 ### Polymarket (`polymarket/`)
 - **Markets**: Prediction markets
 - **Components**: `PolymarketBetEnv`, `MarketScanner`, `PolymarketOrderExecutor`
-- **Features**: `dry_run` paper path
+- **Features**: paper only. `dry_run=False` raises
 
 No environment on any venue models funding fees -- see the note in `binance/README.md`.
 

--- a/torchtrade/envs/utils/README.md
+++ b/torchtrade/envs/utils/README.md
@@ -222,6 +222,6 @@ See the SLTPMixin section above for the real surface.
 ## See Also
 
 - [Core Base Classes](../core/README.md)
-- [Offline Environments](../offline/README.md)
+- [Offline Environments](../../../docs/environments/offline.md)
 - [Live Environments](../live/README.md)
 - [Main README](../README.md)


### PR DESCRIPTION
Third of the docs PRs. This one is the structure documentation: directory trees, the class hierarchy, and the paths docs point readers at.

## Twelve phantom references

Every one verified absent by execution, not by reading:

| Doc | Named | Reality |
|---|---|---|
| `envs/README.md` | `offline/longonly/`, `offline/futures/` | neither directory exists |
| `visualization.md` | `offline/base.py` | `core/offline_base.py` |
| `sampler.md` | `offline/sampler.py` | `offline/infrastructure/sampler.py` |
| `offline-rl.md` ×2 | `examples/offline/iql/` | `examples/offline_rl/iql/` |
| 3 package READMEs ×4 | `offline/README.md` | never existed |
| 2 guides ×4 | `docs/examples.md` | `docs/examples/index.md` |
| `ppo_chronos/README.md` | `cd examples/online/ppo_chronos` | `examples/online_rl/` |

The `examples/offline/iql/` one is why the guard checks the git index and not the filesystem: that directory still exists here as an empty leftover, so it reads as fine locally while being absent for anyone who clones.

## The class hierarchy was wrong in a way that matters

`core/README.md` drew the offline envs as four siblings. They are a chain, so a change to `SequentialTradingEnv` reaches all three. It also placed `VectorizedSequentialTradingEnv(+SLTP)` under `TorchTradeOfflineEnv` when it subclasses `EnvBase` directly, as does `PolymarketBetEnv`. Those two families do **not** inherit the shared bases, so a change there must be applied to them by hand. Given CLAUDE.md's "apply to ALL environments" rule, that is the sort of thing the hierarchy doc exists to tell you. The live side also omitted `TorchTradeFuturesLiveEnv`, the base the four futures venues share.

Rebuilt from `__subclasses__` and `__mro__` rather than transcribed.

## Guards

`test_a_documented_repo_path_is_tracked` asserts every repo path a doc names is in the git index, across four forms: backticked, github tree/blob URL, relative link target, and shell-fence path. Each form has its own floor, because a single floor over the total let the whole github-URL form die unnoticed.

The hierarchy tests parse the diagram by indentation and assert each edge is a real **direct** base, that every intermediate class appears, and that the three envs documented as outside the tree still are. Direct bases rather than `issubclass` on purpose: `issubclass(OneStepTradingEnv, TorchTradeOfflineEnv)` is True, so an `issubclass` check passes the wrong diagram unchanged.

Run against `main`'s diagram they produce exactly the five errors this PR fixed by hand, and zero against this branch.

## Three rounds of review

The rounds mostly caught defects the fix itself introduced, which is the honest summary:

- Round 1: I annotated `TorchTradeFuturesLiveEnv` with `futures_live_base.py` as though it were in `core/`; called Polymarket "with a `dry_run` paper path" when it is paper-only and raises; and kept "each live provider directory has the same layout" in the same diff that added polymarket, which has neither `base.py` nor `env_sltp.py`. It also found 8 broken relative links already shipping.
- Round 2: my guard counted **test-defined** subclasses, so a harness in `test_live_env_base.py` made a production leaf look like an intermediate class and failed naming it. My first fix filtered the wrong site. Also: I generalized "they still share utils" to all three outside-the-tree classes without checking polymarket, which imports one utils module and no reward function.
- Round 3: deleted the venue list instead of maintaining it. It was the third copy in one file and the one that drifted, and my previous response had been to hand-update all three.

`4933 passed, 16 skipped`. ruff clean. 0 broken relative links repo-wide.

## Not covered

The ASCII trees. A correct checker is not the cheap one it looks like: the trees are display-rooted at each README's own directory and some entries are placeholders or generated output. The test docstring says so rather than implying coverage it lacks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LBfyCu9QGCFbqP4urG8co5