### PR TITLE
tests: drop the suite counts from test docstrings

### DIFF
--- a/tests/envs/offline/test_offline_config_has_no_dead_fields_289.py
+++ b/tests/envs/offline/test_offline_config_has_no_dead_fields_289.py
@@ -117,7 +117,7 @@ REJECTED_FLAG_CASES = [
     (SequentialTradingEnvSLTPConfig, {"margin_mode": MarginMode.CROSSED}),
     (OneStepTradingEnvConfig, {"margin_mode": MarginMode.CROSSED}),
     # The two the guard was ADDED for, and the two it was not tested on: removing
-    # `validate_offline_margin_mode` from the vectorized config passed all 4013 tests.
+    # `validate_offline_margin_mode` from the vectorized config left the suite green.
     (VectorizedSequentialTradingEnvConfig, {"margin_mode": MarginMode.CROSSED}),
     (VectorizedSequentialTradingEnvSLTPConfig, {"margin_mode": MarginMode.CROSSED}),
 ]

--- a/tests/envs/offline/test_position_tolerance.py
+++ b/tests/envs/offline/test_position_tolerance.py
@@ -117,7 +117,7 @@ def test_both_engines_close_a_position_worth_less_than_the_floor(price):
 @pytest.mark.parametrize("gap_usd,expect_hold", [(0.50, True), (5.0, False)],
                          ids=["under-the-floor", "over-the-floor"])
 def test_the_vectorized_floor_holds_a_sub_dollar_resize(gap_usd, expect_hold):
-    """The vectorized floor had ZERO coverage: gutting it left all 2865 tests green.
+    """The vectorized floor had ZERO coverage: gutting it left the whole suite green.
 
     The sibling close test does not reach it -- a close sets target 0, which the exemption
     gives a tolerance of 0, so the floor is never consulted. Only a RESIZE consults it, and

--- a/tests/envs/offline/test_vec_scalar_equivalence.py
+++ b/tests/envs/offline/test_vec_scalar_equivalence.py
@@ -286,7 +286,7 @@ class TestScalarVecEquivalenceResize:
         # position is open. Both engines drop that step before classifying it, so the
         # canonical ageing call is the only thing that ages the position -- and nothing
         # else in the suite ever enters that branch holding anything. Re-adding either
-        # engine's removed `hold_counter += 1` there passed all 691 offline tests.
+        # engine's removed `hold_counter += 1` there leaves the whole suite green.
         (5, [0.0, 0.5, 0.505, 1.0], [1, 2, 2, 1, 3]),
     ], ids=["oscillate-spot", "oscillate-levered", "oscillate-short", "through-flat",
             "tolerance-hold"])

--- a/tests/envs/test_live_env_base.py
+++ b/tests/envs/test_live_env_base.py
@@ -5756,8 +5756,8 @@ def test_every_live_env_actually_calls_its_shared_initialiser(env_cls):
     `getattr(cls, m) is getattr(owner, m)` is the right check for `_step`/`_reset`, which
     the framework dispatches. It is a no-op for an initialiser the leaf calls explicitly: a
     venue that inlines a faithful copy still RESOLVES to the shared one, so the table stays
-    green while the fold silently stops applying to it. Verified -- re-forking bybit's SLTP
-    tail that way passed all 4749 tests.
+    green while the fold silently stops applying to it. Verified: re-forking bybit's SLTP
+    tail that way leaves the whole suite green.
 
     AST, not substring, for the reason the guard below records: a comment mentioning the
     name would satisfy a grep. Parametrized over STEPPING_ENVS, which already asserts its
@@ -6889,7 +6889,7 @@ def test_the_notional_is_checked_against_the_quantity_the_venue_will_receive(ven
 
     Every venue formatter truncates to the lot step, so validating before that is the
     same "validated one number, sent another" bug this PR fixes on the plain path --
-    committed once inside the fix itself, and reverting it passed all 3514 tests.
+    committed once inside the fix itself, and reverting it leaves the suite green.
 
     The numbers are the ones from that commit message: step 0.001, floor 100, price
     60000. A quantity of 0.001666... is exactly 100.00 raw and 60.00 once floored, so


### PR DESCRIPTION
Fallout from the test-suite audit. Five test docstrings cite a suite count, and every one was already wrong against the current 4947:

```
test_vec_scalar_equivalence.py               "passed all 691 offline tests"
test_position_tolerance.py                   "left all 2865 tests green"
test_offline_config_has_no_dead_fields_289   "passed all 4013 tests"
test_live_env_base.py                        "passed all 4749 tests"
test_live_env_base.py                        "passed all 3514 tests"
```

Each sentence states something worth keeping: a mutation survived the entire suite, which is the reason that test exists. The number bolted onto it decays the moment anyone adds a test, and then the docstring is making a false claim about the codebase in a file whose whole job is catching those. Reworded to keep the invariant and drop the count.

Comments only. No behaviour change, 4770 passed / 16 skipped.

## On the wider audit

This is the only change I'm proposing to the test suite, and it's worth saying why, since the original brief was whether we have too many tests.

Re-measured, the cross-venue duplication is **12 groups, roughly 394 lines**, not the 1,300-1,700 I estimated earlier. #425 through #428 already folded the large wins.

Almost all of the remainder should stay:

- `test_step_emits_the_whole_done_family` (10 copies) and `test_check_env_specs_passes` (8) are already single calls to shared helpers. The five lines each are the per-venue `env` fixture call site.
- The four replay copies already call `assert_the_replay_portfolio_tracks_price`. What repeats is `open_action=1, hold_action=0, stoploss_levels=...`, and the comment above them records why: the helper used to hardcode those and was silently wrong off-SLTP.
- `test_bankruptcy_termination` (3 copies) documents itself as the only per-venue guard against a `_step` that hardcodes `done=True`, with the threshold arithmetic covered centrally. Its comment also records that action index 2 meant flat on three venues and long on binance, so one shared table tested two different behaviours.

Folding those would recentralise venue data at the seam that has already caused a venue to stop being tested. Prose is 23% of the large test files, which seems right for docstrings that name the mutation each test kills.

## Review

I did not run the five-agent three-round cycle on this one. The diff is six comment lines with no behaviour change, and @CharlieHelps agreed on #429 that source-backed review plus the full suite is the useful check for a docs-only diff. Flagging the choice rather than leaving it implied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LBfyCu9QGCFbqP4urG8co5